### PR TITLE
R-Handoff Spec C++: command palette, attention rules, slash trigger, mobile drawer, sidebar polish, unsaved guard

### DIFF
--- a/migrations/0040_attention_thresholds.sql
+++ b/migrations/0040_attention_thresholds.sql
@@ -1,0 +1,7 @@
+-- handoff-decisions §1: configurable attention thresholds (in hours).
+-- Stored as JSON on tenant_configs. Default 72h per spec, applied uniformly
+-- to the three categories. Per-team configurable; UI lives at
+-- Settings → Automations → Attention Rules.
+
+ALTER TABLE tenant_configs ADD COLUMN attention_thresholds TEXT
+    NOT NULL DEFAULT '{"agreement_unsigned_h":72,"invoice_overdue_h":72,"report_unpublished_h":72}';

--- a/public/js/attention-rules.js
+++ b/public/js/attention-rules.js
@@ -1,0 +1,86 @@
+// Settings → Automations → Attention Rules — handoff-decisions §1.
+// Three configurable thresholds (in hours) controlling when items show up
+// in the dashboard "Needs Attention" bucket.
+
+document.addEventListener('alpine:init', () => {
+    const DEFAULTS = { agreement_unsigned_h: 72, invoice_overdue_h: 72, report_unpublished_h: 72 };
+    const ROWS = [
+        { key: 'agreement_unsigned_h', label: 'Agreement still unsigned',  help: 'Hours since the inspection was booked without a signed agreement.' },
+        { key: 'invoice_overdue_h',    label: 'Invoice past due',           help: 'Hours past the invoice due date with no payment recorded.' },
+        { key: 'report_unpublished_h', label: 'Report not published yet',   help: 'Hours since inspection completed without the report going out.' },
+    ];
+
+    Alpine.data('attentionRules', () => ({
+        rows: ROWS,
+        values: { ...DEFAULTS },
+        original: { ...DEFAULTS },
+        loading: true,
+        saving: false,
+        saved: false,
+        saveError: '',
+
+        async init() {
+            try {
+                const res = await authFetch('/api/admin/attention-thresholds');
+                if (res.ok) {
+                    const json = await res.json();
+                    if (json?.data?.thresholds) {
+                        this.values = { ...DEFAULTS, ...json.data.thresholds };
+                        this.original = { ...this.values };
+                    }
+                }
+            } catch (e) {
+                console.warn('[attention-rules] load failed', e);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        get dirty() {
+            return ROWS.some(r => Number(this.values[r.key]) !== Number(this.original[r.key]));
+        },
+
+        onInput(key, raw) {
+            const n = parseInt(raw, 10);
+            this.values[key] = Number.isFinite(n) ? n : this.original[key];
+            this.saved = false;
+            this.saveError = '';
+        },
+
+        resetDefaults() {
+            this.values = { ...DEFAULTS };
+        },
+
+        async save() {
+            // Clamp to 1..720 client-side; server enforces too.
+            const body = {};
+            for (const r of ROWS) {
+                let n = Number(this.values[r.key]);
+                if (!Number.isFinite(n) || n < 1) n = 1;
+                if (n > 720) n = 720;
+                body[r.key] = n;
+            }
+            this.saving = true;
+            this.saveError = '';
+            try {
+                const res = await authFetch('/api/admin/attention-thresholds', {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body),
+                });
+                if (!res.ok) {
+                    const j = await res.json().catch(() => null);
+                    throw new Error(j?.error?.message || ('HTTP ' + res.status));
+                }
+                this.values = { ...body };
+                this.original = { ...body };
+                this.saved = true;
+                setTimeout(() => { this.saved = false; }, 2500);
+            } catch (e) {
+                this.saveError = e instanceof Error ? e.message : 'Failed to save';
+            } finally {
+                this.saving = false;
+            }
+        },
+    }));
+});

--- a/public/js/attention-rules.js
+++ b/public/js/attention-rules.js
@@ -2,7 +2,7 @@
 // Three configurable thresholds (in hours) controlling when items show up
 // in the dashboard "Needs Attention" bucket.
 
-document.addEventListener('alpine:init', () => {
+(function () {
     const DEFAULTS = { agreement_unsigned_h: 72, invoice_overdue_h: 72, report_unpublished_h: 72 };
     const ROWS = [
         { key: 'agreement_unsigned_h', label: 'Agreement still unsigned',  help: 'Hours since the inspection was booked without a signed agreement.' },
@@ -10,77 +10,83 @@ document.addEventListener('alpine:init', () => {
         { key: 'report_unpublished_h', label: 'Report not published yet',   help: 'Hours since inspection completed without the report going out.' },
     ];
 
-    Alpine.data('attentionRules', () => ({
-        rows: ROWS,
-        values: { ...DEFAULTS },
-        original: { ...DEFAULTS },
-        loading: true,
-        saving: false,
-        saved: false,
-        saveError: '',
+    function register() {
+        if (!window.Alpine) return;
+        Alpine.data('attentionRules', () => ({
+            rows: ROWS,
+            values: { ...DEFAULTS },
+            original: { ...DEFAULTS },
+            loading: true,
+            saving: false,
+            saved: false,
+            saveError: '',
 
-        async init() {
-            try {
-                const res = await authFetch('/api/admin/attention-thresholds');
-                if (res.ok) {
-                    const json = await res.json();
-                    if (json?.data?.thresholds) {
-                        this.values = { ...DEFAULTS, ...json.data.thresholds };
-                        this.original = { ...this.values };
+            async init() {
+                try {
+                    const res = await authFetch('/api/admin/attention-thresholds');
+                    if (res.ok) {
+                        const json = await res.json();
+                        if (json?.data?.thresholds) {
+                            this.values = { ...DEFAULTS, ...json.data.thresholds };
+                            this.original = { ...this.values };
+                        }
                     }
+                } catch (e) {
+                    console.warn('[attention-rules] load failed', e);
+                } finally {
+                    this.loading = false;
                 }
-            } catch (e) {
-                console.warn('[attention-rules] load failed', e);
-            } finally {
-                this.loading = false;
-            }
-        },
+            },
 
-        get dirty() {
-            return ROWS.some(r => Number(this.values[r.key]) !== Number(this.original[r.key]));
-        },
+            get dirty() {
+                return ROWS.some(r => Number(this.values[r.key]) !== Number(this.original[r.key]));
+            },
 
-        onInput(key, raw) {
-            const n = parseInt(raw, 10);
-            this.values[key] = Number.isFinite(n) ? n : this.original[key];
-            this.saved = false;
-            this.saveError = '';
-        },
+            onInput(key, raw) {
+                const n = parseInt(raw, 10);
+                this.values[key] = Number.isFinite(n) ? n : this.original[key];
+                this.saved = false;
+                this.saveError = '';
+            },
 
-        resetDefaults() {
-            this.values = { ...DEFAULTS };
-        },
+            resetDefaults() {
+                this.values = { ...DEFAULTS };
+            },
 
-        async save() {
-            // Clamp to 1..720 client-side; server enforces too.
-            const body = {};
-            for (const r of ROWS) {
-                let n = Number(this.values[r.key]);
-                if (!Number.isFinite(n) || n < 1) n = 1;
-                if (n > 720) n = 720;
-                body[r.key] = n;
-            }
-            this.saving = true;
-            this.saveError = '';
-            try {
-                const res = await authFetch('/api/admin/attention-thresholds', {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(body),
-                });
-                if (!res.ok) {
-                    const j = await res.json().catch(() => null);
-                    throw new Error(j?.error?.message || ('HTTP ' + res.status));
+            async save() {
+                // Clamp to 1..720 client-side; server enforces too.
+                const body = {};
+                for (const r of ROWS) {
+                    let n = Number(this.values[r.key]);
+                    if (!Number.isFinite(n) || n < 1) n = 1;
+                    if (n > 720) n = 720;
+                    body[r.key] = n;
                 }
-                this.values = { ...body };
-                this.original = { ...body };
-                this.saved = true;
-                setTimeout(() => { this.saved = false; }, 2500);
-            } catch (e) {
-                this.saveError = e instanceof Error ? e.message : 'Failed to save';
-            } finally {
-                this.saving = false;
-            }
-        },
-    }));
-});
+                this.saving = true;
+                this.saveError = '';
+                try {
+                    const res = await authFetch('/api/admin/attention-thresholds', {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(body),
+                    });
+                    if (!res.ok) {
+                        const j = await res.json().catch(() => null);
+                        throw new Error(j?.error?.message || ('HTTP ' + res.status));
+                    }
+                    this.values = { ...body };
+                    this.original = { ...body };
+                    this.saved = true;
+                    setTimeout(() => { this.saved = false; }, 2500);
+                } catch (e) {
+                    this.saveError = e instanceof Error ? e.message : 'Failed to save';
+                } finally {
+                    this.saving = false;
+                }
+            },
+        }));
+    }
+
+    if (window.Alpine) register();
+    else document.addEventListener('alpine:init', register);
+})();

--- a/public/js/command-palette.js
+++ b/public/js/command-palette.js
@@ -99,7 +99,8 @@
         return parts.join(', ') || (insp.id ? `Inspection #${String(insp.id).slice(0, 6)}` : 'Inspection');
     }
 
-    document.addEventListener('alpine:init', () => {
+    function register() {
+        if (!window.Alpine) return;
         Alpine.data('commandPalette', () => ({
             open: false,
             loading: false,
@@ -309,5 +310,10 @@
                 }
             },
         }));
-    });
+    }
+
+    // The script may load before or after Alpine starts (defer ordering),
+    // so cover both paths.
+    if (window.Alpine) register();
+    else document.addEventListener('alpine:init', register);
 })();

--- a/public/js/command-palette.js
+++ b/public/js/command-palette.js
@@ -57,6 +57,7 @@
         { label: 'Settings · Embed Widget',        href: '/settings/catalog/widget' },
         { label: 'Settings · Email',               href: '/settings/communication/email' },
         { label: 'Settings · Automations',         href: '/settings/communication/automations' },
+        { label: 'Settings · Attention Rules',     href: '/settings/communication/automations#attention-rules' },
         { label: 'Settings · Apple Calendar',      href: '/settings/communication/calendar' },
         { label: 'Settings · Integrations',        href: '/settings/communication/integrations' },
         { label: 'Settings · Change Password',     href: '/settings/account/password' },

--- a/public/js/command-palette.js
+++ b/public/js/command-palette.js
@@ -269,6 +269,18 @@
                     }));
                 }
 
+                // Sort groups by their best item score so the most relevant
+                // group surfaces first (e.g. "attention" → Settings before
+                // Comment snippets even though comment snippets were collected
+                // earlier). Empty query keeps original order.
+                if (q) {
+                    out.sort((a, b) => {
+                        const aBest = a.items[0]?._score ?? 0;
+                        const bBest = b.items[0]?._score ?? 0;
+                        return bBest - aBest;
+                    });
+                }
+
                 // Re-index all items into a flat highlight order.
                 let n = 0;
                 for (const g of out) {

--- a/public/js/command-palette.js
+++ b/public/js/command-palette.js
@@ -1,0 +1,313 @@
+// ⌘K Command Palette data — handoff-decisions §3.
+//
+// Sources merged into a single ranked list:
+//   - Top-level pages + Settings sub-pages (always-on, instant)
+//   - Recent inspections (lazy-loaded once)
+//   - Contacts (search hits /api/contacts on every keystroke, debounced)
+//   - Comment-library snippets (lazy-loaded once)
+//   - Create actions (always-on)
+//
+// Prefix filters:
+//   ">" → actions only
+//   "@" → people only (contacts)
+//
+// Keyboard:
+//   ↑↓ navigates, Enter activates, Esc closes (window-level).
+//
+// Requires Alpine + same-origin auth cookie (uses authFetch from auth.js).
+
+(function () {
+    'use strict';
+
+    // ───────── Static sources ─────────
+
+    const ICONS = {
+        page: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>',
+        gear:    '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 002.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>',
+        plus:    '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>',
+        person:  '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>',
+        clip:    '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>',
+        chat:    '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-4 4v-4z"/></svg>',
+    };
+
+    const PAGES = [
+        { label: 'Inspections',    href: '/dashboard',       hint: 'G then I' },
+        { label: 'Reports',        href: '/reports',         hint: 'G then R' },
+        { label: 'Templates',      href: '/templates',       hint: 'G then T' },
+        { label: 'Marketplace',    href: '/marketplace' },
+        { label: 'Agreements',     href: '/agreements' },
+        { label: 'Comments',       href: '/comments' },
+        { label: 'Recommendations',href: '/recommendations' },
+        { label: 'Contacts',       href: '/contacts',        hint: 'G then C' },
+        { label: 'Calendar',       href: '/calendar' },
+        { label: 'Invoices',       href: '/invoices' },
+        { label: 'Team',           href: '/team' },
+        { label: 'Metrics',        href: '/metrics' },
+        { label: 'Notifications',  href: '/notifications' },
+    ];
+
+    const SETTINGS_PAGES = [
+        { label: 'Settings',                       href: '/settings' },
+        { label: 'Settings · Profile',             href: '/settings/profile' },
+        { label: 'Settings · Branding',            href: '/settings/workspace/branding' },
+        { label: 'Settings · Report Theme',        href: '/settings/workspace/theme' },
+        { label: 'Settings · Telemetry',           href: '/settings/workspace/telemetry' },
+        { label: 'Settings · Services & Pricing',  href: '/settings/catalog/services' },
+        { label: 'Settings · Event Types',         href: '/settings/catalog/event-types' },
+        { label: 'Settings · Embed Widget',        href: '/settings/catalog/widget' },
+        { label: 'Settings · Email',               href: '/settings/communication/email' },
+        { label: 'Settings · Automations',         href: '/settings/communication/automations' },
+        { label: 'Settings · Apple Calendar',      href: '/settings/communication/calendar' },
+        { label: 'Settings · Integrations',        href: '/settings/communication/integrations' },
+        { label: 'Settings · Change Password',     href: '/settings/account/password' },
+        { label: 'Settings · Two-factor (2FA)',    href: '/settings/account/security' },
+        { label: 'Settings · Bot Protection',      href: '/settings/account/bot-protection' },
+        { label: 'Settings · Payments',            href: '/settings/advanced/payments' },
+        { label: 'Settings · AI',                  href: '/settings/advanced/ai' },
+        { label: 'Settings · Data Import / Export',href: '/settings/advanced/data' },
+    ];
+
+    const ACTIONS = [
+        { label: 'New inspection',  hint: 'create', run: () => { window.location.href = '/dashboard?new=1'; } },
+        { label: 'New template',    hint: 'create', run: () => { window.location.href = '/templates?new=1'; } },
+        { label: 'New contact',     hint: 'create', run: () => { window.location.href = '/contacts?new=1'; } },
+        { label: 'New comment snippet', hint: 'create', run: () => { window.location.href = '/comments?new=1'; } },
+        { label: 'Sign out',        hint: 'action', run: () => { document.getElementById('logoutBtn')?.click(); } },
+    ];
+
+    // ───────── Fuzzy ranking ─────────
+    // Subsequence match with bonus for prefix and word-boundary hits.
+    function score(label, query) {
+        if (!query) return 1;
+        const l = label.toLowerCase();
+        const q = query.toLowerCase();
+        if (l === q) return 1000;
+        if (l.startsWith(q)) return 500 + (q.length / l.length) * 100;
+        const idx = l.indexOf(q);
+        if (idx >= 0) return 200 + (q.length / l.length) * 100 - idx;
+        // Subsequence fallback
+        let li = 0, qi = 0, hits = 0;
+        while (li < l.length && qi < q.length) {
+            if (l[li] === q[qi]) { hits++; qi++; }
+            li++;
+        }
+        return qi === q.length ? hits : -1;
+    }
+
+    function fmtAddress(insp) {
+        const parts = [insp.address1, insp.city, insp.state].filter(Boolean);
+        return parts.join(', ') || (insp.id ? `Inspection #${String(insp.id).slice(0, 6)}` : 'Inspection');
+    }
+
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('commandPalette', () => ({
+            open: false,
+            loading: false,
+            query: '',
+            highlighted: 0,
+            // lazy-loaded sources
+            _recentInspections: null,
+            _snippets: null,
+            // contacts is keystroke-driven, no cache
+            _contacts: [],
+            _contactsTimer: null,
+            // grouped output (computed on demand)
+            groups: [],
+
+            init() {
+                // Build initial groups synchronously so the empty state shows
+                // page + action results.
+                this.recompute();
+                this.$watch('query', () => this.onQueryChange());
+                this.$watch('open', (v) => {
+                    if (v) {
+                        this.query = '';
+                        this.highlighted = 0;
+                        this.recompute();
+                        this.lazyLoad();
+                    }
+                });
+            },
+
+            async lazyLoad() {
+                if (this._recentInspections === null) {
+                    this._recentInspections = [];
+                    try {
+                        const r = await authFetch('/api/inspections?pageSize=10');
+                        if (r.ok) {
+                            const j = await r.json();
+                            this._recentInspections = (j?.data || []).slice(0, 10);
+                            this.recompute();
+                        }
+                    } catch {}
+                }
+                if (this._snippets === null) {
+                    this._snippets = [];
+                    try {
+                        const r = await authFetch('/api/admin/comments');
+                        if (r.ok) {
+                            const j = await r.json();
+                            this._snippets = (j?.data?.comments || []).slice(0, 50);
+                            this.recompute();
+                        }
+                    } catch {}
+                }
+            },
+
+            onQueryChange() {
+                this.recompute();
+                this.maybeSearchContacts();
+            },
+
+            maybeSearchContacts() {
+                const q = this.query.replace(/^@\s*/, '').trim();
+                if (q.length < 2) {
+                    this._contacts = [];
+                    this.recompute();
+                    return;
+                }
+                if (this._contactsTimer) clearTimeout(this._contactsTimer);
+                this._contactsTimer = setTimeout(async () => {
+                    try {
+                        const r = await authFetch('/api/contacts?search=' + encodeURIComponent(q) + '&limit=10');
+                        if (r.ok) {
+                            const j = await r.json();
+                            this._contacts = (j?.data?.contacts || []).slice(0, 10);
+                            this.recompute();
+                        }
+                    } catch {}
+                }, 150);
+            },
+
+            recompute() {
+                const raw = this.query.trim();
+                const isActions = raw.startsWith('>');
+                const isPeople = raw.startsWith('@');
+                const q = raw.replace(/^[>@]\s*/, '');
+
+                const out = [];
+
+                const collect = (label, items, build) => {
+                    const ranked = items
+                        .map((src) => {
+                            const item = build(src);
+                            const s = score(item.label, q);
+                            return s < 0 ? null : { ...item, _score: s };
+                        })
+                        .filter(Boolean)
+                        .sort((a, b) => b._score - a._score)
+                        .slice(0, 8);
+                    if (ranked.length) out.push({ label, items: ranked });
+                };
+
+                if (isActions) {
+                    collect('Actions', ACTIONS, (a) => ({
+                        kind: 'action',
+                        label: a.label,
+                        hint: a.hint,
+                        iconHtml: ICONS.plus,
+                        run: a.run,
+                    }));
+                } else if (isPeople) {
+                    collect('People', this._contacts, (c) => ({
+                        kind: 'contact',
+                        label: c.name + (c.email ? ' · ' + c.email : ''),
+                        hint: c.type,
+                        iconHtml: ICONS.person,
+                        run: () => { window.location.href = '/contacts?id=' + encodeURIComponent(c.id); },
+                    }));
+                } else {
+                    collect('Pages', PAGES, (p) => ({
+                        kind: 'page',
+                        label: p.label,
+                        hint: p.hint || '',
+                        iconHtml: ICONS.page,
+                        run: () => { window.location.href = p.href; },
+                    }));
+
+                    collect('Recent inspections', this._recentInspections || [], (i) => ({
+                        kind: 'inspection',
+                        label: fmtAddress(i),
+                        hint: i.status || '',
+                        iconHtml: ICONS.clip,
+                        run: () => { window.location.href = '/inspections/' + i.id + '/edit'; },
+                    }));
+
+                    collect('People', this._contacts, (c) => ({
+                        kind: 'contact',
+                        label: c.name + (c.email ? ' · ' + c.email : ''),
+                        hint: c.type,
+                        iconHtml: ICONS.person,
+                        run: () => { window.location.href = '/contacts?id=' + encodeURIComponent(c.id); },
+                    }));
+
+                    collect('Comment snippets', this._snippets || [], (s) => ({
+                        kind: 'snippet',
+                        label: s.text || s.title || '(snippet)',
+                        hint: s.section || '',
+                        iconHtml: ICONS.chat,
+                        // Snippets aren't directly addressable — jump to the library page.
+                        run: () => { window.location.href = '/comments?id=' + encodeURIComponent(s.id); },
+                    }));
+
+                    collect('Settings', SETTINGS_PAGES, (p) => ({
+                        kind: 'settings',
+                        label: p.label,
+                        hint: '',
+                        iconHtml: ICONS.gear,
+                        run: () => { window.location.href = p.href; },
+                    }));
+
+                    collect('Actions', ACTIONS, (a) => ({
+                        kind: 'action',
+                        label: a.label,
+                        hint: a.hint,
+                        iconHtml: ICONS.plus,
+                        run: a.run,
+                    }));
+                }
+
+                // Re-index all items into a flat highlight order.
+                let n = 0;
+                for (const g of out) {
+                    for (const it of g.items) {
+                        it._idx = n++;
+                        // Stable id so x-for can key.
+                        it.id = it.kind + ':' + it._idx + ':' + it.label;
+                    }
+                }
+                this.groups = out;
+                if (this.highlighted >= n) this.highlighted = 0;
+            },
+
+            flatItems() {
+                const out = [];
+                for (const g of this.groups) for (const it of g.items) out.push(it);
+                return out;
+            },
+
+            setHighlight(i) { this.highlighted = i; },
+
+            onKeydown(e) {
+                const flat = this.flatItems();
+                if (e.key === 'ArrowDown') {
+                    this.highlighted = Math.min(this.highlighted + 1, flat.length - 1);
+                    e.preventDefault();
+                } else if (e.key === 'ArrowUp') {
+                    this.highlighted = Math.max(this.highlighted - 1, 0);
+                    e.preventDefault();
+                } else if (e.key === 'Enter') {
+                    const item = flat[this.highlighted];
+                    if (item) { this.run(item); e.preventDefault(); }
+                }
+            },
+
+            run(item) {
+                this.open = false;
+                if (typeof item.run === 'function') {
+                    setTimeout(() => item.run(), 0);
+                }
+            },
+        }));
+    });
+})();

--- a/public/js/hotkeys.js
+++ b/public/js/hotkeys.js
@@ -1,0 +1,35 @@
+// Shared keyboard helpers — handoff-decisions §2.
+//
+// Single-letter and single-symbol shortcuts MUST be ignored when the user is
+// typing into an input, textarea or contenteditable region. Any global hotkey
+// handler (KeyboardHUD, command palette, page-level rating keys, etc.) should
+// gate on `isTyping()` before reacting to a bare character.
+//
+// Combos with a real modifier (Cmd/Ctrl/Meta + letter, Esc) stay live so power
+// users can still trigger ⌘K / ⌘S / Esc while typing.
+
+(function () {
+    'use strict';
+
+    function isTyping(target) {
+        const el = target || document.activeElement;
+        if (!el) return false;
+        const tag = el.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+        if (el.isContentEditable) return true;
+        return false;
+    }
+
+    function hasNonShiftModifier(event) {
+        return event.metaKey || event.ctrlKey || event.altKey;
+    }
+
+    // Convenience: returns true if the key event should be ignored as a
+    // "single character while typing" — i.e. user is in an input AND the
+    // event has no real modifier other than Shift.
+    function shouldIgnoreSingleChar(event) {
+        return isTyping(event.target) && !hasNonShiftModifier(event);
+    }
+
+    window.OIHotkeys = { isTyping, hasNonShiftModifier, shouldIgnoreSingleChar };
+})();

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -1229,6 +1229,9 @@ function inspectionEditor(inspectionId) {
     debounceSave() {
       clearTimeout(this.saveTimer);
       this.saveState = 'saving';
+      // handoff §7 — mark dirty so the unsaved-guard guards browser close
+      // and in-app nav until saveResults flips it back.
+      window.OIDirty?.set?.(true);
       this.saveTimer = setTimeout(() => this.saveResults(), 1000);
     },
 
@@ -1241,6 +1244,7 @@ function inspectionEditor(inspectionId) {
           body: JSON.stringify({ data: this.results }),
         });
         this.saveState = res.ok ? 'saved' : 'error';
+        if (res.ok) window.OIDirty?.set?.(false);
       } catch (e) {
         console.error('Failed to save results:', e);
         this.saveState = 'error';

--- a/public/js/slash-trigger.js
+++ b/public/js/slash-trigger.js
@@ -4,9 +4,15 @@
 // character) and a comment-library picker opens 150ms later. ESC, backspace,
 // or blur cancels. Pure character-position check — no soft-line-start.
 //
-// Wire it on a textarea by adding the Alpine x-data binding:
-//   <textarea x-data="slashSnippet({ section: 'roof', rating: 'defect' })" ...>
-// `section` and `rating` filter the snippet library; both are optional.
+// Wire it on a textarea by adding the data attribute:
+//   <textarea data-slash-trigger="true"
+//             data-slash-section="Roof"        (optional)
+//             data-slash-rating="defect" ...>  (optional)
+//
+// Vanilla DOM (no Alpine.data) so it composes cleanly with parent x-data
+// scopes — the existing form-renderer textarea wraps in `x-data="form"`
+// and uses `x-model="results[item.id].notes"`; we just attach listeners
+// to the same element without owning its data.
 //
 // Requires window.OIHotkeys (loaded by hotkeys.js, before Alpine).
 
@@ -38,166 +44,232 @@
         }
     }
 
-    function init() {
-        if (!window.Alpine) return;
+    // Per-textarea state. Stored on the element so a re-attach is a no-op.
+    function attach(ta) {
+        if (ta.__slashAttached) return;
+        ta.__slashAttached = true;
 
-        // Re-export the helper so other code (tests, other Alpine plugins) can use it.
-        window.OISlashTrigger = { isLineStart };
+        // Read config lazily — Alpine x-bind:data-* may not have set the
+        // attribute when attach() runs (MutationObserver can fire before
+        // Alpine flushes its bindings).
+        const readConfig = () => ({
+            section: ta.dataset.slashSection || undefined,
+            rating: ta.dataset.slashRating || undefined,
+        });
 
-        Alpine.data('slashSnippet', (config = {}) => ({
-            open: false,
-            loading: false,
-            items: [],
+        const state = {
+            slashPos: -1,
+            filter: '',
+            debounceTimer: null,
+            allItems: [],
+            visibleItems: [],
             highlighted: 0,
-            // Position the picker absolutely below the textarea — caller wraps
-            // the <textarea> in a `position: relative` parent so x-show works.
-            anchorTop: 0,
-            anchorLeft: 0,
-            // Internals
-            _slashPos: -1,
-            _debounceTimer: null,
-            _filter: '',
+            picker: null,
+            isOpen: false,
+        };
+        ta.__slashState = state;
 
-            init() {
-                this.$el.addEventListener('keydown', (e) => this.onKeydown(e));
-                this.$el.addEventListener('input', () => this.onInput());
-                this.$el.addEventListener('blur', () => {
-                    // Slight delay so click on a picker item still registers.
-                    setTimeout(() => { this.close(); }, 100);
+        function ensurePicker() {
+            if (state.picker) return state.picker;
+            const parent = ta.parentElement;
+            if (!parent) return null;
+            // Caller is expected to provide a `position: relative` parent
+            // (form-renderer's `<div class="relative group mb-8">` qualifies).
+            const p = document.createElement('div');
+            p.className = 'oi-slash-picker absolute z-50 bg-white rounded-xl shadow-2xl border border-slate-200 overflow-hidden hidden';
+            p.style.minWidth = '320px';
+            p.style.maxWidth = '480px';
+            p.setAttribute('role', 'listbox');
+            const header = document.createElement('div');
+            header.className = 'px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 bg-slate-50 border-b border-slate-100';
+            header.textContent = 'Comment library · / to search';
+            p.appendChild(header);
+            const ul = document.createElement('ul');
+            ul.className = 'max-h-72 overflow-y-auto';
+            p.appendChild(ul);
+            const footer = document.createElement('div');
+            footer.className = 'px-4 py-2 text-[10px] text-slate-400 bg-slate-50 border-t border-slate-100 flex justify-between';
+            footer.innerHTML = '<span><kbd class="px-1 py-0.5 bg-white border rounded text-[10px] font-mono">↑↓</kbd> nav · <kbd class="px-1 py-0.5 bg-white border rounded text-[10px] font-mono">⏎</kbd> insert · <kbd class="px-1 py-0.5 bg-white border rounded text-[10px] font-mono">Esc</kbd> close</span>';
+            p.appendChild(footer);
+            parent.appendChild(p);
+            state.picker = p;
+            return p;
+        }
+
+        function position() {
+            const p = state.picker;
+            if (!p) return;
+            const r = ta.getBoundingClientRect();
+            const parent = ta.parentElement;
+            const pr = parent ? parent.getBoundingClientRect() : { top: 0, left: 0 };
+            p.style.top = `${r.bottom - pr.top + 4}px`;
+            p.style.left = `${r.left - pr.left}px`;
+        }
+
+        function render() {
+            const p = ensurePicker();
+            if (!p) return;
+            const ul = p.querySelector('ul');
+            ul.innerHTML = '';
+            state.visibleItems.forEach((item, idx) => {
+                const li = document.createElement('li');
+                li.className = 'px-4 py-2 cursor-pointer text-sm transition-colors ' + (idx === state.highlighted ? 'bg-indigo-50 text-indigo-700' : 'text-slate-700 hover:bg-slate-50');
+                li.setAttribute('role', 'option');
+                li.setAttribute('data-idx', String(idx));
+                // Truncate long snippets visually
+                li.textContent = (item.text || item.title || '(snippet)').slice(0, 200);
+                li.addEventListener('mousedown', (e) => {
+                    // Use mousedown so click happens before blur close.
+                    e.preventDefault();
+                    state.highlighted = idx;
+                    insert();
                 });
-            },
+                li.addEventListener('mouseenter', () => {
+                    state.highlighted = idx;
+                    render();
+                });
+                ul.appendChild(li);
+            });
+            position();
+        }
 
-            onInput() {
-                const ta = this.$el;
-                if (!this.open) {
-                    if (ta.value[ta.selectionStart - 1] === '/' && this._wasLineStart(ta)) {
-                        this._slashPos = ta.selectionStart - 1;
-                        this._filter = '';
-                        this._scheduleOpen();
+        function applyFilter() {
+            const f = state.filter.trim().toLowerCase();
+            state.visibleItems = !f ? state.allItems
+                : state.allItems.filter((c) => (c.text || c.title || '').toLowerCase().includes(f));
+            if (state.visibleItems.length === 0) {
+                close();
+                return;
+            }
+            state.highlighted = 0;
+            render();
+        }
+
+        function open() {
+            if (state.isOpen) return;
+            state.isOpen = true;
+            const p = ensurePicker();
+            if (!p) return;
+            p.classList.remove('hidden');
+            position();
+        }
+
+        function close() {
+            state.isOpen = false;
+            state.slashPos = -1;
+            state.filter = '';
+            state.allItems = [];
+            state.visibleItems = [];
+            if (state.debounceTimer) {
+                clearTimeout(state.debounceTimer);
+                state.debounceTimer = null;
+            }
+            if (state.picker) state.picker.classList.add('hidden');
+        }
+
+        function scheduleOpen() {
+            if (state.debounceTimer) clearTimeout(state.debounceTimer);
+            state.debounceTimer = setTimeout(async () => {
+                if (state.slashPos < 0 || ta.value[state.slashPos] !== '/') return;
+                open();
+                state.allItems = await fetchSnippets(readConfig());
+                applyFilter();
+            }, DEBOUNCE_MS);
+        }
+
+        function insert() {
+            const item = state.visibleItems[state.highlighted];
+            if (!item) return;
+            const before = ta.value.slice(0, state.slashPos);
+            const after = ta.value.slice(ta.selectionStart);
+            const text = item.text || item.title || '';
+            ta.value = before + text + after;
+            const newCursor = before.length + text.length;
+            ta.selectionStart = ta.selectionEnd = newCursor;
+            // Bubble for x-model + per-textarea input handlers.
+            ta.dispatchEvent(new Event('input', { bubbles: true }));
+            ta.focus();
+            close();
+        }
+
+        ta.addEventListener('input', () => {
+            if (!state.isOpen) {
+                if (ta.value[ta.selectionStart - 1] === '/' && isLineStart({ value: ta.value, selectionStart: ta.selectionStart - 0 }) /* still pre-slash */ ) {
+                    // Slash was just inserted at line start.
+                    const slashIdx = ta.selectionStart - 1;
+                    // line-start check using the slash position as the anchor
+                    if (slashIdx === 0 || ta.value[slashIdx - 1] === '\n') {
+                        state.slashPos = slashIdx;
+                        state.filter = '';
+                        scheduleOpen();
                     }
-                    return;
                 }
-                // Track typing after the slash.
-                const after = ta.value.slice(this._slashPos + 1, ta.selectionStart);
-                if (after.includes('\n') || ta.selectionStart <= this._slashPos) {
-                    this.close();
-                    return;
-                }
-                this._filter = after;
-                this.applyFilter();
-            },
+                return;
+            }
+            const after = ta.value.slice(state.slashPos + 1, ta.selectionStart);
+            if (after.includes('\n') || ta.selectionStart <= state.slashPos) {
+                close();
+                return;
+            }
+            state.filter = after;
+            applyFilter();
+        });
 
-            _wasLineStart(ta) {
-                // The `/` is already inserted at selectionStart - 1. Line-start
-                // = there is either no char before it, or the prior char is a newline.
-                const slash = ta.selectionStart - 1;
-                if (slash === 0) return true;
-                return ta.value[slash - 1] === '\n';
-            },
-
-            _scheduleOpen() {
-                if (this._debounceTimer) clearTimeout(this._debounceTimer);
-                this._debounceTimer = setTimeout(async () => {
-                    // Bail if the user already typed past the slash with a
-                    // character that disqualifies a trigger (e.g. another '/').
-                    const ta = this.$el;
-                    if (this._slashPos < 0) return;
-                    if (ta.value[this._slashPos] !== '/') return;
-                    this.open = true;
-                    this.loading = true;
-                    this._positionPicker();
-                    const items = await fetchSnippets(config);
-                    this.items = items;
-                    this.loading = false;
-                    this.applyFilter();
-                }, DEBOUNCE_MS);
-            },
-
-            _positionPicker() {
-                // Anchor below the textarea; cheap and predictable.
-                const r = this.$el.getBoundingClientRect();
-                const parent = this.$el.parentElement;
-                const pr = parent ? parent.getBoundingClientRect() : { top: 0, left: 0 };
-                this.anchorTop = r.bottom - pr.top + 4;
-                this.anchorLeft = r.left - pr.left;
-            },
-
-            applyFilter() {
-                const f = this._filter.trim().toLowerCase();
-                const all = this._allItems || (this._allItems = this.items);
-                if (!f) {
-                    this.items = all;
-                } else {
-                    this.items = all.filter((c) =>
-                        (c.text || c.title || '').toLowerCase().includes(f)
-                    );
-                }
-                if (this.items.length === 0) this.close();
-                else this.highlighted = 0;
-            },
-
-            onKeydown(e) {
-                if (!this.open) return;
-                if (e.key === 'Escape') {
-                    this.close();
+        ta.addEventListener('keydown', (e) => {
+            if (!state.isOpen) return;
+            if (e.key === 'Escape') {
+                close();
+                e.preventDefault();
+                return;
+            }
+            if (e.key === 'ArrowDown') {
+                state.highlighted = Math.min(state.highlighted + 1, state.visibleItems.length - 1);
+                render();
+                e.preventDefault();
+            } else if (e.key === 'ArrowUp') {
+                state.highlighted = Math.max(state.highlighted - 1, 0);
+                render();
+                e.preventDefault();
+            } else if (e.key === 'Enter' || e.key === 'Tab') {
+                if (state.visibleItems.length > 0) {
+                    insert();
                     e.preventDefault();
-                    return;
                 }
-                if (e.key === 'Backspace') {
-                    const ta = this.$el;
-                    if (ta.selectionStart - 1 <= this._slashPos) {
-                        this.close();
-                    }
-                    return;
-                }
-                if (e.key === 'ArrowDown') {
-                    this.highlighted = Math.min(this.highlighted + 1, this.items.length - 1);
-                    e.preventDefault();
-                } else if (e.key === 'ArrowUp') {
-                    this.highlighted = Math.max(this.highlighted - 1, 0);
-                    e.preventDefault();
-                } else if (e.key === 'Enter') {
-                    const item = this.items[this.highlighted];
-                    if (item) {
-                        this.insert(item);
-                        e.preventDefault();
-                    }
-                } else if (e.key === 'Tab') {
-                    const item = this.items[this.highlighted];
-                    if (item) {
-                        this.insert(item);
-                        e.preventDefault();
-                    }
-                }
-            },
+            }
+        });
 
-            insert(item) {
-                const ta = this.$el;
-                const before = ta.value.slice(0, this._slashPos);
-                const after = ta.value.slice(ta.selectionStart);
-                const text = item.text || item.title || '';
-                ta.value = before + text + after;
-                const newCursor = before.length + text.length;
-                ta.selectionStart = ta.selectionEnd = newCursor;
-                ta.dispatchEvent(new Event('input', { bubbles: true }));
-                ta.focus();
-                this.close();
-            },
-
-            close() {
-                this.open = false;
-                this.items = [];
-                this._allItems = null;
-                this._slashPos = -1;
-                this._filter = '';
-                if (this._debounceTimer) {
-                    clearTimeout(this._debounceTimer);
-                    this._debounceTimer = null;
-                }
-            },
-        }));
+        ta.addEventListener('blur', () => {
+            // Delay so a mousedown on a picker item still registers.
+            setTimeout(() => { close(); }, 120);
+        });
     }
 
-    if (window.Alpine) init();
-    else document.addEventListener('alpine:init', init);
+    function scan(root = document) {
+        root.querySelectorAll('textarea[data-slash-trigger]').forEach(attach);
+    }
+
+    // Initial scan + observe future inserts (form-renderer adds textareas
+    // dynamically as Alpine renders inspection items).
+    function start() {
+        scan();
+        const obs = new MutationObserver((records) => {
+            for (const rec of records) {
+                rec.addedNodes.forEach((node) => {
+                    if (node.nodeType !== 1) return;
+                    if (node.matches?.('textarea[data-slash-trigger]')) attach(node);
+                    scan(node);
+                });
+            }
+        });
+        obs.observe(document.body, { childList: true, subtree: true });
+    }
+
+    // Re-export the helper so other code (tests, other plugins) can use it.
+    window.OISlashTrigger = { isLineStart, attach };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
 })();

--- a/public/js/slash-trigger.js
+++ b/public/js/slash-trigger.js
@@ -1,0 +1,203 @@
+// Slash-trigger comment-snippet picker — handoff-decisions §4.
+//
+// Type "/" at the start of a line in any opted-in textarea (or the very first
+// character) and a comment-library picker opens 150ms later. ESC, backspace,
+// or blur cancels. Pure character-position check — no soft-line-start.
+//
+// Wire it on a textarea by adding the Alpine x-data binding:
+//   <textarea x-data="slashSnippet({ section: 'roof', rating: 'defect' })" ...>
+// `section` and `rating` filter the snippet library; both are optional.
+//
+// Requires window.OIHotkeys (loaded by hotkeys.js, before Alpine).
+
+(function () {
+    'use strict';
+
+    const DEBOUNCE_MS = 150;
+
+    function isLineStart(textarea) {
+        const pos = textarea.selectionStart;
+        if (pos === 0) return true;
+        return textarea.value[pos - 1] === '\n';
+    }
+
+    async function fetchSnippets({ section, rating }) {
+        const params = new URLSearchParams();
+        if (section) params.set('section', section);
+        if (rating) params.set('rating', rating);
+        const qs = params.toString();
+        try {
+            const res = await fetch('/api/admin/comments' + (qs ? '?' + qs : ''), {
+                credentials: 'same-origin',
+            });
+            if (!res.ok) return [];
+            const json = await res.json();
+            return (json?.data?.comments || []).slice(0, 30);
+        } catch {
+            return [];
+        }
+    }
+
+    function init() {
+        if (!window.Alpine) return;
+
+        // Re-export the helper so other code (tests, other Alpine plugins) can use it.
+        window.OISlashTrigger = { isLineStart };
+
+        Alpine.data('slashSnippet', (config = {}) => ({
+            open: false,
+            loading: false,
+            items: [],
+            highlighted: 0,
+            // Position the picker absolutely below the textarea — caller wraps
+            // the <textarea> in a `position: relative` parent so x-show works.
+            anchorTop: 0,
+            anchorLeft: 0,
+            // Internals
+            _slashPos: -1,
+            _debounceTimer: null,
+            _filter: '',
+
+            init() {
+                this.$el.addEventListener('keydown', (e) => this.onKeydown(e));
+                this.$el.addEventListener('input', () => this.onInput());
+                this.$el.addEventListener('blur', () => {
+                    // Slight delay so click on a picker item still registers.
+                    setTimeout(() => { this.close(); }, 100);
+                });
+            },
+
+            onInput() {
+                const ta = this.$el;
+                if (!this.open) {
+                    if (ta.value[ta.selectionStart - 1] === '/' && this._wasLineStart(ta)) {
+                        this._slashPos = ta.selectionStart - 1;
+                        this._filter = '';
+                        this._scheduleOpen();
+                    }
+                    return;
+                }
+                // Track typing after the slash.
+                const after = ta.value.slice(this._slashPos + 1, ta.selectionStart);
+                if (after.includes('\n') || ta.selectionStart <= this._slashPos) {
+                    this.close();
+                    return;
+                }
+                this._filter = after;
+                this.applyFilter();
+            },
+
+            _wasLineStart(ta) {
+                // The `/` is already inserted at selectionStart - 1. Line-start
+                // = there is either no char before it, or the prior char is a newline.
+                const slash = ta.selectionStart - 1;
+                if (slash === 0) return true;
+                return ta.value[slash - 1] === '\n';
+            },
+
+            _scheduleOpen() {
+                if (this._debounceTimer) clearTimeout(this._debounceTimer);
+                this._debounceTimer = setTimeout(async () => {
+                    // Bail if the user already typed past the slash with a
+                    // character that disqualifies a trigger (e.g. another '/').
+                    const ta = this.$el;
+                    if (this._slashPos < 0) return;
+                    if (ta.value[this._slashPos] !== '/') return;
+                    this.open = true;
+                    this.loading = true;
+                    this._positionPicker();
+                    const items = await fetchSnippets(config);
+                    this.items = items;
+                    this.loading = false;
+                    this.applyFilter();
+                }, DEBOUNCE_MS);
+            },
+
+            _positionPicker() {
+                // Anchor below the textarea; cheap and predictable.
+                const r = this.$el.getBoundingClientRect();
+                const parent = this.$el.parentElement;
+                const pr = parent ? parent.getBoundingClientRect() : { top: 0, left: 0 };
+                this.anchorTop = r.bottom - pr.top + 4;
+                this.anchorLeft = r.left - pr.left;
+            },
+
+            applyFilter() {
+                const f = this._filter.trim().toLowerCase();
+                const all = this._allItems || (this._allItems = this.items);
+                if (!f) {
+                    this.items = all;
+                } else {
+                    this.items = all.filter((c) =>
+                        (c.text || c.title || '').toLowerCase().includes(f)
+                    );
+                }
+                if (this.items.length === 0) this.close();
+                else this.highlighted = 0;
+            },
+
+            onKeydown(e) {
+                if (!this.open) return;
+                if (e.key === 'Escape') {
+                    this.close();
+                    e.preventDefault();
+                    return;
+                }
+                if (e.key === 'Backspace') {
+                    const ta = this.$el;
+                    if (ta.selectionStart - 1 <= this._slashPos) {
+                        this.close();
+                    }
+                    return;
+                }
+                if (e.key === 'ArrowDown') {
+                    this.highlighted = Math.min(this.highlighted + 1, this.items.length - 1);
+                    e.preventDefault();
+                } else if (e.key === 'ArrowUp') {
+                    this.highlighted = Math.max(this.highlighted - 1, 0);
+                    e.preventDefault();
+                } else if (e.key === 'Enter') {
+                    const item = this.items[this.highlighted];
+                    if (item) {
+                        this.insert(item);
+                        e.preventDefault();
+                    }
+                } else if (e.key === 'Tab') {
+                    const item = this.items[this.highlighted];
+                    if (item) {
+                        this.insert(item);
+                        e.preventDefault();
+                    }
+                }
+            },
+
+            insert(item) {
+                const ta = this.$el;
+                const before = ta.value.slice(0, this._slashPos);
+                const after = ta.value.slice(ta.selectionStart);
+                const text = item.text || item.title || '';
+                ta.value = before + text + after;
+                const newCursor = before.length + text.length;
+                ta.selectionStart = ta.selectionEnd = newCursor;
+                ta.dispatchEvent(new Event('input', { bubbles: true }));
+                ta.focus();
+                this.close();
+            },
+
+            close() {
+                this.open = false;
+                this.items = [];
+                this._allItems = null;
+                this._slashPos = -1;
+                this._filter = '';
+                if (this._debounceTimer) {
+                    clearTimeout(this._debounceTimer);
+                    this._debounceTimer = null;
+                }
+            },
+        }));
+    }
+
+    if (window.Alpine) init();
+    else document.addEventListener('alpine:init', init);
+})();

--- a/public/js/slash-trigger.js
+++ b/public/js/slash-trigger.js
@@ -194,11 +194,13 @@
 
         ta.addEventListener('input', () => {
             if (!state.isOpen) {
-                if (ta.value[ta.selectionStart - 1] === '/' && isLineStart({ value: ta.value, selectionStart: ta.selectionStart - 0 }) /* still pre-slash */ ) {
-                    // Slash was just inserted at line start.
-                    const slashIdx = ta.selectionStart - 1;
-                    // line-start check using the slash position as the anchor
-                    if (slashIdx === 0 || ta.value[slashIdx - 1] === '\n') {
+                // Just-inserted "/"? selectionStart points right after it.
+                const slashIdx = ta.selectionStart - 1;
+                if (slashIdx >= 0 && ta.value[slashIdx] === '/') {
+                    // Line-start = slash is the very first char OR the char
+                    // immediately before it is a newline.
+                    const atLineStart = slashIdx === 0 || ta.value[slashIdx - 1] === '\n';
+                    if (atLineStart) {
                         state.slashPos = slashIdx;
                         state.filter = '';
                         scheduleOpen();

--- a/public/js/unsaved-guard.js
+++ b/public/js/unsaved-guard.js
@@ -1,0 +1,74 @@
+// handoff-decisions §7 — unsaved-changes guard.
+//
+// The original spec assumed React Router sub-routes; this codebase uses
+// hono/jsx + Alpine with no SPA router. Pragmatic adaptation:
+//   - beforeunload covers tab close / refresh / external nav (browser native dialog)
+//   - document-level click guard intercepts <a href> nav within the app —
+//     when dirty, asks via confirm(): leave or stay
+//   - inspection-edit.js calls window.OIDirty.set(true) on input,
+//     OIDirty.set(false) when saveResults succeeds.
+//
+// Tests this for inspection-edit. Other pages can opt in by calling
+// window.OIDirty.set(true|false) anywhere they want guarded.
+
+(function () {
+    'use strict';
+
+    let dirty = false;
+
+    function set(value) {
+        dirty = !!value;
+    }
+
+    function is() {
+        return dirty;
+    }
+
+    // beforeunload — browser native. Chrome ignores returnValue text in
+    // recent versions but still shows the dialog when truthy.
+    window.addEventListener('beforeunload', function (e) {
+        if (!dirty) return;
+        e.preventDefault();
+        e.returnValue = '';
+        return '';
+    });
+
+    // In-app link guard. Use capture so we run before any page-level handler
+    // that might also intercept the click. Only triggers on real navigations
+    // (anchor with href, target absent or _self). Modal use:
+    //   "You have unsaved changes. [Leave page] [Stay]"
+    document.addEventListener('click', function (e) {
+        if (!dirty) return;
+        // Walk up the tree from the click target to find an anchor.
+        let node = e.target;
+        while (node && node !== document) {
+            if (node.tagName === 'A') break;
+            node = node.parentNode;
+        }
+        if (!node || node.tagName !== 'A') return;
+        const href = node.getAttribute('href');
+        if (!href) return;
+        // Skip mailto/tel/javascript/anchor-only fragments.
+        if (/^(mailto:|tel:|javascript:|#)/.test(href)) return;
+        // Skip new-window links.
+        const target = node.getAttribute('target');
+        if (target && target !== '_self') return;
+        // Skip same-page hash links to the current path.
+        const url = new URL(node.href, window.location.href);
+        if (url.pathname === window.location.pathname && url.hash) return;
+
+        // Confirm.
+        const ok = window.confirm(
+            'You have unsaved changes that may be lost. Leave this page?'
+        );
+        if (!ok) {
+            e.preventDefault();
+            e.stopPropagation();
+        } else {
+            // User chose to leave; clear dirty so beforeunload doesn't fire again.
+            dirty = false;
+        }
+    }, true);
+
+    window.OIDirty = { set, is };
+})();

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -878,7 +878,7 @@ adminRoutes.openapi(getSigningRequestDetailRoute, async (c) => {
             agreement: agreement ? { id: agreement.id, name: agreement.name } : null,
             auditEvents: auditRows.map((r) => {
                 let payload: Record<string, unknown> = {};
-                try { payload = JSON.parse(r.payloadJson); } catch (_) { /* ignore */ }
+                try { payload = JSON.parse(r.payloadJson); } catch { /* ignore */ }
                 return {
                     id: r.id,
                     event: r.event,

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -29,6 +29,9 @@ import {
     UpdateCommentSchema,
     ListCommentsQuerySchema,
     StripeConnectAccountSchema,
+    AttentionThresholdsSchema,
+    AttentionThresholdsResponseSchema,
+    ATTENTION_THRESHOLDS_DEFAULTS,
 } from '../lib/validations/admin.schema';
 import { SuccessResponseSchema } from '../lib/validations/shared.schema';
 import { templates, agreements as agreementTable, agreements as agreementsTable, agreementRequests as agreementRequestsTable, inspections, inspectionResults, comments, tenantConfigs } from '../lib/db/schema';
@@ -1353,6 +1356,77 @@ adminRoutes.openapi({
     const totalSkipped = results.reduce((sum, r) => sum + r.skipped, 0);
     logger.info('Backfill complete', { tenantCount: results.length, totalSeeded, totalSkipped });
     return c.json({ success: true as const, data: { success: true } }, 200);
+});
+
+// --- Attention Thresholds (handoff-decisions §1) ---
+//
+// Configurable per-team thresholds (in hours) applied to the dashboard
+// "Needs Attention" bucket. Stored as JSON on `tenant_configs.attention_thresholds`.
+
+const getAttentionThresholdsRoute = createRoute({
+    method: 'get',
+    path: '/attention-thresholds',
+    tags: ['Admin'],
+    summary: 'Get attention thresholds',
+    middleware: [requireRole(['owner', 'admin'])] as const,
+    responses: {
+        200: {
+            content: { 'application/json': { schema: AttentionThresholdsResponseSchema } },
+            description: 'Success',
+        },
+    },
+});
+
+adminRoutes.openapi(getAttentionThresholdsRoute, async (c) => {
+    const tenantId = c.get('tenantId');
+    const db = drizzle(c.env.DB);
+    const row = await db.select({ thresholds: tenantConfigs.attentionThresholds })
+        .from(tenantConfigs)
+        .where(eq(tenantConfigs.tenantId, tenantId))
+        .limit(1);
+    const thresholds = row[0]?.thresholds ?? ATTENTION_THRESHOLDS_DEFAULTS;
+    return c.json({ success: true as const, data: { thresholds } }, 200);
+});
+
+const updateAttentionThresholdsRoute = createRoute({
+    method: 'patch',
+    path: '/attention-thresholds',
+    tags: ['Admin'],
+    summary: 'Update attention thresholds',
+    middleware: [requireRole(['owner', 'admin'])] as const,
+    request: { body: { content: { 'application/json': { schema: AttentionThresholdsSchema } } } },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: AttentionThresholdsResponseSchema } },
+            description: 'Success',
+        },
+    },
+});
+
+adminRoutes.openapi(updateAttentionThresholdsRoute, async (c) => {
+    const tenantId = c.get('tenantId');
+    const body = c.req.valid('json');
+    const db = drizzle(c.env.DB);
+
+    const existing = await db.select({ tenantId: tenantConfigs.tenantId })
+        .from(tenantConfigs)
+        .where(eq(tenantConfigs.tenantId, tenantId))
+        .limit(1);
+
+    if (existing.length === 0) {
+        await db.insert(tenantConfigs).values({
+            tenantId,
+            reportTheme: 'modern',
+            attentionThresholds: body,
+            updatedAt: new Date(),
+        });
+    } else {
+        await db.update(tenantConfigs)
+            .set({ attentionThresholds: body, updatedAt: new Date() })
+            .where(eq(tenantConfigs.tenantId, tenantId));
+    }
+    auditFromContext(c, 'config.attention_thresholds.update', 'tenant_config', { metadata: { ...body } });
+    return c.json({ success: true as const, data: { thresholds: body } }, 200);
 });
 
 export default adminRoutes;

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -626,7 +626,7 @@ inspectionsRoutes.openapi(aggregateRecommendationsRoute, async (c) => {
     const { id } = c.req.valid('param');
     const tenantId = c.get('tenantId') as string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db = drizzle(c.env.DB as any);
+    const db = drizzle(c.env.DB);
     const row = await db.select().from(inspectionResults)
         .where(and(eq(inspectionResults.inspectionId, id), eq(inspectionResults.tenantId, tenantId))).get();
     const data = (row?.data as Record<string, { recommendations?: Array<Record<string, unknown>> }>) ?? {};
@@ -841,7 +841,7 @@ inspectionsRoutes.get('/:id/report', async (c) => {
 
     let inspectorName: string | null = null;
     if (inspection.inspectorId) {
-        const dbForName = drizzle(c.env.DB as any);
+        const dbForName = drizzle(c.env.DB);
         const inspectorRow = await dbForName.select({ name: users.name })
             .from(users)
             .where(and(eq(users.id, inspection.inspectorId), eq(users.tenantId, c.get('tenantId'))))
@@ -862,7 +862,7 @@ inspectionsRoutes.get('/:id/report', async (c) => {
     }
 
     if (inspection.agreementRequired === true) {
-        const db2 = drizzle(c.env.DB as any);
+        const db2 = drizzle(c.env.DB);
         const signed = await db2.select({ id: agreementRequests.id })
             .from(agreementRequests)
             .where(and(

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -17,7 +17,7 @@ metricsRoutes.openapi(createRoute({
 }), async (c) => {
     const tenantId = c.get('tenantId');
     const { period } = c.req.valid('query');
-    const db = drizzle(c.env.DB as any);
+    const db = drizzle(c.env.DB);
 
     const months = period === '3m' ? 3 : period === '6m' ? 6 : 12;
     const fromDate = new Date();

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,7 +587,7 @@ app.get('/m2m/cert-render/:token', async (c) => {
 
         const timelineEvents = auditRows.map((r) => {
             let payload: Record<string, unknown> = {};
-            try { payload = JSON.parse(r.payloadJson); } catch (_) { /* ignore */ }
+            try { payload = JSON.parse(r.payloadJson); } catch { /* ignore */ }
             return {
                 event: r.event,
                 timestampUtc: new Date(r.createdAt).toISOString(),
@@ -610,7 +610,7 @@ app.get('/m2m/cert-render/:token', async (c) => {
                 if (r.event === 'workflow.complete' && typeof p.signedPdfHash === 'string') {
                     documentHash = (p.signedPdfHash as string).replace(/^sha256:/, '');
                 }
-            } catch (_) { /* ignore parse errors */ }
+            } catch { /* ignore parse errors */ }
         }
 
         // Tenant signing key fingerprint (any audit row's key_fingerprint works since rotation is rare)
@@ -645,7 +645,7 @@ app.get('/m2m/cert-render/:token', async (c) => {
 
 // Spec 5H P2 — Public verifier (no-auth, court-friendly).
 // HTML page at /verify/{envelopeId} + JSON API at /api/public/verify/*
-async function loadVerifyData(c: any, envelopeId: string) {
+async function loadVerifyData(c: Context<HonoConfig>, envelopeId: string) {
     const db = drizzle(c.env.DB, { schema });
     const reqRow = await db.select().from(schema.agreementRequests).where(eq(schema.agreementRequests.id, envelopeId)).get();
     if (!reqRow) return null;
@@ -675,7 +675,7 @@ app.get('/verify/:envelopeId', async (c) => {
     }
     const events = data.auditRows.map((r) => {
         let payload: Record<string, unknown> = {};
-        try { payload = JSON.parse(r.payloadJson); } catch (_) { /* ignore */ }
+        try { payload = JSON.parse(r.payloadJson); } catch { /* ignore */ }
         return {
             event: r.event, createdAtUtc: new Date(r.createdAt).toISOString(),
             valid: data.verify.valid, payload, hash: r.hash,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -43,7 +43,8 @@ export type AuditAction =
     | 'audit.view'
     | 'comment.updated'
     | 'config.integration.update'
-    | 'config.secrets.update';
+    | 'config.secrets.update'
+    | 'config.attention_thresholds.update';
 
 export interface AuditParams {
     db: D1Database;

--- a/src/lib/db/schema/tenant.ts
+++ b/src/lib/db/schema/tenant.ts
@@ -1,4 +1,5 @@
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
 
 export const tenants = sqliteTable('tenants', {
     id: text('id').primaryKey(),
@@ -57,6 +58,12 @@ export const tenantConfigs = sqliteTable('tenant_configs', {
     icsToken: text('ics_token'),
     widgetAllowedOrigins: text('widget_allowed_origins', { mode: 'json' }).$type<string[]>(),
     reportTheme: text('report_theme', { enum: ['modern', 'classic', 'minimal'] }).notNull().default('modern'),
+    // handoff-decisions §1 — per-team attention thresholds in hours.
+    // Default 72h applies uniformly to the three categories.
+    attentionThresholds: text('attention_thresholds', { mode: 'json' })
+        .$type<{ agreement_unsigned_h: number; invoice_overdue_h: number; report_unpublished_h: number }>()
+        .notNull()
+        .default(sql`'{"agreement_unsigned_h":72,"invoice_overdue_h":72,"report_unpublished_h":72}'`),
     updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 });
 

--- a/src/lib/validations/admin.schema.ts
+++ b/src/lib/validations/admin.schema.ts
@@ -244,3 +244,21 @@ export const ListCommentsQuerySchema = z.object({
     section: z.string().max(64).optional().openapi({ example: 'Roof' }),
     search: z.string().max(200).optional(),
 }).openapi('ListCommentsQuery');
+
+// handoff-decisions §1 — attention thresholds (in hours, 1..720 = 30 days max)
+export const AttentionThresholdsSchema = z.object({
+    agreement_unsigned_h: z.number().int().min(1).max(720),
+    invoice_overdue_h:    z.number().int().min(1).max(720),
+    report_unpublished_h: z.number().int().min(1).max(720),
+}).openapi('AttentionThresholds');
+
+export const AttentionThresholdsResponseSchema = z.object({
+    success: z.literal(true),
+    data: z.object({ thresholds: AttentionThresholdsSchema }),
+}).openapi('AttentionThresholdsResponse');
+
+export const ATTENTION_THRESHOLDS_DEFAULTS = {
+    agreement_unsigned_h: 72,
+    invoice_overdue_h:    72,
+    report_unpublished_h: 72,
+} as const;

--- a/src/services/automation.service.ts
+++ b/src/services/automation.service.ts
@@ -23,7 +23,7 @@ interface TriggerContext {
 export class AutomationService {
     constructor(private db: D1Database, private notification?: NotificationService, private agreementService?: AgreementService) {}
 
-    private getDrizzle() { return drizzle(this.db as any); }
+    private getDrizzle() { return drizzle(this.db); }
 
     async ensureSeeds(tenantId: string): Promise<void> {
         const db = this.getDrizzle();
@@ -67,7 +67,11 @@ export class AutomationService {
         const id = nanoid();
         await db.insert(automations).values({
             id, tenantId, ...data,
+            // Casts narrow the public string param to the schema's enum literal
+            // union; runtime values are validated by the API zod schema.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             trigger:   data.trigger as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             recipient: data.recipient as any,
             active: true, isDefault: false, createdAt: new Date(),
         });
@@ -82,6 +86,8 @@ export class AutomationService {
         const existing = await db.select().from(automations)
             .where(and(eq(automations.id, id), eq(automations.tenantId, tenantId))).limit(1);
         if (!existing[0]) throw Errors.NotFound('Automation not found');
+        // Same enum-narrowing as create() — public Partial<{string}> → table's enum literals.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await db.update(automations).set(data as any)
             .where(and(eq(automations.id, id), eq(automations.tenantId, tenantId)));
         return (await db.select().from(automations).where(eq(automations.id, id)))[0];
@@ -103,6 +109,7 @@ export class AutomationService {
         const rules = await db.select().from(automations)
             .where(and(
                 eq(automations.tenantId, ctx.tenantId),
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 eq(automations.trigger, ctx.triggerEvent as any),
                 eq(automations.active, true),
             ));

--- a/src/services/data.service.ts
+++ b/src/services/data.service.ts
@@ -30,7 +30,7 @@ function parseCSV(text: string): string[][] {
 
 export class DataService {
     constructor(private db: D1Database) {}
-    private getDrizzle() { return drizzle(this.db as any); }
+    private getDrizzle() { return drizzle(this.db); }
 
     // ── Export ─────────────────────────────────────────────────────────────────
 

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -1,6 +1,6 @@
 import { drizzle } from 'drizzle-orm/d1';
 import { eq, and, or, lt, gte, lte, sql, inArray } from 'drizzle-orm';
-import { inspections, inspectionResults, templates, inspectionAgreements, users, services, inspectionServices } from '../lib/db/schema';
+import { inspections, inspectionResults, templates, inspectionAgreements, users, services, inspectionServices, tenantConfigs } from '../lib/db/schema';
 import { contacts } from '../lib/db/schema/contact';
 import { Errors } from '../lib/errors';
 import { computeReportStats, getRatingColor, getRatingBucket, type RatingLevel } from '../lib/report-utils';
@@ -825,6 +825,16 @@ export class InspectionService {
         const all = await db.select().from(inspections)
             .where(eq(inspections.tenantId, tenantId));
 
+        // handoff-decisions §1 — pull the configurable report-unpublished
+        // threshold. Falls back to 24h when the row is missing (legacy tenants
+        // pre-migration 0040). 72h is the new default applied at insert time.
+        const cfg = await db.select({ thresholds: tenantConfigs.attentionThresholds })
+            .from(tenantConfigs)
+            .where(eq(tenantConfigs.tenantId, tenantId))
+            .limit(1);
+        const thresholds = cfg[0]?.thresholds ?? null;
+        const reportUnpublishedH = thresholds?.report_unpublished_h ?? 24;
+
         const now           = Date.now();
         // Use UTC boundaries to match the `date` column which stores "YYYY-MM-DD" (UTC midnight when parsed).
         const startOfToday  = new Date(); startOfToday.setUTCHours(0, 0, 0, 0);
@@ -832,7 +842,7 @@ export class InspectionService {
         const in48h         = new Date(now + 48 * 3600 * 1000);
         const in7days       = new Date(now + 7 * 86400 * 1000);
         const minus30days   = new Date(now - 30 * 86400 * 1000);
-        const minus24h      = new Date(now - 24 * 3600 * 1000);
+        const reportStaleAt  = new Date(now - reportUnpublishedH * 3600 * 1000);
 
         // Parse the text `date` column ("YYYY-MM-DD") to a Date at midnight UTC.
         const insDate = (i: typeof inspections.$inferSelect) =>
@@ -843,11 +853,12 @@ export class InspectionService {
             return d !== null && d >= startOfToday && d <= endOfToday;
         };
 
-        // Needs attention: scheduled within 48h OR in_progress >24h after inspection date.
+        // Needs attention: scheduled within 48h OR in_progress past the
+        // configured `report_unpublished_h` threshold (handoff-decisions §1).
         const needsAttention = all.filter(i => {
             const d = insDate(i);
             if (i.status === 'scheduled' && d && d <= in48h) return true;
-            if (i.status === 'in_progress' && d && d <= minus24h) return true;
+            if (i.status === 'in_progress' && d && d <= reportStaleAt) return true;
             return false;
         });
 

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -52,10 +52,11 @@ export class InspectionService {
             )!);
         }
 
-        if ((params as any).tab && (params as any).tab !== 'all') {
+        const tabParam = (params as { tab?: string }).tab;
+        if (tabParam && tabParam !== 'all') {
             const todayStr = new Date().toISOString().slice(0, 10);
             const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-            switch ((params as any).tab) {
+            switch (tabParam) {
                 case 'today':
                     conditions.push(sql`date(${inspections.date}) = ${todayStr}`);
                     break;
@@ -70,11 +71,11 @@ export class InspectionService {
                     )!);
                     break;
                 case 'unconfirmed':
-                    conditions.push(eq(inspections.status, 'scheduled' as any));
+                    conditions.push(eq(inspections.status, 'scheduled'));
                     conditions.push(sql`${inspections.createdAt} < ${cutoff}`);
                     break;
                 case 'in_progress':
-                    conditions.push(eq(inspections.status, 'in_progress' as any));
+                    conditions.push(eq(inspections.status, 'in_progress'));
                     break;
             }
         }
@@ -667,7 +668,7 @@ export class InspectionService {
         const { db, inspection } = await this.fetchForStatusChange(tenantId, id);
         if (inspection.status === 'cancelled') throw Errors.BadRequest('Cannot confirm a cancelled inspection');
         await db.update(inspections).set({
-            status:      'confirmed' as any,
+            status:      'confirmed',
             confirmedAt: new Date().toISOString(),
         }).where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));
         fireAutomation(this.db, tenantId, id, 'inspection.confirmed');
@@ -676,7 +677,7 @@ export class InspectionService {
     async cancelInspection(tenantId: string, id: string, reason: string, notes?: string): Promise<void> {
         const { db } = await this.fetchForStatusChange(tenantId, id);
         await db.update(inspections).set({
-            status:       'cancelled' as any,
+            status:       'cancelled',
             cancelReason: reason,
             cancelNotes:  notes ?? null,
         }).where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));
@@ -687,7 +688,7 @@ export class InspectionService {
         const { db, inspection } = await this.fetchForStatusChange(tenantId, id);
         if (inspection.status !== 'cancelled') throw Errors.BadRequest('Inspection is not cancelled');
         await db.update(inspections).set({
-            status:       'scheduled' as any,
+            status:       'scheduled',
             cancelReason: null,
             cancelNotes:  null,
         }).where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -1,6 +1,6 @@
 import { drizzle } from 'drizzle-orm/d1';
 import { eq, and, or, lt, gte, lte, sql, inArray } from 'drizzle-orm';
-import { inspections, inspectionResults, templates, inspectionAgreements, users, services, inspectionServices, tenantConfigs } from '../lib/db/schema';
+import { inspections, inspectionResults, templates, inspectionAgreements, users, services, inspectionServices, tenantConfigs, invoices } from '../lib/db/schema';
 import { contacts } from '../lib/db/schema/contact';
 import { Errors } from '../lib/errors';
 import { computeReportStats, getRatingColor, getRatingBucket, type RatingLevel } from '../lib/report-utils';
@@ -833,7 +833,9 @@ export class InspectionService {
             .where(eq(tenantConfigs.tenantId, tenantId))
             .limit(1);
         const thresholds = cfg[0]?.thresholds ?? null;
-        const reportUnpublishedH = thresholds?.report_unpublished_h ?? 24;
+        const reportUnpublishedH  = thresholds?.report_unpublished_h ?? 24;
+        const agreementUnsignedH  = thresholds?.agreement_unsigned_h ?? 72;
+        const invoiceOverdueH     = thresholds?.invoice_overdue_h    ?? 72;
 
         const now           = Date.now();
         // Use UTC boundaries to match the `date` column which stores "YYYY-MM-DD" (UTC midnight when parsed).
@@ -842,7 +844,28 @@ export class InspectionService {
         const in48h         = new Date(now + 48 * 3600 * 1000);
         const in7days       = new Date(now + 7 * 86400 * 1000);
         const minus30days   = new Date(now - 30 * 86400 * 1000);
-        const reportStaleAt  = new Date(now - reportUnpublishedH * 3600 * 1000);
+        const reportStaleAt    = new Date(now - reportUnpublishedH * 3600 * 1000);
+        const agreementStaleAt = new Date(now - agreementUnsignedH * 3600 * 1000);
+        const invoiceStaleAt   = new Date(now - invoiceOverdueH    * 3600 * 1000);
+
+        // handoff §1 — extra signals for needsAttention bucket.
+        // 1) Inspections with NO signed agreement record older than threshold.
+        const signedRows = await db.select({ inspectionId: inspectionAgreements.inspectionId })
+            .from(inspectionAgreements)
+            .where(eq(inspectionAgreements.tenantId, tenantId));
+        const signedSet = new Set(signedRows.map(r => r.inspectionId as string));
+        // 2) Unpaid invoices with dueDate past invoice-overdue threshold.
+        const overdueInvoices = await db.select({ inspectionId: invoices.inspectionId, dueDate: invoices.dueDate })
+            .from(invoices)
+            .where(and(eq(invoices.tenantId, tenantId), sql`${invoices.paidAt} IS NULL`));
+        const overdueSet = new Set(
+            overdueInvoices
+                .filter(r => {
+                    if (!r.dueDate || !r.inspectionId) return false;
+                    return new Date(r.dueDate as string) <= invoiceStaleAt;
+                })
+                .map(r => r.inspectionId as string)
+        );
 
         // Parse the text `date` column ("YYYY-MM-DD") to a Date at midnight UTC.
         const insDate = (i: typeof inspections.$inferSelect) =>
@@ -853,12 +876,17 @@ export class InspectionService {
             return d !== null && d >= startOfToday && d <= endOfToday;
         };
 
-        // Needs attention: scheduled within 48h OR in_progress past the
-        // configured `report_unpublished_h` threshold (handoff-decisions §1).
+        // Needs attention (handoff §1):
+        //  - scheduled within 48h, OR
+        //  - in_progress past the report-unpublished threshold, OR
+        //  - active inspection with no signed agreement past the agreement threshold, OR
+        //  - active inspection with an overdue invoice past the invoice threshold.
         const needsAttention = all.filter(i => {
             const d = insDate(i);
             if (i.status === 'scheduled' && d && d <= in48h) return true;
             if (i.status === 'in_progress' && d && d <= reportStaleAt) return true;
+            if (i.status !== 'cancelled' && new Date(i.createdAt) <= agreementStaleAt && !signedSet.has(i.id as string)) return true;
+            if (i.status !== 'cancelled' && overdueSet.has(i.id as string)) return true;
             return false;
         });
 

--- a/src/services/marketplace.service.ts
+++ b/src/services/marketplace.service.ts
@@ -6,12 +6,12 @@ import { Errors } from '../lib/errors';
 import { TemplateService } from './template.service';
 
 export class MarketplaceService {
-  private db: ReturnType<typeof drizzle<any>>;
+  private db: ReturnType<typeof drizzle>;
   private rawDb: D1Database;
   private tenantId: string;
 
   constructor(db: D1Database, tenantId: string) {
-    this.db = drizzle(db as any);
+    this.db = drizzle(db);
     this.rawDb = db;
     this.tenantId = tenantId;
   }

--- a/src/services/service.service.ts
+++ b/src/services/service.service.ts
@@ -13,7 +13,7 @@ type CreateDiscountData = z.infer<typeof CreateDiscountCodeSchema>;
 export class ServiceService {
     constructor(private db: D1Database) {}
 
-    private getDrizzle() { return drizzle(this.db as any); }
+    private getDrizzle() { return drizzle(this.db); }
 
     async listServices(tenantId: string) {
         const db = this.getDrizzle();

--- a/src/templates/components/command-palette.tsx
+++ b/src/templates/components/command-palette.tsx
@@ -21,7 +21,7 @@ export function CommandPalette(): JSX.Element {
         <div
             x-data="commandPalette"
             {...{
-                'x-on:keydown.window': "if ($event.key === 'k' && ($event.metaKey || $event.ctrlKey)) { open = !open; if (open) { $nextTick(() => $refs.queryInput?.focus()); } $event.preventDefault(); }",
+                'x-on:keydown.window': "const k = $event.key; const meta = $event.metaKey || $event.ctrlKey; const isTyping = window.OIHotkeys?.isTyping?.(); if (meta && k === 'k') { open = !open; if (open) { $nextTick(() => $refs.queryInput?.focus()); } $event.preventDefault(); } else if (meta && k === '/' && !isTyping) { open = !open; if (open) { $nextTick(() => $refs.queryInput?.focus()); } $event.preventDefault(); }",
                 'x-on:keydown.escape.window': 'if (open) { open = false; $event.stopPropagation(); }',
                 'x-cloak': '',
             }}

--- a/src/templates/components/command-palette.tsx
+++ b/src/templates/components/command-palette.tsx
@@ -1,0 +1,119 @@
+/**
+ * ⌘K Command Palette — handoff-decisions §3.
+ *
+ * Mounted globally from main-layout.tsx. Sources include:
+ *   - top-level page jumps + every settings sub-page
+ *   - recent inspections
+ *   - contacts (clients + agents)
+ *   - comment-library snippets
+ *   - create actions (New Inspection / Template / Snippet)
+ *
+ * Prefix filters:
+ *   "> " — actions only
+ *   "@ " — people only
+ *
+ * Hotkey: ⌘K / Ctrl+K to toggle. Esc closes. ↑↓ navigates. ⏎ activates.
+ * The global `?` HUD docs the same shortcut.
+ */
+
+export function CommandPalette(): JSX.Element {
+    return (
+        <div
+            x-data="commandPalette"
+            {...{
+                'x-on:keydown.window': "if ($event.key === 'k' && ($event.metaKey || $event.ctrlKey)) { open = !open; if (open) { $nextTick(() => $refs.queryInput?.focus()); } $event.preventDefault(); }",
+                'x-on:keydown.escape.window': 'if (open) { open = false; $event.stopPropagation(); }',
+                'x-cloak': '',
+            }}
+            x-show="open"
+            class="fixed inset-0 z-[10000] flex items-start justify-center pt-[12vh] px-4"
+            style="display:none"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Command palette"
+        >
+            <div
+                class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"
+                x-on:click="open = false"
+                x-transition:enter="transition ease-out duration-150"
+                x-transition:enter-start="opacity-0"
+                x-transition:enter-end="opacity-100"
+                x-transition:leave="transition ease-in duration-100"
+                x-transition:leave-start="opacity-100"
+                x-transition:leave-end="opacity-0"
+            />
+            <div
+                class="relative w-full max-w-2xl bg-white rounded-2xl shadow-2xl border border-slate-200 overflow-hidden flex flex-col max-h-[70vh]"
+                x-transition:enter="transition ease-out duration-150"
+                x-transition:enter-start="opacity-0 scale-[0.98] translate-y-1"
+                x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+                x-transition:leave="transition ease-in duration-100"
+                x-transition:leave-start="opacity-100 scale-100"
+                x-transition:leave-end="opacity-0 scale-[0.98]"
+            >
+                {/* Search input */}
+                <div class="flex items-center gap-3 px-5 py-4 border-b border-slate-100">
+                    <svg class="w-5 h-5 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z"></path></svg>
+                    <input
+                        x-ref="queryInput"
+                        x-model="query"
+                        x-on:keydown="onKeydown($event)"
+                        type="text"
+                        autocomplete="off"
+                        spellcheck={false}
+                        placeholder='Search · ">" actions · "@" people'
+                        class="flex-1 bg-transparent border-0 text-base font-medium text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-0"
+                    />
+                    <kbd class="hidden sm:inline-block px-2 py-0.5 bg-slate-50 border border-slate-200 rounded text-[10px] font-mono text-slate-500">Esc</kbd>
+                </div>
+
+                {/* Results */}
+                <div class="flex-1 overflow-y-auto">
+                    <template x-if="loading">
+                        <div class="px-5 py-8 text-center text-xs text-slate-400">Loading…</div>
+                    </template>
+                    <template x-if="!loading && groups.length === 0">
+                        <div class="px-5 py-12 text-center">
+                            <p class="text-sm font-semibold text-slate-700">No results</p>
+                            <p class="text-xs text-slate-400 mt-1">Try a different query, or press <kbd class="px-1.5 py-0.5 bg-slate-50 border border-slate-200 rounded text-[10px] font-mono">Esc</kbd> to close.</p>
+                        </div>
+                    </template>
+                    <template x-for="(group, gi) in groups" {...{ 'x-bind:key': 'group.label' }}>
+                        <div>
+                            <div class="px-5 pt-3 pb-1 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400" x-text="group.label"></div>
+                            <ul class="pb-1">
+                                <template x-for="item in group.items" {...{ 'x-bind:key': 'item.id' }}>
+                                    <li>
+                                        <button
+                                            type="button"
+                                            x-on:mouseenter="setHighlight(item._idx)"
+                                            x-on:click="run(item)"
+                                            x-bind:class="highlighted === item._idx ? 'bg-indigo-50 text-indigo-700' : 'text-slate-700 hover:bg-slate-50'"
+                                            class="w-full flex items-center gap-3 px-5 py-2.5 text-left text-sm font-medium transition-colors"
+                                        >
+                                            <span x-html="item.iconHtml" class="flex-shrink-0 w-5 h-5 text-slate-400"></span>
+                                            <span class="flex-1 min-w-0 truncate" x-text="item.label"></span>
+                                            <span x-show="item.hint" class="text-[11px] text-slate-400 flex-shrink-0" x-text="item.hint"></span>
+                                        </button>
+                                    </li>
+                                </template>
+                            </ul>
+                        </div>
+                    </template>
+                </div>
+
+                {/* Footer */}
+                <div class="px-5 py-2.5 border-t border-slate-100 bg-slate-50/60 flex items-center justify-between text-[11px] text-slate-500">
+                    <div class="flex items-center gap-3">
+                        <span class="flex items-center gap-1"><kbd class="px-1.5 py-0.5 bg-white border border-slate-200 rounded font-mono text-[10px]">↑</kbd><kbd class="px-1.5 py-0.5 bg-white border border-slate-200 rounded font-mono text-[10px]">↓</kbd> navigate</span>
+                        <span class="flex items-center gap-1"><kbd class="px-1.5 py-0.5 bg-white border border-slate-200 rounded font-mono text-[10px]">⏎</kbd> open</span>
+                    </div>
+                    <div class="flex items-center gap-1">
+                        <kbd class="px-1.5 py-0.5 bg-white border border-slate-200 rounded font-mono text-[10px]">⌘K</kbd>
+                        <span>to toggle</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/templates/components/keyboard-hud.tsx
+++ b/src/templates/components/keyboard-hud.tsx
@@ -26,6 +26,7 @@ const COLUMNS: ShortcutColumn[] = [
             { key: '⇧⏎',   label: 'Previous item' },
             { key: 'GS',   label: 'Jump to section' },
             { key: '⌘K',   label: 'Command palette' },
+            { key: '⌃/',   label: 'Command palette (Win)' },
         ],
     },
     {

--- a/src/templates/components/keyboard-hud.tsx
+++ b/src/templates/components/keyboard-hud.tsx
@@ -65,7 +65,7 @@ export function KeyboardHUD(): JSX.Element {
         <div
             x-data="{ open: false }"
             {...{
-                'x-on:keydown.window': "if (($event.key === '?' || ($event.shiftKey && $event.key === '/')) && !['INPUT','TEXTAREA','SELECT'].includes(document.activeElement?.tagName)) { open = !open; $event.preventDefault(); }",
+                'x-on:keydown.window': "if (($event.key === '?' || ($event.shiftKey && $event.key === '/')) && !window.OIHotkeys?.isTyping?.()) { open = !open; $event.preventDefault(); }",
                 'x-on:keydown.escape.window': 'open = false',
                 'x-transition.opacity': '',
                 'x-cloak': '',

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -258,6 +258,20 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                         </div>
 
                         <nav class="flex-1 p-6 space-y-2 overflow-y-auto">
+                            {/* Search pill — opens command palette. Visible click affordance
+                                in addition to ⌘K (Mac) / Ctrl+K. Chrome on Windows captures
+                                Ctrl+K for the omnibox so this button is the primary path. */}
+                            <button
+                                type="button"
+                                id="oi-cmdk-trigger"
+                                x-on:click="window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }))"
+                                class="w-full flex items-center gap-3 px-5 py-3 mb-2 rounded-2xl bg-slate-50 hover:bg-slate-100 text-slate-500 hover:text-slate-700 transition-all border border-slate-200/60 group"
+                                aria-label="Open command palette"
+                            >
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z"></path></svg>
+                                <span class="text-sm font-medium">Search…</span>
+                                <kbd class="ml-auto px-1.5 py-0.5 bg-white border border-slate-200 rounded text-[10px] font-mono text-slate-500 group-hover:border-slate-300">⌘K</kbd>
+                            </button>
                             <a href="/dashboard" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group relative">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6z"></path></svg>
                                 <span>Inspections</span>

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -2,6 +2,7 @@ import { BrandingConfig } from '../../types/auth';
 import { NetworkPill } from '../components/network-pill';
 import { ConflictModal } from '../components/conflict-modal';
 import { KeyboardHUD } from '../components/keyboard-hud';
+import { CommandPalette } from '../components/command-palette';
 
 function sanitizePrimaryColor(branding?: BrandingConfig): string {
     const raw = branding?.primaryColor || '#6366f1';
@@ -27,8 +28,15 @@ function SharedHead({ title, primaryColor, gaMeasurementId, extraHead }: {
             <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
             <link rel="stylesheet" href="/fonts.css" />
             <link rel="stylesheet" href="/vendor/flatpickr.min.css" />
+            {/* hotkeys.js exposes window.OIHotkeys (isTyping/shouldIgnoreSingleChar).
+                Loaded synchronously so global keydown handlers see it on first paint. */}
+            <script src="/js/hotkeys.js"></script>
             <script defer src="/vendor/alpine-collapse.min.js"></script>
             <script defer src="/vendor/alpine.min.js"></script>
+            {/* slash-trigger registers an Alpine `slashSnippet` data plugin —
+                opt-in per textarea via x-data="slashSnippet({ section, rating })". */}
+            <script defer src="/js/slash-trigger.js"></script>
+            <script defer src="/js/command-palette.js"></script>
             <script defer src="/vendor/flatpickr.min.js"></script>
             <script defer src="/js/flatpickr-init.js"></script>
             {/* B4 — Dexie importmap: must precede every type="module" script that imports 'dexie' */}
@@ -91,6 +99,7 @@ export const BareLayout = (props: { title: string, children: unknown, branding?:
                 <NetworkPill />
                 <ConflictModal />
                 <KeyboardHUD />
+                <CommandPalette />
             </body>
         </html>
     );
@@ -196,13 +205,34 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
                                 <span>Metrics</span>
                             </a>
+
+                            {/* handoff-decisions §5 — Settings group fully expanded as
+                                a flat sub-list. Section header has no chevron. */}
+                            <div class="pt-4 mt-4 border-t border-slate-100">
+                                <a href="/settings" class="block px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 hover:text-indigo-600">Settings</a>
+                                <div class="space-y-0">
+                                    <a href="/settings/profile" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Profile</a>
+                                    <a href="/settings/workspace/branding" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Branding</a>
+                                    <a href="/settings/workspace/theme" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Report Theme</a>
+                                    <a href="/settings/workspace/telemetry" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Telemetry</a>
+                                    <a href="/settings/catalog/services" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Services &amp; Pricing</a>
+                                    <a href="/settings/catalog/event-types" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Event Types</a>
+                                    <a href="/settings/catalog/widget" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Embed Widget</a>
+                                    <a href="/settings/communication/email" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Email</a>
+                                    <a href="/settings/communication/automations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Automations</a>
+                                    <a href="/settings/communication/calendar" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Apple Calendar</a>
+                                    <a href="/settings/communication/integrations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Integrations</a>
+                                    <a href="/settings/account/password" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Change Password</a>
+                                    <a href="/settings/account/security" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Two-factor (2FA)</a>
+                                    <a href="/settings/account/bot-protection" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Bot Protection</a>
+                                    <a href="/settings/advanced/payments" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Payments</a>
+                                    <a href="/settings/advanced/ai" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">AI</a>
+                                    <a href="/settings/advanced/data" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Data Import / Export</a>
+                                </div>
+                            </div>
                         </nav>
                         {/* Bottom section */}
                         <div class="p-4 border-t border-slate-100 bg-slate-50/50 space-y-1">
-                            <a href="/settings" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-white hover:text-indigo-600 hover:shadow-sm transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 002.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
-                                <span>Settings</span>
-                            </a>
                             <button id="mobileLogoutBtn" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-red-600 hover:bg-red-50 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
                                 <span>Sign Out</span>
@@ -310,12 +340,24 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                 <script dangerouslySetInnerHTML={{ __html: `
                     (function() {
                         var p = location.pathname;
+                        var firstActive = null;
                         document.querySelectorAll('aside a[href], nav a[href]').forEach(function(a) {
                             if (a.getAttribute('href') === p || (a.getAttribute('href') === '/dashboard' && p === '/')) {
                                 a.classList.add('bg-indigo-50', 'text-indigo-600');
                                 a.classList.remove('text-slate-600');
+                                if (!firstActive) firstActive = a;
                             }
                         });
+                        // handoff-decisions §6 — bring the active sub-item into view
+                        // inside the sidebar's overflow-y:auto scroll region.
+                        if (firstActive && typeof firstActive.scrollIntoView === 'function') {
+                            try {
+                                firstActive.scrollIntoView({ block: 'nearest', behavior: 'instant' });
+                            } catch (e) {
+                                // 'instant' lands on older browsers; fall back to non-smooth.
+                                firstActive.scrollIntoView({ block: 'nearest' });
+                            }
+                        }
                     })();
                 ` }} />
                 {/* B4 module loads moved into SharedHead so BareLayout pages
@@ -394,6 +436,7 @@ navigator.serviceWorker?.addEventListener('message', function(e) {
                 <NetworkPill />
                 <ConflictModal />
                 <KeyboardHUD />
+                <CommandPalette />
             </body>
         </html>
     );

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -31,6 +31,9 @@ function SharedHead({ title, primaryColor, gaMeasurementId, extraHead }: {
             {/* hotkeys.js exposes window.OIHotkeys (isTyping/shouldIgnoreSingleChar).
                 Loaded synchronously so global keydown handlers see it on first paint. */}
             <script src="/js/hotkeys.js"></script>
+            {/* handoff §7 — unsaved-changes guard. Pages opt in by calling
+                window.OIDirty.set(true|false). beforeunload + a-click intercept. */}
+            <script src="/js/unsaved-guard.js"></script>
             <script defer src="/vendor/alpine-collapse.min.js"></script>
             <script defer src="/vendor/alpine.min.js"></script>
             {/* These two register Alpine.data factories. Loaded SYNC (no defer)

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -267,13 +267,14 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                             <button
                                 type="button"
                                 id="oi-cmdk-trigger"
+                                x-data="{ isMac: navigator.platform?.startsWith('Mac') }"
                                 x-on:click="window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }))"
                                 class="w-full flex items-center gap-3 px-5 py-3 mb-2 rounded-2xl bg-slate-50 hover:bg-slate-100 text-slate-500 hover:text-slate-700 transition-all border border-slate-200/60 group"
                                 aria-label="Open command palette"
                             >
                                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z"></path></svg>
                                 <span class="text-sm font-medium">Search…</span>
-                                <kbd class="ml-auto px-1.5 py-0.5 bg-white border border-slate-200 rounded text-[10px] font-mono text-slate-500 group-hover:border-slate-300">⌘K</kbd>
+                                <kbd class="ml-auto px-1.5 py-0.5 bg-white border border-slate-200 rounded text-[10px] font-mono text-slate-500 group-hover:border-slate-300" x-text="isMac ? '⌘K' : 'Ctrl /'">⌘K</kbd>
                             </button>
                             <a href="/dashboard" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group relative">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6z"></path></svg>

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -33,10 +33,12 @@ function SharedHead({ title, primaryColor, gaMeasurementId, extraHead }: {
             <script src="/js/hotkeys.js"></script>
             <script defer src="/vendor/alpine-collapse.min.js"></script>
             <script defer src="/vendor/alpine.min.js"></script>
-            {/* slash-trigger registers an Alpine `slashSnippet` data plugin —
-                opt-in per textarea via x-data="slashSnippet({ section, rating })". */}
-            <script defer src="/js/slash-trigger.js"></script>
-            <script defer src="/js/command-palette.js"></script>
+            {/* These two register Alpine.data factories. Loaded SYNC (no defer)
+                so their alpine:init listener attaches BEFORE the deferred
+                alpine.min.js fires that event. With defer they ran too late
+                and the factories never registered. */}
+            <script src="/js/slash-trigger.js"></script>
+            <script src="/js/command-palette.js"></script>
             <script defer src="/vendor/flatpickr.min.js"></script>
             <script defer src="/js/flatpickr-init.js"></script>
             {/* B4 — Dexie importmap: must precede every type="module" script that imports 'dexie' */}

--- a/src/templates/pages/form-renderer.tsx
+++ b/src/templates/pages/form-renderer.tsx
@@ -121,8 +121,12 @@ export const FormRendererPage = (props: { inspectionId: string, branding?: Brand
                                                 <div class="relative group mb-8">
                                                     <textarea
                                                         x-model="results[item.id].notes"
-                                                        {...{ 'x-on:input.debounce.500ms': `noteChanged(item.id)` }}
-                                                        placeholder="Record clinical observations..."
+                                                        data-slash-trigger="true"
+                                                        {...{
+                                                            'x-on:input.debounce.500ms': `noteChanged(item.id)`,
+                                                            'x-bind:data-slash-section': 'section.title',
+                                                        }}
+                                                        placeholder="Record clinical observations · type / for snippets…"
                                                         class="w-full bg-slate-50/50 border-2 border-transparent rounded-md p-6 text-sm font-medium focus:bg-white focus:border-indigo-600 focus:ring-4 focus:ring-indigo-50 outline-none min-h-[140px] transition-all placeholder:text-slate-300 leading-relaxed"
                                                     ></textarea>
 

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -197,7 +197,8 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                       x-bind:id="'notes-mob-' + item.id"
                       x-model="results[item.id].notes"
                       x-on:input="debounceSave()"
-                      placeholder="Add notes..."
+                      data-slash-trigger="true"
+                      placeholder="Add notes — type / for snippets"
                       class="w-full p-3 text-sm rounded-xl border resize-none"
                       style="background: #f1f5f9; border-color: #e2e8f0; color: #0f172a"
                       rows={3}
@@ -906,7 +907,8 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                         x-bind:id="'notes-dsk-' + item.id"
                         x-model="results[item.id].notes"
                         x-on:input="debounceSave()"
-                        placeholder="Add notes..."
+                        data-slash-trigger="true"
+                        placeholder="Add notes — type / for snippets"
                         class="w-full p-3 text-sm rounded-xl border resize-none"
                         style="background: #f1f5f9; border-color: #e2e8f0; color: #0f172a"
                         rows={3}

--- a/src/templates/pages/settings-automations.tsx
+++ b/src/templates/pages/settings-automations.tsx
@@ -47,7 +47,7 @@ export function SettingsAutomationsPage({ branding }: SettingsAutomationsPagePro
                 </div>
 
                 {/* handoff-decisions §1 — Attention Rules */}
-                <section class="space-y-4 pt-2 border-t border-surface-200" x-data="attentionRules">
+                <section id="attention-rules" class="space-y-4 pt-2 border-t border-surface-200 scroll-mt-24" x-data="attentionRules">
                     <div class="space-y-1 mt-4">
                         <h2 class="text-sm font-bold text-ink-700 uppercase tracking-[0.2em]">Attention Rules</h2>
                         <p class="text-xs text-ink-500">

--- a/src/templates/pages/settings-automations.tsx
+++ b/src/templates/pages/settings-automations.tsx
@@ -15,7 +15,7 @@ export function SettingsAutomationsPage({ branding }: SettingsAutomationsPagePro
             pageTitle="Email Automations"
             pageSubtitle="Emails sent automatically when inspection events occur."
         >
-            <div x-data="automations" class="max-w-3xl space-y-6">
+            <div x-data="automations" class="max-w-3xl space-y-8">
                 <div x-show="loading" class="text-sm text-ink-500 py-8 text-center">Loading...</div>
                 <div x-show="!!error" x-text="error" class="text-sm text-rose-600 py-4" />
 
@@ -46,6 +46,60 @@ export function SettingsAutomationsPage({ branding }: SettingsAutomationsPagePro
                     </template>
                 </div>
 
+                {/* handoff-decisions §1 — Attention Rules */}
+                <section class="space-y-4 pt-2 border-t border-surface-200" x-data="attentionRules">
+                    <div class="space-y-1 mt-4">
+                        <h2 class="text-sm font-bold text-ink-700 uppercase tracking-[0.2em]">Attention Rules</h2>
+                        <p class="text-xs text-ink-500">
+                            How long an item can stay in a stuck state before it shows up in the dashboard's
+                            <em>Needs Attention</em> bucket. Default is 72 hours.
+                        </p>
+                    </div>
+
+                    <div x-show="loading" class="text-xs text-ink-500">Loading…</div>
+                    <div x-show="!!saveError" x-text="saveError" class="text-xs text-rose-600" />
+
+                    <div x-show="!loading" class="bg-white border border-surface-200 rounded-md divide-y divide-surface-200">
+                        <template x-for="row in rows" {...{ 'x-bind:key': 'row.key' }}>
+                            <label class="flex items-center gap-4 px-4 py-3">
+                                <div class="flex-1 min-w-0">
+                                    <div class="text-sm font-semibold text-ink-900" x-text="row.label" />
+                                    <div class="text-[11px] text-ink-500 mt-0.5" x-text="row.help" />
+                                </div>
+                                <div class="flex items-center gap-2 flex-shrink-0">
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        max="720"
+                                        step="1"
+                                        x-bind:value="values[row.key]"
+                                        x-on:input="onInput(row.key, $event.target.value)"
+                                        class="w-20 px-3 py-1.5 border border-surface-300 rounded text-sm font-mono text-ink-900 text-right focus:outline-none focus:border-blueprint-500"
+                                    />
+                                    <span class="text-xs text-ink-500 font-medium">hours</span>
+                                </div>
+                            </label>
+                        </template>
+                    </div>
+
+                    <div class="flex items-center gap-3">
+                        <button
+                            type="button"
+                            x-on:click="save()"
+                            x-bind:disabled="saving || !dirty"
+                            x-bind:class="saving || !dirty ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blueprint-600'"
+                            class="px-4 py-2 bg-blueprint-500 text-white text-xs font-bold uppercase tracking-widest rounded transition-colors"
+                            x-text="saving ? 'Saving…' : 'Save'"
+                        />
+                        <button
+                            type="button"
+                            x-on:click="resetDefaults()"
+                            class="px-4 py-2 border border-surface-300 text-ink-700 text-xs font-bold uppercase tracking-widest rounded hover:bg-surface-100 transition-colors"
+                        >Reset to default</button>
+                        <span x-show="saved" class="text-xs text-emerald-600 font-semibold">Saved</span>
+                    </div>
+                </section>
+
                 <section class="space-y-3 pt-2 border-t border-surface-200">
                     <h2 class="text-sm font-bold text-ink-700 uppercase tracking-[0.2em] mt-4">Recent Activity</h2>
                     <div x-show="logsLoading" class="text-xs text-ink-500">Loading activity…</div>
@@ -65,6 +119,7 @@ export function SettingsAutomationsPage({ branding }: SettingsAutomationsPagePro
 
                 <script src="/js/auth.js" />
                 <script src="/js/automations.js" />
+                <script src="/js/attention-rules.js" />
             </div>
         </SettingsLayout>
     );


### PR DESCRIPTION
## Summary

Implements all 7 decisions from the R-Handoff Spec C++ design package (`docs/handoff-decisions.md`):

- **§1** Configurable attention thresholds (per-team, in hours; default 72h) — Settings → Automations → Attention Rules. Wires all three thresholds into `getDashboardBuckets` so the *Needs Attention* bucket surfaces inspections with unsigned agreements, overdue invoices, or unpublished reports past their threshold (in addition to the existing scheduled-soon and in-progress checks).
- **§2** Shared `isTyping()` helper (`public/js/hotkeys.js`) — global keyboard handlers gate single-character shortcuts on `window.OIHotkeys.isTyping()`.
- **§3** ⌘K command palette + visible Search pill in sidebar. Sources: top-level pages, every settings sub-page (incl. *Settings · Attention Rules* alias), recent inspections, contacts (`@` prefix), comment snippets, create actions (`>` prefix). Groups sort by best-item score so direct hits surface first. ⌘K on Mac, **Ctrl+/** on Windows (Chrome reserves Ctrl+K for the omnibox), or click the pill.
- **§4** Line-start `/` snippet picker — vanilla DOM with `[data-slash-trigger]` attribute, MutationObserver picks up dynamic textareas. Wired into 8 textareas across `inspection-edit.tsx` (mobile + desktop) and `form-renderer.tsx`. 150ms debounce, ESC/blur/0-match/backspace cancel.
- **§5** Mobile drawer fully expanded — Settings group inline as flat 17 sub-page links at 28px height / 30px indent.
- **§6** Sidebar internal scroll — fixed-aside + `overflow-y:auto` nav, active sub-item `scrollIntoView({block:'nearest', behavior:'instant'})` on every page load.
- **§7** Unsaved-changes guard — `public/js/unsaved-guard.js` exposes `window.OIDirty.set/is`; `beforeunload` listener + document-level `a[href]` click intercept showing `confirm()`. `inspection-edit.js` autosave flips dirty true/false. Pragmatic adaptation since project has no SPA router (original spec assumed React Router `useBlocker`).

### Migration

`migrations/0040_attention_thresholds.sql` adds `attention_thresholds JSON` column to `tenant_configs` with defaults `{agreement_unsigned_h: 72, invoice_overdue_h: 72, report_unpublished_h: 72}`.

### Side effects

- Lint baseline 25 errors → **0 errors**: `catch (_)` → `catch`, `drizzle(... as any)` → `drizzle(...)`, `status: 'X' as any` → `status: 'X'` (no enum constraint), `c: any` → `Context<HonoConfig>`. Genuine enum-narrowing casts kept with `eslint-disable-next-line` + a one-line rationale.
- Type-check still clean (0 errors).
- New `docs/use-cases-personas.md` (Inspector / Agent / Customer workflows + R-Handoff test scripts appendix).

### Verified live

Deployed and smoke-tested on `https://openinspection-standalone.important-new.workers.dev` (12 deploys across 6 /loop iterations). End-to-end browser checks confirmed:
- Cmd-K palette opens via Search pill, ⌘K (Mac), and Ctrl+/ (Win)
- "attention" search ranks Settings · Attention Rules first (score 223 vs comment-snippet 9)
- Slash-trigger creates picker and renders 30 li with real comment snippets
- Save persists in `/settings/communication/automations`
- *Needs Attention* dashboard bucket showing 4 real inspections that match the new threshold logic on prod

## Test plan

- [ ] `npm run type-check` — 0 errors
- [ ] `npm run lint` — 0 errors (25 pre-existing x-cloak warnings remain, documented in main-layout.tsx)
- [ ] `npm run db:migrate` (local), apply `0040_attention_thresholds.sql`
- [ ] Login as tenant owner, walk T-1..T-8 from `docs/use-cases-personas.md` Appendix
- [ ] Verify Cmd-K palette + Search pill on desktop 1440px
- [ ] Verify mobile drawer Settings flatten on phone 390px (DOM check, since `lg:hidden` switches at <1024px)
- [ ] On `/inspections/{id}/edit`, type `/` at line start in a notes textarea → picker opens after 150ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)