### PR TITLE
fix(deploy): downgrade eslint to v9 for deploy button compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.2",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
     "@hono/zod-openapi": "^1.2.4",
     "@playwright/test": "^1.58.2",
     "@types/better-sqlite3": "^7.6.13",
@@ -47,7 +47,7 @@
     "better-sqlite3": "^12.8.0",
     "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.7",
-    "eslint": "^10.0.2",
+    "eslint": "^9.39.4",
     "eslint-plugin-import": "^2.32.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Problem

The Cloudflare Deploy Button fails during `npm clean-install` with an `ERESOLVE` conflict:

```
npm error ERESOLVE could not resolve
npm error While resolving: eslint-plugin-import @2.32.0
npm error Found: eslint @10.0.3
npm error peer eslint @"^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" from eslint-plugin-import @2.32.0
```

`eslint-plugin-import@2.32.0` does not support `eslint@10.x` yet.

## Solution

Downgrade `eslint` and `@eslint/js` from `^10.x` to `^9.39.4` to maintain compatibility.

## Changes

- `eslint`: `^10.0.2` → `^9.39.4`
- `@eslint/js`: `^10.0.1` → `^9.39.4`

## Verification

- ✅ Clean install (`npm clean-install`) passes without `ERESOLVE` errors
- ✅ `npm run lint` passes with no errors
- ✅ All 9 unit tests passing
