### PR TITLE
Round 43-46: photo upload + audit closeout + Modal component + dashboard counters + comments unify

### DIFF
--- a/migrations/0039_comments_rating_bucket.sql
+++ b/migrations/0039_comments_rating_bucket.sql
@@ -1,0 +1,12 @@
+-- Migration: 0039_comments_rating_bucket
+-- Adds rating_bucket and section columns to the comments library so user
+-- snippets can be classified the same way the inspection-edit Library
+-- drawer classifies the seeded 248-entry library
+-- (satisfactory / monitor / defect / null=uncategorized).
+--
+-- Both columns are nullable; existing rows stay null and are surfaced
+-- under the "All" tab on /comments and the "All" / "My snippets" tabs in
+-- the Library drawer. No backfill required.
+ALTER TABLE comments ADD COLUMN rating_bucket TEXT;
+ALTER TABLE comments ADD COLUMN section TEXT;
+CREATE INDEX IF NOT EXISTS idx_comments_rating_bucket ON comments(tenant_id, rating_bucket);

--- a/public/js/comments-admin.js
+++ b/public/js/comments-admin.js
@@ -3,25 +3,64 @@ function commentsAdminFactory() {
         items: [],
         loading: false,
         saving: false,
+        // Spec 2026-05-07 — primary axis is rating bucket (matches the
+        // inspection-edit Library drawer tabs); category + section stay as
+        // secondary filters.
+        bucket: '',
         categoryFilter: '',
+        sectionFilter: '',
+        bucketTabs: [
+            { value: '',             label: 'All' },
+            { value: 'satisfactory', label: 'Satisfactory' },
+            { value: 'monitor',      label: 'Monitor' },
+            { value: 'defect',       label: 'Defect' },
+        ],
         modalOpen: false,
         editingId: null,
-        form: { category: '', text: '' },
+        form: { category: '', text: '', ratingBucket: '', section: '' },
 
         async init() {
             await this.reload();
         },
 
         get distinctCategories() {
-            return [...new Set(this.items.map(r => r.category).filter(Boolean))].sort();
+            return [...new Set(this._allItems.map(r => r.category).filter(Boolean))].sort();
+        },
+        get distinctSections() {
+            return [...new Set(this._allItems.map(r => r.section).filter(Boolean))].sort();
+        },
+
+        // Cache the unfiltered server response so the dropdown options stay
+        // populated even after the user narrows the bucket tab.
+        _allItems: [],
+
+        setBucket(b) {
+            this.bucket = b || '';
+            this.reload();
         },
 
         async reload() {
             this.loading = true;
             try {
-                const res = await authFetch('/api/admin/comments');
+                // Server-side bucket + section filtering (matches spec API
+                // contract). Category stays client-side because it's a
+                // free-text legacy field and the dataset is tiny.
+                const qs = new URLSearchParams();
+                if (this.bucket) qs.set('rating', this.bucket);
+                if (this.sectionFilter) qs.set('section', this.sectionFilter);
+                const url = '/api/admin/comments' + (qs.toString() ? '?' + qs.toString() : '');
+                const res = await authFetch(url);
                 const json = await res.json();
                 const all = json.data?.comments || [];
+                // Preserve the full set for the category/section autocompletes,
+                // even though the visible list is filtered.
+                if (!this.bucket && !this.sectionFilter) {
+                    this._allItems = all;
+                } else if (this._allItems.length === 0) {
+                    // first load with a filter applied — re-fetch unfiltered
+                    // in the background so dropdowns populate.
+                    void this._refreshAllItems();
+                }
                 this.items = this.categoryFilter
                     ? all.filter(c => c.category === this.categoryFilter)
                     : all;
@@ -32,9 +71,17 @@ function commentsAdminFactory() {
             }
         },
 
+        async _refreshAllItems() {
+            try {
+                const res = await authFetch('/api/admin/comments');
+                const json = await res.json();
+                this._allItems = json.data?.comments || [];
+            } catch { /* non-fatal — autocompletes just stay empty */ }
+        },
+
         openCreate() {
             this.editingId = null;
-            this.form = { category: '', text: '' };
+            this.form = { category: '', text: '', ratingBucket: '', section: '' };
             this.modalOpen = true;
         },
 
@@ -43,6 +90,8 @@ function commentsAdminFactory() {
             this.form = {
                 category: comment.category || '',
                 text: comment.text,
+                ratingBucket: comment.ratingBucket || '',
+                section: comment.section || '',
             };
             this.modalOpen = true;
         },
@@ -57,6 +106,8 @@ function commentsAdminFactory() {
                 const body = {
                     text: this.form.text,
                     category: this.form.category || null,
+                    ratingBucket: this.form.ratingBucket || null,
+                    section: this.form.section || null,
                 };
                 const url = this.editingId
                     ? '/api/admin/comments/' + this.editingId

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -609,20 +609,16 @@ function dashboardFactory() {
         },
 
         computeStats() {
+            // R45 — each stat's number, label, and click-target bucket are now
+            // aligned. No more double-counting recentReports as both 'review'
+            // and 'completed'. No more renaming the same number under two
+            // different headers.
             const b = this.buckets;
-            const allActive = [...b.today, ...b.thisWeek, ...b.later];
             const inProgressItems = [
                 ...b.needsAttention.filter(i => i.status === 'in_progress'),
                 ...b.today.filter(i => i.status === 'in_progress'),
                 ...b.thisWeek.filter(i => i.status === 'in_progress'),
                 ...b.later.filter(i => i.status === 'in_progress'),
-            ];
-            const completedItems = [
-                ...b.needsAttention.filter(i => i.status === 'completed'),
-                ...b.today.filter(i => i.status === 'completed'),
-                ...b.thisWeek.filter(i => i.status === 'completed'),
-                ...b.later.filter(i => i.status === 'completed'),
-                ...b.recentReports,
             ];
             const dedupCount = (rows) => new Set(rows.map(r => r.id)).size;
 
@@ -631,10 +627,15 @@ function dashboardFactory() {
                 if (el) el.textContent = String(val);
             };
 
-            setText('statActive',    allActive.length);
-            setText('statProgress',  dedupCount(inProgressItems));
-            setText('statReview',    b.recentReports.length);
-            setText('statCompleted', dedupCount(completedItems));
+            // Upcoming = scheduled work (today + thisWeek + later, dedup'd)
+            setText('statUpcoming',   dedupCount([...b.today, ...b.thisWeek, ...b.later]));
+            // In Progress = inspections currently being worked on
+            setText('statInProgress', dedupCount(inProgressItems));
+            // Needs Attention = inspections flagged as needing review
+            setText('statNeedsAttn',  b.needsAttention.length);
+            // Recent Reports = published reports (was previously double-named
+            // 'Ready for Review' AND 'Completed' for the same dataset)
+            setText('statRecentRpt',  b.recentReports.length);
         },
 
         async loadAllLater() {

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -1212,10 +1212,13 @@ function inspectionEditor(inspectionId) {
       var file = event.target.files && event.target.files[0];
       if (!file) return;
       var formData = new FormData();
-      formData.append('photo', file);
+      // Server endpoint is POST /api/inspections/:id/upload with form field
+      // 'file' + 'itemId' (see src/api/inspections.ts:760). Earlier client
+      // versions used /photos + 'photo' which 404'd silently.
+      formData.append('file', file);
       formData.append('itemId', itemId);
       try {
-        var res = await authFetch('/api/inspections/' + this.inspectionId + '/photos', {
+        var res = await authFetch('/api/inspections/' + this.inspectionId + '/upload', {
           method: 'POST',
           body: formData,
         });

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -87,6 +87,11 @@ function inspectionEditor(inspectionId) {
     aiSuggestions: [],
     aiTargetField: null,
     showAiPopover: false,
+    // Spec 2026-05-07 — user snippets fetched from /api/admin/comments
+    // (the same data source as the /comments page). Lets MY SNIPPETS show
+    // bucket-classified user comments, so /comments + Library drawer agree.
+    // Keeps localStorage-only snippets as a fallback (offline / older saves).
+    _userSnippets: [],
 
     publishOptions: {
       theme: 'modern',
@@ -353,7 +358,34 @@ function inspectionEditor(inspectionId) {
           photos[photoIndex] = Object.assign({}, photos[photoIndex], { annotatedKey });
         }
       });
+      // Spec 2026-05-07 — user snippets from the unified comments table.
+      // Fire-and-forget: the drawer falls back to localStorage snippets if
+      // this fails (e.g. offline reload).
+      this.loadUserSnippets();
+
       await this.loadData();
+    },
+
+    async loadUserSnippets() {
+      try {
+        var res = await authFetch('/api/admin/comments');
+        if (!res.ok) return;
+        var json = await res.json();
+        var rows = (json.data && json.data.comments) || [];
+        // Map server schema to the in-memory snippet shape consumed by
+        // _commentLibraryPool / commentLibraryItems. Use 'all' for the
+        // null-bucket case so the seeded "All" filter still surfaces them.
+        this._userSnippets = rows.map(function (r) {
+          return {
+            id: r.id,
+            rating: r.ratingBucket || 'all',
+            section: r.section || null,
+            category: r.category || null,
+            text: r.text,
+            source: 'snippet',
+          };
+        });
+      } catch (_) { /* non-fatal */ }
     },
 
     async loadData() {
@@ -1047,12 +1079,22 @@ function inspectionEditor(inspectionId) {
         { rating: 'all', text: 'Item was not accessible during the inspection; recommend re-evaluation when accessible.' },
       ];
       COMMENTS = COMMENTS.map(function (c) { return Object.assign({}, c, { source: 'preset' }); });
-      var SNIPPETS = [];
+      // Spec 2026-05-07 — server-backed user snippets (from /api/admin/comments)
+      // are the canonical source for MY SNIPPETS. Fall back to localStorage
+      // snippets (kept for offline + older saves) and dedupe on `text`.
+      var SERVER = (this._userSnippets || []).slice();
+      var seen = {};
+      for (var i = 0; i < SERVER.length; i++) seen[SERVER[i].text] = true;
+      var LOCAL = [];
       try {
         var raw = localStorage.getItem('oi:snippets');
-        if (raw) SNIPPETS = JSON.parse(raw).map(function (c) { return Object.assign({}, c, { source: 'snippet' }); });
+        if (raw) {
+          LOCAL = JSON.parse(raw)
+            .filter(function (c) { return c && !seen[c.text]; })
+            .map(function (c) { return Object.assign({}, c, { source: 'snippet' }); });
+        }
       } catch (_) {}
-      return COMMENTS.concat(SNIPPETS);
+      return COMMENTS.concat(SERVER, LOCAL);
     },
 
     get commentLibraryItems() {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -27,6 +27,7 @@ import {
     CommentSchema,
     CommentResponseSchema,
     UpdateCommentSchema,
+    ListCommentsQuerySchema,
     StripeConnectAccountSchema,
 } from '../lib/validations/admin.schema';
 import { SuccessResponseSchema } from '../lib/validations/shared.schema';
@@ -953,6 +954,19 @@ adminRoutes.openapi(downloadAuditTrailRoute, async (c) => {
 
 // --- Comments Library ---
 
+// Spec 2026-05-07 — narrow Drizzle's generic `string | null` for
+// `ratingBucket` down to the Zod enum shape the OpenAPI response schema
+// declares. The DB column is just TEXT (column constraint isn't enforced
+// at the SQLite layer), so we cast at the response boundary.
+type RatingBucketResp = 'satisfactory' | 'monitor' | 'defect' | null;
+function commentRowToResponse(r: typeof comments.$inferSelect) {
+    return {
+        ...r,
+        ratingBucket: (r.ratingBucket as RatingBucketResp) ?? null,
+        createdAt: safeISODate(r.createdAt),
+    };
+}
+
 const listCommentsRoute = createRoute({
     method: 'get',
     path: '/comments',
@@ -961,6 +975,7 @@ const listCommentsRoute = createRoute({
     // Inspectors need read access so the inspection-edit picker (T7+1) can
     // populate. Create/delete remain admin-only further below.
     middleware: [requireRole(['owner', 'admin', 'inspector'])],
+    request: { query: ListCommentsQuerySchema },
     responses: {
         200: {
             content: { 'application/json': { schema: z.object({ success: z.literal(true), data: z.object({ comments: z.array(CommentResponseSchema) }) }) } },
@@ -972,9 +987,20 @@ const listCommentsRoute = createRoute({
 
 adminRoutes.openapi(listCommentsRoute, async (c) => {
     const tenantId = c.get('tenantId');
+    const { rating, section, search } = c.req.valid('query');
     const db = drizzle(c.env.DB);
-    const rows = await db.select().from(comments).where(eq(comments.tenantId, tenantId)).all();
-    return c.json({ success: true as const, data: { comments: rows.map(r => ({ ...r, createdAt: safeISODate(r.createdAt) })) } }, 200);
+    // Filters layered defensively: tenantId always first (multi-tenant
+    // isolation rule from CLAUDE.md), then optional rating bucket / section
+    // / free-text search.
+    const conditions = [eq(comments.tenantId, tenantId)];
+    if (rating) conditions.push(eq(comments.ratingBucket, rating));
+    if (section) conditions.push(eq(comments.section, section));
+    let rows = await db.select().from(comments).where(and(...conditions)).all();
+    if (search && search.trim()) {
+        const needle = search.trim().toLowerCase();
+        rows = rows.filter(r => r.text.toLowerCase().includes(needle));
+    }
+    return c.json({ success: true as const, data: { comments: rows.map(commentRowToResponse) } }, 200);
 });
 
 const createCommentRoute = createRoute({
@@ -995,11 +1021,19 @@ const createCommentRoute = createRoute({
 
 adminRoutes.openapi(createCommentRoute, async (c) => {
     const tenantId = c.get('tenantId');
-    const { text, category } = c.req.valid('json');
+    const { text, category, ratingBucket, section } = c.req.valid('json');
     const db = drizzle(c.env.DB);
-    const row = { id: crypto.randomUUID(), tenantId, text, category: category ?? null, createdAt: new Date() };
+    const row = {
+        id: crypto.randomUUID(),
+        tenantId,
+        text,
+        category: category ?? null,
+        ratingBucket: ratingBucket ?? null,
+        section: section ?? null,
+        createdAt: new Date(),
+    };
     await db.insert(comments).values(row);
-    return c.json({ success: true as const, data: { comment: { ...row, createdAt: safeISODate(row.createdAt) } } }, 201);
+    return c.json({ success: true as const, data: { comment: commentRowToResponse(row) } }, 201);
 });
 
 const deleteCommentRoute = createRoute({
@@ -1053,20 +1087,31 @@ const updateCommentRoute = createRoute({
 adminRoutes.openapi(updateCommentRoute, async (c) => {
     const tenantId = c.get('tenantId');
     const { id } = c.req.valid('param');
-    const { text, category } = c.req.valid('json');
+    const { text, category, ratingBucket, section } = c.req.valid('json');
     const db = drizzle(c.env.DB);
     const existing = await db.select().from(comments)
         .where(and(eq(comments.id, id), eq(comments.tenantId, tenantId))).get();
     if (!existing) throw Errors.NotFound('Comment not found');
+    const patch = {
+        text,
+        category: category ?? null,
+        ratingBucket: ratingBucket ?? null,
+        section: section ?? null,
+    };
     await db.update(comments)
-        .set({ text, category: category ?? null })
+        .set(patch)
         .where(and(eq(comments.id, id), eq(comments.tenantId, tenantId)));
-    const updated = { ...existing, text, category: category ?? null };
+    const updated = { ...existing, ...patch };
     auditFromContext(c, 'comment.updated', 'comment', {
         entityId: id,
-        metadata: { category: category ?? null, textPreview: text.slice(0, 80) },
+        metadata: {
+            category: category ?? null,
+            ratingBucket: ratingBucket ?? null,
+            section: section ?? null,
+            textPreview: text.slice(0, 80),
+        },
     });
-    return c.json({ success: true as const, data: { comment: { ...updated, createdAt: safeISODate(updated.createdAt) } } }, 200);
+    return c.json({ success: true as const, data: { comment: commentRowToResponse(updated) } }, 200);
 });
 
 // --- Widget Origin Allowlist ---

--- a/src/lib/db/schema/inspection.ts
+++ b/src/lib/db/schema/inspection.ts
@@ -117,6 +117,13 @@ export const comments = sqliteTable('comments', {
     tenantId: text('tenant_id').notNull().references(() => tenants.id),
     text: text('text').notNull(),
     category: text('category'),
+    // Spec 2026-05-07 — rating bucket so user snippets stack alongside the
+    // 248 seeded library entries in the inspection-edit Library drawer.
+    // 'satisfactory' | 'monitor' | 'defect' | null (= uncategorized / "All")
+    ratingBucket: text('rating_bucket'),
+    // Section label (Roof, Electrical, ...) — same shape as canned-comments.js
+    // entries. Free-text so tenants can grow their own taxonomy.
+    section: text('section'),
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 });
 

--- a/src/lib/validations/admin.schema.ts
+++ b/src/lib/validations/admin.schema.ts
@@ -208,14 +208,25 @@ export const TeamMembersResponseSchema = createApiResponseSchema(z.object({
     })),
 })).openapi('TeamMembersResponse');
 
+// Spec 2026-05-07 — Comments Library unification.
+// `ratingBucket` aligns user snippets with the seeded 248-entry library so
+// both surfaces (the /comments page and the inspection-edit Library drawer)
+// classify entries identically. `section` is free-text so tenants can grow
+// their own taxonomy alongside the seeded sections (Roof / Electrical / …).
+const RatingBucketSchema = z.enum(['satisfactory', 'monitor', 'defect']);
+
 export const CommentSchema = z.object({
     text: z.string().min(1).max(1000).openapi({ example: 'Evidence of previous repair was observed.' }),
     category: z.string().max(50).optional().nullable().openapi({ example: 'Roofing' }),
+    ratingBucket: RatingBucketSchema.optional().nullable().openapi({ example: 'defect' }),
+    section: z.string().max(64).optional().nullable().openapi({ example: 'Roof' }),
 }).openapi('Comment');
 
 export const UpdateCommentSchema = z.object({
     text: z.string().min(1).max(1000).openapi({ example: 'Evidence of previous repair was observed.' }),
     category: z.string().max(50).nullable().optional().openapi({ example: 'Roofing' }),
+    ratingBucket: RatingBucketSchema.nullable().optional().openapi({ example: 'defect' }),
+    section: z.string().max(64).nullable().optional().openapi({ example: 'Roof' }),
 }).openapi('UpdateComment');
 
 export const CommentResponseSchema = z.object({
@@ -223,5 +234,13 @@ export const CommentResponseSchema = z.object({
     tenantId: z.string().uuid(),
     text: z.string(),
     category: z.string().nullable(),
+    ratingBucket: RatingBucketSchema.nullable(),
+    section: z.string().nullable(),
     createdAt: z.string(),
 }).openapi('CommentResponse');
+
+export const ListCommentsQuerySchema = z.object({
+    rating: RatingBucketSchema.optional().openapi({ example: 'defect' }),
+    section: z.string().max(64).optional().openapi({ example: 'Roof' }),
+    search: z.string().max(200).optional(),
+}).openapi('ListCommentsQuery');

--- a/src/templates/components/atmospheric-bg.tsx
+++ b/src/templates/components/atmospheric-bg.tsx
@@ -1,8 +1,5 @@
+// Spec 5F R2 Step 6 — atmospheric blob retired (Round 41 / audit P1-4).
+// Component is now a no-op so existing imports keep compiling.
 export function AtmosphericBg(): JSX.Element {
-    return (
-        <div class="fixed inset-0 pointer-events-none overflow-hidden select-none">
-            <div class="absolute -top-[10%] -left-[10%] w-[40%] h-[40%] bg-indigo-500/5 blur-[120px] rounded-full animate-float"></div>
-            <div class="absolute -bottom-[10%] -right-[10%] w-[40%] h-[40%] bg-blue-500/5 blur-[120px] rounded-full animate-float" style="animation-delay: -2s"></div>
-        </div>
-    );
+    return <></>;
 }

--- a/src/templates/components/cancel-modal.tsx
+++ b/src/templates/components/cancel-modal.tsx
@@ -1,38 +1,44 @@
 // Spec 3A — Cancel inspection modal. Mounted ONCE per page (e.g. on dashboard).
 // Listens for 'open-cancel-modal' event with { id }. POSTs to /api/inspections/:id/cancel.
 
+import { Modal, ModalFooter } from './modal';
+
 export const CancelModal = () => (
     <div x-data="cancelModalFactory()" x-cloak>
-        <div x-show="open" class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
-             {...{ 'x-on:click': 'if ($event.target === $el) open = false' }}>
-            <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6">
-                <h2 class="text-lg font-bold text-slate-900 mb-4">Cancel inspection</h2>
-                <div class="space-y-3">
-                    <div>
-                        <label class="block text-xs font-bold text-slate-600 mb-1 uppercase tracking-wider">Reason</label>
-                        <select x-model="reason" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
-                            <option value="client_cancelled">Client cancelled</option>
-                            <option value="weather">Weather</option>
-                            <option value="inspector_unavailable">Inspector unavailable</option>
-                            <option value="property_unavailable">Property unavailable</option>
-                            <option value="rescheduled">Rescheduled</option>
-                            <option value="other">Other</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label class="block text-xs font-bold text-slate-600 mb-1 uppercase tracking-wider">Notes (optional)</label>
-                        <textarea x-model="notes" rows={3} maxlength={500} placeholder="Optional details..."
-                                  class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
-                    </div>
+        <Modal
+            name="open"
+            title="Cancel inspection"
+            size="md"
+            footer={
+                <ModalFooter
+                    cancelText="Back"
+                    onCancel="open = false"
+                    onConfirm="submit()"
+                    confirmDisabled="busy"
+                    confirmTextExpr="busy ? 'Cancelling...' : 'Cancel inspection'"
+                    danger={true}
+                />
+            }
+        >
+            <div class="space-y-3">
+                <div>
+                    <label class="block text-xs font-bold text-slate-600 mb-1 uppercase tracking-wider">Reason</label>
+                    <select x-model="reason" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                        <option value="client_cancelled">Client cancelled</option>
+                        <option value="weather">Weather</option>
+                        <option value="inspector_unavailable">Inspector unavailable</option>
+                        <option value="property_unavailable">Property unavailable</option>
+                        <option value="rescheduled">Rescheduled</option>
+                        <option value="other">Other</option>
+                    </select>
                 </div>
-                <div class="flex gap-3 justify-end mt-6">
-                    <button x-on:click="open = false" class="px-5 py-2 rounded-lg ring-2 ring-slate-300 text-slate-700 text-xs font-bold uppercase tracking-widest">Back</button>
-                    <button x-on:click="submit()" {...{ 'x-bind:disabled': 'busy' }} class="px-5 py-2 rounded-lg bg-rose-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-rose-700 disabled:opacity-50">
-                        <span x-text="busy ? 'Cancelling...' : 'Cancel inspection'"></span>
-                    </button>
+                <div>
+                    <label class="block text-xs font-bold text-slate-600 mb-1 uppercase tracking-wider">Notes (optional)</label>
+                    <textarea x-model="notes" rows={3} maxlength={500} placeholder="Optional details..."
+                              class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
                 </div>
             </div>
-        </div>
+        </Modal>
         <script dangerouslySetInnerHTML={{ __html: `
             function cancelModalFactory() {
                 return {

--- a/src/templates/components/modal.tsx
+++ b/src/templates/components/modal.tsx
@@ -1,0 +1,232 @@
+/**
+ * Unified Modal component.
+ *
+ * One canonical shape for every page-level modal in apps/core. Matches the
+ * Round 38 / 39 design language: backdrop bg-black/40, white card with
+ * rounded-2xl, h-10 button row, normal-case copy.
+ *
+ * Two driver modes:
+ *   - Alpine: pass `name="showXxxModal"`. The component wires x-show + click-
+ *     outside + Esc-to-close to that state name.
+ *   - Static (id-based JS toggle): pass `id="xxxModal"`. The element starts
+ *     `hidden`; consumer JS calls `el.classList.remove('hidden')` to open
+ *     and `.add('hidden')` to close. Click-outside / Esc still close it via
+ *     a tiny inline script attached per-instance.
+ *
+ * Pass exactly one of `name` or `id`. The body slot is `children`. The
+ * footer slot is the optional `footer` prop — pass `<ModalFooter>` for the
+ * canonical Cancel + Confirm row, or any JSX for non-standard layouts.
+ */
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '5xl';
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl',
+    '5xl': 'max-w-5xl',
+};
+
+interface ModalProps {
+    /** Alpine state variable name (e.g. `showPublishModal`). Mutually exclusive with `id`. */
+    name?: string;
+    /** DOM id for JS-toggled modals (e.g. `createModal`). Mutually exclusive with `name`. */
+    id?: string;
+    /** Title (h2). Optional only if you build the header yourself in `children`. */
+    title?: string;
+    /** Optional static subtitle under the title. */
+    subtitle?: string;
+    /** Alpine x-text expression for a dynamic subtitle (overrides `subtitle`). */
+    subtitleExpr?: string;
+    /** Alpine x-text expression for a dynamic title (overrides `title` when present). */
+    titleExpr?: string;
+    /** Body width preset. Default `md`. */
+    size?: ModalSize;
+    /** Body slot. */
+    children: unknown;
+    /** Footer slot (button row). Omit if your body has its own footer. */
+    footer?: unknown;
+    /** Hide the default close (X) button in the header (rare — e.g. when no header is rendered). */
+    hideClose?: boolean;
+    /** Hide the rendered header entirely (if you want full custom body). */
+    hideHeader?: boolean;
+}
+
+/**
+ * Build the close-action expression for the chosen driver.
+ * Alpine mode: `<name> = false`.
+ * Static mode: walks up to the modal root and toggles `.hidden`.
+ */
+function closeExpr(name: string | undefined, id: string | undefined): { close: string; clickOutside: string; escape: string } {
+    if (name) {
+        return {
+            close: `${name} = false`,
+            clickOutside: `if ($event.target === $el) ${name} = false`,
+            escape: `${name} = false`,
+        };
+    }
+    // Static mode: find the modal root by id and toggle .hidden
+    const sel = `document.getElementById('${id}')`;
+    return {
+        close: `${sel}?.classList.add('hidden')`,
+        clickOutside: `if (event.target === this) ${sel}?.classList.add('hidden')`,
+        escape: `${sel}?.classList.add('hidden')`,
+    };
+}
+
+export const Modal = ({
+    name,
+    id,
+    title,
+    titleExpr,
+    subtitle,
+    subtitleExpr,
+    size = 'md',
+    children,
+    footer,
+    hideClose = false,
+    hideHeader = false,
+}: ModalProps): JSX.Element => {
+    const { close, clickOutside, escape } = closeExpr(name, id);
+
+    // Backdrop attributes vary by driver mode.
+    const backdropClass = `fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4${id ? ' hidden overflow-y-auto' : ''}`;
+
+    const alpineAttrs: Record<string, unknown> = name
+        ? {
+              'x-show': name,
+              'x-cloak': true,
+              'x-transition.opacity': '',
+              'x-on:click': clickOutside,
+              'x-on:keydown.escape.window': escape,
+          }
+        : {
+              // Static-mode: bind close behaviour via plain DOM events.
+              onclick: clickOutside,
+          };
+
+    return (
+        <div
+            {...(id ? { id } : {})}
+            class={backdropClass}
+            role="dialog"
+            aria-modal="true"
+            {...alpineAttrs}
+        >
+            <div
+                class={`bg-white rounded-2xl shadow-xl w-full ${SIZE_CLASS[size]} p-6 max-h-[90vh] overflow-y-auto`}
+                {...(name ? { 'x-on:click.stop': '' } : { onclick: 'event.stopPropagation()' })}
+            >
+                {!hideHeader && (
+                    <header class="flex items-start justify-between gap-3 mb-4">
+                        <div class="min-w-0 flex-1">
+                            {titleExpr ? (
+                                <h2 class="text-lg font-bold text-slate-900 truncate" x-text={titleExpr} />
+                            ) : title ? (
+                                <h2 class="text-lg font-bold text-slate-900 truncate">{title}</h2>
+                            ) : null}
+                            {subtitleExpr ? (
+                                <p class="text-sm text-slate-500 mt-0.5" x-text={subtitleExpr} />
+                            ) : subtitle ? (
+                                <p class="text-sm text-slate-500 mt-0.5">{subtitle}</p>
+                            ) : null}
+                        </div>
+                        {!hideClose && (
+                            <button
+                                type="button"
+                                aria-label="Close dialog"
+                                class="w-8 h-8 rounded-xl bg-slate-100 hover:bg-slate-200 flex items-center justify-center text-slate-500 flex-shrink-0"
+                                {...(name ? { 'x-on:click': close } : { onclick: close })}
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        )}
+                    </header>
+                )}
+                <div>{children}</div>
+                {footer ? <div class="mt-6 flex gap-3 justify-end">{footer}</div> : null}
+            </div>
+        </div>
+    );
+};
+
+interface ModalFooterProps {
+    cancelText?: string;
+    confirmText?: string;
+    /** Alpine expression for confirm action (Alpine mode only). */
+    onConfirm?: string;
+    /** Plain JS expression for confirm action (static mode). */
+    onConfirmJs?: string;
+    /** Alpine expression returning a boolean (e.g. `saving`). */
+    confirmDisabled?: string;
+    /** Alpine expression for cancel action. Defaults to closing the modal. */
+    onCancel?: string;
+    /** Plain JS expression for cancel action (static mode). */
+    onCancelJs?: string;
+    /** Optional id for the confirm button (some pages query it via getElementById). */
+    confirmId?: string;
+    /** Make the Confirm button visually destructive (rose) instead of indigo. */
+    danger?: boolean;
+    /** Override Confirm button text via x-text expression (e.g. `saving ? 'Saving…' : 'Save'`). */
+    confirmTextExpr?: string;
+}
+
+/**
+ * Canonical modal footer button row. Cancel (white + border) + Confirm
+ * (indigo solid, or rose if danger). Both `flex-1 h-10 px-4 rounded-xl
+ * text-sm font-semibold`. Use this for 90% of modals; for >2 buttons or
+ * unusual layouts, inline custom JSX directly into Modal's `footer` slot.
+ */
+export const ModalFooter = ({
+    cancelText = 'Cancel',
+    confirmText = 'Confirm',
+    onConfirm,
+    onConfirmJs,
+    confirmDisabled,
+    onCancel,
+    onCancelJs,
+    confirmId,
+    danger = false,
+    confirmTextExpr,
+}: ModalFooterProps): JSX.Element => {
+    const cancelAttrs: Record<string, unknown> = onCancel
+        ? { 'x-on:click': onCancel }
+        : onCancelJs
+        ? { onclick: onCancelJs }
+        : {};
+
+    const confirmAttrs: Record<string, unknown> = {};
+    if (onConfirm) confirmAttrs['x-on:click'] = onConfirm;
+    if (onConfirmJs) confirmAttrs['onclick'] = onConfirmJs;
+    if (confirmDisabled) confirmAttrs['x-bind:disabled'] = confirmDisabled;
+    if (confirmId) confirmAttrs['id'] = confirmId;
+
+    const confirmBg = danger
+        ? 'bg-rose-600 hover:bg-rose-700'
+        : 'bg-indigo-600 hover:bg-indigo-700';
+
+    return (
+        <>
+            <button
+                type="button"
+                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                style="border-color: #e2e8f0"
+                {...cancelAttrs}
+            >
+                {cancelText}
+            </button>
+            <button
+                type="button"
+                class={`flex-1 h-10 px-4 rounded-xl ${confirmBg} text-white text-sm font-semibold disabled:opacity-50 transition-all`}
+                {...confirmAttrs}
+            >
+                {confirmTextExpr ? <span x-text={confirmTextExpr} /> : confirmText}
+            </button>
+        </>
+    );
+};

--- a/src/templates/pages/agreements.tsx
+++ b/src/templates/pages/agreements.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
@@ -99,74 +100,83 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                     </div>
                 </div>
 
-                {/* Create Agreement Modal */}
-                <div id="createModal" class="fixed inset-0 z-[100] hidden overflow-y-auto px-4 py-6 sm:px-0">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-md transition-opacity" onclick="closeModal()"></div>
-                    <div class="flex min-h-full items-center justify-center">
-                        <div role="dialog" aria-modal="true" class="relative w-full max-w-2xl transform overflow-hidden rounded-xl bg-white p-6 text-left shadow-[0_35px_60px_-15px_rgba(0,0,0,0.3)] animate-slide-in">
-                            <div class="absolute top-8 right-8">
-                                <button onclick="closeModal()" aria-label="Close dialog" class="p-3 text-slate-400 hover:text-slate-900 rounded-2xl hover:bg-slate-50 transition-all active:scale-95">
-                                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                                </button>
+                {/* Create Agreement Modal — external JS toggles the title via
+                    id="modalAgreementTitle" (Create vs Edit), so the Modal renders
+                    with hideHeader and a custom in-body header keeps the id intact. */}
+                <Modal
+                    id="createModal"
+                    size="2xl"
+                    hideHeader={true}
+                    footer={
+                        <ModalFooter
+                            cancelText="Discard"
+                            onCancelJs="closeModal()"
+                            onConfirmJs="submitAgreement()"
+                            confirmText="Publish Agreement"
+                            confirmId="submitAgreementBtn"
+                        />
+                    }
+                >
+                    <header class="flex items-start justify-between gap-3 mb-4">
+                        <div class="min-w-0 flex-1">
+                            <h2 id="modalAgreementTitle" class="text-lg font-bold text-slate-900">Create Professional Agreement</h2>
+                            <p class="text-sm text-slate-500 mt-0.5">Draft a new service agreement or liability waiver.</p>
+                        </div>
+                        <button
+                            type="button"
+                            aria-label="Close dialog"
+                            onclick="closeModal()"
+                            class="w-8 h-8 rounded-xl bg-slate-100 hover:bg-slate-200 flex items-center justify-center text-slate-500 flex-shrink-0"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
+                        </button>
+                    </header>
+                    <input type="hidden" id="editAgreementId" />
+                    <div class="space-y-4">
+                        <div class="space-y-2">
+                            <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Agreement Name</label>
+                            <input type="text" id="agreementName" placeholder="e.g., Standard Home Inspection Version 2.0"
+                                class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Legal Content (Rich Text)</label>
+                            <link rel="stylesheet" href="/vendor/quill/quill.snow.css" />
+                            <div class="rounded-2xl border-2 border-slate-100 focus-within:border-indigo-600 focus-within:ring-4 focus-within:ring-indigo-50 transition-all overflow-hidden bg-white">
+                                <div id="agreementEditor" style="min-height: 280px; font-size: 15px;"></div>
                             </div>
-                            <div class="mb-6">
-                                <h3 id="modalAgreementTitle" class="text-xl font-bold text-slate-900 mb-3 tracking-tight leading-tight">Create Professional Agreement</h3>
-                                <p class="text-lg text-slate-400 font-medium">Draft a new service agreement or liability waiver.</p>
-                            </div>
-                            <input type="hidden" id="editAgreementId" />
-                            <div class="space-y-4">
-                                <div class="space-y-2">
-                                    <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Agreement Name</label>
-                                    <input type="text" id="agreementName" placeholder="e.g., Standard Home Inspection Version 2.0"
-                                        class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                </div>
-                                <div class="space-y-2">
-                                    <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Legal Content (Rich Text)</label>
-                                    <link rel="stylesheet" href="/vendor/quill/quill.snow.css" />
-                                    <div class="rounded-2xl border-2 border-slate-100 focus-within:border-indigo-600 focus-within:ring-4 focus-within:ring-indigo-50 transition-all overflow-hidden bg-white">
-                                        <div id="agreementEditor" style="min-height: 280px; font-size: 15px;"></div>
-                                    </div>
-                                    <input type="hidden" id="agreementContent" />
-                                    <p class="text-[10px] text-slate-400 font-semibold ml-1 mt-1">Tip: variables like {'{{client_name}}'}, {'{{property_address}}'}, {'{{inspection_date}}'}, {'{{inspector_name}}'}, and {'{{inspector_license}}'} will be substituted on the sign page.</p>
-                                </div>
-                                <div class="pt-4 flex gap-6">
-                                    <button type="button" onclick="closeModal()" class="flex-1 px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all">
-                                        Discard
-                                    </button>
-                                    <button type="button" onclick="submitAgreement()" id="submitAgreementBtn" class="flex-[2] px-4 py-2 bg-indigo-600 text-white rounded-md font-bold text-sm hover:bg-indigo-700 active:scale-[.98] transition-all disabled:bg-slate-300 disabled:cursor-not-allowed">
-                                        Publish Agreement
-                                    </button>
-                                </div>
-                            </div>
+                            <input type="hidden" id="agreementContent" />
+                            <p class="text-[10px] text-slate-400 font-semibold ml-1 mt-1">Tip: variables like {'{{client_name}}'}, {'{{property_address}}'}, {'{{inspection_date}}'}, {'{{inspector_name}}'}, and {'{{inspector_license}}'} will be substituted on the sign page.</p>
                         </div>
                     </div>
-                </div>
+                </Modal>
 
                 {/* Send Agreement Modal */}
-                <div id="sendModal" class="fixed inset-0 z-[100] hidden overflow-y-auto px-4 py-6 sm:px-0">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-md" onclick="closeSendModal()"></div>
-                    <div class="flex min-h-full items-center justify-center">
-                        <div class="relative w-full max-w-md bg-white rounded-xl p-6 shadow-2xl">
-                            <h3 class="text-xl font-bold text-slate-900 mb-2">Send for Signature</h3>
-                            <p class="text-sm text-slate-400 font-semibold mb-8">Client will receive an email with a link to review and sign.</p>
-                            <input type="hidden" id="sendAgreementId" />
-                            <div class="space-y-4">
-                                <div>
-                                    <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Email *</label>
-                                    <input type="email" id="sendClientEmail" placeholder="client@example.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                </div>
-                                <div>
-                                    <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Name</label>
-                                    <input type="text" id="sendClientName" placeholder="John Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                </div>
-                            </div>
-                            <div class="mt-8 flex gap-4">
-                                <button onclick="closeSendModal()" class="flex-1 px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all">Cancel</button>
-                                <button onclick="submitSend()" id="submitSendBtn" class="flex-[2] px-4 py-2 bg-indigo-600 text-white rounded-md font-bold text-sm hover:bg-indigo-700 active:scale-[.98] transition-all disabled:bg-slate-300 disabled:cursor-not-allowed">Send Request</button>
-                            </div>
+                <Modal
+                    id="sendModal"
+                    title="Send for Signature"
+                    subtitle="Client will receive an email with a link to review and sign."
+                    size="md"
+                    footer={
+                        <ModalFooter
+                            onCancelJs="closeSendModal()"
+                            onConfirmJs="submitSend()"
+                            confirmText="Send Request"
+                            confirmId="submitSendBtn"
+                        />
+                    }
+                >
+                    <input type="hidden" id="sendAgreementId" />
+                    <div class="space-y-4">
+                        <div>
+                            <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Email *</label>
+                            <input type="email" id="sendClientEmail" placeholder="client@example.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                        </div>
+                        <div>
+                            <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Name</label>
+                            <input type="text" id="sendClientName" placeholder="John Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                         </div>
                     </div>
-                </div>
+                </Modal>
 
                 <script src="/js/modal-dialog.js"></script>
                 <script src="/js/auth.js"></script>

--- a/src/templates/pages/cert.template.tsx
+++ b/src/templates/pages/cert.template.tsx
@@ -55,7 +55,7 @@ function fmtUa(ua: string | null | undefined): string {
 }
 
 function eventLabel(ev: string): string {
-    return ev.replace(/\./g, '.').replace(/_/g, ' ');
+    return ev.replace(/_/g, ' ');
 }
 
 export function CertTemplatePage(props: CertTemplateProps): JSX.Element {

--- a/src/templates/pages/comments.tsx
+++ b/src/templates/pages/comments.tsx
@@ -15,11 +15,34 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                 <button x-on:click="openCreate()" class="px-4 py-2 rounded-md bg-indigo-600 text-white text-xs font-bold uppercase tracking-wide hover:bg-indigo-700">+ Add comment</button>
             </header>
 
+            {/*
+              Spec 2026-05-07 — rating-bucket tabs mirror the inspection-edit
+              Library drawer pills (rounded-full, indigo active state). The
+              `categoryFilter` dropdown stays as a secondary filter so a user
+              can combine "Defect" tab + "Plumbing" category.
+            */}
+            <div class="flex flex-wrap items-center gap-2">
+                <template x-for="b in bucketTabs" {...{ 'x-bind:key': 'b.value' }}>
+                    <button
+                        x-on:click="setBucket(b.value)"
+                        x-bind:class="bucket === b.value ? 'bg-indigo-600 text-white shadow' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'"
+                        class="px-3 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wide transition"
+                        x-text="b.label"
+                    ></button>
+                </template>
+            </div>
+
             <div class="flex gap-3 flex-wrap">
                 <select x-model="categoryFilter" x-on:change="reload()" class="px-3 py-2 rounded-lg border border-slate-200 text-sm">
                     <option value="">All categories</option>
                     <template x-for="cat in distinctCategories" {...{ 'x-bind:key': 'cat' }}>
                         <option x-bind:value="cat" x-text="cat"></option>
+                    </template>
+                </select>
+                <select x-model="sectionFilter" x-on:change="reload()" class="px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                    <option value="">All sections</option>
+                    <template x-for="s in distinctSections" {...{ 'x-bind:key': 's' }}>
+                        <option x-bind:value="s" x-text="s"></option>
                     </template>
                 </select>
             </div>
@@ -34,8 +57,19 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                     <div class="p-4 bg-white border border-slate-200 rounded-lg shadow-sm hover:shadow-md transition">
                         <div class="flex items-start justify-between gap-3">
                             <div class="flex-1 min-w-0">
-                                <div class="flex items-center gap-2 mb-1">
-                                    <span class="text-xs text-slate-500" x-text="comment.category || '(no category)'"></span>
+                                <div class="flex items-center gap-2 mb-1 flex-wrap">
+                                    {/*
+                                      Pill uses the shared .ih-pill / ih-pill--sat / monitor / defect / gen
+                                      classes so /comments matches the
+                                      inspection-edit drawer + report PDF pill styling.
+                                    */}
+                                    <span
+                                        class="ih-pill"
+                                        x-bind:class="comment.ratingBucket === 'satisfactory' ? 'ih-pill--sat' : comment.ratingBucket === 'monitor' ? 'ih-pill--monitor' : comment.ratingBucket === 'defect' ? 'ih-pill--defect' : 'ih-pill--gen'"
+                                        x-text="comment.ratingBucket ? comment.ratingBucket : 'general'"
+                                    ></span>
+                                    <span x-show="comment.section" class="text-[10px] font-bold uppercase tracking-wide text-slate-500" x-text="comment.section"></span>
+                                    <span x-show="comment.category" class="text-[10px] text-slate-400" x-text="'· ' + comment.category"></span>
                                 </div>
                                 <p class="text-sm text-slate-700 line-clamp-3" x-text="comment.text"></p>
                             </div>
@@ -48,7 +82,9 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                 </template>
             </div>
 
-            {/* Create / Edit modal */}
+            {/* Create / Edit modal — wrapped in shared <Modal> component (R44).
+                When adding new fields, KEEP them inside this body slot — do
+                NOT recreate the modal markup. */}
             <Modal
                 name="modalOpen"
                 titleExpr="editingId ? 'Edit comment' : 'New comment'"
@@ -63,6 +99,35 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                 }
             >
                 <div class="space-y-3">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div>
+                            <label class="block text-xs font-bold text-slate-600 mb-1">Rating bucket</label>
+                            <select x-model="form.ratingBucket" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm bg-white">
+                                <option value="">Unspecified</option>
+                                <option value="satisfactory">Satisfactory</option>
+                                <option value="monitor">Monitor</option>
+                                <option value="defect">Defect</option>
+                            </select>
+                            <p class="text-[10px] text-slate-400 mt-1">Determines which tab it appears under in the Library drawer.</p>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-bold text-slate-600 mb-1">Section</label>
+                            <input
+                                type="text"
+                                list="commentSectionOptions"
+                                x-model="form.section"
+                                placeholder="e.g., Roof"
+                                autocomplete="off"
+                                class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"
+                            />
+                            <datalist id="commentSectionOptions">
+                                <template x-for="s in distinctSections" {...{ 'x-bind:key': 's' }}>
+                                    <option x-bind:value="s"></option>
+                                </template>
+                            </datalist>
+                            <p class="text-[10px] text-slate-400 mt-1">Pick from your existing sections or type a new one.</p>
+                        </div>
+                    </div>
                     <div>
                         <label class="block text-xs font-bold text-slate-600 mb-1">Category</label>
                         <input
@@ -78,7 +143,7 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                                 <option x-bind:value="cat"></option>
                             </template>
                         </datalist>
-                        <p class="text-[10px] text-slate-400 mt-1">Pick from your existing categories or type a new one.</p>
+                        <p class="text-[10px] text-slate-400 mt-1">Optional free-text label, kept for backward compat.</p>
                     </div>
                     <div>
                         <label class="block text-xs font-bold text-slate-600 mb-1">Comment text</label>

--- a/src/templates/pages/comments.tsx
+++ b/src/templates/pages/comments.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig; }
@@ -48,40 +49,43 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
             </div>
 
             {/* Create / Edit modal */}
-            <div x-show="modalOpen" x-cloak class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) modalOpen = false' }}>
-                <div class="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6">
-                    <h2 class="text-lg font-bold text-slate-900 mb-4" x-text="editingId ? 'Edit comment' : 'New comment'"></h2>
-                    <div class="space-y-3">
-                        <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Category</label>
-                            <input
-                                type="text"
-                                list="commentCategoryOptions"
-                                x-model="form.category"
-                                placeholder="e.g., Roof"
-                                autocomplete="off"
-                                class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"
-                            />
-                            <datalist id="commentCategoryOptions">
-                                <template x-for="cat in distinctCategories" {...{ 'x-bind:key': 'cat' }}>
-                                    <option x-bind:value="cat"></option>
-                                </template>
-                            </datalist>
-                            <p class="text-[10px] text-slate-400 mt-1">Pick from your existing categories or type a new one.</p>
-                        </div>
-                        <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Comment text</label>
-                            <textarea x-model="form.text" required rows={4} placeholder="e.g., Evidence of previous repair was observed." class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
-                        </div>
+            <Modal
+                name="modalOpen"
+                titleExpr="editingId ? 'Edit comment' : 'New comment'"
+                size="lg"
+                footer={
+                    <ModalFooter
+                        onCancel="modalOpen = false"
+                        onConfirm="save()"
+                        confirmDisabled="saving"
+                        confirmTextExpr="saving ? 'Saving...' : 'Save'"
+                    />
+                }
+            >
+                <div class="space-y-3">
+                    <div>
+                        <label class="block text-xs font-bold text-slate-600 mb-1">Category</label>
+                        <input
+                            type="text"
+                            list="commentCategoryOptions"
+                            x-model="form.category"
+                            placeholder="e.g., Roof"
+                            autocomplete="off"
+                            class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"
+                        />
+                        <datalist id="commentCategoryOptions">
+                            <template x-for="cat in distinctCategories" {...{ 'x-bind:key': 'cat' }}>
+                                <option x-bind:value="cat"></option>
+                            </template>
+                        </datalist>
+                        <p class="text-[10px] text-slate-400 mt-1">Pick from your existing categories or type a new one.</p>
                     </div>
-                    <div class="flex gap-3 justify-end mt-6">
-                        <button x-on:click="modalOpen = false" class="px-5 py-2 rounded-lg ring-2 ring-slate-300 text-slate-700 text-xs font-bold">Cancel</button>
-                        <button x-on:click="save()" {...{ 'x-bind:disabled': 'saving' }} class="px-5 py-2 rounded-lg bg-slate-900 text-white text-xs font-bold uppercase tracking-widest hover:bg-black disabled:opacity-50">
-                            <span x-text="saving ? 'Saving...' : 'Save'"></span>
-                        </button>
+                    <div>
+                        <label class="block text-xs font-bold text-slate-600 mb-1">Comment text</label>
+                        <textarea x-model="form.text" required rows={4} placeholder="e.g., Evidence of previous repair was observed." class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
                     </div>
                 </div>
-            </div>
+            </Modal>
         </div>
 
         <script src="/js/auth.js"></script>

--- a/src/templates/pages/contacts.tsx
+++ b/src/templates/pages/contacts.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const ContactsPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
@@ -51,47 +52,60 @@ export const ContactsPage = ({ branding }: { branding?: BrandingConfig | undefin
                     </table>
                 </div>
 
-                {/* Create/Edit Modal */}
-                <div id="contactModal" class="fixed inset-0 z-[100] hidden overflow-y-auto">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-xl" onclick="closeContactModal()"></div>
-                    <div class="flex min-h-full items-center justify-center p-6">
-                        <div class="relative w-full max-w-lg bg-white rounded-xl p-6 shadow-2xl">
-                            <h3 id="contactModalTitle" class="text-xl font-bold text-slate-900 mb-8">Add Contact</h3>
-                            <input type="hidden" id="editContactId" />
-                            <div class="space-y-5">
-                                <div>
-                                    <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Type</label>
-                                    <select id="contactType" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm bg-white">
-                                        <option value="agent">Agent</option>
-                                        <option value="client">Client</option>
-                                    </select>
-                                </div>
-                                <div>
-                                    <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Full Name *</label>
-                                    <input type="text" id="contactName" placeholder="Jane Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                </div>
-                                <div class="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Email</label>
-                                        <input type="email" id="contactEmail" placeholder="jane@realty.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                    </div>
-                                    <div>
-                                        <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Phone</label>
-                                        <input type="tel" id="contactPhone" placeholder="(555) 123-4567" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                    </div>
-                                </div>
-                                <div>
-                                    <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Agency</label>
-                                    <input type="text" id="contactAgency" placeholder="Sunrise Realty" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                </div>
+                {/* Create/Edit Modal — contacts.js toggles #contactModalTitle text
+                    so we keep that id on a custom in-body header (hideHeader=true). */}
+                <Modal
+                    id="contactModal"
+                    size="lg"
+                    hideHeader={true}
+                    footer={
+                        <ModalFooter
+                            onCancelJs="closeContactModal()"
+                            onConfirmJs="submitContact()"
+                            confirmText="Save"
+                        />
+                    }
+                >
+                    <header class="flex items-start justify-between gap-3 mb-4">
+                        <h3 id="contactModalTitle" class="text-lg font-bold text-slate-900 flex-1">Add Contact</h3>
+                        <button
+                            type="button"
+                            aria-label="Close dialog"
+                            onclick="closeContactModal()"
+                            class="w-8 h-8 rounded-xl bg-slate-100 hover:bg-slate-200 flex items-center justify-center text-slate-500 flex-shrink-0"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
+                        </button>
+                    </header>
+                    <input type="hidden" id="editContactId" />
+                    <div class="space-y-5">
+                        <div>
+                            <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Type</label>
+                            <select id="contactType" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm bg-white">
+                                <option value="agent">Agent</option>
+                                <option value="client">Client</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Full Name *</label>
+                            <input type="text" id="contactName" placeholder="Jane Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                        </div>
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Email</label>
+                                <input type="email" id="contactEmail" placeholder="jane@realty.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                             </div>
-                            <div class="mt-8 flex gap-4">
-                                <button onclick="closeContactModal()" class="flex-1 px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all">Cancel</button>
-                                <button onclick="submitContact()" class="flex-[2] px-4 py-2 bg-indigo-600 text-white rounded-md font-bold text-sm hover:bg-indigo-700 active:scale-[.98] transition-all disabled:bg-slate-300 disabled:cursor-not-allowed">Save</button>
+                            <div>
+                                <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Phone</label>
+                                <input type="tel" id="contactPhone" placeholder="(555) 123-4567" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                             </div>
                         </div>
+                        <div>
+                            <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Agency</label>
+                            <input type="text" id="contactAgency" placeholder="Sunrise Realty" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                        </div>
                     </div>
-                </div>
+                </Modal>
 
                 {/* CSV import modal — mounted at page root */}
                 <div

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { MainLayout } from '../layouts/main-layout';
 import { BrandingConfig } from '../../types/auth';
 import { CancelModal } from '../components/cancel-modal';
+import { Modal } from '../components/modal';
 
 export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
     const siteName = branding?.siteName || 'OpenInspection';
@@ -356,26 +357,36 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
 
                 {/* Create Inspection Modal — R7-11 fix: add overflow-x-hidden so
                     in-modal vertical scroll doesn't spill into page-level
-                    horizontal scroll on narrow viewports. */}
-                <div id="createModal" class="fixed inset-0 z-[100] hidden overflow-y-auto overflow-x-hidden">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-xl transition-opacity animate-fade-in" onclick="closeModal()"></div>
-                    <div class="flex min-h-full items-center justify-center p-6">
-                        <div role="dialog" aria-modal="true" class="relative w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left shadow-[0_32px_128px_-16px_rgba(0,0,0,0.3)] animate-fade-in border border-white/40">
-                            <div class="absolute top-6 right-10">
-                                <button onclick="closeModal()" aria-label="Close dialog" class="group p-3 text-slate-300 hover:text-slate-900 rounded-2xl hover:bg-slate-50 transition-all">
-                                    <svg class="w-6 h-6 transition-transform group-hover:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M6 18L18 6M6 6l12 12"></path></svg>
-                                </button>
-                            </div>
-
-                            <div class="mb-6">
-                                <div class="w-14 h-14 bg-emerald-600/10 rounded-2xl flex items-center justify-center text-emerald-600 mb-6">
-                                    <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"></path></svg>
-                                </div>
-                                <h3 class="text-xl font-bold text-slate-900 tracking-tight mb-2 leading-none">New Inspection</h3>
-                                <p class="text-sm text-slate-500 font-semibold tracking-tight">Enter the details for this inspection.</p>
-                            </div>
-
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                    horizontal scroll on narrow viewports.
+                    R39 — canonical h-10 button row (asymmetric flex-1 / flex-[2]
+                    Create Inspection variant kept; footer inlined). */}
+                <Modal
+                    id="createModal"
+                    title="New Inspection"
+                    subtitle="Enter the details for this inspection."
+                    size="2xl"
+                    footer={
+                        <>
+                            <button
+                                type="button"
+                                onclick="closeModal()"
+                                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                style="border-color: #e2e8f0"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onclick="submitInspection()"
+                                id="submitInsBtn"
+                                class="flex-[2] h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-all active:scale-95"
+                            >
+                                Create Inspection
+                            </button>
+                        </>
+                    }
+                >
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-2">
                                 <div class="space-y-2 md:col-span-2 relative">
                                     <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-[0.2em] ml-1">Property Address</label>
                                     <input type="text" id="propAddress" placeholder="Start typing — autocomplete via Google" autocomplete="off" data-places-autocomplete
@@ -497,26 +508,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                 </div>
                             </div>
 
-                            {/* Round 39 — match Publish Report modal canonical
-                                button row: h-10 / px-4 / rounded-xl / text-sm
-                                font-semibold / normal-case. Cancel = white +
-                                border (secondary), Create = indigo solid
-                                (primary). Removes legacy py-4.5 + text-[10px]
-                                tracking-[0.2em] + font-black. */}
-                            <div class="pt-4 flex gap-3">
-                                <button type="button" onclick="closeModal()"
-                                    class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
-                                    style="border-color: #e2e8f0">
-                                    Cancel
-                                </button>
-                                <button type="button" onclick="submitInspection()" id="submitInsBtn"
-                                    class="flex-[2] h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-all active:scale-95">
-                                    Create Inspection
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                </Modal>
 
                 <script src="/js/modal-dialog.js"></script>
                 <script src="/js/auth.js"></script>

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -34,12 +34,19 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     that opens the matching bucket section + scrolls into
                     view. anchor maps to a section in the inspections list
                     rendered below. */}
+                {/* R45 fix — labels, count semantics, and click targets now
+                    align. Each card's number, name, and the bucket it scrolls
+                    to all reference the same dataset. Was previously a 3-way
+                    mismatch (Active = today+thisWeek+later but click jumps to
+                    just `today`; Ready for Review = recentReports but click
+                    jumps to needsAttention; Completed double-counted recent
+                    reports as both 'review' and 'completed'). */}
                 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                     {[
-                        { label: 'Active Jobs',     id: 'statActive',    target: 'today',          icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z', color: 'indigo' },
-                        { label: 'In Progress',     id: 'statProgress',  target: 'thisWeek',       icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z', color: 'blue' },
-                        { label: 'Ready for Review',id: 'statReview',    target: 'needsAttention', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2', color: 'amber' },
-                        { label: 'Completed',       id: 'statCompleted', target: 'recentReports', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z', color: 'emerald' }
+                        { label: 'Upcoming',        id: 'statUpcoming',   target: 'later',          icon: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z', color: 'indigo' },
+                        { label: 'In Progress',     id: 'statInProgress', target: 'thisWeek',       icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z', color: 'blue' },
+                        { label: 'Needs Attention', id: 'statNeedsAttn',  target: 'needsAttention', icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z', color: 'amber' },
+                        { label: 'Recent Reports',  id: 'statRecentRpt',  target: 'recentReports',  icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z', color: 'emerald' }
                     ].map((stat, i) => (
                         <button
                             key={stat.id}

--- a/src/templates/pages/form-renderer.tsx
+++ b/src/templates/pages/form-renderer.tsx
@@ -1,6 +1,7 @@
 import { BareLayout } from '../layouts/main-layout';
 import { AtmosphericBg } from '../components/atmospheric-bg';
 import { TemplateDriftBanner } from '../components/template-drift-banner';
+import { Modal } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const FormRendererPage = (props: { inspectionId: string, branding?: BrandingConfig | undefined }): JSX.Element => {
@@ -258,99 +259,101 @@ export const FormRendererPage = (props: { inspectionId: string, branding?: Brand
                         <button x-on:click="backToDashboard" class="text-[10px] font-bold uppercase tracking-widest text-slate-400 hover:text-indigo-600 transition-colors py-4">Return to Operational Control</button>
                     </div>
 
-                    {/* Annotation Intelligence Interface */}
-                    <div
-                        x-show="showAnnotationModal"
-                        {...{ 'x-transition:enter': 'transition ease-out duration-300' }}
-                        {...{ 'x-transition:enter-start': 'opacity-0 scale-95' }}
-                        {...{ 'x-transition:enter-end': 'opacity-100 scale-100' }}
-                        x-cloak="true"
-                        class="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-slate-950/90 backdrop-blur-xl"
+                    {/* Annotation Intelligence Interface — full-app modal w/ canvas.
+                        Inlined custom controls (drawing-mode toggles, two-button save row)
+                        rather than ModalFooter; kept original size (max-w-5xl). */}
+                    <Modal
+                        name="showAnnotationModal"
+                        title="Annotation Studio"
+                        subtitle="Precision markup engine for evidence clarification"
+                        size="5xl"
+                        footer={
+                            <>
+                                <button
+                                    type="button"
+                                    x-on:click="showAnnotationModal = false"
+                                    class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                    style="border-color: #e2e8f0"
+                                >
+                                    Discard Changes
+                                </button>
+                                <button
+                                    type="button"
+                                    x-on:click="saveAnnotation"
+                                    x-bind:disabled="syncing"
+                                    class="flex-[2] h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-all"
+                                >
+                                    <span x-text="syncing ? 'Saving...' : 'Save Markup'"></span>
+                                </button>
+                            </>
+                        }
                     >
-                        <div class="bg-white rounded-xl shadow-[0_50px_100px_-20px_rgba(0,0,0,0.5)] max-w-5xl w-full max-h-[92vh] overflow-hidden flex flex-col relative animate-slide-in">
-                            {/* Modal High-End Header */}
-                            <div class="px-12 py-8 border-b border-slate-50 flex justify-between items-center bg-slate-50/30">
-                                <div>
-                                    <h3 class="text-xl font-bold tracking-tight text-slate-900">Annotation Studio</h3>
-                                    <p class="text-sm text-slate-400 font-medium">Precision markup engine for evidence clarification</p>
-                                </div>
-                                <button x-on:click="showAnnotationModal = false" class="w-12 h-12 flex items-center justify-center rounded-2xl hover:bg-slate-100 text-slate-400 hover:text-slate-900 transition-all active:scale-95">
-                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                        {/* Canvas Simulation Tier */}
+                        <div class="bg-slate-100 flex items-center justify-center relative shadow-inner rounded-xl overflow-hidden">
+                            <div class="relative bg-white shadow-2xl rounded-2xl overflow-hidden ring-8 ring-white">
+                                <canvas
+                                    x-ref="annotationCanvas"
+                                    x-on:mousedown="handleCanvasStart"
+                                    x-on:mousemove="handleCanvasMove"
+                                    x-on:mouseup="handleCanvasEnd"
+                                    {...{ 'x-on:touchstart.passive': 'handleCanvasStart' }}
+                                    {...{ 'x-on:touchmove.passive': 'handleCanvasMove' }}
+                                    {...{ 'x-on:touchend.passive': 'handleCanvasEnd' }}
+                                    class="cursor-crosshair touch-none max-w-full h-auto"
+                                ></canvas>
+                            </div>
+                        </div>
+
+                        {/* Control Surface */}
+                        <div class="mt-4 flex items-center justify-between">
+                            <div class="flex gap-4">
+                                <button
+                                    type="button"
+                                    x-on:click="drawingMode = 'circle'"
+                                    class="flex items-center gap-3 px-4 py-2 rounded-2xl text-[10px] font-bold uppercase tracking-widest transition-all shadow-sm"
+                                    x-bind:class="drawingMode === 'circle' ? 'bg-rose-500 text-white shadow-rose-200' : 'bg-slate-50 text-slate-500 hover:bg-slate-100'"
+                                >
+                                    <div class="w-3 h-3 rounded-full border-2 border-current"></div>
+                                    Elliptical Highlight
+                                </button>
+                                <button
+                                    type="button"
+                                    x-on:click="drawingMode = 'arrow'"
+                                    class="flex items-center gap-3 px-4 py-2 rounded-2xl text-[10px] font-bold uppercase tracking-widest transition-all shadow-sm"
+                                    x-bind:class="drawingMode === 'arrow' ? 'bg-rose-500 text-white shadow-rose-200' : 'bg-slate-50 text-slate-500 hover:bg-slate-100'"
+                                >
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
+                                    Vector Pointer
                                 </button>
                             </div>
 
-                            {/* Canvas Simulation Tier */}
-                            <div class="flex-1 overflow-auto bg-slate-100 flex items-center justify-center relative shadow-inner">
-                                <div class="relative bg-white shadow-2xl rounded-2xl overflow-hidden ring-8 ring-white">
-                                    <canvas
-                                        x-ref="annotationCanvas"
-                                        x-on:mousedown="handleCanvasStart"
-                                        x-on:mousemove="handleCanvasMove"
-                                        x-on:mouseup="handleCanvasEnd"
-                                        {...{ 'x-on:touchstart.passive': 'handleCanvasStart' }}
-                                        {...{ 'x-on:touchmove.passive': 'handleCanvasMove' }}
-                                        {...{ 'x-on:touchend.passive': 'handleCanvasEnd' }}
-                                        class="cursor-crosshair touch-none max-w-full h-auto"
-                                    ></canvas>
-                                </div>
-                            </div>
-
-                            {/* Control Surface */}
-                            <div class="px-12 py-10 bg-white space-y-4">
-                                <div class="flex items-center justify-between">
-                                    <div class="flex gap-4">
-                                        <button
-                                            x-on:click="drawingMode = 'circle'"
-                                            class="flex items-center gap-3 px-4 py-2 rounded-2xl text-[10px] font-bold uppercase tracking-widest transition-all shadow-sm"
-                                            x-bind:class="drawingMode === 'circle' ? 'bg-rose-500 text-white shadow-rose-200' : 'bg-slate-50 text-slate-500 hover:bg-slate-100'"
-                                        >
-                                            <div class="w-3 h-3 rounded-full border-2 border-current"></div>
-                                            Elliptical Highlight
-                                        </button>
-                                        <button
-                                            x-on:click="drawingMode = 'arrow'"
-                                            class="flex items-center gap-3 px-4 py-2 rounded-2xl text-[10px] font-bold uppercase tracking-widest transition-all shadow-sm"
-                                            x-bind:class="drawingMode === 'arrow' ? 'bg-rose-500 text-white shadow-rose-200' : 'bg-slate-50 text-slate-500 hover:bg-slate-100'"
-                                        >
-                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
-                                            Vector Pointer
-                                        </button>
-                                    </div>
-
-                                    <button x-on:click="clearAnnotation" class="text-[10px] font-bold text-slate-300 hover:text-rose-500 transition-colors uppercase tracking-[0.2em]">
-                                        Clear Drawing Layer
-                                    </button>
-                                </div>
-
-                                <div class="flex gap-6">
-                                    <button
-                                        x-on:click="showAnnotationModal = false"
-                                        class="flex-1 py-5 rounded-md text-[10px] font-bold uppercase tracking-widest text-slate-400 hover:text-slate-900 transition-all"
-                                    >
-                                        Discard Changes
-                                    </button>
-                                    <button
-                                        x-on:click="saveAnnotation"
-                                        class="flex-[2] premium-button py-5 bg-indigo-600 text-white rounded-md font-bold shadow-md hover:bg-indigo-700 transition-all flex items-center justify-center gap-3"
-                                        x-bind:disabled="syncing"
-                                    >
-                                        <svg x-show="syncing" class="w-5 h-5 animate-spin text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
-                                        <span class="tracking-tight text-lg" x-text="syncing ? 'Saving...' : 'Save Markup'"></span>
-                                    </button>
-                                </div>
-                            </div>
+                            <button type="button" x-on:click="clearAnnotation" class="text-[10px] font-bold text-slate-300 hover:text-rose-500 transition-colors uppercase tracking-[0.2em]">
+                                Clear Drawing Layer
+                            </button>
                         </div>
-                    </div>
+                    </Modal>
                 </div>
-                
-                {/* Recommendation Picker Overlay */}
-                <div x-data="recommendationPicker" x-cloak x-show="open" class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) close()' }}>
-                    <div class="bg-white rounded-2xl shadow-2xl max-w-3xl w-full max-h-[80vh] flex flex-col">
-                        <div class="p-5 border-b border-slate-100 flex items-center justify-between">
-                            <h2 class="text-lg font-bold text-slate-900">Attach recommendation</h2>
-                            <button x-on:click="close()" class="text-slate-400 hover:text-slate-700 text-2xl leading-none">&times;</button>
-                        </div>
-                        <div class="p-5 space-y-3 border-b border-slate-100">
+
+                {/* Recommendation Picker Overlay — single Close button (selecting an
+                    item attaches and closes), so footer is inlined. The `recommendationPicker`
+                    Alpine component owns `open`, so x-data wraps the Modal. */}
+                <div x-data="recommendationPicker">
+                    <Modal
+                        name="open"
+                        title="Attach recommendation"
+                        size="3xl"
+                        footer={
+                            <button
+                                type="button"
+                                x-on:click="close()"
+                                class="h-10 px-6 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                style="border-color: #e2e8f0"
+                            >
+                                Close
+                            </button>
+                        }
+                    >
+                        <div class="space-y-3">
                             <input type="text" x-model="search" x-on:input="applyFilter()" placeholder="Search recommendations..." class="w-full px-4 py-2 rounded-lg border border-slate-200 text-sm" />
                             <div class="flex gap-3 flex-wrap">
                                 <select x-model="categoryFilter" x-on:change="applyFilter()" class="px-3 py-2 rounded-lg border border-slate-200 text-sm">
@@ -366,25 +369,25 @@ export const FormRendererPage = (props: { inspectionId: string, branding?: Brand
                                     <option value="defect">Defect</option>
                                 </select>
                             </div>
-                        </div>
-                        <div class="p-5 flex-1 overflow-y-auto">
-                            <p x-show="loading" class="text-sm text-slate-400 italic">Loading library...</p>
-                            <p x-show="!loading && results.length === 0" class="text-sm text-slate-400 italic">No matching recommendations.</p>
-                            <div class="space-y-2">
-                                <template x-for="rec in results" {...{ 'x-bind:key': 'rec.id' }}>
-                                    <button type="button" x-on:click="attach(rec)" class="block w-full text-left p-3 rounded-xl border border-slate-200 hover:border-indigo-400 hover:bg-indigo-50 transition">
-                                        <div class="flex items-center gap-2 mb-1">
-                                            <span class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full" x-bind:class="severityClass(rec.severity)" x-text="rec.severity"></span>
-                                            <span class="text-xs text-slate-500" x-text="rec.category || '(no category)'"></span>
-                                            <span class="text-xs font-bold text-slate-700 ml-auto" x-text="estimateLabel(rec)"></span>
-                                        </div>
-                                        <p class="font-bold text-slate-900" x-text="rec.name"></p>
-                                        <p class="text-xs text-slate-500 mt-1 line-clamp-2" x-text="rec.defaultRepairSummary"></p>
-                                    </button>
-                                </template>
+                            <div class="overflow-y-auto" style="max-height: 50vh">
+                                <p x-show="loading" class="text-sm text-slate-400 italic">Loading library...</p>
+                                <p x-show="!loading && results.length === 0" class="text-sm text-slate-400 italic">No matching recommendations.</p>
+                                <div class="space-y-2">
+                                    <template x-for="rec in results" {...{ 'x-bind:key': 'rec.id' }}>
+                                        <button type="button" x-on:click="attach(rec)" class="block w-full text-left p-3 rounded-xl border border-slate-200 hover:border-indigo-400 hover:bg-indigo-50 transition">
+                                            <div class="flex items-center gap-2 mb-1">
+                                                <span class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full" x-bind:class="severityClass(rec.severity)" x-text="rec.severity"></span>
+                                                <span class="text-xs text-slate-500" x-text="rec.category || '(no category)'"></span>
+                                                <span class="text-xs font-bold text-slate-700 ml-auto" x-text="estimateLabel(rec)"></span>
+                                            </div>
+                                            <p class="font-bold text-slate-900" x-text="rec.name"></p>
+                                            <p class="text-xs text-slate-500 mt-1 line-clamp-2" x-text="rec.defaultRepairSummary"></p>
+                                        </button>
+                                    </template>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </Modal>
                 </div>
 
                 <script src="/js/modal-dialog.js"></script>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -1,5 +1,6 @@
 // src/templates/pages/inspection-edit.tsx
 import { BareLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import type { BrandingConfig } from '../../types/auth';
 
 interface InspectionEditProps {
@@ -44,31 +45,33 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
           id="hotkey-photo-input"
           x-on:change="if (activeItemId) { uploadPhoto(activeItemId, $event); $event.target.value = ''; }"
         />
-        {/* P2 — AI Suggest Comment popover (shared scope with inspectionEditor) */}
-        <div x-cloak x-show="showAiPopover" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm p-4">
-          <div {...{ 'x-on:click.stop': '$event' }}
-               class="w-full max-w-md bg-white rounded-lg shadow-2xl p-6 space-y-4"
-               {...{ 'x-transition:enter': 'transition ease-out duration-150', 'x-transition:enter-start': 'opacity-0 scale-95', 'x-transition:enter-end': 'opacity-100 scale-100' }}>
-            <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" /></svg>
-                <h3 class="font-bold text-slate-900">AI Suggestions</h3>
-              </div>
-              <button type="button" x-on:click="showAiPopover = false" class="w-8 h-8 rounded-lg hover:bg-slate-100 text-slate-500" aria-label="Close">×</button>
-            </div>
-            <p class="text-xs text-slate-500">Pick one to insert into the notes field.</p>
-            <div class="space-y-2">
-              <template x-for="(s, idx) in aiSuggestions" x-bind:key="idx">
-                <button type="button" x-on:click="insertSuggestion(s)" class="w-full text-left p-3 rounded-xl border border-slate-200 hover:border-amber-400 hover:bg-amber-50 transition-all text-sm text-slate-700">
-                  <span x-text="s"></span>
+        {/* P2 — AI Suggest Comment popover (shared scope with inspectionEditor).
+            Single-button footer (Cancel only — picking a suggestion inserts and
+            closes), inlined since ModalFooter assumes a Cancel + Confirm pair. */}
+        <Modal
+            name="showAiPopover"
+            title="AI Suggestions"
+            subtitle="Pick one to insert into the notes field."
+            size="md"
+            footer={
+                <button
+                    type="button"
+                    x-on:click="showAiPopover = false"
+                    class="h-10 px-6 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                    style="border-color: #e2e8f0"
+                >
+                    Cancel
                 </button>
-              </template>
+            }
+        >
+            <div class="space-y-2">
+                <template x-for="(s, idx) in aiSuggestions" x-bind:key="idx">
+                    <button type="button" x-on:click="insertSuggestion(s)" class="w-full text-left p-3 rounded-xl border border-slate-200 hover:border-amber-400 hover:bg-amber-50 transition-all text-sm text-slate-700">
+                        <span x-text="s"></span>
+                    </button>
+                </template>
             </div>
-            <div class="flex justify-end pt-2">
-              <button type="button" x-on:click="showAiPopover = false" class="px-4 py-2 rounded-lg text-xs font-semibold text-slate-500 hover:bg-slate-100">Cancel</button>
-            </div>
-          </div>
-        </div>
+        </Modal>
 
         {/* ===== Mobile View ===== */}
         <div x-show="!isDesktop" class="lg:hidden">
@@ -725,27 +728,30 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                     >Restore</button>
                 </div>
                 {/* Cancel Modal */}
-                <div x-show="showCancelModal" class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" {...{'x-cloak': ''}}>
-                    <div class="bg-white rounded-2xl p-6 w-full max-w-sm mx-4 shadow-2xl">
-                        <h3 class="text-base font-bold mb-4" style="color: #0f172a">Cancel Inspection</h3>
-                        <label class="block text-xs font-bold text-slate-600 mb-1">Reason</label>
-                        <select x-model="cancelReason" class="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm mb-3 bg-white">
-                            <option value="client_cancelled">Client Cancelled</option>
-                            <option value="scheduling_conflict">Scheduling Conflict</option>
-                            <option value="weather">Weather</option>
-                            <option value="other">Other</option>
-                        </select>
-                        <label class="block text-xs font-bold text-slate-600 mb-1">Notes (optional)</label>
-                        <textarea x-model="cancelNotes" rows={3} class="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm mb-4" />
-                        <div class="flex gap-2">
-                            <button
-                                x-on:click={`authFetch('/api/inspections/${inspectionId}/cancel',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({reason:cancelReason,notes:cancelNotes||undefined})}).then(r=>r.json()).then(d=>{if(d.success){inspection.status='cancelled';showCancelModal=false;}})`}
-                                class="flex-1 bg-red-600 text-white rounded-lg py-2 text-sm font-bold"
-                            >Cancel Inspection</button>
-                            <button x-on:click="showCancelModal=false" class="px-4 text-slate-500 text-sm">Back</button>
-                        </div>
-                    </div>
-                </div>
+                <Modal
+                    name="showCancelModal"
+                    title="Cancel Inspection"
+                    size="sm"
+                    footer={
+                        <ModalFooter
+                            cancelText="Back"
+                            onCancel="showCancelModal = false"
+                            onConfirm={`authFetch('/api/inspections/${inspectionId}/cancel',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({reason:cancelReason,notes:cancelNotes||undefined})}).then(r=>r.json()).then(d=>{if(d.success){inspection.status='cancelled';showCancelModal=false;}})`}
+                            confirmText="Cancel Inspection"
+                            danger={true}
+                        />
+                    }
+                >
+                    <label class="block text-xs font-bold text-slate-600 mb-1">Reason</label>
+                    <select x-model="cancelReason" class="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm mb-3 bg-white">
+                        <option value="client_cancelled">Client Cancelled</option>
+                        <option value="scheduling_conflict">Scheduling Conflict</option>
+                        <option value="weather">Weather</option>
+                        <option value="other">Other</option>
+                    </select>
+                    <label class="block text-xs font-bold text-slate-600 mb-1">Notes (optional)</label>
+                    <textarea x-model="cancelNotes" rows={3} class="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm" />
+                </Modal>
             </div>
 
             {/* Inspection Events (Spec 4D.T9) */}
@@ -773,56 +779,59 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                 </ul>
 
                 {/* Create modal */}
-                <div x-show="showCreate" x-cloak class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) showCreate = false' }}>
-                    <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6">
-                        <h3 class="text-lg font-bold text-slate-900 mb-4">New event</h3>
-                        <div class="space-y-3">
+                <Modal
+                    name="showCreate"
+                    title="New event"
+                    size="md"
+                    footer={
+                        <ModalFooter
+                            onCancel="showCreate = false"
+                            onConfirm="submitCreate()"
+                            confirmDisabled="saving"
+                            confirmTextExpr="saving ? 'Saving...' : 'Add event'"
+                        />
+                    }
+                >
+                    <div class="space-y-3">
+                        <div>
+                            <label class="block text-xs font-bold text-slate-600 mb-1">Type</label>
+                            <select x-model="form.eventTypeId" x-on:change="onTypeChange()" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                                <option value="">— Select —</option>
+                                <template x-for="t in types" {...{ 'x-bind:key': 't.id' }}>
+                                    <option {...{ 'x-bind:value': 't.id' }} x-text="t.name"></option>
+                                </template>
+                            </select>
+                            <p x-show="!types.length" class="text-[10px] text-amber-600 mt-1">No event types defined. <a href="/settings/event-types" class="underline">Create one</a> first.</p>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-bold text-slate-600 mb-1">Date &amp; time</label>
+                            <input type="datetime-local" x-model="form.scheduledAt" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
+                        </div>
+                        <div class="grid grid-cols-2 gap-3">
                             <div>
-                                <label class="block text-xs font-bold text-slate-600 mb-1">Type</label>
-                                <select x-model="form.eventTypeId" x-on:change="onTypeChange()" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
-                                    <option value="">— Select —</option>
-                                    <template x-for="t in types" {...{ 'x-bind:key': 't.id' }}>
-                                        <option {...{ 'x-bind:value': 't.id' }} x-text="t.name"></option>
-                                    </template>
-                                </select>
-                                <p x-show="!types.length" class="text-[10px] text-amber-600 mt-1">No event types defined. <a href="/settings/event-types" class="underline">Create one</a> first.</p>
+                                <label class="block text-xs font-bold text-slate-600 mb-1">Duration (min)</label>
+                                <input type="number" {...{ 'x-model.number': 'form.durationMin' }} min="1" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
                             </div>
                             <div>
-                                <label class="block text-xs font-bold text-slate-600 mb-1">Date &amp; time</label>
-                                <input type="datetime-local" x-model="form.scheduledAt" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
-                            </div>
-                            <div class="grid grid-cols-2 gap-3">
-                                <div>
-                                    <label class="block text-xs font-bold text-slate-600 mb-1">Duration (min)</label>
-                                    <input type="number" {...{ 'x-model.number': 'form.durationMin' }} min="1" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
-                                </div>
-                                <div>
-                                    <label class="block text-xs font-bold text-slate-600 mb-1">Price (cents)</label>
-                                    <input type="number" {...{ 'x-model.number': 'form.priceCents' }} min="0" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
-                                </div>
-                            </div>
-                            <div>
-                                <label class="block text-xs font-bold text-slate-600 mb-1">Inspector (optional)</label>
-                                <select x-model="form.inspectorId" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
-                                    <option value="">Unassigned</option>
-                                    <template x-for="i in inspectors" {...{ 'x-bind:key': 'i.id' }}>
-                                        <option {...{ 'x-bind:value': 'i.id' }} x-text="i.name || i.email"></option>
-                                    </template>
-                                </select>
-                            </div>
-                            <div>
-                                <label class="block text-xs font-bold text-slate-600 mb-1">Notes (optional)</label>
-                                <textarea x-model="form.notes" rows={2} class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
+                                <label class="block text-xs font-bold text-slate-600 mb-1">Price (cents)</label>
+                                <input type="number" {...{ 'x-model.number': 'form.priceCents' }} min="0" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
                             </div>
                         </div>
-                        <div class="flex gap-3 justify-end mt-5">
-                            <button type="button" x-on:click="showCreate = false" class="px-4 py-2 rounded-lg ring-2 ring-slate-200 text-slate-600 text-xs font-bold">Cancel</button>
-                            <button type="button" x-on:click="submitCreate()" {...{ 'x-bind:disabled': 'saving' }} class="px-4 py-2 rounded-lg bg-indigo-600 text-white text-xs font-bold disabled:opacity-50">
-                                <span x-text="saving ? 'Saving...' : 'Add event'"></span>
-                            </button>
+                        <div>
+                            <label class="block text-xs font-bold text-slate-600 mb-1">Inspector (optional)</label>
+                            <select x-model="form.inspectorId" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                                <option value="">Unassigned</option>
+                                <template x-for="i in inspectors" {...{ 'x-bind:key': 'i.id' }}>
+                                    <option {...{ 'x-bind:value': 'i.id' }} x-text="i.name || i.email"></option>
+                                </template>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-xs font-bold text-slate-600 mb-1">Notes (optional)</label>
+                            <textarea x-model="form.notes" rows={2} class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
                         </div>
                     </div>
-                </div>
+                </Modal>
             </section>
 
             {/* Card Grid */}
@@ -1175,79 +1184,81 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
           </aside>
         </div>
 
-        {/* ===== Publish Modal ===== */}
-        <div {...{'x-cloak': ''}} x-show="showPublishModal" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-          <div class="w-full max-w-md rounded-lg p-6 shadow-xl" style="background: rgba(255,255,255,0.95); backdrop-filter: blur(20px);" x-on:click="if ($event.target === $el) showPublishModal = false">
-            <h3 class="text-lg font-bold mb-4" style="color: #0f172a">Publish Report</h3>
-            <div class="space-y-4">
-              <div class="p-3 rounded-xl" style="background: #f1f5f9">
-                <div class="text-xs font-mono" style="color: #94a3b8">Report Summary</div>
-                <div class="text-sm mt-1" style="color: #1e293b" x-text="reportStats.total + ' items  |  ' + reportStats.defect + ' defects  |  ' + reportStats.monitor + ' monitors'"></div>
-              </div>
-              <div class="space-y-3">
-                <label class="flex items-center justify-between">
-                  <span class="text-sm" style="color: #475569">Email client</span>
-                  <input type="checkbox" x-model="publishOptions.notifyClient" class="rounded" checked />
-                </label>
-                <label class="flex items-center justify-between">
-                  <span class="text-sm" style="color: #475569">Email agent</span>
-                  <input type="checkbox" x-model="publishOptions.notifyAgent" class="rounded" checked />
-                </label>
-                <label class="flex items-center justify-between">
-                  <span class="text-sm" style="color: #475569">Require signature</span>
-                  <input type="checkbox" x-model="publishOptions.requireSignature" class="rounded" />
-                </label>
-                <label class="flex items-center justify-between">
-                  <span class="text-sm" style="color: #475569">Require payment</span>
-                  <input type="checkbox" x-model="publishOptions.requirePayment" class="rounded" />
-                </label>
-              </div>
-              <div>
-                <div class="text-xs font-semibold mb-2" style="color: #94a3b8">THEME</div>
-                <div class="flex gap-2">
-                  <template x-for="t in ['modern', 'classic', 'minimal']" x-bind:key="t">
+        {/* ===== Publish Modal — 3 distinct buttons (Cancel, Send PDF [tertiary
+             emerald], Confirm Publish), so footer is inlined rather than using
+             ModalFooter. All three share the canonical h-10/rounded-xl shape. */}
+        <Modal
+            name="showPublishModal"
+            title="Publish Report"
+            size="md"
+            footer={
+                <>
                     <button
-                      x-on:click="publishOptions.theme = t"
-                      class="px-4 py-2 text-xs font-semibold rounded-lg border capitalize transition-all"
-                      x-bind:style="publishOptions.theme === t ? 'background: var(--ih-primary, #6366f1); color: white; border-color: transparent' : 'border-color: #e2e8f0; color: #64748b'"
-                      x-text="t"
-                    ></button>
-                  </template>
+                        type="button"
+                        x-on:click="showPublishModal = false"
+                        class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border bg-white hover:bg-slate-50 transition-all"
+                        style="border-color: #e2e8f0; color: #475569"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        {...{ 'x-on:click': 'sendReportPdf()' }}
+                        {...{ 'x-bind:disabled': 'sendingPdf' }}
+                        class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 disabled:opacity-50 transition-all"
+                    >
+                        <span x-show="!sendingPdf">Send PDF</span>
+                        <span x-show="sendingPdf">Sending…</span>
+                    </button>
+                    <button
+                        type="button"
+                        x-on:click="publish()"
+                        x-bind:disabled="publishing"
+                        class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 transition-all"
+                    >
+                        <span x-text="publishing ? 'Publishing…' : 'Confirm Publish'"></span>
+                    </button>
+                </>
+            }
+        >
+            <div class="space-y-4">
+                <div class="p-3 rounded-xl" style="background: #f1f5f9">
+                    <div class="text-xs font-mono" style="color: #94a3b8">Report Summary</div>
+                    <div class="text-sm mt-1" style="color: #1e293b" x-text="reportStats.total + ' items  |  ' + reportStats.defect + ' defects  |  ' + reportStats.monitor + ' monitors'"></div>
                 </div>
-              </div>
+                <div class="space-y-3">
+                    <label class="flex items-center justify-between">
+                        <span class="text-sm" style="color: #475569">Email client</span>
+                        <input type="checkbox" x-model="publishOptions.notifyClient" class="rounded" checked />
+                    </label>
+                    <label class="flex items-center justify-between">
+                        <span class="text-sm" style="color: #475569">Email agent</span>
+                        <input type="checkbox" x-model="publishOptions.notifyAgent" class="rounded" checked />
+                    </label>
+                    <label class="flex items-center justify-between">
+                        <span class="text-sm" style="color: #475569">Require signature</span>
+                        <input type="checkbox" x-model="publishOptions.requireSignature" class="rounded" />
+                    </label>
+                    <label class="flex items-center justify-between">
+                        <span class="text-sm" style="color: #475569">Require payment</span>
+                        <input type="checkbox" x-model="publishOptions.requirePayment" class="rounded" />
+                    </label>
+                </div>
+                <div>
+                    <div class="text-xs font-semibold mb-2" style="color: #94a3b8">THEME</div>
+                    <div class="flex gap-2">
+                        <template x-for="t in ['modern', 'classic', 'minimal']" x-bind:key="t">
+                            <button
+                                x-on:click="publishOptions.theme = t"
+                                class="px-4 py-2 text-xs font-semibold rounded-lg border capitalize transition-all"
+                                x-bind:style="publishOptions.theme === t ? 'background: var(--ih-primary, #6366f1); color: white; border-color: transparent' : 'border-color: #e2e8f0; color: #64748b'"
+                                x-text="t"
+                            ></button>
+                        </template>
+                    </div>
+                </div>
             </div>
-            {/* Round 38 — unified button row: 40px height, text-sm semibold,
-                normal case. Cancel = secondary (border); Send PDF = tertiary
-                (light tinted); Confirm = primary (indigo solid). All three
-                share the same h-10/rounded-xl/text-sm shape so the modal
-                reads as a single design language. */}
-            <div class="flex gap-3 mt-6">
-              <button
-                x-on:click="showPublishModal = false"
-                class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border bg-white hover:bg-slate-50 transition-all"
-                style="border-color: #e2e8f0; color: #475569"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                {...{ 'x-on:click': 'sendReportPdf()' }}
-                {...{ 'x-bind:disabled': 'sendingPdf' }}
-                class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 disabled:opacity-50 transition-all"
-              >
-                <span x-show="!sendingPdf">Send PDF</span>
-                <span x-show="sendingPdf">Sending…</span>
-              </button>
-              <button
-                x-on:click="publish()"
-                x-bind:disabled="publishing"
-                class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-              >
-                <span x-text="publishing ? 'Publishing…' : 'Confirm Publish'"></span>
-              </button>
-            </div>
-          </div>
-        </div>
+        </Modal>
 
         {/* Onboarding overlay (T6) */}
         <div x-data="inspectionOnboarding()" {...{'x-on:rating-levels-ready.window': 'init($event.detail)'}}>

--- a/src/templates/pages/invoices.tsx
+++ b/src/templates/pages/invoices.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const InvoicesPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
@@ -56,44 +57,45 @@ export const InvoicesPage = ({ branding }: { branding?: BrandingConfig | undefin
                 </div>
 
                 {/* Create Modal */}
-                <div id="invoiceModal" class="fixed inset-0 z-[100] hidden overflow-y-auto">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-xl" onclick="closeInvoiceModal()"></div>
-                    <div class="flex min-h-full items-center justify-center p-6">
-                        <div class="relative w-full max-w-lg bg-white rounded-xl p-6 shadow-2xl">
-                            <h3 class="text-xl font-bold text-slate-900 mb-8">New Invoice</h3>
-                            <div class="space-y-5">
-                                <div class="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Name *</label>
-                                        <input type="text" id="invClientName" placeholder="John Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                    </div>
-                                    <div>
-                                        <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Email</label>
-                                        <input type="email" id="invClientEmail" placeholder="john@example.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                    </div>
-                                </div>
-                                <div class="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Amount ($)</label>
-                                        <input type="number" id="invAmount" min="0" step="0.01" placeholder="350.00" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                    </div>
-                                    <div>
-                                        <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Due Date</label>
-                                        <input type="date" id="invDueDate" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
-                                    </div>
-                                </div>
-                                <div>
-                                    <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Notes</label>
-                                    <textarea id="invNotes" rows={3} placeholder="Optional notes..." class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm resize-none"></textarea>
-                                </div>
+                <Modal
+                    id="invoiceModal"
+                    title="New Invoice"
+                    size="lg"
+                    footer={
+                        <ModalFooter
+                            onCancelJs="closeInvoiceModal()"
+                            onConfirmJs="submitInvoice()"
+                            confirmText="Create"
+                        />
+                    }
+                >
+                    <div class="space-y-5">
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Name *</label>
+                                <input type="text" id="invClientName" placeholder="John Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                             </div>
-                            <div class="mt-8 flex gap-4">
-                                <button onclick="closeInvoiceModal()" class="flex-1 px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all">Cancel</button>
-                                <button onclick="submitInvoice()" class="flex-[2] px-4 py-2 bg-indigo-600 text-white rounded-md font-bold text-sm hover:bg-indigo-700 active:scale-[.98] transition-all disabled:bg-slate-300 disabled:cursor-not-allowed">Create</button>
+                            <div>
+                                <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Email</label>
+                                <input type="email" id="invClientEmail" placeholder="john@example.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                             </div>
                         </div>
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Amount ($)</label>
+                                <input type="number" id="invAmount" min="0" step="0.01" placeholder="350.00" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                            </div>
+                            <div>
+                                <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Due Date</label>
+                                <input type="date" id="invDueDate" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Notes</label>
+                            <textarea id="invNotes" rows={3} placeholder="Optional notes..." class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm resize-none"></textarea>
+                        </div>
                     </div>
-                </div>
+                </Modal>
 
                 <script src="/js/modal-dialog.js"></script>
                 <script src="/js/auth.js"></script>

--- a/src/templates/pages/marketplace.tsx
+++ b/src/templates/pages/marketplace.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
@@ -154,104 +155,120 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                         class="px-4 py-2 rounded-xl border border-slate-200 text-sm font-bold disabled:opacity-40">Next</button>
                 </div>
 
-                {/* Polish 5 — Preview modal. NOTE: NO x-cloak here — Alpine doesn't auto-remove
-                    x-cloak from descendant elements, so combining it with main-layout's
-                    [x-cloak] { display: none !important } would permanently hide the modal even
-                    when previewOpen=true. x-show alone correctly toggles display. */}
-                <div x-show="previewOpen" style="display:none" x-transition class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" {...{ 'x-on:click.self': 'previewOpen = false' }}>
-                    <div class="bg-white rounded-lg shadow-2xl max-w-3xl w-full max-h-[85vh] overflow-hidden flex flex-col">
-                        <header class="px-8 py-5 border-b border-slate-100 flex items-center justify-between">
-                            <div>
-                                <h2 class="text-xl font-black text-slate-900" x-text="previewTemplate?.name || 'Preview'"></h2>
-                                <p class="text-xs text-slate-500" x-text="previewTemplate?.changelog || ''"></p>
-                            </div>
-                            <button x-on:click="previewOpen = false" class="text-slate-400 hover:text-slate-600 text-2xl leading-none">&times;</button>
-                        </header>
-                        <div class="flex-1 overflow-y-auto p-6 space-y-3">
-                            {/* Spec 5B P3 — totals row: items, canned comments, defects */}
-                            <p class="text-xs font-bold uppercase tracking-widest text-slate-400">
-                                <span x-text="previewSchema?.sections?.length || 0"></span> sections ·
-                                <span x-text="previewItemCount"></span> items ·
-                                <span x-text="previewCannedTotal"></span> canned comments ·
-                                <span class="text-rose-500" x-text="previewDefectTotal + ' defects'"></span>
-                            </p>
-                            <template x-for="sec in (previewSchema?.sections || [])" {...{ 'x-bind:key': 'sec.id' }}>
-                                <details class="bg-slate-50 rounded-xl p-3" open>
-                                    <summary class="cursor-pointer font-bold text-sm text-slate-800 flex items-center justify-between">
-                                        <span x-text="sec.title || sec.name || sec.id"></span>
-                                        <span class="text-xs text-slate-400" x-text="(sec.items?.length || 0) + ' items'"></span>
-                                    </summary>
-                                    <ul class="mt-2 space-y-1 text-xs text-slate-600 pl-3">
-                                        <template x-for="it in (sec.items || [])" {...{ 'x-bind:key': 'it.id' }}>
-                                            <li class="flex items-center gap-2 flex-wrap py-1">
-                                                <span class="w-1 h-1 rounded-full bg-slate-300"></span>
-                                                <span class="font-semibold text-slate-700" x-text="it.label || it.name || it.id"></span>
-                                                {/* Spec 5B P3 — rating type pill */}
-                                                <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 text-slate-600" x-text="it.type || 'rich'"></span>
-                                                {/* Tab counts (info / lim / def). Only render
-                                                    when the template ships any canned content. */}
-                                                <span x-show="it._info > 0" class="text-[10px] font-mono text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded" x-text="'info: ' + it._info"></span>
-                                                <span x-show="it._lim > 0" class="text-[10px] font-mono text-sky-700 bg-sky-50 px-1.5 py-0.5 rounded" x-text="'lim: ' + it._lim"></span>
-                                                <span x-show="it._def > 0" class="text-[10px] font-mono text-rose-700 bg-rose-50 px-1.5 py-0.5 rounded" x-text="'def: ' + it._def"></span>
-                                            </li>
-                                        </template>
-                                    </ul>
-                                </details>
-                            </template>
-                        </div>
-                        <footer class="px-4 py-2 border-t border-slate-100 flex items-center justify-end gap-3">
-                            <button x-on:click="previewOpen = false" class="px-4 py-2 rounded-lg ring-2 ring-slate-200 text-slate-600 text-xs font-bold">Close</button>
-                            <button x-show="previewTemplate && !previewTemplate.importedSemver"
+                {/* Polish 5 — Preview modal. Footer has Close + Import (conditional),
+                    so it's inlined rather than using ModalFooter. */}
+                <Modal
+                    name="previewOpen"
+                    titleExpr="previewTemplate?.name || 'Preview'"
+                    subtitleExpr="previewTemplate?.changelog || ''"
+                    size="3xl"
+                    footer={
+                        <>
+                            <button
+                                type="button"
+                                x-on:click="previewOpen = false"
+                                class="h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                style="border-color: #e2e8f0"
+                            >
+                                Close
+                            </button>
+                            <button
+                                type="button"
+                                x-show="previewTemplate && !previewTemplate.importedSemver"
                                 x-on:click="importTemplate(previewTemplate.id); previewOpen = false"
-                                class="px-4 py-2 rounded-lg bg-violet-600 text-white text-xs font-bold">
+                                class="h-10 px-4 rounded-xl bg-violet-600 text-white text-sm font-semibold hover:bg-violet-700 transition-all"
+                            >
                                 Import this template
                             </button>
-                        </footer>
+                        </>
+                    }
+                >
+                    <div class="space-y-3">
+                        {/* Spec 5B P3 — totals row: items, canned comments, defects */}
+                        <p class="text-xs font-bold uppercase tracking-widest text-slate-400">
+                            <span x-text="previewSchema?.sections?.length || 0"></span> sections ·
+                            <span x-text="previewItemCount"></span> items ·
+                            <span x-text="previewCannedTotal"></span> canned comments ·
+                            <span class="text-rose-500" x-text="previewDefectTotal + ' defects'"></span>
+                        </p>
+                        <template x-for="sec in (previewSchema?.sections || [])" {...{ 'x-bind:key': 'sec.id' }}>
+                            <details class="bg-slate-50 rounded-xl p-3" open>
+                                <summary class="cursor-pointer font-bold text-sm text-slate-800 flex items-center justify-between">
+                                    <span x-text="sec.title || sec.name || sec.id"></span>
+                                    <span class="text-xs text-slate-400" x-text="(sec.items?.length || 0) + ' items'"></span>
+                                </summary>
+                                <ul class="mt-2 space-y-1 text-xs text-slate-600 pl-3">
+                                    <template x-for="it in (sec.items || [])" {...{ 'x-bind:key': 'it.id' }}>
+                                        <li class="flex items-center gap-2 flex-wrap py-1">
+                                            <span class="w-1 h-1 rounded-full bg-slate-300"></span>
+                                            <span class="font-semibold text-slate-700" x-text="it.label || it.name || it.id"></span>
+                                            <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 text-slate-600" x-text="it.type || 'rich'"></span>
+                                            <span x-show="it._info > 0" class="text-[10px] font-mono text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded" x-text="'info: ' + it._info"></span>
+                                            <span x-show="it._lim > 0" class="text-[10px] font-mono text-sky-700 bg-sky-50 px-1.5 py-0.5 rounded" x-text="'lim: ' + it._lim"></span>
+                                            <span x-show="it._def > 0" class="text-[10px] font-mono text-rose-700 bg-rose-50 px-1.5 py-0.5 rounded" x-text="'def: ' + it._def"></span>
+                                        </li>
+                                    </template>
+                                </ul>
+                            </details>
+                        </template>
                     </div>
-                </div>
+                </Modal>
 
                 {/* Round 37 — Update confirm modal. Explains the "new copy"
                     semantics (Scheme 2) so the inspector knows their existing
-                    template/library entries are preserved. */}
-                <div x-show="updateConfirmOpen" style="display:none" x-transition class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" {...{ 'x-on:click.self': 'closeUpdateConfirm()' }}>
-                    <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full overflow-hidden">
-                        <header class="px-6 py-4 border-b border-slate-100">
-                            <h2 class="text-lg font-black text-slate-900">
-                                <span x-text="updateKind === 'library' ? 'Update library?' : 'Update template?'"></span>
-                            </h2>
-                        </header>
-                        <div class="px-6 py-5 space-y-3 text-sm text-slate-700">
-                            <p>
-                                <strong x-text="updateTarget?.name || ''"></strong>
-                                <span class="text-slate-500"> will move from </span>
-                                <span class="font-mono text-xs text-slate-700" x-text="'v' + (updateTarget?.importedSemver || '?')"></span>
-                                <span class="text-slate-500"> to </span>
-                                <span class="font-mono text-xs font-bold text-amber-700" x-text="'v' + (updateTarget?.semver || '?')"></span>.
+                    template/library entries are preserved. Custom amber Continue
+                    button — inlined rather than using ModalFooter. */}
+                <Modal
+                    name="updateConfirmOpen"
+                    titleExpr="updateKind === 'library' ? 'Update library?' : 'Update template?'"
+                    size="md"
+                    footer={
+                        <>
+                            <button
+                                type="button"
+                                x-on:click="closeUpdateConfirm()"
+                                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                style="border-color: #e2e8f0"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                x-on:click="confirmUpdate()"
+                                class="flex-1 h-10 px-4 rounded-xl bg-amber-500 text-white text-sm font-semibold hover:bg-amber-600 transition-all"
+                            >
+                                Continue
+                            </button>
+                        </>
+                    }
+                >
+                    <div class="space-y-3 text-sm text-slate-700">
+                        <p>
+                            <strong x-text="updateTarget?.name || ''"></strong>
+                            <span class="text-slate-500"> will move from </span>
+                            <span class="font-mono text-xs text-slate-700" x-text="'v' + (updateTarget?.importedSemver || '?')"></span>
+                            <span class="text-slate-500"> to </span>
+                            <span class="font-mono text-xs font-bold text-amber-700" x-text="'v' + (updateTarget?.semver || '?')"></span>.
+                        </p>
+                        <template x-if="updateKind === 'template'">
+                            <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
+                                A new copy will be created with the suffix
+                                <span class="font-mono font-bold" x-text="'(v' + (updateTarget?.semver || '?') + ')'"></span>.
+                                Your current copy is <strong>preserved</strong> so existing
+                                inspections keep working. You can compare side-by-side or
+                                delete the old copy later.
                             </p>
-                            <template x-if="updateKind === 'template'">
-                                <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
-                                    A new copy will be created with the suffix
-                                    <span class="font-mono font-bold" x-text="'(v' + (updateTarget?.semver || '?') + ')'"></span>.
-                                    Your current copy is <strong>preserved</strong> so existing
-                                    inspections keep working. You can compare side-by-side or
-                                    delete the old copy later.
-                                </p>
-                            </template>
-                            <template x-if="updateKind === 'library'">
-                                <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
-                                    The new pack's entries will be <strong>added</strong> alongside
-                                    your existing ones. Old entries are <strong>not deleted</strong>.
-                                    If you want a clean state, delete the old entries from
-                                    <a href="/comments" class="underline">/comments</a> after updating.
-                                </p>
-                            </template>
-                        </div>
-                        <footer class="px-6 py-4 border-t border-slate-100 flex items-center justify-end gap-3">
-                            <button x-on:click="closeUpdateConfirm()" class="px-4 py-2 rounded-lg ring-2 ring-slate-200 text-slate-600 text-xs font-bold">Cancel</button>
-                            <button x-on:click="confirmUpdate()" class="px-4 py-2 rounded-lg bg-amber-500 text-white text-xs font-bold hover:bg-amber-600">Continue</button>
-                        </footer>
+                        </template>
+                        <template x-if="updateKind === 'library'">
+                            <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
+                                The new pack's entries will be <strong>added</strong> alongside
+                                your existing ones. Old entries are <strong>not deleted</strong>.
+                                If you want a clean state, delete the old entries from
+                                <a href="/comments" class="underline">/comments</a> after updating.
+                            </p>
+                        </template>
                     </div>
-                </div>
+                </Modal>
 
                 {/* Toast — Bug #7 (4-30 review) fix: pre-Alpine render leaks the
                     static "View" anchor text. Default style=display:none keeps toast

--- a/src/templates/pages/recommendations.tsx
+++ b/src/templates/pages/recommendations.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig; }
@@ -60,10 +61,20 @@ export const RecommendationsPage = ({ branding }: Props): JSX.Element => (
             </div>
 
             {/* Create / Edit modal */}
-            <div x-show="modalOpen" x-cloak class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) modalOpen = false' }}>
-                <div class="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6">
-                    <h2 class="text-lg font-bold text-slate-900 mb-4" x-text="editingId ? 'Edit recommendation' : 'New recommendation'"></h2>
-                    <div class="space-y-3">
+            <Modal
+                name="modalOpen"
+                titleExpr="editingId ? 'Edit recommendation' : 'New recommendation'"
+                size="lg"
+                footer={
+                    <ModalFooter
+                        onCancel="modalOpen = false"
+                        onConfirm="save()"
+                        confirmDisabled="saving"
+                        confirmTextExpr="saving ? 'Saving...' : 'Save'"
+                    />
+                }
+            >
+                <div class="space-y-3">
                         <div>
                             <label class="block text-xs font-bold text-slate-600 mb-1">Category</label>
                             <input
@@ -107,15 +118,8 @@ export const RecommendationsPage = ({ branding }: Props): JSX.Element => (
                             <label class="block text-xs font-bold text-slate-600 mb-1">Repair summary</label>
                             <textarea x-model="form.defaultRepairSummary" required rows={4} placeholder="Recommend evaluation by licensed contractor..." class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
                         </div>
-                    </div>
-                    <div class="flex gap-3 justify-end mt-6">
-                        <button x-on:click="modalOpen = false" class="px-5 py-2 rounded-lg ring-2 ring-slate-300 text-slate-700 text-xs font-bold">Cancel</button>
-                        <button x-on:click="save()" {...{ 'x-bind:disabled': 'saving' }} class="px-5 py-2 rounded-lg bg-slate-900 text-white text-xs font-bold uppercase tracking-widest hover:bg-black disabled:opacity-50">
-                            <span x-text="saving ? 'Saving...' : 'Save'"></span>
-                        </button>
-                    </div>
                 </div>
-            </div>
+            </Modal>
         </div>
 
         <script src="/js/auth.js"></script>

--- a/src/templates/pages/report.template.tsx
+++ b/src/templates/pages/report.template.tsx
@@ -94,11 +94,7 @@ export function renderProfessionalReport(data: {
     x-data={`reportGatekeeper('${inspection.id}')`}
     class="min-h-screen bg-slate-50/50 antialiased py-6 px-6 relative"
 >
-    {/* Atmospheric Background */}
-    <div class="fixed inset-0 pointer-events-none overflow-hidden select-none no-print">
-        <div class="absolute -top-[10%] -left-[10%] w-[40%] h-[40%] bg-indigo-500/5 blur-[120px] rounded-full"></div>
-        <div class="absolute -bottom-[10%] -right-[10%] w-[40%] h-[40%] bg-blue-500/5 blur-[120px] rounded-full"></div>
-    </div>
+    {/* Spec 5F R2 Step 6 — atmospheric blobs removed (audit P1-4). */}
 
     <div
         {...{':class': "(showAgreement || (signed && showPayment && !paid)) ? 'blur-content' : ''"}}

--- a/src/templates/pages/settings-event-types.tsx
+++ b/src/templates/pages/settings-event-types.tsx
@@ -1,4 +1,5 @@
 import { SettingsLayout } from '../components/settings-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig; }
@@ -64,10 +65,20 @@ export const SettingsEventTypesPage = ({ branding }: Props): JSX.Element => (
             </div>
 
             {/* Create / edit modal */}
-            <div x-show="modalOpen" x-cloak class="fixed inset-0 z-50 bg-ink-900/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) modalOpen = false' }}>
-                <div class="bg-white rounded-lg border border-surface-200 max-w-lg w-full p-6">
-                    <h2 class="text-lg font-bold text-ink-900 mb-4" x-text="editingId ? 'Edit event type' : 'New event type'"></h2>
-                    <div class="space-y-3">
+            <Modal
+                name="modalOpen"
+                titleExpr="editingId ? 'Edit event type' : 'New event type'"
+                size="lg"
+                footer={
+                    <ModalFooter
+                        onCancel="modalOpen = false"
+                        onConfirm="save()"
+                        confirmDisabled="saving"
+                        confirmTextExpr="saving ? 'Saving...' : 'Save'"
+                    />
+                }
+            >
+                <div class="space-y-3">
                         <div>
                             <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Name</label>
                             <input type="text" x-model="form.name" required placeholder="e.g., Radon Test — Pickup" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
@@ -100,15 +111,8 @@ export const SettingsEventTypesPage = ({ branding }: Props): JSX.Element => (
                                 <input type="number" {...{ 'x-model.number': 'form.sortOrder' }} min="0" placeholder="0" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
                             </div>
                         </div>
-                    </div>
-                    <div class="flex gap-3 justify-end mt-6">
-                        <button x-on:click="modalOpen = false" class="px-4 py-2 rounded-md border border-surface-200 bg-white text-ink-700 text-sm font-semibold hover:bg-surface-100 transition-all">Cancel</button>
-                        <button x-on:click="save()" {...{ 'x-bind:disabled': 'saving' }} class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all disabled:opacity-50">
-                            <span x-text="saving ? 'Saving...' : 'Save'"></span>
-                        </button>
-                    </div>
                 </div>
-            </div>
+            </Modal>
         </div>
 
         <script src="/js/auth.js"></script>

--- a/src/templates/pages/settings-security.tsx
+++ b/src/templates/pages/settings-security.tsx
@@ -1,4 +1,5 @@
 import { SettingsLayout } from '../components/settings-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig; }
@@ -40,11 +41,9 @@ export const SettingsSecurityPage = ({ branding }: Props): JSX.Element => (
                 </div>
             </div>
 
-            {/* Enable modal */}
-            <div x-show="enableModalOpen" x-cloak class="fixed inset-0 z-50 bg-ink-900/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) closeEnable()' }}>
-                <div class="bg-white rounded-lg border border-surface-200 max-w-md w-full p-6 space-y-4">
-                    <h2 class="text-lg font-bold text-ink-900">Enable two-factor authentication</h2>
-
+            {/* Enable modal — two-step body (qr / recovery), so footer is inlined per step. */}
+            <Modal name="enableModalOpen" title="Enable two-factor authentication" size="md">
+                <div class="space-y-4">
                     <div x-show="enableStep === 'qr'" class="space-y-4">
                         <p class="text-sm text-ink-700">Scan this QR code with your authenticator app, then enter the 6-digit code it shows.</p>
                         <div class="flex justify-center">
@@ -59,11 +58,13 @@ export const SettingsSecurityPage = ({ branding }: Props): JSX.Element => (
                             <input type="text" x-model="enableCode" inputmode="numeric" autocomplete="one-time-code" maxlength={6} placeholder="123456" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm font-mono tracking-widest text-center" />
                         </div>
                         <p x-show="enableError" class="text-xs text-rose-600" x-text="enableError"></p>
-                        <div class="flex gap-3 justify-end">
-                            <button x-on:click="closeEnable()" class="px-4 py-2 rounded-md border border-surface-200 bg-white text-ink-700 text-sm font-semibold hover:bg-surface-100 transition-all">Cancel</button>
-                            <button x-on:click="verifyEnable()" {...{ 'x-bind:disabled': 'busy || enableCode.length !== 6' }} class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all disabled:opacity-50">
-                                <span x-text="busy ? 'Verifying...' : 'Verify &amp; Enable'"></span>
-                            </button>
+                        <div class="flex gap-3 mt-2">
+                            <ModalFooter
+                                onCancel="closeEnable()"
+                                onConfirm="verifyEnable()"
+                                confirmDisabled="busy || enableCode.length !== 6"
+                                confirmTextExpr="busy ? 'Verifying...' : 'Verify &amp; Enable'"
+                            />
                         </div>
                     </div>
 
@@ -76,20 +77,32 @@ export const SettingsSecurityPage = ({ branding }: Props): JSX.Element => (
                             </template>
                         </div>
                         <div class="flex gap-3">
-                            <button x-on:click="downloadRecoveryCodes()" class="text-xs font-bold text-blueprint-700 hover:underline">Download as .txt</button>
-                            <button x-on:click="copyRecoveryCodes()" class="text-xs font-bold text-blueprint-700 hover:underline">Copy all</button>
+                            <button type="button" x-on:click="downloadRecoveryCodes()" class="text-xs font-bold text-blueprint-700 hover:underline">Download as .txt</button>
+                            <button type="button" x-on:click="copyRecoveryCodes()" class="text-xs font-bold text-blueprint-700 hover:underline">Copy all</button>
                         </div>
-                        <div class="flex justify-end">
-                            <button x-on:click="closeEnable()" class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all">Done</button>
+                        <div class="flex justify-end mt-2">
+                            <button type="button" x-on:click="closeEnable()" class="h-10 px-6 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 transition-all">Done</button>
                         </div>
                     </div>
                 </div>
-            </div>
+            </Modal>
 
             {/* Disable modal */}
-            <div x-show="disableModalOpen" x-cloak class="fixed inset-0 z-50 bg-ink-900/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) disableModalOpen = false' }}>
-                <div class="bg-white rounded-lg border border-surface-200 max-w-md w-full p-6 space-y-4">
-                    <h2 class="text-lg font-bold text-ink-900">Disable two-factor authentication</h2>
+            <Modal
+                name="disableModalOpen"
+                title="Disable two-factor authentication"
+                size="md"
+                footer={
+                    <ModalFooter
+                        onCancel="disableModalOpen = false"
+                        onConfirm="confirmDisable()"
+                        confirmDisabled="busy || !disableForm.password || !disableForm.code"
+                        confirmTextExpr="busy ? 'Disabling...' : 'Disable 2FA'"
+                        danger={true}
+                    />
+                }
+            >
+                <div class="space-y-4">
                     <p class="text-sm text-ink-700">Enter your password and a current 2FA code (or recovery code) to confirm.</p>
                     <div>
                         <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Current password</label>
@@ -100,56 +113,52 @@ export const SettingsSecurityPage = ({ branding }: Props): JSX.Element => (
                         <input type="text" x-model="disableForm.code" autocomplete="one-time-code" placeholder="123456 or XXXX-XXXX" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm font-mono" />
                     </div>
                     <p x-show="disableError" class="text-xs text-rose-600" x-text="disableError"></p>
-                    <div class="flex gap-3 justify-end">
-                        <button x-on:click="disableModalOpen = false" class="px-4 py-2 rounded-md border border-surface-200 bg-white text-ink-700 text-sm font-semibold hover:bg-surface-100 transition-all">Cancel</button>
-                        <button x-on:click="confirmDisable()" {...{ 'x-bind:disabled': 'busy || !disableForm.password || !disableForm.code' }} class="px-4 py-2 bg-rose-600 text-white rounded-md font-bold text-sm hover:bg-rose-700 transition-all disabled:opacity-50">
-                            <span x-text="busy ? 'Disabling...' : 'Disable 2FA'"></span>
-                        </button>
+                </div>
+            </Modal>
+
+            {/* Regenerate modal — two-step (verify / show) so footer is inlined per step. */}
+            <Modal
+                name="regenModalOpen"
+                titleExpr="regenStep === 'verify' ? 'Regenerate recovery codes' : 'New recovery codes'"
+                size="md"
+            >
+                <div x-show="regenStep === 'verify'" class="space-y-4">
+                    <p class="text-sm text-ink-700">Old recovery codes will be invalidated immediately.</p>
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Current password</label>
+                        <input type="password" x-model="regenForm.password" autocomplete="current-password" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
+                    </div>
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">2FA code or recovery code</label>
+                        <input type="text" x-model="regenForm.code" autocomplete="one-time-code" placeholder="123456 or XXXX-XXXX" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm font-mono" />
+                    </div>
+                    <p x-show="regenError" class="text-xs text-rose-600" x-text="regenError"></p>
+                    <div class="flex gap-3 mt-2">
+                        <ModalFooter
+                            onCancel="regenModalOpen = false"
+                            onConfirm="confirmRegen()"
+                            confirmDisabled="busy || !regenForm.password || !regenForm.code"
+                            confirmTextExpr="busy ? 'Regenerating...' : 'Regenerate'"
+                        />
                     </div>
                 </div>
-            </div>
 
-            {/* Regenerate modal */}
-            <div x-show="regenModalOpen" x-cloak class="fixed inset-0 z-50 bg-ink-900/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) regenModalOpen = false' }}>
-                <div class="bg-white rounded-lg border border-surface-200 max-w-md w-full p-6 space-y-4">
-                    <h2 class="text-lg font-bold text-ink-900" x-text="regenStep === 'verify' ? 'Regenerate recovery codes' : 'New recovery codes'"></h2>
-
-                    <div x-show="regenStep === 'verify'" class="space-y-4">
-                        <p class="text-sm text-ink-700">Old recovery codes will be invalidated immediately.</p>
-                        <div>
-                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Current password</label>
-                            <input type="password" x-model="regenForm.password" autocomplete="current-password" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
-                        </div>
-                        <div>
-                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">2FA code or recovery code</label>
-                            <input type="text" x-model="regenForm.code" autocomplete="one-time-code" placeholder="123456 or XXXX-XXXX" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm font-mono" />
-                        </div>
-                        <p x-show="regenError" class="text-xs text-rose-600" x-text="regenError"></p>
-                        <div class="flex gap-3 justify-end">
-                            <button x-on:click="regenModalOpen = false" class="px-4 py-2 rounded-md border border-surface-200 bg-white text-ink-700 text-sm font-semibold hover:bg-surface-100 transition-all">Cancel</button>
-                            <button x-on:click="confirmRegen()" {...{ 'x-bind:disabled': 'busy || !regenForm.password || !regenForm.code' }} class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all disabled:opacity-50">
-                                <span x-text="busy ? 'Regenerating...' : 'Regenerate'"></span>
-                            </button>
-                        </div>
+                <div x-show="regenStep === 'show'" class="space-y-4">
+                    <p class="text-xs text-ink-500">Save these in a safe place — your old codes no longer work.</p>
+                    <div class="bg-surface-50 border border-surface-200 rounded-md p-4 grid grid-cols-2 gap-2 font-mono text-sm">
+                        <template x-for="code in regenData.recoveryCodes" {...{ 'x-bind:key': 'code' }}>
+                            <code class="select-all" x-text="code"></code>
+                        </template>
                     </div>
-
-                    <div x-show="regenStep === 'show'" class="space-y-4">
-                        <p class="text-xs text-ink-500">Save these in a safe place — your old codes no longer work.</p>
-                        <div class="bg-surface-50 border border-surface-200 rounded-md p-4 grid grid-cols-2 gap-2 font-mono text-sm">
-                            <template x-for="code in regenData.recoveryCodes" {...{ 'x-bind:key': 'code' }}>
-                                <code class="select-all" x-text="code"></code>
-                            </template>
-                        </div>
-                        <div class="flex gap-3">
-                            <button x-on:click="downloadRecoveryCodes(regenData.recoveryCodes)" class="text-xs font-bold text-blueprint-700 hover:underline">Download as .txt</button>
-                            <button x-on:click="copyRecoveryCodes(regenData.recoveryCodes)" class="text-xs font-bold text-blueprint-700 hover:underline">Copy all</button>
-                        </div>
-                        <div class="flex justify-end">
-                            <button x-on:click="regenModalOpen = false" class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all">Done</button>
-                        </div>
+                    <div class="flex gap-3">
+                        <button type="button" x-on:click="downloadRecoveryCodes(regenData.recoveryCodes)" class="text-xs font-bold text-blueprint-700 hover:underline">Download as .txt</button>
+                        <button type="button" x-on:click="copyRecoveryCodes(regenData.recoveryCodes)" class="text-xs font-bold text-blueprint-700 hover:underline">Copy all</button>
+                    </div>
+                    <div class="flex justify-end mt-2">
+                        <button type="button" x-on:click="regenModalOpen = false" class="h-10 px-6 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 transition-all">Done</button>
                     </div>
                 </div>
-            </div>
+            </Modal>
         </div>
 
         <script src="/js/auth.js"></script>

--- a/src/templates/pages/settings-services.tsx
+++ b/src/templates/pages/settings-services.tsx
@@ -1,4 +1,5 @@
 import { SettingsLayout } from '../components/settings-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig; }
@@ -76,69 +77,75 @@ export const SettingsServicesPage = ({ branding }: Props): JSX.Element => (
             </section>
 
             {/* Service create / edit modal */}
-            <div x-show="serviceModalOpen" x-cloak class="fixed inset-0 z-50 bg-ink-900/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) serviceModalOpen = false' }}>
-                <div class="bg-white rounded-lg border border-surface-200 max-w-lg w-full p-6">
-                    <h2 class="text-lg font-bold text-ink-900 mb-4" x-text="editingServiceId ? 'Edit service' : 'New service'"></h2>
-                    <div class="space-y-3">
-                        <div>
-                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Name</label>
-                            <input type="text" x-model="serviceForm.name" required placeholder="e.g., Standard Home Inspection" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
-                        </div>
-                        <div>
-                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Description</label>
-                            <textarea x-model="serviceForm.description" rows={2} placeholder="Optional details..." class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm"></textarea>
-                        </div>
-                        <div>
-                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Default price ($)</label>
-                            <input type="number" {...{ 'x-model.number': 'serviceForm.priceDollars' }} min="0" step="0.01" placeholder="450.00" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
-                        </div>
+            <Modal
+                name="serviceModalOpen"
+                titleExpr="editingServiceId ? 'Edit service' : 'New service'"
+                size="lg"
+                footer={
+                    <ModalFooter
+                        onCancel="serviceModalOpen = false"
+                        onConfirm="saveService()"
+                        confirmDisabled="saving"
+                        confirmTextExpr="saving ? 'Saving...' : 'Save'"
+                    />
+                }
+            >
+                <div class="space-y-3">
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Name</label>
+                        <input type="text" x-model="serviceForm.name" required placeholder="e.g., Standard Home Inspection" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
                     </div>
-                    <div class="flex gap-3 justify-end mt-6">
-                        <button x-on:click="serviceModalOpen = false" class="px-4 py-2 rounded-md border border-surface-200 bg-white text-ink-700 text-sm font-semibold hover:bg-surface-100 transition-all">Cancel</button>
-                        <button x-on:click="saveService()" {...{ 'x-bind:disabled': 'saving' }} class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all disabled:opacity-50">
-                            <span x-text="saving ? 'Saving...' : 'Save'"></span>
-                        </button>
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Description</label>
+                        <textarea x-model="serviceForm.description" rows={2} placeholder="Optional details..." class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm"></textarea>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Default price ($)</label>
+                        <input type="number" {...{ 'x-model.number': 'serviceForm.priceDollars' }} min="0" step="0.01" placeholder="450.00" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
                     </div>
                 </div>
-            </div>
+            </Modal>
 
             {/* Discount code create / edit modal */}
-            <div x-show="discountModalOpen" x-cloak class="fixed inset-0 z-50 bg-ink-900/50 flex items-center justify-center p-4" {...{ 'x-on:click': 'if ($event.target === $el) discountModalOpen = false' }}>
-                <div class="bg-white rounded-lg border border-surface-200 max-w-lg w-full p-6">
-                    <h2 class="text-lg font-bold text-ink-900 mb-4" x-text="editingDiscountId ? 'Edit discount code' : 'New discount code'"></h2>
-                    <div class="space-y-3">
+            <Modal
+                name="discountModalOpen"
+                titleExpr="editingDiscountId ? 'Edit discount code' : 'New discount code'"
+                size="lg"
+                footer={
+                    <ModalFooter
+                        onCancel="discountModalOpen = false"
+                        onConfirm="saveDiscount()"
+                        confirmDisabled="saving"
+                        confirmTextExpr="saving ? 'Saving...' : 'Save'"
+                    />
+                }
+            >
+                <div class="space-y-3">
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Code</label>
+                        <input type="text" x-model="discountForm.code" required placeholder="EARLYBIRD" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm uppercase font-mono" />
+                    </div>
+                    <div class="grid grid-cols-2 gap-3">
                         <div>
-                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Code</label>
-                            <input type="text" x-model="discountForm.code" required placeholder="EARLYBIRD" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm uppercase font-mono" />
-                        </div>
-                        <div class="grid grid-cols-2 gap-3">
-                            <div>
-                                <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Type</label>
-                                <select x-model="discountForm.type" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm">
-                                    <option value="percent">Percent off</option>
-                                    <option value="fixed">Fixed $ off</option>
-                                </select>
-                            </div>
-                            <div>
-                                <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]" x-text="discountForm.type === 'percent' ? 'Value (%)' : 'Value ($)'"></label>
-                                <input type="number" {...{ 'x-model.number': 'discountForm.valueInput' }} min="0" placeholder="10" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
-                            </div>
+                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Type</label>
+                            <select x-model="discountForm.type" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm">
+                                <option value="percent">Percent off</option>
+                                <option value="fixed">Fixed $ off</option>
+                            </select>
                         </div>
                         <div>
-                            <label class="flex items-center gap-2 text-xs font-bold text-ink-700 cursor-pointer">
-                                <input type="checkbox" x-model="discountForm.active" />
-                                Active
-                            </label>
+                            <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]" x-text="discountForm.type === 'percent' ? 'Value (%)' : 'Value ($)'"></label>
+                            <input type="number" {...{ 'x-model.number': 'discountForm.valueInput' }} min="0" placeholder="10" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
                         </div>
                     </div>
-                    <div class="flex gap-3 justify-end mt-6">
-                        <button x-on:click="discountModalOpen = false" class="px-4 py-2 rounded-md border border-surface-200 bg-white text-ink-700 text-sm font-semibold hover:bg-surface-100 transition-all">Cancel</button>
-                        <button x-on:click="saveDiscount()" {...{ 'x-bind:disabled': 'saving' }} class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all disabled:opacity-50">
-                            <span x-text="saving ? 'Saving...' : 'Save'"></span>
-                        </button>
+                    <div>
+                        <label class="flex items-center gap-2 text-xs font-bold text-ink-700 cursor-pointer">
+                            <input type="checkbox" x-model="discountForm.active" />
+                            Active
+                        </label>
                     </div>
                 </div>
-            </div>
+            </Modal>
         </div>
 
         <script src="/js/auth.js"></script>

--- a/src/templates/pages/team.tsx
+++ b/src/templates/pages/team.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const TeamPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
@@ -82,56 +83,52 @@ export const TeamPage = ({ branding }: { branding?: BrandingConfig | undefined }
                     </div>
                 </div>
 
-                {/* Invite Modal */}
-                <div id="inviteModal" class="fixed inset-0 z-[100] hidden overflow-y-auto">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-xl transition-opacity animate-fade-in"></div>
-                    <div class="fixed inset-0 flex items-center justify-center p-6">
-                        <div role="dialog" aria-modal="true" class="relative bg-white rounded-2xl shadow-[0_32px_128px_-16px_rgba(0,0,0,0.3)] w-full max-w-xl p-6 overflow-hidden border border-white/40 animate-fade-in">
-                            <div class="mb-6">
-                                <div class="w-16 h-16 bg-indigo-600/10 rounded-2xl flex items-center justify-center text-indigo-600 mb-6">
-                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"></path></svg>
-                                </div>
-                                <h3 class="text-2xl font-bold text-slate-900 tracking-tight mb-3 leading-none">Invite Team Member</h3>
-                                <p class="text-base text-slate-500 font-semibold tracking-tight">Send an invitation to join your workspace.</p>
-                            </div>
-
-                            <form id="inviteForm" class="space-y-4">
-                                <div class="space-y-3">
-                                    <label for="inviteEmail" class="block text-xs font-bold text-slate-900 ml-1 uppercase tracking-[0.2em]">Email Address</label>
-                                    <div class="relative group">
-                                         <div class="absolute -inset-0.5 bg-gradient-to-r from-indigo-500 to-blue-500 rounded-2xl blur opacity-0 group-focus-within:opacity-20 transition-opacity"></div>
-                                         <input type="email" id="inviteEmail" name="email" required placeholder="colleague@example.com"
-                                            class="relative w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all placeholder:text-slate-300 font-medium text-sm" />
-                                    </div>
-                                </div>
-                                <div class="space-y-3">
-                                    <label for="inviteRole" class="block text-xs font-bold text-slate-900 ml-1 uppercase tracking-[0.2em]">Role</label>
-                                    <div class="relative group">
-                                         <div class="absolute -inset-0.5 bg-gradient-to-r from-indigo-500 to-blue-500 rounded-2xl blur opacity-0 group-focus-within:opacity-20 transition-opacity"></div>
-                                         <select id="inviteRole" name="role"
-                                            class="relative w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all appearance-none cursor-pointer font-medium text-sm bg-no-repeat bg-[right_1.5rem_center]">
-                                            <option value="admin">Admin</option>
-                                            <option value="inspector">Inspector</option>
-                                            <option value="office_staff">Office Staff</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <div id="inviteResult" class="hidden text-sm font-bold text-red-600 px-3 py-2 bg-red-50 rounded-2xl border border-red-100 animate-fade-in"></div>
-                            </form>
-
-                            <div class="mt-10 flex flex-col sm:flex-row gap-4">
-                                <button type="button" id="submitInviteBtn"
-                                    class="flex-[2] px-4 py-2 bg-indigo-600 text-white rounded-md font-bold text-sm hover:bg-indigo-700 active:scale-[.98] transition-all disabled:bg-slate-300 disabled:cursor-not-allowed">
-                                    Send Invitation
-                                </button>
-                                <button type="button" id="closeInviteModalBtn"
-                                    class="flex-1 px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all">
-                                    Cancel
-                                </button>
-                            </div>
+                {/* Invite Modal — team.js looks up #closeInviteModalBtn / #submitInviteBtn
+                    by id to bind onclick handlers, so those ids are preserved on the
+                    inlined footer buttons. */}
+                <Modal
+                    id="inviteModal"
+                    title="Invite Team Member"
+                    subtitle="Send an invitation to join your workspace."
+                    size="xl"
+                    footer={
+                        <>
+                            <button
+                                type="button"
+                                id="closeInviteModalBtn"
+                                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                style="border-color: #e2e8f0"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                id="submitInviteBtn"
+                                class="flex-[2] h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-all"
+                            >
+                                Send Invitation
+                            </button>
+                        </>
+                    }
+                >
+                    <form id="inviteForm" class="space-y-4">
+                        <div class="space-y-3">
+                            <label for="inviteEmail" class="block text-xs font-bold text-slate-900 ml-1 uppercase tracking-[0.2em]">Email Address</label>
+                            <input type="email" id="inviteEmail" name="email" required placeholder="colleague@example.com"
+                                class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all placeholder:text-slate-300 font-medium text-sm" />
                         </div>
-                    </div>
-                </div>
+                        <div class="space-y-3">
+                            <label for="inviteRole" class="block text-xs font-bold text-slate-900 ml-1 uppercase tracking-[0.2em]">Role</label>
+                            <select id="inviteRole" name="role"
+                                class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all appearance-none cursor-pointer font-medium text-sm bg-no-repeat bg-[right_1.5rem_center]">
+                                <option value="admin">Admin</option>
+                                <option value="inspector">Inspector</option>
+                                <option value="office_staff">Office Staff</option>
+                            </select>
+                        </div>
+                        <div id="inviteResult" class="hidden text-sm font-bold text-red-600 px-3 py-2 bg-red-50 rounded-2xl border border-red-100"></div>
+                    </form>
+                </Modal>
 
                 <script src="/js/auth.js"></script>
                 <script src="/js/team.js"></script>

--- a/src/templates/pages/template-editor.tsx
+++ b/src/templates/pages/template-editor.tsx
@@ -1,4 +1,5 @@
 import { BareLayout } from '../layouts/main-layout';
+import { Modal } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 const EDITOR_CSS = `
@@ -427,80 +428,83 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                     </aside>
                 </div>
 
-                {/* Rating System Modal */}
-                <div x-show="showRatingModal" x-cloak class="fixed inset-0 z-[100] flex items-center justify-center p-6"
-                    x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
-                    x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0">
-                    <div class="absolute inset-0 bg-ink-900/50 backdrop-blur-sm" {...{'@click': 'showRatingModal = false'}}></div>
-                    <div class="relative w-full max-w-xl bg-white rounded-lg shadow-2xl animate-scale-in max-h-[85vh] overflow-hidden flex flex-col">
-                        <div class="px-8 pt-8 pb-4 border-b border-surface-100">
-                            <h3 class="text-2xl font-display font-700 text-ink-900">Rating System</h3>
-                            <p class="text-sm text-ink-400 mt-1">Configure the rating levels for this template</p>
-                        </div>
-                        <div class="flex-1 overflow-y-auto p-8 space-y-4">
-                            <div class="space-y-2">
-                                <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Preset</label>
-                                <div class="flex flex-wrap gap-2">
-                                    <template x-for="preset in ratingPresets" x-bind:key="preset.name">
-                                        <button {...{'@click': 'applyRatingPreset(preset)'}} class="px-3 py-1.5 text-sm rounded-lg border transition-colors"
-                                            x-bind:class="template.ratingSystem.name === preset.name ? 'border-blueprint-500 bg-blueprint-50 text-blueprint-700 font-600' : 'border-surface-200 text-ink-500 hover:border-surface-300'"
-                                            x-text="preset.name"></button>
-                                    </template>
-                                </div>
-                            </div>
-                            <hr class="border-surface-100" />
-                            <div class="space-y-1.5">
-                                <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">System Name</label>
-                                <input type="text" x-model="template.ratingSystem.name" class="w-full px-3 py-2.5 text-sm font-500 rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors" />
-                            </div>
-                            <div class="space-y-2">
-                                <div class="flex items-center justify-between">
-                                    <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Levels</label>
-                                    <button {...{'@click': 'addRatingLevel()'}} class="text-[10px] font-600 text-blueprint-600 hover:text-blueprint-700 flex items-center gap-1">
-                                        <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" d="M12 5v14m7-7H5"/></svg>
-                                        Add Level
-                                    </button>
-                                </div>
-                                <template x-for="(level, li) in template.ratingSystem.levels" x-bind:key="level.id">
-                                    <div class="space-y-2 p-3 rounded-xl bg-surface-50 group animate-scale-in">
-                                        <div class="flex items-center gap-3">
-                                            <input type="color" x-model="level.color" class="w-8 h-8 rounded-lg border-0 cursor-pointer" />
-                                            <div class="flex-1 grid grid-cols-4 gap-2">
-                                                <input type="text" x-model="level.id" class="text-[10px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white uppercase font-600" placeholder="ID" />
-                                                <input type="text" x-model="level.label" class="col-span-2 text-sm px-2 py-1.5 rounded-md border border-surface-200 bg-white font-500" placeholder="Label" />
-                                                <input type="text" x-model="level.abbreviation" class="text-[10px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white" placeholder="Abbr" />
-                                            </div>
-                                            <select x-model="level.severity" class="text-[10px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white">
-                                                <option value="good">good</option>
-                                                <option value="marginal">marginal</option>
-                                                <option value="significant">significant</option>
-                                                <option value="minor">minor</option>
-                                            </select>
-                                            <label class="flex items-center gap-1 text-[10px] text-ink-400 whitespace-nowrap">
-                                                <input type="checkbox" x-model="level.isDefect" class="w-3 h-3 rounded" /> defect
-                                            </label>
-                                            <label class="flex items-center gap-1 text-[10px] text-ink-400 whitespace-nowrap">
-                                                <input type="radio" name="default_level" x-bind:value="level.id" x-model="template.ratingSystem.defaultLevelId" class="w-3 h-3" /> default
-                                            </label>
-                                            <button {...{'@click': 'template.ratingSystem.levels.splice(li, 1)'}} class="text-ink-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100">
-                                                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" d="M6 18L18 6M6 6l12 12"/></svg>
-                                            </button>
-                                        </div>
-                                        <input type="text"
-                                            x-model="level.description"
-                                            aria-label="Level description"
-                                            maxlength={120}
-                                            class="w-full text-xs px-2 py-1.5 rounded-md border border-surface-200 bg-white text-ink-600"
-                                            placeholder="Description (shown in tooltip & onboarding)" />
-                                    </div>
+                {/* Rating System Modal — single-button (Close) footer, inlined. */}
+                <Modal
+                    name="showRatingModal"
+                    title="Rating System"
+                    subtitle="Configure the rating levels for this template"
+                    size="xl"
+                    footer={
+                        <button
+                            type="button"
+                            {...{'@click': 'showRatingModal = false'}}
+                            class="h-10 px-6 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                            style="border-color: #e2e8f0"
+                        >
+                            Close
+                        </button>
+                    }
+                >
+                    <div class="space-y-4">
+                        <div class="space-y-2">
+                            <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Preset</label>
+                            <div class="flex flex-wrap gap-2">
+                                <template x-for="preset in ratingPresets" x-bind:key="preset.name">
+                                    <button {...{'@click': 'applyRatingPreset(preset)'}} class="px-3 py-1.5 text-sm rounded-lg border transition-colors"
+                                        x-bind:class="template.ratingSystem.name === preset.name ? 'border-blueprint-500 bg-blueprint-50 text-blueprint-700 font-600' : 'border-surface-200 text-ink-500 hover:border-surface-300'"
+                                        x-text="preset.name"></button>
                                 </template>
                             </div>
                         </div>
-                        <div class="px-8 py-5 border-t border-surface-100 flex justify-end gap-3">
-                            <button {...{'@click': 'showRatingModal = false'}} class="px-5 py-2.5 rounded-xl text-sm font-600 text-ink-500 hover:bg-surface-100 transition-colors">Close</button>
+                        <hr class="border-surface-100" />
+                        <div class="space-y-1.5">
+                            <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">System Name</label>
+                            <input type="text" x-model="template.ratingSystem.name" class="w-full px-3 py-2.5 text-sm font-500 rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors" />
+                        </div>
+                        <div class="space-y-2">
+                            <div class="flex items-center justify-between">
+                                <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Levels</label>
+                                <button {...{'@click': 'addRatingLevel()'}} class="text-[10px] font-600 text-blueprint-600 hover:text-blueprint-700 flex items-center gap-1">
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" d="M12 5v14m7-7H5"/></svg>
+                                    Add Level
+                                </button>
+                            </div>
+                            <template x-for="(level, li) in template.ratingSystem.levels" x-bind:key="level.id">
+                                <div class="space-y-2 p-3 rounded-xl bg-surface-50 group animate-scale-in">
+                                    <div class="flex items-center gap-3">
+                                        <input type="color" x-model="level.color" class="w-8 h-8 rounded-lg border-0 cursor-pointer" />
+                                        <div class="flex-1 grid grid-cols-4 gap-2">
+                                            <input type="text" x-model="level.id" class="text-[10px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white uppercase font-600" placeholder="ID" />
+                                            <input type="text" x-model="level.label" class="col-span-2 text-sm px-2 py-1.5 rounded-md border border-surface-200 bg-white font-500" placeholder="Label" />
+                                            <input type="text" x-model="level.abbreviation" class="text-[10px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white" placeholder="Abbr" />
+                                        </div>
+                                        <select x-model="level.severity" class="text-[10px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white">
+                                            <option value="good">good</option>
+                                            <option value="marginal">marginal</option>
+                                            <option value="significant">significant</option>
+                                            <option value="minor">minor</option>
+                                        </select>
+                                        <label class="flex items-center gap-1 text-[10px] text-ink-400 whitespace-nowrap">
+                                            <input type="checkbox" x-model="level.isDefect" class="w-3 h-3 rounded" /> defect
+                                        </label>
+                                        <label class="flex items-center gap-1 text-[10px] text-ink-400 whitespace-nowrap">
+                                            <input type="radio" name="default_level" x-bind:value="level.id" x-model="template.ratingSystem.defaultLevelId" class="w-3 h-3" /> default
+                                        </label>
+                                        <button {...{'@click': 'template.ratingSystem.levels.splice(li, 1)'}} class="text-ink-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100">
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                                        </button>
+                                    </div>
+                                    <input type="text"
+                                        x-model="level.description"
+                                        aria-label="Level description"
+                                        maxlength={120}
+                                        class="w-full text-xs px-2 py-1.5 rounded-md border border-surface-200 bg-white text-ink-600"
+                                        placeholder="Description (shown in tooltip & onboarding)" />
+                                </div>
+                            </template>
                         </div>
                     </div>
-                </div>
+                </Modal>
 
                 {/* Canned Comments Slide Panel */}
                 <div x-show="showCannedPanel" x-cloak

--- a/src/templates/pages/templates.tsx
+++ b/src/templates/pages/templates.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '../layouts/main-layout';
+import { Modal, ModalFooter } from '../components/modal';
 import { BrandingConfig } from '../../types/auth';
 
 export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
@@ -49,40 +50,31 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                 </div>
 
                 {/* Create Template Modal */}
-                <div id="createModal" class="fixed inset-0 z-[100] hidden overflow-y-auto px-4 py-6 sm:px-0">
-                    <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-md transition-opacity" onclick="closeModal()"></div>
-                    <div class="flex min-h-full items-center justify-center">
-                        <div role="dialog" aria-modal="true" class="relative w-full max-w-xl transform overflow-hidden rounded-xl bg-white p-6 text-left shadow-[0_35px_60px_-15px_rgba(0,0,0,0.3)] animate-slide-in">
-                            <div class="absolute top-8 right-8">
-                                <button onclick="closeModal()" aria-label="Close dialog" class="p-3 text-slate-400 hover:text-slate-900 rounded-2xl hover:bg-slate-50 transition-all active:scale-95">
-                                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                                </button>
-                            </div>
-                            <div class="mb-6">
-                                <h3 class="text-xl font-bold text-slate-900 mb-3 tracking-tight leading-tight">New Template</h3>
-                                <p class="text-lg text-slate-400 font-medium">Create an inspection checklist.</p>
-                            </div>
-                            <div class="space-y-4">
-                                <div class="space-y-2">
-                                    <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Template Name</label>
-                                    <input type="text" id="tplName" placeholder="e.g., Luxury Residential Standard"
-                                        class="premium-input w-full px-3 py-2.5 rounded-2xl border-2 border-slate-100 focus:border-indigo-600 focus:ring-4 focus:ring-indigo-50 outline-none transition-all font-semibold" />
-                                </div>
-                                <p class="text-sm text-slate-400 font-medium leading-relaxed">
-                                    After creating the template, you will be taken to the visual editor where you can add sections and inspection items.
-                                </p>
-                                <div class="pt-4 flex gap-6">
-                                    <button type="button" onclick="closeModal()" class="flex-1 py-4.5 rounded-2xl font-black text-slate-400 hover:text-slate-900 transition-all uppercase text-[10px] tracking-widest">
-                                        Cancel
-                                    </button>
-                                    <button type="button" onclick="submitTemplate()" id="submitTplBtn" class="flex-[2] premium-button py-4.5 rounded-2xl bg-indigo-600 text-white font-bold shadow-md hover:bg-indigo-700 active:scale-95 transition-all">
-                                        Create Template
-                                    </button>
-                                </div>
-                            </div>
+                <Modal
+                    id="createModal"
+                    title="New Template"
+                    subtitle="Create an inspection checklist."
+                    size="xl"
+                    footer={
+                        <ModalFooter
+                            onCancelJs="closeModal()"
+                            onConfirmJs="submitTemplate()"
+                            confirmText="Create Template"
+                            confirmId="submitTplBtn"
+                        />
+                    }
+                >
+                    <div class="space-y-4">
+                        <div class="space-y-2">
+                            <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Template Name</label>
+                            <input type="text" id="tplName" placeholder="e.g., Luxury Residential Standard"
+                                class="premium-input w-full px-3 py-2.5 rounded-2xl border-2 border-slate-100 focus:border-indigo-600 focus:ring-4 focus:ring-indigo-50 outline-none transition-all font-semibold" />
                         </div>
+                        <p class="text-sm text-slate-400 font-medium leading-relaxed">
+                            After creating the template, you will be taken to the visual editor where you can add sections and inspection items.
+                        </p>
                     </div>
-                </div>
+                </Modal>
 
                 <script src="/js/modal-dialog.js"></script>
                 <script src="/js/auth.js"></script>

--- a/src/templates/pages/verify.tsx
+++ b/src/templates/pages/verify.tsx
@@ -7,6 +7,8 @@
  * "vendor must testify to its own integrity" weakness).
  */
 
+import { BareLayout } from '../layouts/main-layout';
+
 interface VerifierEvent {
     event: string;
     createdAtUtc: string;
@@ -40,13 +42,12 @@ function shortHash(hex: string | null): string {
 export function VerifyPage(props: VerifierProps): JSX.Element {
     if (!props.found) {
         return (
-            <html>
-                <head><meta charSet="utf-8" /><title>Envelope not found · Verify</title></head>
-                <body style="font-family:Inter,sans-serif;padding:48px;text-align:center;color:#475569">
-                    <h1 style="font-size:20px;font-weight:700;color:#dc2626">Envelope not found</h1>
+            <BareLayout title={`Envelope not found · Verify · ${props.siteName}`}>
+                <div style="padding:48px;text-align:center;color:var(--ih-fg-2, #475569)">
+                    <h1 style="font-size:20px;font-weight:700;color:#dc2626">Envelope not found</h1> {/* dc2626: no token equivalent */}
                     <p style="margin-top:8px">The envelope ID <code>{props.envelopeId}</code> does not exist.</p>
-                </body>
-            </html>
+                </div>
+            </BareLayout>
         );
     }
     return (
@@ -56,29 +57,29 @@ export function VerifyPage(props: VerifierProps): JSX.Element {
                 <title>Verify {props.envelopeId.slice(0, 8)} · {props.siteName}</title>
                 <style dangerouslySetInnerHTML={{ __html: `
                     *{box-sizing:border-box}
-                    body{font-family:-apple-system,BlinkMacSystemFont,Inter,sans-serif;color:#1e293b;background:#f8fafc;margin:0;padding:32px}
+                    body{font-family:-apple-system,BlinkMacSystemFont,Inter,sans-serif;color:var(--ih-slate-800, #1e293b);background:var(--ih-bg-app, #f8fafc);margin:0;padding:32px}
                     .container{max-width:760px;margin:0 auto}
                     .verdict{padding:18px 24px;border-radius:8px;border:1px solid;font-weight:600;font-size:14px;margin-bottom:24px;display:flex;align-items:center;gap:12px}
-                    .verdict.valid{background:#ecfdf5;border-color:#a7f3d0;color:#065f46}
-                    .verdict.invalid{background:#fef2f2;border-color:#fecaca;color:#991b1b}
+                    .verdict.valid{background:var(--ih-status-ok-bg, #ecfdf5);border-color:#a7f3d0;color:var(--ih-status-ok-fg, #047857)} /* a7f3d0: no token equivalent */
+                    .verdict.invalid{background:var(--ih-status-bad-bg, #fef2f2);border-color:#fecaca;color:#991b1b} /* fecaca, 991b1b: no token equivalent */
                     .icon{font-size:20px}
-                    .panel{background:#fff;border:1px solid #e2e8f0;border-radius:8px;padding:20px 24px;margin-bottom:16px}
-                    .panel-title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:#64748b;margin:0 0 12px}
+                    .panel{background:var(--ih-bg-card, #fff);border:1px solid var(--ih-slate-200, #e2e8f0);border-radius:8px;padding:20px 24px;margin-bottom:16px}
+                    .panel-title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;color:var(--ih-fg-3, #64748b);margin:0 0 12px}
                     .row{display:grid;grid-template-columns:160px 1fr;gap:12px;margin-bottom:6px}
-                    .row-key{font-size:12px;color:#64748b}
-                    .row-val{font-size:13px;color:#1e293b;word-break:break-all}
+                    .row-key{font-size:12px;color:var(--ih-fg-3, #64748b)}
+                    .row-val{font-size:13px;color:var(--ih-slate-800, #1e293b);word-break:break-all}
                     .row-val.mono{font-family:"JetBrains Mono",ui-monospace,monospace;font-size:11px}
                     table.events{width:100%;border-collapse:collapse;font-size:12px}
-                    table.events th{text-align:left;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:#64748b;padding:6px 8px;border-bottom:1px solid #e2e8f0;font-size:9px}
-                    table.events td{padding:8px;border-bottom:1px solid #f1f5f9;vertical-align:top}
-                    .evt-ok{color:#10b981}
-                    .evt-bad{color:#ef4444}
+                    table.events th{text-align:left;font-weight:700;text-transform:uppercase;letter-spacing:0.06em;color:var(--ih-fg-3, #64748b);padding:6px 8px;border-bottom:1px solid var(--ih-slate-200, #e2e8f0);font-size:9px}
+                    table.events td{padding:8px;border-bottom:1px solid var(--ih-bg-muted, #f1f5f9);vertical-align:top}
+                    .evt-ok{color:var(--ih-status-ok, #10b981)}
+                    .evt-bad{color:var(--ih-status-bad, #ef4444)}
                     .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px}
-                    .btn{display:inline-flex;align-items:center;justify-content:center;height:32px;padding:0 14px;border-radius:6px;font-size:12px;font-weight:600;text-decoration:none;border:1px solid #e2e8f0;color:#1e293b;background:#fff}
-                    .btn:hover{background:#f1f5f9}
-                    .footer{margin-top:32px;padding-top:16px;border-top:1px solid #e2e8f0;font-size:10px;color:#64748b;line-height:1.6}
-                    code{background:#f1f5f9;padding:1px 6px;border-radius:4px;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:11px}
-                    pre{background:#0f172a;color:#e2e8f0;padding:12px;border-radius:6px;font-size:11px;overflow-x:auto;line-height:1.5}
+                    .btn{display:inline-flex;align-items:center;justify-content:center;height:32px;padding:0 14px;border-radius:6px;font-size:12px;font-weight:600;text-decoration:none;border:1px solid var(--ih-slate-200, #e2e8f0);color:var(--ih-slate-800, #1e293b);background:var(--ih-bg-card, #fff)}
+                    .btn:hover{background:var(--ih-bg-muted, #f1f5f9)}
+                    .footer{margin-top:32px;padding-top:16px;border-top:1px solid var(--ih-slate-200, #e2e8f0);font-size:10px;color:var(--ih-fg-3, #64748b);line-height:1.6}
+                    code{background:var(--ih-bg-muted, #f1f5f9);padding:1px 6px;border-radius:4px;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:11px}
+                    pre{background:var(--ih-slate-900, #0f172a);color:var(--ih-slate-200, #e2e8f0);padding:12px;border-radius:6px;font-size:11px;overflow-x:auto;line-height:1.5}
                 `}} />
             </head>
             <body>
@@ -106,7 +107,7 @@ export function VerifyPage(props: VerifierProps): JSX.Element {
                             <tbody>
                                 {props.events.map((ev, i) => (
                                     <tr key={i}>
-                                        <td style="font-family:monospace;font-size:11px;color:#475569;white-space:nowrap">{ev.createdAtUtc}</td>
+                                        <td style="font-family:monospace;font-size:11px;color:var(--ih-fg-2, #475569);white-space:nowrap">{ev.createdAtUtc}</td>
                                         <td style="font-weight:600">{ev.event}</td>
                                         <td class="row-val mono">{shortHash(ev.hash)}</td>
                                         <td class={ev.valid ? 'evt-ok' : 'evt-bad'} style="font-weight:600">{ev.valid ? '✓ valid' : '✗ invalid'}</td>
@@ -130,7 +131,7 @@ export function VerifyPage(props: VerifierProps): JSX.Element {
 
                     <div class="panel">
                         <h2 class="panel-title">Verify Yourself</h2>
-                        <p style="font-size:12px;color:#475569;margin:0 0 12px">Re-run the verification offline using openssl + the public key:</p>
+                        <p style="font-size:12px;color:var(--ih-fg-2, #475569);margin:0 0 12px">Re-run the verification offline using openssl + the public key:</p>
                         <pre>{`# 1. Download public key + audit JSON\ncurl -o pubkey.pem ${props.apiBase}/api/public/verify/${props.envelopeId}/public-key\ncurl -o audit.json ${props.apiBase}/api/public/verify/${props.envelopeId}/audit-trail\n\n# 2. For each event in audit.json, decode hash + signature, then:\n#   openssl pkeyutl -verify -pubin -inkey pubkey.pem \\\n#     -sigfile event.sig -in event.hash`}</pre>
                     </div>
 

--- a/src/types/alpine-jsx.d.ts
+++ b/src/types/alpine-jsx.d.ts
@@ -39,6 +39,7 @@ declare global {
             'x-on:click.self'?: string;
             'x-on:click.stop'?: string;
             'x-on:click.outside'?: string;
+            'x-on:keydown.escape.window'?: string;
             'x-on:submit'?: string;
             'x-on:input'?: string;
             'x-on:input.debounce.500ms'?: string;

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -1,0 +1,15 @@
+/**
+ * Spec 2026-05-07 — Comments Library unification.
+ *
+ * `ratingBucket` classifies a saved user snippet so it stacks alongside
+ * the 248 seeded entries in `public/js/canned-comments.js` inside the
+ * inspection-edit Library drawer. Mirrors the `rating` field on those
+ * seeded entries (`'satisfactory' | 'monitor' | 'defect' | 'all'`), but
+ * uses `null` for the "general / uncategorized" case so the column is
+ * trivially nullable in D1 (the seeded library uses the literal string
+ * `'all'` for the same idea).
+ */
+export type RatingBucket = 'satisfactory' | 'monitor' | 'defect';
+
+/** Whitelist used by Zod enum + UI tabs. */
+export const RATING_BUCKETS = ['satisfactory', 'monitor', 'defect'] as const;

--- a/tests/unit/comments.spec.ts
+++ b/tests/unit/comments.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { eq, and } from 'drizzle-orm';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import { comments, tenants } from '../../src/lib/db/schema';
+
+/**
+ * Spec 2026-05-07 — Comments Library unification.
+ *
+ * Verifies that the new `rating_bucket` + `section` columns added in
+ * migration 0039 round-trip cleanly through Drizzle and that filter-by-bucket
+ * / filter-by-section / combined filters work the way the /api/admin/comments
+ * route expects.
+ *
+ * Smoke-tests migration backward compatibility too: rows inserted with the
+ * pre-migration shape (no bucket / no section) MUST survive and stay queryable.
+ */
+describe('comments table — rating bucket + section', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let sqlite: any;
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        testDb = setup.db;
+        sqlite = setup.sqlite;
+        await setupSchema(sqlite);
+
+        await testDb.insert(tenants).values({
+            id: 't1',
+            name: 'Test Tenant',
+            subdomain: 'test',
+            createdAt: new Date(),
+        });
+    });
+
+    afterEach(() => {
+        sqlite.close();
+    });
+
+    it('round-trips ratingBucket and section', async () => {
+        await testDb.insert(comments).values({
+            id: 'c1',
+            tenantId: 't1',
+            text: 'Active leak observed.',
+            category: null,
+            ratingBucket: 'defect',
+            section: 'Plumbing',
+            createdAt: new Date(),
+        });
+
+        const row = await testDb.select().from(comments).where(eq(comments.id, 'c1')).get();
+        expect(row).toBeDefined();
+        expect(row!.ratingBucket).toBe('defect');
+        expect(row!.section).toBe('Plumbing');
+    });
+
+    it('keeps pre-migration rows queryable with null bucket/section', async () => {
+        // Simulate a row created before the 0039 migration shipped: no
+        // bucket or section. Both should default to null and round-trip.
+        await testDb.insert(comments).values({
+            id: 'c-legacy',
+            tenantId: 't1',
+            text: 'Legacy snippet.',
+            category: 'Roofing',
+            createdAt: new Date(),
+        });
+
+        const row = await testDb.select().from(comments).where(eq(comments.id, 'c-legacy')).get();
+        expect(row).toBeDefined();
+        expect(row!.ratingBucket).toBeNull();
+        expect(row!.section).toBeNull();
+        expect(row!.category).toBe('Roofing');
+    });
+
+    it('filters by ratingBucket + tenantId', async () => {
+        await testDb.insert(comments).values([
+            { id: 'a', tenantId: 't1', text: 'A', ratingBucket: 'satisfactory', section: null, category: null, createdAt: new Date() },
+            { id: 'b', tenantId: 't1', text: 'B', ratingBucket: 'monitor',      section: null, category: null, createdAt: new Date() },
+            { id: 'c', tenantId: 't1', text: 'C', ratingBucket: 'defect',       section: null, category: null, createdAt: new Date() },
+            { id: 'd', tenantId: 't1', text: 'D', ratingBucket: 'defect',       section: null, category: null, createdAt: new Date() },
+        ]);
+
+        const defects = await testDb.select().from(comments)
+            .where(and(eq(comments.tenantId, 't1'), eq(comments.ratingBucket, 'defect')))
+            .all();
+        expect(defects).toHaveLength(2);
+        expect(defects.map(r => r.id).sort()).toEqual(['c', 'd']);
+    });
+
+    it('filters by section + ratingBucket combined', async () => {
+        await testDb.insert(comments).values([
+            { id: 'r-sat',  tenantId: 't1', text: 'roof sat',  ratingBucket: 'satisfactory', section: 'Roof',     category: null, createdAt: new Date() },
+            { id: 'r-def',  tenantId: 't1', text: 'roof def',  ratingBucket: 'defect',       section: 'Roof',     category: null, createdAt: new Date() },
+            { id: 'p-def',  tenantId: 't1', text: 'plmb def',  ratingBucket: 'defect',       section: 'Plumbing', category: null, createdAt: new Date() },
+        ]);
+
+        const roofDefects = await testDb.select().from(comments)
+            .where(and(
+                eq(comments.tenantId, 't1'),
+                eq(comments.ratingBucket, 'defect'),
+                eq(comments.section, 'Roof'),
+            ))
+            .all();
+        expect(roofDefects).toHaveLength(1);
+        expect(roofDefects[0]!.id).toBe('r-def');
+    });
+
+    it('does not leak across tenants when filtering by bucket', async () => {
+        // Tenant isolation rule (CLAUDE.md): bucket filter alone is not
+        // enough — must always combine with tenantId.
+        await testDb.insert(tenants).values({
+            id: 't2',
+            name: 'Other Tenant',
+            subdomain: 'other',
+            createdAt: new Date(),
+        });
+        await testDb.insert(comments).values([
+            { id: 't1-def', tenantId: 't1', text: 'mine',  ratingBucket: 'defect', section: null, category: null, createdAt: new Date() },
+            { id: 't2-def', tenantId: 't2', text: 'theirs', ratingBucket: 'defect', section: null, category: null, createdAt: new Date() },
+        ]);
+
+        const mine = await testDb.select().from(comments)
+            .where(and(eq(comments.tenantId, 't1'), eq(comments.ratingBucket, 'defect')))
+            .all();
+        expect(mine).toHaveLength(1);
+        expect(mine[0]!.id).toBe('t1-def');
+    });
+});


### PR DESCRIPTION
Bundle of 4 commits from rounds R43–R46. Builds on the previous PR #19 (R33–R42).

## Highlights

### Fixes
- **R43 photo upload 404** — client was POSTing to `/api/inspections/:id/photos` (field `photo`); server is `/api/inspections/:id/upload` (field `file`). Aligned client to server.
- **R45 dashboard counters** — three bugs in computeStats(): label/data/click-target mismatched per card. Renamed cards to align ("Active Jobs"→"Upcoming", "Ready for Review"→"Needs Attention", "Completed"→"Recent Reports") and removed double-counting of recentReports.

### Audit closeouts
- **R43 P1-1** verify.tsx token bypass (24 substitutions to `var(--ih-*)` so tenant brand color propagates).
- **R43 P1-4** AtmosphericBg → no-op + removed inline `bg-indigo-500/N blur-[120px]` divs from report.template.tsx.
- **R43 P2-7** verify.tsx 404 branch wrapped in BareLayout.
- **R43 CodeQL** `js/identity-replacement` open alert: `cert.template.tsx:58` `ev.replace(/\./g, '.')` was no-op dead code.

### Design system
- **R44 unified `<Modal>` component** — single Modal + ModalFooter shipped at `src/templates/components/modal.tsx`. 16 modals across 18 files migrated (Publish, AI popover, Cancel inspection, Add event, Comment editor, Recommendation editor, Service editor, Discount editor, Event type editor, 2FA enable/disable/regenerate, Marketplace preview/update-confirm, Rating system, Annotation studio, Recommendation picker, Cancel inspection, Create inspection, Create template, Create+Send agreement, Invite team, New invoice, Contact add/edit). Lint dropped from 64 to 49 (x-cloak warnings disappear).

### Feature
- **R46 comments library unification** — D1 migration 0039 adds `rating_bucket` + `section` to `comments` table; API + UI tabbed by Sat/Mon/Def matching the inspection-edit Library drawer; drawer's MY SNIPPETS tab now pulls server snippets and surfaces them under the correct rating bucket. Closes the user-reported "/comments page has no Sat/Mon/Def categorization" inconsistency.

## Verification
- Type-check 0 errors
- 29 files / 172 vitest tests passing (+5 in R46)
- Lint 25 errors / 24 warnings (down from baseline 64; only pre-existing unrelated `any`/x-cloak findings remain)
- CSS rebuild clean

## Migration notes
- D1 migration 0039 is additive (nullable columns + index). Pre-launch system, no backfill needed.
- All modal markup follows the canonical shape; future modal additions should use `<Modal>` + `<ModalFooter>` from the new component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)