### PR TITLE
fix(deploy): use setup-cloudflare script and add placeholder IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "dev": "concurrently --kill-others \"wrangler dev --port 8788\" \"npx tailwindcss -i ./src/styles/input.css -o ./public/styles.css --watch\"",
     "build": "npm run css:build && tsc",
-    "deploy": "npx wrangler d1 migrations apply openinspection-db --remote --yes && npm run css:build && npx wrangler deploy",
+    "deploy": "node scripts/setup-cloudflare.js --force",
     "setup:cloudflare": "node scripts/setup-cloudflare.js",
     "setup:local": "node scripts/setup-cloudflare.js --local",
     "teardown:cloudflare": "node scripts/teardown-cloudflare.js",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,10 +45,12 @@ SETUP_CODE = "" # Optional: Set a custom 6-digit code for first-time setup
 [[d1_databases]]
 binding = "DB"
 database_name = "openinspection-db"
+database_id = "00000000-0000-0000-0000-000000000000"
 migrations_dir = "migrations"
 
 [[kv_namespaces]]
 binding = "TENANT_CACHE"
+id = "00000000000000000000000000000000"
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Problem

Cloudflare one-click deployment fails because:
1. Raw wrangler commands fail when resources don't exist yet
2. `wrangler.toml` is missing `database_id` and `kv id` placeholders needed by the setup script

## Solution

1. Use `setup-cloudflare.js --force` for the deploy script, which handles resource creation, migrations, and deployment idempotently
2. Add `database_id` and `id` placeholders to `wrangler.toml` so the setup script can patch them with real resource IDs