### PR TITLE
feat(deploy): use standalone resource naming

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -57,4 +57,4 @@ enabled = true
 
 [[r2_buckets]]
 binding = "PHOTOS"
-bucket_name = "openinspection-photos"
+bucket_name = "openinspection-standalone-photos"


### PR DESCRIPTION
## Changes

Rename all Cloudflare resources with `standalone` prefix to distinguish from the multi-tenant SaaS version.

### Resource Naming

| Type | Old Name | New Name |
|------|----------|----------|
| Worker | `openinspection` | `openinspection-standalone` |
| D1 | `openinspection-db` | `openinspection-standalone-db` |
| KV | `openinspection-tenant-cache` | `openinspection-standalone-tenant-cache` |
| R2 | `openinspection-photos`, `openinspection-photos-preview` | `openinspection-standalone-photos` |

### Additional Changes
- Removed unnecessary `openinspection-photos-preview` R2 bucket