### PR TITLE
fix(deploy): replace --batch with --yes for wrangler d1 migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "dev": "concurrently --kill-others \"wrangler dev --port 8788\" \"npx tailwindcss -i ./src/styles/input.css -o ./public/styles.css --watch\"",
     "build": "npm run css:build && tsc",
-    "deploy": "npx wrangler d1 migrations apply openinspection-db --remote --batch && npm run css:build && npx wrangler deploy",
+    "deploy": "npx wrangler d1 migrations apply openinspection-db --remote --yes && npm run css:build && npx wrangler deploy",
     "setup:cloudflare": "node scripts/setup-cloudflare.js",
     "setup:local": "node scripts/setup-cloudflare.js --local",
     "teardown:cloudflare": "node scripts/teardown-cloudflare.js",


### PR DESCRIPTION
## Problem

The `wrangler d1 migrations apply` command does not recognize the `--batch` flag, causing Cloudflare one-click deployments to fail with:

```
✘ [ERROR] Unknown argument: batch
```

## Solution

Replace `--batch` with `--yes` in the deploy script to skip confirmation prompts in non-interactive CI/CD environments.

## Changes

- `package.json`: Updated deploy script from `--batch` to `--yes`

## Testing

- [x] Build passes locally
- [ ] Cloudflare deploy should work with `--yes` flag