### PR TITLE
feat(deploy): rename resources with standalone prefix

### DIFF
--- a/scripts/setup-cloudflare.js
+++ b/scripts/setup-cloudflare.js
@@ -17,13 +17,13 @@ const getArg = (key) => {
 
 // Configuration Paths & Naming
 const TOML_PATH = path.resolve(getArg('--config') || getArg('--toml') || 'wrangler.toml');
-const PROJECT_SLUG = getArg('--name') || 'openinspection';
+const PROJECT_SLUG = getArg('--name') || 'openinspection-standalone';
 const PROJECT_TITLE = getArg('--app-name') || getArg('--title') || 'OpenInspection';
 
 // Dynamic Resource Naming
 const DB_NAME = getArg('--db-name') || `${PROJECT_SLUG}-db`;
 const KV_NAME = getArg('--kv-name') || `${PROJECT_SLUG}-tenant-cache`;
-const BUCKETS = [`${PROJECT_SLUG}-photos`, `${PROJECT_SLUG}-photos-preview`];
+const BUCKETS = [`${PROJECT_SLUG}-photos`];
 const WORKER_NAME = PROJECT_SLUG;
 
 const isForce = args.includes('--force') || args.includes('-y') || args.includes('--yes');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "openinspection"
+name = "openinspection-standalone"
 main = "src/index.ts"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
@@ -44,7 +44,7 @@ SETUP_CODE = "" # Optional: Set a custom 6-digit code for first-time setup
 
 [[d1_databases]]
 binding = "DB"
-database_name = "openinspection-db"
+database_name = "openinspection-standalone-db"
 database_id = "00000000-0000-0000-0000-000000000000"
 migrations_dir = "migrations"
 


### PR DESCRIPTION
## Changes

Rename all Cloudflare resources with `standalone` prefix to distinguish from the multi-tenant SaaS version.

### Resource Naming

| Type | Old Name | New Name |
|------|----------|----------|
| Worker | `openinspection` | `openinspection-standalone` |
| D1 | `openinspection-db` | `openinspection-standalone-db` |
| KV | `openinspection-tenant-cache` | `openinspection-standalone-tenant-cache` |
| R2 | `openinspection-photos`, `openinspection-photos-preview` | `openinspection-standalone-photos` |

### Additional Changes
- Removed unnecessary `openinspection-photos-preview` R2 bucket (only 1 bucket needed)