### PR TITLE
Sprint 2 polish: regression fixes + UX + competitor Top 3

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,6 +71,12 @@ export default defineConfig({
             dependencies: ['api'],
         },
         {
+            // Sprint 2 regression — Track A fixes (A1-A4). Source-level +
+            // route-level guards so the regressions can't reappear.
+            name: 'sprint2-regression',
+            testMatch: 'sprint2-regression.spec.ts',
+        },
+        {
             name: 'cloud',
             testMatch: 'cloud-e2e.spec.ts',
             use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,6 +71,11 @@ export default defineConfig({
             dependencies: ['api'],
         },
         {
+            // R7-06 — public booking page native date input.
+            name: 'booking-date-input',
+            testMatch: 'booking-date-input.spec.ts',
+        },
+        {
             name: 'cloud',
             testMatch: 'cloud-e2e.spec.ts',
             use: {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -9,6 +9,13 @@ async function logout() {
     window.location.href = '/login';
 }
 
+// Expose to window so scripts that use `window.authFetch` (e.g. the Sprint 2
+// inspection sub-page Alpine factories) work the same as scripts that use the
+// bare `authFetch` reference. Top-level `const` does NOT attach to window in
+// modern browsers — `window.authFetch` would otherwise be undefined.
+window.authFetch = authFetch;
+window.logout = logout;
+
 function _escapeHtml(str) {
     const d = document.createElement('div');
     d.textContent = str;

--- a/public/js/booking.js
+++ b/public/js/booking.js
@@ -1,8 +1,9 @@
 // Sprint 1 Sub-spec C — public booking page Alpine handler.
 //
 // Owns:
-//   * date input formatting/validation (C-1) — keeps placeholder "MM / DD / YYYY"
-//     stable across locales, validates the parsed Date is real and in the future
+//   * date input validation (R7-06) — uses native <input type="date">; values
+//     arrive as ISO "YYYY-MM-DD" strings regardless of OS locale, so we just
+//     verify the date is real and not in the past
 //   * 4-option time window radio cards (C-6) — morning / afternoon / all-day /
 //     custom, with inline time picker for custom
 //   * form submit flow with Turnstile token + AddressAutocomplete hidden fields
@@ -14,7 +15,7 @@
 document.addEventListener('alpine:init', () => {
     // ─── Sprint 1 page-level data ────────────────────────────────────────────
     Alpine.data('bookingPage', () => ({
-        dateMasked: '',          // "MM / DD / YYYY" string the user types
+        inspectionDate: '',       // ISO "YYYY-MM-DD" from native date input
         dateError:  '',
         selectedWindow: '',
         customTime:  '',
@@ -51,31 +52,20 @@ document.addEventListener('alpine:init', () => {
                 .reduce((sum, s) => sum + (s.price || 0), 0);
         },
 
-        formatDate(e) {
-            // Strip non-digits, cap at MMDDYYYY, then re-insert slashes with spaces.
-            const v = (e.target.value || '').replace(/\D/g, '').slice(0, 8);
-            let out = v;
-            if (v.length > 4)      out = v.slice(0, 2) + ' / ' + v.slice(2, 4) + ' / ' + v.slice(4);
-            else if (v.length > 2) out = v.slice(0, 2) + ' / ' + v.slice(2);
-            this.dateMasked = out;
-            // Clear the error eagerly while the user is fixing the field.
-            if (this.dateError) this.dateError = '';
-        },
-
         validateDate() {
             this.dateError = '';
-            if (!this.dateMasked) return;
-            const m = this.dateMasked.match(/^(\d{2})\s*\/\s*(\d{2})\s*\/\s*(\d{4})$/);
-            if (!m) { this.dateError = 'Please enter the date as MM / DD / YYYY'; return; }
-            const month = parseInt(m[1], 10);
-            const day   = parseInt(m[2], 10);
-            const year  = parseInt(m[3], 10);
+            if (!this.inspectionDate) return;
+            const m = this.inspectionDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+            if (!m) { this.dateError = 'Please pick a valid date'; return; }
+            const year  = parseInt(m[1], 10);
+            const month = parseInt(m[2], 10);
+            const day   = parseInt(m[3], 10);
             const dt = new Date(year, month - 1, day);
             if (isNaN(dt.getTime()) ||
                 dt.getFullYear() !== year ||
                 dt.getMonth() !== month - 1 ||
                 dt.getDate() !== day) {
-                this.dateError = 'Please enter a valid date';
+                this.dateError = 'Please pick a valid date';
                 return;
             }
             const today = new Date();
@@ -86,9 +76,9 @@ document.addEventListener('alpine:init', () => {
         },
 
         toIsoDate() {
-            const m = (this.dateMasked || '').match(/^(\d{2})\s*\/\s*(\d{2})\s*\/\s*(\d{4})$/);
-            if (!m) return null;
-            return `${m[3]}-${m[1]}-${m[2]}`;
+            // Native <input type="date"> already gives us "YYYY-MM-DD".
+            const m = (this.inspectionDate || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+            return m ? this.inspectionDate : null;
         },
 
         async submitBooking() {
@@ -96,7 +86,7 @@ document.addEventListener('alpine:init', () => {
             this.validateDate();
             if (this.dateError) return;
             const isoDate = this.toIsoDate();
-            if (!isoDate) { this.dateError = 'Please enter the date as MM / DD / YYYY'; return; }
+            if (!isoDate) { this.dateError = 'Please pick a valid date'; return; }
             if (!this.selectedWindow) {
                 this.message = 'Please pick a time window';
                 this.messageOk = false;
@@ -143,7 +133,7 @@ document.addEventListener('alpine:init', () => {
                         : 'Inspection requested — check your email for confirmation.';
                     this.messageOk = true;
                     form.reset();
-                    this.dateMasked = '';
+                    this.inspectionDate = '';
                     this.selectedWindow = '';
                     this.customTime = '';
                     this.selectedServiceIds = [];

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -603,6 +603,75 @@ window.cloneInspection = cloneInspection;
 window.deleteInspection = deleteInspection;
 window.submitInspection = submitInspection;
 
+// ─── Time-based filter helpers (Competitor parity Feature C1) ───────────────
+// Pure JS port of src/lib/inspection-filter.ts — kept in sync by the unit
+// tests in tests/unit/inspection-filter.spec.ts. Both modules share the same
+// filter ids and date semantics so the dashboard tab strip behaves identically
+// to any future server-side filter.
+const INSPECTION_FILTERS = [
+    { id: 'all',         label: 'All' },
+    { id: 'past',        label: 'Past' },
+    { id: 'yesterday',   label: 'Yesterday' },
+    { id: 'today',       label: 'Today' },
+    { id: 'tomorrow',    label: 'Tomorrow' },
+    { id: 'this_week',   label: 'This Week' },
+    { id: 'future',      label: 'Future' },
+    { id: 'unconfirmed', label: 'Unconfirmed' },
+    { id: 'in_progress', label: 'In Progress' },
+];
+
+function _startOfDay(d) {
+    const x = new Date(d);
+    x.setHours(0, 0, 0, 0);
+    return x;
+}
+
+function _addDays(d, days) {
+    const x = new Date(d);
+    x.setDate(x.getDate() + days);
+    return x;
+}
+
+function _startOfWeek(d) {
+    const x = _startOfDay(d);
+    x.setDate(x.getDate() - x.getDay());
+    return x;
+}
+
+function _parseInspectionDate(raw) {
+    if (!raw) return null;
+    if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw;
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function matchesInspectionFilter(insp, filter, now) {
+    if (filter === 'all') return true;
+    const status = ((insp && insp.status) || '').toLowerCase();
+    if (filter === 'unconfirmed') return status === 'scheduled' || status === 'draft';
+    if (filter === 'in_progress') return status === 'in_progress';
+    const date = _parseInspectionDate(insp && insp.date != null ? insp.date : null);
+    if (!date) return false;
+    const today     = _startOfDay(now || new Date());
+    const yesterday = _addDays(today, -1);
+    const tomorrow  = _addDays(today, 1);
+    const weekStart = _startOfWeek(today);
+    const weekEnd   = _addDays(weekStart, 7);
+    const dayStart  = _startOfDay(date);
+    switch (filter) {
+        case 'past':       return dayStart.getTime() < today.getTime();
+        case 'yesterday':  return dayStart.getTime() === yesterday.getTime();
+        case 'today':      return dayStart.getTime() === today.getTime();
+        case 'tomorrow':   return dayStart.getTime() === tomorrow.getTime();
+        case 'this_week':  return dayStart.getTime() >= weekStart.getTime() && dayStart.getTime() < weekEnd.getTime();
+        case 'future':     return dayStart.getTime() >= weekEnd.getTime();
+    }
+    return false;
+}
+
+window.INSPECTION_FILTERS         = INSPECTION_FILTERS;
+window.matchesInspectionFilter    = matchesInspectionFilter;
+
 // ─── Alpine dashboard factory ───────────────────────────────────────────────
 
 function dashboardFactory() {
@@ -626,6 +695,11 @@ function dashboardFactory() {
             recentReports: false,
             cancelled: false,
         },
+        // Competitor parity C1 — time-based filter tabs.
+        // 'all' shows the existing grouped buckets; any other filter id
+        // collapses to a single flat list filtered in-memory.
+        activeFilter: 'all',
+        filterOptions: INSPECTION_FILTERS,
         // Spec 4D.T10 — Today's events bucket
         todayEvents: [],
         eventTypes: [],
@@ -750,6 +824,69 @@ function dashboardFactory() {
                 b.recentReports.length +
                 b.cancelled.length
             ) === 0;
+        },
+
+        // Competitor parity C1 — flat dedup'd union of every bucket. Used
+        // exclusively when activeFilter !== 'all' so the inspector sees one
+        // clean list instead of 5 collapsing sections.
+        get _allInspections() {
+            const b = this.buckets;
+            const seen = new Set();
+            const out  = [];
+            const push = (rows) => {
+                for (let i = 0; i < (rows || []).length; i++) {
+                    const r = rows[i];
+                    const id = r && r.id;
+                    if (!id || seen.has(id)) continue;
+                    seen.add(id);
+                    out.push(r);
+                }
+            };
+            push(b.needsAttention);
+            push(b.today);
+            push(b.thisWeek);
+            push(b.later);
+            push(b.recentReports);
+            push(b.cancelled);
+            return out;
+        },
+
+        // Inspections matching the currently active non-'all' filter, sorted
+        // by inspection date ascending (closest first). Stable enough that
+        // re-renders don't shuffle rows when the same data reloads.
+        get filteredInspections() {
+            if (this.activeFilter === 'all') return [];
+            const now = new Date();
+            const list = this._allInspections.filter(i => matchesInspectionFilter(i, this.activeFilter, now));
+            list.sort((a, b) => {
+                const da = a && a.date ? new Date(a.date).getTime() : 0;
+                const db = b && b.date ? new Date(b.date).getTime() : 0;
+                return da - db;
+            });
+            return list;
+        },
+
+        // Counts for the tab strip pills, e.g. "TODAY (3)". Computed once
+        // per Alpine reactive cycle.
+        get filterCounts() {
+            const counts = { all: 0, past: 0, yesterday: 0, today: 0, tomorrow: 0,
+                             this_week: 0, future: 0, unconfirmed: 0, in_progress: 0 };
+            const now = new Date();
+            const list = this._allInspections;
+            counts.all = list.length;
+            for (let i = 0; i < list.length; i++) {
+                const insp = list[i];
+                for (let j = 0; j < INSPECTION_FILTERS.length; j++) {
+                    const f = INSPECTION_FILTERS[j].id;
+                    if (f === 'all') continue;
+                    if (matchesInspectionFilter(insp, f, now)) counts[f]++;
+                }
+            }
+            return counts;
+        },
+
+        setFilter(filter) {
+            this.activeFilter = filter || 'all';
         },
     };
 }

--- a/public/js/inline-text-popover.js
+++ b/public/js/inline-text-popover.js
@@ -42,6 +42,10 @@
                 value:       '',
                 scope:       'default',
                 history:     [],
+                // Competitor parity C3 — quick-pick instruction templates.
+                // Render as small chips above the textarea; clicking a chip
+                // populates the textarea with the chip text.
+                templates:   [],
                 _onApply:    null,
 
                 show: function (opts) {
@@ -51,6 +55,7 @@
                     this.value       = opts.initial || '';
                     this.scope       = opts.scope || 'default';
                     this.history     = loadHistory(this.scope);
+                    this.templates   = Array.isArray(opts.templates) ? opts.templates.slice(0, 6) : [];
                     this._onApply    = opts.onApply || null;
                     this.open        = true;
                     var self = this;
@@ -62,6 +67,16 @@
                             try { self.$refs.ta.setSelectionRange(len, len); } catch (e) { /* ignore */ }
                         }
                     }, 50);
+                },
+
+                pickTemplate: function (text) {
+                    this.value = text || '';
+                    var self = this;
+                    if (self.$refs && self.$refs.ta) {
+                        self.$refs.ta.focus();
+                        var len = (self.value || '').length;
+                        try { self.$refs.ta.setSelectionRange(len, len); } catch (e) { /* ignore */ }
+                    }
                 },
 
                 apply: function () {
@@ -76,9 +91,10 @@
                 },
 
                 close: function () {
-                    this.open     = false;
-                    this.value    = '';
-                    this._onApply = null;
+                    this.open      = false;
+                    this.value     = '';
+                    this.templates = [];
+                    this._onApply  = null;
                 },
             };
         });

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -779,6 +779,14 @@ function inspectionEditor(inspectionId) {
       var entry = entries.find(function (e) { return e.cannedId === cannedId; });
       if (!entry) return;
       var originalComment = entry.effectiveComment || entry.comment || '';
+      // Competitor parity C3 — never call the rewriter on empty text. The
+      // spec is explicit: "DO NOT generate from scratch — only rewrite
+      // existing text." Server-side Zod also enforces min:1 but we'd rather
+      // catch this with a friendly toast than a 400.
+      if (!originalComment.trim()) {
+        if (typeof showToast === 'function') showToast('Add a comment first, then rewrite with AI.', false);
+        return;
+      }
       var category = (tabName === 'defects' && entry.category) ? entry.category : null;
       var location = (tabName === 'defects' && entry.location) ? entry.location : null;
       var self = this;
@@ -791,6 +799,14 @@ function inspectionEditor(inspectionId) {
         title:       'Rewrite instruction',
         placeholder: 'e.g. shorten, make professional, add NW corner detail',
         scope:       'ai-rewrite',
+        // Competitor parity C3 — quick-pick instruction templates.
+        templates: [
+          'shorten',
+          'more specific',
+          'less alarming',
+          'more professional',
+          'add specific location detail',
+        ],
         onApply: function (instruction) {
           self._performAiRewrite(itemId, tabName, cannedId, ev, {
             item:            item,
@@ -873,6 +889,12 @@ function inspectionEditor(inspectionId) {
       var entry = entries.find(function (e) { return e.id === customId; });
       if (!entry) return;
       var originalComment = entry.comment || '';
+      // Competitor parity C3 — only rewrite, never generate. See the matching
+      // guard in rewriteCannedComment above.
+      if (!originalComment.trim()) {
+        if (typeof showToast === 'function') showToast('Add a comment first, then rewrite with AI.', false);
+        return;
+      }
       var category = (tabName === 'defects' && entry.category) ? entry.category : null;
       var location = (tabName === 'defects' && entry.location) ? entry.location : null;
       var self = this;
@@ -885,6 +907,14 @@ function inspectionEditor(inspectionId) {
         title:       'Rewrite custom comment',
         placeholder: 'e.g. shorten, sound less alarming, more specific',
         scope:       'ai-rewrite',
+        // Competitor parity C3 — quick-pick instruction templates.
+        templates: [
+          'shorten',
+          'more specific',
+          'less alarming',
+          'more professional',
+          'add specific location detail',
+        ],
         onApply: function (instruction) {
           self._performCustomRewrite(itemId, tabName, customId, ev, {
             item:            item,

--- a/src/lib/inspection-filter.ts
+++ b/src/lib/inspection-filter.ts
@@ -1,0 +1,156 @@
+/**
+ * Inspection list time-filter helpers — Competitor parity Feature C1.
+ *
+ * Pure utility functions used by the dashboard to filter the inspection list
+ * by time bucket and status. The dashboard (Alpine `dashboard()` factory)
+ * imports these via the bundled JS shim (public/js/dashboard.js).
+ *
+ * The filter ids match the Spectora App.E.7 spec:
+ *   ALL / PAST / YESTERDAY / TODAY / TOMORROW / THIS WEEK / FUTURE /
+ *   UNCONFIRMED / IN PROGRESS
+ *
+ * All date math runs in the browser's local timezone — the inspection
+ * `date` column is stored as `YYYY-MM-DD` (UTC midnight) but inspectors
+ * read the dashboard in their own day. Filters use day-level granularity
+ * (Date.toDateString()) so a noon-UTC inspection still shows under "today"
+ * for an inspector in PT.
+ */
+
+export type InspectionFilter =
+    | 'all'
+    | 'past'
+    | 'yesterday'
+    | 'today'
+    | 'tomorrow'
+    | 'this_week'
+    | 'future'
+    | 'unconfirmed'
+    | 'in_progress';
+
+/** All filter ids in tab-render order. Exported so the UI can render the
+ *  exact same set without drift. */
+export const INSPECTION_FILTERS: ReadonlyArray<{ id: InspectionFilter; label: string }> = [
+    { id: 'all',         label: 'All' },
+    { id: 'past',        label: 'Past' },
+    { id: 'yesterday',   label: 'Yesterday' },
+    { id: 'today',       label: 'Today' },
+    { id: 'tomorrow',    label: 'Tomorrow' },
+    { id: 'this_week',   label: 'This Week' },
+    { id: 'future',      label: 'Future' },
+    { id: 'unconfirmed', label: 'Unconfirmed' },
+    { id: 'in_progress', label: 'In Progress' },
+];
+
+export interface FilterableInspection {
+    id?:     unknown;
+    /** Either a JS Date, an ISO timestamp string, or `YYYY-MM-DD`. */
+    date?:   string | Date | null;
+    /** Free-form status; only `scheduled`, `draft`, `in_progress` are matched. */
+    status?: string;
+}
+
+/** Returns the start of the local day for the given date (00:00:00.000). */
+function startOfDay(d: Date): Date {
+    const x = new Date(d);
+    x.setHours(0, 0, 0, 0);
+    return x;
+}
+
+/** Adds `days` to the given date and returns the new instance. */
+function addDays(d: Date, days: number): Date {
+    const x = new Date(d);
+    x.setDate(x.getDate() + days);
+    return x;
+}
+
+/** Returns the start of the calendar week (Sunday 00:00) containing `d`. */
+function startOfWeek(d: Date): Date {
+    const x = startOfDay(d);
+    x.setDate(x.getDate() - x.getDay());
+    return x;
+}
+
+/** Parses an inspection date into a JS Date, or returns null if missing. */
+function parseInspectionDate(raw: string | Date | null | undefined): Date | null {
+    if (!raw) return null;
+    if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw;
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Returns true when the given inspection matches the given time-filter,
+ * relative to `now` (defaults to `new Date()`).
+ */
+export function matchesInspectionFilter(
+    insp: FilterableInspection,
+    filter: InspectionFilter,
+    now: Date = new Date(),
+): boolean {
+    if (filter === 'all') return true;
+
+    if (filter === 'unconfirmed') {
+        const s = (insp.status || '').toLowerCase();
+        // Spectora maps "unconfirmed" → not yet started, no in-person agreement.
+        // Internally we map this to `scheduled` (calendar booked) and `draft`
+        // (manually created, not yet started). Cancelled inspections never
+        // match.
+        return s === 'scheduled' || s === 'draft';
+    }
+
+    if (filter === 'in_progress') {
+        return (insp.status || '').toLowerCase() === 'in_progress';
+    }
+
+    const date = parseInspectionDate(insp.date ?? null);
+    if (!date) return false;
+
+    const today        = startOfDay(now);
+    const yesterday    = addDays(today, -1);
+    const tomorrow     = addDays(today, 1);
+    const weekStart    = startOfWeek(today);
+    const weekEnd      = addDays(weekStart, 7); // exclusive
+    const dayStart     = startOfDay(date);
+
+    switch (filter) {
+        case 'past':
+            return dayStart.getTime() < today.getTime();
+        case 'yesterday':
+            return dayStart.getTime() === yesterday.getTime();
+        case 'today':
+            return dayStart.getTime() === today.getTime();
+        case 'tomorrow':
+            return dayStart.getTime() === tomorrow.getTime();
+        case 'this_week':
+            return dayStart.getTime() >= weekStart.getTime() && dayStart.getTime() < weekEnd.getTime();
+        case 'future':
+            return dayStart.getTime() >= weekEnd.getTime();
+    }
+    return false;
+}
+
+/**
+ * Counts inspections matching each filter, returning an object keyed by
+ * filter id. Used by the tab strip to render "TODAY (3)" style chips.
+ *
+ * The `all` count is always the total length of `inspections` (deduplicating
+ * is the caller's responsibility — buckets in the dashboard already share ids
+ * across needsAttention/today/etc., so callers should pass a deduped union).
+ */
+export function countByFilter(
+    inspections: FilterableInspection[],
+    now: Date = new Date(),
+): Record<InspectionFilter, number> {
+    const out: Record<InspectionFilter, number> = {
+        all: 0, past: 0, yesterday: 0, today: 0, tomorrow: 0,
+        this_week: 0, future: 0, unconfirmed: 0, in_progress: 0,
+    };
+    for (const i of inspections) {
+        out.all++;
+        for (const f of INSPECTION_FILTERS) {
+            if (f.id === 'all') continue;
+            if (matchesInspectionFilter(i, f.id, now)) out[f.id]++;
+        }
+    }
+    return out;
+}

--- a/src/templates/components/inline-text-popover.tsx
+++ b/src/templates/components/inline-text-popover.tsx
@@ -57,6 +57,22 @@ export const InlineTextPopover = (): JSX.Element => (
                 <h3 id="oi-prompt-title" class="text-[15px] font-semibold text-slate-900 tracking-tight" x-text="title"></h3>
             </div>
             <div class="p-5 space-y-3">
+                {/*
+                  Competitor parity C3 — quick-pick instruction templates.
+                  Render as outlined pills above the textarea so the
+                  inspector can click "shorten" / "less alarming" without
+                  typing. Empty templates array hides the row entirely.
+                */}
+                <div x-show="templates.length > 0" class="flex flex-wrap items-center gap-1.5" data-test="oi-prompt-templates">
+                    <template x-for="t in templates" {...{ 'x-bind:key': 't' }}>
+                        <button
+                            type="button"
+                            x-on:click="pickTemplate(t)"
+                            class="inline-flex items-center h-6 px-2.5 rounded-full bg-indigo-50 text-indigo-700 text-[11px] font-bold hover:bg-indigo-100 active:scale-95 transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                            x-text="t"
+                        ></button>
+                    </template>
+                </div>
                 <textarea
                     x-ref="ta"
                     x-model="value"

--- a/src/templates/components/report-sidebar.tsx
+++ b/src/templates/components/report-sidebar.tsx
@@ -55,7 +55,9 @@ export const ReportSidebar = ({ sections, role, inspectionId, brandLogo, siteNam
 
         {/* Sections nav */}
         <nav class="flex-1 overflow-y-auto py-2" aria-label="Report sections">
-            {sections.map((s) => (
+            {sections.map((s) => {
+                const total = s.defects.safety + s.defects.recommendation + s.defects.maintenance;
+                return (
                 <a
                     href={`#section-${s.id}`}
                     key={s.id}
@@ -66,8 +68,26 @@ export const ReportSidebar = ({ sections, role, inspectionId, brandLogo, siteNam
                         <svg class="w-3.5 h-3.5 flex-shrink-0 opacity-60 group-hover:opacity-100" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={s.icon}></path></svg>
                     )}
                     <span class="flex-1 truncate">{s.title}</span>
-                    {/* Defect count badges — only render non-zero */}
-                    <span class="flex items-center gap-0.5 text-[10px] font-bold tabular-nums">
+                    {/*
+                      Competitor parity C2 — single red total-defects badge
+                      per Spectora App.F.2 ("count of defects in that section").
+                      Sums safety + recommendation + maintenance. Only renders
+                      when total > 0. The per-category breakdown below stays
+                      as the secondary signal so inspectors don't lose the
+                      severity split.
+                    */}
+                    {total > 0 && (
+                        <span
+                            data-test="section-defect-total"
+                            class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full bg-rose-500 text-white text-[10px] font-bold tabular-nums"
+                            title={`${total} issue${total === 1 ? '' : 's'} in this section`}
+                            aria-label={`${total} issues`}
+                        >{total}</span>
+                    )}
+                    {/* Per-category breakdown — only render non-zero. Wrapped
+                        in `hidden lg:flex` so on smaller side-rail widths the
+                        single combined badge above stands alone. */}
+                    <span class="hidden xl:flex items-center gap-0.5 text-[10px] font-bold tabular-nums">
                         {s.defects.safety > 0 && (
                             <span class="inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-rose-500 text-white" title="Safety hazards">{s.defects.safety}</span>
                         )}
@@ -79,7 +99,8 @@ export const ReportSidebar = ({ sections, role, inspectionId, brandLogo, siteNam
                         )}
                     </span>
                 </a>
-            ))}
+                );
+            })}
         </nav>
 
         {/* Footer status */}

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -198,7 +198,7 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                     <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Repair Items</a>
                                     <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
                                     <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-400 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems <span class="ml-1 text-[10px] uppercase tracking-widest">soon</span></a>
+                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
                                 </div>
                             </details>
                             <a href="/contacts" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
@@ -307,7 +307,7 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                     <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Repair Items</a>
                                     <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
                                     <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-400 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems <span class="ml-1 text-[10px] uppercase tracking-widest">soon</span></a>
+                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
                                 </div>
                             </details>
                             <a href="/contacts" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">

--- a/src/templates/pages/booking.tsx
+++ b/src/templates/pages/booking.tsx
@@ -159,26 +159,27 @@ export const PublicBookingPage = ({ siteKey, branding, embed, style }: PublicBoo
                                     <p class="text-[13px] text-slate-500">Pick a date and time window that works.</p>
                                 </div>
 
-                                {/* Date — text input + JS mask, locale-stable English placeholder. */}
+                                {/* Date — native date input (R7-06). type="date" triggers
+                                    the native iOS spinner picker on mobile Safari and the
+                                    native picker on Chrome/Edge/Firefox; values are always
+                                    serialized as "YYYY-MM-DD" regardless of OS locale. */}
                                 <label class="block">
                                     <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Inspection date</span>
                                     <input
-                                        type="text"
-                                        name="dateMasked"
-                                        x-model="dateMasked"
+                                        type="date"
+                                        name="inspectionDate"
+                                        x-model="inspectionDate"
                                         {...{
-                                            'x-on:input':  'formatDate($event)',
+                                            'x-on:change': 'validateDate()',
                                             'x-on:blur':   'validateDate()',
                                         }}
-                                        placeholder="MM / DD / YYYY"
+                                        placeholder="YYYY-MM-DD"
                                         autocomplete="off"
-                                        inputmode="numeric"
                                         required
-                                        pattern="\\d{2}\\s*/\\s*\\d{2}\\s*/\\s*\\d{4}"
                                         class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none text-[14px] font-medium tabular-nums transition-colors"
                                         aria-describedby="date-hint date-error"
                                     />
-                                    <p id="date-hint" class="mt-1 text-[11px] text-slate-400">Format: MM / DD / YYYY</p>
+                                    <p id="date-hint" class="mt-1 text-[11px] text-slate-400">Pick a date that is not in the past.</p>
                                     <p
                                         id="date-error"
                                         x-show="dateError"

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -112,8 +112,83 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                         </div>
                     </div>
 
+                    {/*
+                      Competitor parity Feature C1 — time-based filter tabs.
+                      Renders ALL / PAST / YESTERDAY / TODAY / TOMORROW /
+                      THIS WEEK / FUTURE / UNCONFIRMED / IN PROGRESS as a
+                      horizontal pill strip. ALL keeps the existing grouped
+                      bucket layout below. Any other filter swaps to a flat
+                      list filtered in-memory by `matchesInspectionFilter`.
+                      Counts (e.g. "TODAY (3)") render only when > 0.
+                    */}
+                    <div
+                        x-show="!loading && !allBucketsEmpty"
+                        {...{ 'x-cloak': true }}
+                        role="tablist"
+                        aria-label="Inspection time filter"
+                        class="flex flex-wrap items-center gap-1.5 -mt-1"
+                        data-test="inspection-filter-tabs"
+                    >
+                        <template x-for="opt in filterOptions" {...{ 'x-bind:key': 'opt.id' }}>
+                            <button
+                                type="button"
+                                role="tab"
+                                x-bind:aria-selected="activeFilter === opt.id ? 'true' : 'false'"
+                                x-bind:data-active={`activeFilter === opt.id ? '1' : '0'`}
+                                x-on:click="setFilter(opt.id)"
+                                x-bind:class={`activeFilter === opt.id
+                                    ? 'bg-indigo-600 text-white border-indigo-600 shadow-sm'
+                                    : 'bg-white text-slate-600 border-slate-200 hover:border-slate-300 hover:text-slate-900'`}
+                                class="inline-flex items-center gap-1.5 h-7 px-3 rounded-full border text-[11px] font-bold uppercase tracking-[0.08em] transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                            >
+                                <span x-text="opt.label"></span>
+                                <span
+                                    x-show="opt.id !== 'all' && filterCounts[opt.id] > 0"
+                                    x-bind:class={`activeFilter === opt.id ? 'bg-white/20 text-white' : 'bg-slate-100 text-slate-600'`}
+                                    class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full text-[10px] tabular-nums"
+                                    x-text="filterCounts[opt.id]"
+                                ></span>
+                            </button>
+                        </template>
+                    </div>
+
+                    {/* C1 — Flat filtered list, shown only when activeFilter !== 'all'. */}
+                    <section
+                        x-show="!loading && activeFilter !== 'all'"
+                        {...{ 'x-cloak': true }}
+                        class="bg-white border border-slate-200 rounded-md scroll-mt-20"
+                        data-test="inspection-filter-list"
+                    >
+                        <div class="px-5 py-3 border-b border-slate-100 flex items-center justify-between">
+                            <div class="flex items-center gap-2">
+                                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Filtered</span>
+                                <span class="text-[12px] font-bold text-slate-700" x-text="filteredInspections.length + ' result' + (filteredInspections.length === 1 ? '' : 's')"></span>
+                            </div>
+                            <button type="button" x-on:click="setFilter('all')" class="text-[11px] font-bold text-indigo-600 hover:text-indigo-700">Clear</button>
+                        </div>
+                        <div x-show="filteredInspections.length === 0" class="px-5 py-6 text-center text-[12px] text-slate-400">
+                            No inspections match this filter.
+                        </div>
+                        <template x-for="i in filteredInspections" {...{ 'x-bind:key': 'i.id' }}>
+                            <div class="px-5 py-3 border-t border-slate-100 flex items-center gap-3" data-test="inspection-row">
+                                <a x-bind:href="'/inspections/' + i.id + '/edit'" class="flex-1 min-w-0">
+                                    <p class="font-bold text-slate-900 truncate text-[14px]" x-text="i.propertyAddress || i.address || '(no address)'"></p>
+                                    <p class="text-[12px] text-slate-500 mt-0.5">
+                                        <span x-text="i.clientName || '—'"></span>
+                                        <template x-if="i.agentName"><span> · <span class="text-slate-400">via</span> <span x-text="i.agentName"></span></span></template>
+                                        <span> · </span>
+                                        <span x-text="i.date ? new Date(i.date).toLocaleString() : 'no date'"></span>
+                                        <span> · </span>
+                                        <span class="uppercase tracking-wide text-[10px] font-bold text-slate-400" x-text="(i.status || '').replace('_', ' ')"></span>
+                                    </p>
+                                </a>
+                                <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
+                            </div>
+                        </template>
+                    </section>
+
                     {/* Section: Needs Attention */}
-                    <section id="bucket-needsAttention" x-show="!loading && buckets.needsAttention.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-needsAttention" x-show="!loading && activeFilter === 'all' && buckets.needsAttention.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.needsAttention = !sections.needsAttention"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -176,7 +251,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Today */}
-                    <section id="bucket-today" x-show="!loading && buckets.today.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-today" x-show="!loading && activeFilter === 'all' && buckets.today.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.today = !sections.today"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -239,7 +314,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Today's events (Spec 4D.T10) */}
-                    <section x-show="!loading && todayEvents.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
+                    <section x-show="!loading && activeFilter === 'all' && todayEvents.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
                         <button type="button" x-on:click="sections.todayEvents = !sections.todayEvents"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -262,7 +337,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: This Week */}
-                    <section id="bucket-thisWeek" x-show="!loading && buckets.thisWeek.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-thisWeek" x-show="!loading && activeFilter === 'all' && buckets.thisWeek.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.thisWeek = !sections.thisWeek"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -325,7 +400,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Later */}
-                    <section x-show="!loading && (buckets.later.length > 0 || buckets.laterTotal > 0)" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
+                    <section x-show="!loading && activeFilter === 'all' && (buckets.later.length > 0 || buckets.laterTotal > 0)" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
                         <button type="button" x-on:click="sections.later = !sections.later"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -393,7 +468,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Recent Reports */}
-                    <section id="bucket-recentReports" x-show="!loading && buckets.recentReports.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-recentReports" x-show="!loading && activeFilter === 'all' && buckets.recentReports.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.recentReports = !sections.recentReports"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -456,7 +531,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Cancelled */}
-                    <section x-show="!loading && buckets.cancelled.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
+                    <section x-show="!loading && activeFilter === 'all' && buckets.cancelled.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
                         <button type="button" x-on:click="sections.cancelled = !sections.cancelled"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -50,6 +50,50 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
     ),
     children: (
       <>
+      {/* Sprint 2 S2-5 — Inspection sub-route nav. Renders the 5-tab bar
+          (Report / Photos / Summary / Signatures / Settings) at the top of
+          the editor so users can switch between sub-routes without leaving
+          the page. Kept outside the inspectionEditor x-data scope so it
+          stays interactive even if the editor's Alpine init fails. */}
+      <nav
+        role="tablist"
+        aria-label="Inspection sections"
+        class="sticky top-0 z-[60] bg-white border-b border-slate-200 print:hidden"
+      >
+        <div class="max-w-full mx-auto px-4 flex items-center gap-1 overflow-x-auto hide-scrollbar">
+          <a
+            href={`/inspections/${inspectionId}/report`}
+            role="tab"
+            aria-current="page"
+            aria-selected="true"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-indigo-500 text-slate-900 whitespace-nowrap"
+          >Report</a>
+          <a
+            href={`/inspections/${inspectionId}/photos`}
+            role="tab"
+            aria-selected="false"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+          >Photos</a>
+          <a
+            href={`/inspections/${inspectionId}/summary`}
+            role="tab"
+            aria-selected="false"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+          >Summary</a>
+          <a
+            href={`/inspections/${inspectionId}/signatures`}
+            role="tab"
+            aria-selected="false"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+          >Signatures</a>
+          <a
+            href={`/inspections/${inspectionId}/settings`}
+            role="tab"
+            aria-selected="false"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+          >Settings</a>
+        </div>
+      </nav>
       <div
         x-data={`inspectionEditor('${inspectionId}')`}
         class="min-h-screen"

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -208,7 +208,11 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                     onboarding overlay (T6 / step 0) highlights so the user
                     knows which buttons the tour is talking about. */}
                 {/* Spec 5G mobile field-flow (Round 12) — 44px+ tap target on
-                    mobile per Apple HIG; desktop keeps compact 28px height. */}
+                    mobile per Apple HIG; desktop keeps compact 28px height.
+                    R7-16 — show the full rating label on tablet+ (≥640px) so
+                    new inspectors can read "Satisfactory" instead of decoding
+                    "Sat". Mobile keeps the abbreviation to fit 5 buttons in
+                    one row. aria-label still provides the full name to AT. */}
                 <div data-rating-row class="flex flex-wrap gap-1.5 mb-3">
                   <template x-for="level in ratingLevels" x-bind:key="level.id">
                     <button
@@ -218,8 +222,10 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                       class="px-4 py-2.5 min-h-[44px] lg:min-h-0 lg:px-3 lg:py-1.5 text-sm lg:text-xs font-semibold rounded-lg border transition-all"
                       x-bind:class="getItemRating(item.id) === level.id ? 'text-white border-transparent' : 'text-gray-400 hover:text-gray-600'"
                       x-bind:style="getItemRating(item.id) === level.id ? 'background:' + level.color + ';border-color:transparent' : 'border-color: #e2e8f0'"
-                      x-text="level.abbreviation"
-                    ></button>
+                    >
+                      <span class="hidden sm:inline" x-text="level.label"></span>
+                      <span class="sm:hidden" x-text="level.abbreviation"></span>
+                    </button>
                   </template>
                 </div>
 
@@ -770,7 +776,15 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
               <span class="font-semibold" style="color: var(--ih-primary, #6366f1)" x-text="'Selected ' + selectedBatchCount + '/' + currentSectionItems.length"></span>
               <button x-on:click="batchSelectAll()" class="px-3 py-1 rounded-lg text-xs font-semibold" style="background: white; color: var(--ih-primary, #6366f1)">Select All</button>
               <template x-for="level in ratingLevels" x-bind:key="level.id">
-                <button x-on:click="batchSetRating(level.id)" class="px-3 py-1 rounded-lg text-xs font-semibold" style="background: white; color: #475569" x-text="'Set ' + level.abbreviation"></button>
+                <button
+                    x-on:click="batchSetRating(level.id)"
+                    x-bind:aria-label="'Set ' + level.label"
+                    class="px-3 py-1 rounded-lg text-xs font-semibold"
+                    style="background: white; color: #475569"
+                >
+                  <span class="hidden sm:inline" x-text="'Set ' + level.label"></span>
+                  <span class="sm:hidden" x-text="'Set ' + level.abbreviation"></span>
+                </button>
               </template>
               <button x-on:click="batchMode = false; batchSelected = {}" class="ml-auto px-3 py-1 rounded-lg text-xs font-semibold" style="color: #64748b">Exit</button>
             </div>
@@ -948,7 +962,8 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                       x-bind:style="'background:' + getRatingColor(getItemRating(item.id)) + '20; color:' + getRatingColor(getItemRating(item.id))"
                     ></span>
                   </div>
-                  {/* Rating Buttons */}
+                  {/* Rating Buttons (R7-16 — full label on ≥640px, abbreviation
+                      on mobile; aria-label preserves the full name for AT). */}
                   <div class="flex flex-wrap gap-1.5 mb-3" x-on:click="$event.stopPropagation()">
                     <template x-for="level in ratingLevels" x-bind:key="level.id">
                       <button
@@ -958,8 +973,10 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                         class="px-2.5 py-1 text-[10px] font-semibold rounded-lg border transition-all"
                         x-bind:class="getItemRating(item.id) === level.id ? 'text-white border-transparent' : 'text-gray-400 hover:text-gray-600'"
                         x-bind:style="getItemRating(item.id) === level.id ? 'background:' + level.color + ';border-color:transparent' : 'border-color: #e2e8f0'"
-                        x-text="level.abbreviation"
-                      ></button>
+                      >
+                        <span class="hidden sm:inline" x-text="level.label"></span>
+                        <span class="sm:hidden" x-text="level.abbreviation"></span>
+                      </button>
                     </template>
                   </div>
                   {/* Round 39 — formerly the whole row had stopPropagation,

--- a/src/templates/pages/inspection/photos.tsx
+++ b/src/templates/pages/inspection/photos.tsx
@@ -27,9 +27,10 @@ export const InspectionPhotosPage = ({
     requestId,
     siblings,
 }: InspectionPhotosPageProps): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout
-            title="Photos"
+            title={`${siteName} | Photos`}
             {...(branding ? { branding } : {})}
             extraHead={(
                 <style dangerouslySetInnerHTML={{ __html: `

--- a/src/templates/pages/inspection/settings.tsx
+++ b/src/templates/pages/inspection/settings.tsx
@@ -30,9 +30,10 @@ export const InspectionSettingsPage = ({
     requestId,
     siblings,
 }: InspectionSettingsPageProps): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout
-            title="Settings"
+            title={`${siteName} | Settings`}
             {...(branding ? { branding } : {})}
         >
             <InspectionShell

--- a/src/templates/pages/inspection/signatures.tsx
+++ b/src/templates/pages/inspection/signatures.tsx
@@ -26,9 +26,10 @@ export const InspectionSignaturesPage = ({
     requestId,
     siblings,
 }: InspectionSignaturesPageProps): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout
-            title="Signatures"
+            title={`${siteName} | Signatures`}
             {...(branding ? { branding } : {})}
         >
             <InspectionShell

--- a/src/templates/pages/inspection/summary.tsx
+++ b/src/templates/pages/inspection/summary.tsx
@@ -25,9 +25,10 @@ export const InspectionSummaryPage = ({
     requestId,
     siblings,
 }: InspectionSummaryPageProps): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout
-            title="Summary"
+            title={`${siteName} | Summary`}
             {...(branding ? { branding } : {})}
         >
             <InspectionShell

--- a/src/templates/pages/rating-systems.tsx
+++ b/src/templates/pages/rating-systems.tsx
@@ -156,6 +156,9 @@ export const RatingSystemsPage = ({ branding }: Props): JSX.Element => {
                     </p>
                 </Modal>
             </div>
+            {/* auth.js MUST load before rating-systems.js — the latter calls
+                window.authFetch from auth.js. Order matches dashboard/templates. */}
+            <script src="/js/auth.js"></script>
             <script src="/js/rating-systems.js"></script>
         </MainLayout>
     );

--- a/tests/booking-date-input.spec.ts
+++ b/tests/booking-date-input.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * R7-06 — /book Inspection Date input is a native date picker.
+ *
+ * The original implementation used <input type="text"> with a JS mask so the
+ * placeholder stayed locale-stable ("MM / DD / YYYY"). On mobile Safari this
+ * meant the soft keyboard came up as a free-text keyboard rather than the
+ * native iOS date spinner — brittle and slow.
+ *
+ * Switching to type="date" gives every browser its native picker (iOS spinner,
+ * Android calendar, desktop popover) and the value is always serialized as
+ * the locale-stable ISO "YYYY-MM-DD" — so the placeholder leak that the old
+ * mask was working around no longer matters.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('R7-06 — /book inspection date input', () => {
+    test('uses native date picker (type=date)', async ({ page }) => {
+        await page.goto('/book');
+        const dateInput = page.locator('input[name="inspectionDate"]');
+        await expect(dateInput).toHaveCount(1);
+        const type = await dateInput.getAttribute('type');
+        expect(['date', 'datetime-local']).toContain(type);
+    });
+
+    test('accepts an ISO YYYY-MM-DD value and round-trips it', async ({ page }) => {
+        await page.goto('/book');
+        const dateInput = page.locator('input[name="inspectionDate"]');
+        // A date a few days in the future so the validation passes.
+        const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+        const iso = future.toISOString().slice(0, 10); // "YYYY-MM-DD"
+        await dateInput.fill(iso);
+        await dateInput.blur();
+        await expect(dateInput).toHaveValue(iso);
+        // The error region should stay hidden when the date is valid + in
+        // the future. (Alpine sets style="display:none" via x-show.)
+        const err = page.locator('#date-error');
+        const display = await err.evaluate((el) => getComputedStyle(el).display);
+        expect(display).toBe('none');
+    });
+
+    test('shows an error when a past date is selected', async ({ page }) => {
+        await page.goto('/book');
+        // Wait for Alpine to load (loaded with `defer`, runs `bookingPage()`
+        // factory on alpine:init) — the date input becomes visible to
+        // `dateInput.fill()` once the input is rendered.
+        const dateInput = page.locator('input[name="inspectionDate"]');
+        await expect(dateInput).toBeVisible();
+        // Give Alpine a beat to attach event listeners after the script
+        // finishes parsing.
+        await page.waitForTimeout(500);
+        // 30 days ago.
+        const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+        const iso = past.toISOString().slice(0, 10);
+        await dateInput.fill(iso);
+        // Fire the events Alpine listens to: x-model picks up `input`, our
+        // explicit handler is on `change` + `blur`. Dispatching both manually
+        // ensures the validator runs even when the headless browser collapses
+        // focus events.
+        await dateInput.evaluate((el: HTMLInputElement) => {
+            el.dispatchEvent(new Event('input',  { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+            el.dispatchEvent(new Event('blur',   { bubbles: true }));
+        });
+        // x-show sets style.display; poll the message text directly.
+        await expect(page.locator('#date-error')).toContainText(/past/i, { timeout: 5000 });
+    });
+});

--- a/tests/sprint2-regression.spec.ts
+++ b/tests/sprint2-regression.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Sprint 2 regression suite — Track A fixes (A1-A4).
+ *
+ * Covers four bugs verified live on production after Sprint 2 ship:
+ *   A1 — /library/rating-systems shows "authFetch is not defined" because
+ *        the page's <script> tag for rating-systems.js loaded before auth.js,
+ *        so the bare authFetch reference was unresolved.
+ *   A2 — Sidebar in main-layout.tsx still rendered a "SOON" badge next to
+ *        the Rating Systems link — Sprint 1 stub artifact that S2-1 was
+ *        supposed to remove.
+ *   A3 — /inspections/:id/report did NOT show the 5-tab inspection sub-nav
+ *        (Report / Photos / Summary / Signatures / Settings) — InspectionShell
+ *        only wrapped the four passive sub-pages, not the Report editor.
+ *   A4 — Sub-pages (/photos /summary /signatures /settings) had a generic
+ *        <title> ("Photos" instead of "OpenInspection | Photos") and the
+ *        Alpine factories called window.authFetch which was undefined because
+ *        auth.js declared authFetch as a top-level const — never attached to
+ *        window.
+ *
+ * Tests run unauthenticated where possible — the htmlAuthGuard 302s to /login,
+ * but the response body inspection happens before the redirect on routes that
+ * are public, and we use server-side template rendering checks for the rest.
+ *
+ * For pages that require auth, we follow the 302 to /login, then assert the
+ * underlying page source via a direct HTML scrape of the dev worker response
+ * (the Playwright `request` API doesn't trip Alpine init so JS hangs are
+ * irrelevant — we just inspect the static HTML for the expected markup).
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:8789';
+const FAKE_INSPECTION_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+test.describe('Sprint 2 regression — A1 rating-systems wiring', () => {
+    test('A1: rating-systems page loads /js/auth.js BEFORE /js/rating-systems.js', async ({ request }) => {
+        // Hit the route — even if htmlAuthGuard redirects to /login, the page
+        // template is what we care about here. Follow redirects to land on
+        // the actual page when possible.
+        const res = await request.get(`${BASE_URL}/library/rating-systems`, {
+            failOnStatusCode: false,
+            maxRedirects: 0,
+        });
+        // If unauthenticated we get 302 to /login; we want to inspect the
+        // actual rating-systems page, so make a direct fetch of the static
+        // template via a HEAD-then-GET pattern. To avoid auth, we accept either
+        // the rating-systems page body OR the login page. When we see the
+        // rating-systems body, we inspect script tag order.
+        if ([301, 302, 303, 307, 308].includes(res.status())) {
+            // Auth redirect — we can't easily get the authenticated body in
+            // this test scope. Instead, assert the source template is correct
+            // by virtue of our earlier inspection. The unit-style assertion
+            // below covers it.
+            test.skip(true, 'Authenticated route — covered by source-level test below');
+            return;
+        }
+        const html = await res.text();
+        const authIdx = html.indexOf('/js/auth.js');
+        const ratingIdx = html.indexOf('/js/rating-systems.js');
+        expect(authIdx, 'auth.js must be present on rating-systems page').toBeGreaterThan(-1);
+        expect(ratingIdx, 'rating-systems.js must be present on rating-systems page').toBeGreaterThan(-1);
+        expect(authIdx, 'auth.js must load BEFORE rating-systems.js so authFetch is defined').toBeLessThan(ratingIdx);
+    });
+
+    test('A1 (source-level): rating-systems.tsx template wires auth.js before rating-systems.js', async () => {
+        // Source-level guard so the regression is caught even when the dev
+        // worker is offline. Reads the compiled-from-source template file.
+        const fs = await import('node:fs/promises');
+        const path = await import('node:path');
+        const tsxPath = path.resolve(process.cwd(), 'src/templates/pages/rating-systems.tsx');
+        const src = await fs.readFile(tsxPath, 'utf-8');
+        const authIdx = src.indexOf('/js/auth.js');
+        const ratingIdx = src.indexOf('/js/rating-systems.js');
+        expect(authIdx, 'auth.js script tag missing from rating-systems.tsx').toBeGreaterThan(-1);
+        expect(ratingIdx, 'rating-systems.js script tag missing from rating-systems.tsx').toBeGreaterThan(-1);
+        expect(authIdx, 'auth.js must precede rating-systems.js').toBeLessThan(ratingIdx);
+    });
+
+    test('A1 (runtime): auth.js exposes authFetch on window for sub-page JS files', async () => {
+        // The Sprint 2 inspection sub-page Alpine factories call
+        // window.authFetch directly. Top-level `const` does not attach to
+        // window in modern browsers, so auth.js explicitly exports it.
+        const fs = await import('node:fs/promises');
+        const path = await import('node:path');
+        const jsPath = path.resolve(process.cwd(), 'public/js/auth.js');
+        const src = await fs.readFile(jsPath, 'utf-8');
+        expect(src, 'auth.js must explicitly attach authFetch to window').toMatch(/window\.authFetch\s*=\s*authFetch/);
+    });
+});
+
+test.describe('Sprint 2 regression — A2 SOON badge removed', () => {
+    test('A2: main-layout.tsx no longer renders a SOON badge next to Rating Systems', async () => {
+        const fs = await import('node:fs/promises');
+        const path = await import('node:path');
+        const tsxPath = path.resolve(process.cwd(), 'src/templates/layouts/main-layout.tsx');
+        const src = await fs.readFile(tsxPath, 'utf-8');
+        // The Rating Systems link must still exist.
+        expect(src).toMatch(/href="\/library\/rating-systems"/);
+        // But the SOON badge span must be gone.
+        const ratingMatches = src.match(/href="\/library\/rating-systems"[^>]*>[^<]*<\/a>/g) ?? [];
+        expect(ratingMatches.length, 'expected 2 Rating Systems links (mobile + desktop)').toBeGreaterThanOrEqual(2);
+        for (const link of ratingMatches) {
+            expect(link, 'SOON badge must be removed from Rating Systems link').not.toContain('soon');
+        }
+    });
+});
+
+test.describe('Sprint 2 regression — A3 inspection /report has 5-tab sub-nav', () => {
+    test('A3: /inspections/:id/report renders the 5-tab inspection sub-nav', async ({ request }) => {
+        // The route is htmlAuthGuard'd — without auth we get redirected to
+        // /login. We assert at the template-source level instead, since the
+        // actual fix is in inspection-edit.tsx.
+        const res = await request.get(`${BASE_URL}/inspections/${FAKE_INSPECTION_ID}/report`, {
+            failOnStatusCode: false,
+            maxRedirects: 0,
+        });
+        // Either 302 (auth redirect) or 200 (the actual page). For 200, scan
+        // for the sub-nav.
+        if (res.status() === 200) {
+            const html = await res.text();
+            expect(html).toContain('aria-label="Inspection sections"');
+            for (const tab of ['Report', 'Photos', 'Summary', 'Signatures', 'Settings']) {
+                expect(html, `Sub-nav must include ${tab} tab link`).toContain(`>${tab}</a>`);
+            }
+        } else {
+            // Source-level fallback — verify inspection-edit.tsx contains the
+            // 5-tab nav block we added.
+            const fs = await import('node:fs/promises');
+            const path = await import('node:path');
+            const tsxPath = path.resolve(process.cwd(), 'src/templates/pages/inspection-edit.tsx');
+            const src = await fs.readFile(tsxPath, 'utf-8');
+            expect(src, 'inspection-edit.tsx must include the inspection sections sub-nav').toContain('aria-label="Inspection sections"');
+            for (const tab of ['Report', 'Photos', 'Summary', 'Signatures', 'Settings']) {
+                expect(src, `Sub-nav must include ${tab} tab link`).toContain(`>${tab}</a>`);
+            }
+        }
+    });
+});
+
+test.describe('Sprint 2 regression — A4 sub-pages have proper <title>', () => {
+    const SUBS = [
+        { route: 'photos',     label: 'Photos' },
+        { route: 'summary',    label: 'Summary' },
+        { route: 'signatures', label: 'Signatures' },
+        { route: 'settings',   label: 'Settings' },
+    ];
+
+    for (const { route, label } of SUBS) {
+        test(`A4: /inspections/:id/${route} template uses '\${siteName} | ${label}' title`, async () => {
+            const fs = await import('node:fs/promises');
+            const path = await import('node:path');
+            const tsxPath = path.resolve(process.cwd(), `src/templates/pages/inspection/${route}.tsx`);
+            const src = await fs.readFile(tsxPath, 'utf-8');
+            // The title prop must include the siteName branding pattern, NOT a
+            // bare label like "Photos".
+            expect(src, `${route}.tsx must derive siteName from branding`).toContain('siteName');
+            expect(src, `${route}.tsx title must follow '\${siteName} | ${label}' pattern`).toContain(`\${siteName} | ${label}`);
+        });
+    }
+});
+
+test.describe('Sprint 2 regression — A4 sub-route HTTP smoke', () => {
+    const SUBS = ['photos', 'summary', 'signatures', 'settings'] as const;
+
+    for (const sub of SUBS) {
+        test(`A4: /inspections/:id/${sub} returns a route response (200 or auth 302), never 5xx`, async ({ request }) => {
+            const res = await request.get(`${BASE_URL}/inspections/${FAKE_INSPECTION_ID}/${sub}`, {
+                failOnStatusCode: false,
+                maxRedirects: 0,
+                timeout: 10000,
+            });
+            // 200 = page renders, 302 = auth guard redirect to /login.
+            // 404 means the route is not mounted, 5xx means it errors out.
+            expect([200, 301, 302, 303, 307, 308]).toContain(res.status());
+        });
+    }
+});

--- a/tests/unit/booking-date-input.spec.ts
+++ b/tests/unit/booking-date-input.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * R7-06 — /book inspection date input is a native date picker.
+ *
+ * Static check on the JSX template + Alpine handler so the responsive label
+ * regression is caught without needing a fully-seeded local Cloudflare dev
+ * server. The complementary Playwright spec at
+ * `tests/booking-date-input.spec.ts` exercises the live page when the dev
+ * server is running; this unit spec is the always-green floor.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tsxPath = resolve(__dirname, '../../src/templates/pages/booking.tsx');
+const jsPath  = resolve(__dirname, '../../public/js/booking.js');
+const tsx = readFileSync(tsxPath, 'utf8');
+const js  = readFileSync(jsPath,  'utf8');
+
+describe('R7-06 — /book inspection date input', () => {
+    it('uses type="date" so mobile Safari shows the native spinner', () => {
+        // The previous code used type="text" + a JS mask. The fix flips the
+        // input to a native <input type="date"> which triggers the native
+        // iOS spinner picker on mobile Safari.
+        expect(tsx).toMatch(/type="date"\s+name="inspectionDate"/);
+        // And no leftover "type=text" + "name=dateMasked" remnant.
+        expect(tsx).not.toMatch(/type="text"\s+name="dateMasked"/);
+    });
+
+    it('Alpine handler reads the ISO YYYY-MM-DD value into `inspectionDate`', () => {
+        // The handler must declare an `inspectionDate` field initialized to
+        // the empty string and a `validateDate()` method that checks for the
+        // ISO YYYY-MM-DD shape produced by the native date picker.
+        expect(js).toMatch(/inspectionDate:\s*''/);
+        expect(js).toMatch(/inspectionDate\.match\(\/\^\(\\d\{4\}\)-\(\\d\{2\}\)-\(\\d\{2\}\)\$\//);
+        // `toIsoDate()` should pass the value straight through (it's already
+        // in the wire format).
+        expect(js).toMatch(/this\.inspectionDate \|\| ''/);
+    });
+
+    it('removed the legacy mask state (`dateMasked` / `formatDate`)', () => {
+        // Old fields gone — they shouldn't reappear in a future revert.
+        expect(js).not.toMatch(/dateMasked:\s*''/);
+        expect(js).not.toMatch(/formatDate\(e\)/);
+    });
+});

--- a/tests/unit/inline-text-popover.spec.ts
+++ b/tests/unit/inline-text-popover.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Competitor parity Feature C3 — InlineTextPopover instruction templates.
+ *
+ * Verifies the global rewrite popover renders a templates row that lets
+ * the inspector pick a quick-pick instruction (e.g. "shorten",
+ * "less alarming") without typing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { InlineTextPopover } from '../../src/templates/components/inline-text-popover';
+
+function render(node: unknown): string {
+    return String(node);
+}
+
+describe('InlineTextPopover — competitor C3 templates', () => {
+    const html = render(InlineTextPopover());
+
+    it('renders the templates row with x-show binding to templates.length', () => {
+        expect(html).toContain('data-test="oi-prompt-templates"');
+        // hono/jsx HTML-escapes > inside attribute values.
+        expect(html).toMatch(/x-show="templates\.length\s*&gt;\s*0"/);
+    });
+
+    it('binds template chips via x-for over templates array', () => {
+        // Loose check — the JSX template loop is preserved as <template x-for>.
+        expect(html).toMatch(/x-for="t in templates"/);
+        expect(html).toContain('pickTemplate(t)');
+    });
+
+    it('keeps the textarea apply / cancel surface', () => {
+        expect(html).toContain('Apply');
+        expect(html).toContain('Cancel');
+    });
+
+    it('preserves Cmd/Ctrl+Enter shortcut on the textarea', () => {
+        expect(html).toContain('x-on:keydown.cmd.enter.prevent="apply()"');
+        expect(html).toContain('x-on:keydown.ctrl.enter.prevent="apply()"');
+    });
+});

--- a/tests/unit/inspection-filter.spec.ts
+++ b/tests/unit/inspection-filter.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+    matchesInspectionFilter,
+    countByFilter,
+    INSPECTION_FILTERS,
+    type FilterableInspection,
+} from '../../src/lib/inspection-filter';
+
+/**
+ * Competitor parity Feature C1 — time-based inspection filter tabs.
+ * Pure-function unit tests for the dashboard filter helpers.
+ */
+describe('inspection-filter', () => {
+    // Pinned reference "now" — Wednesday 2026-05-13 12:00 local.
+    const now = new Date(2026, 4, 13, 12, 0, 0); // month is 0-indexed
+
+    function makeInsp(date: string | null, status = 'scheduled'): FilterableInspection {
+        return { id: 'i1', date, status };
+    }
+
+    describe('matchesInspectionFilter', () => {
+        it('all returns true regardless of date / status', () => {
+            expect(matchesInspectionFilter(makeInsp(null), 'all', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-13'), 'all', now)).toBe(true);
+            expect(matchesInspectionFilter({ status: 'cancelled' }, 'all', now)).toBe(true);
+        });
+
+        it('today matches inspection scheduled today', () => {
+            expect(matchesInspectionFilter(makeInsp('2026-05-13'), 'today', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-12'), 'today', now)).toBe(false);
+            expect(matchesInspectionFilter(makeInsp('2026-05-14'), 'today', now)).toBe(false);
+        });
+
+        it('yesterday and tomorrow are exact-day matches', () => {
+            expect(matchesInspectionFilter(makeInsp('2026-05-12'), 'yesterday', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-14'), 'tomorrow', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-11'), 'yesterday', now)).toBe(false);
+        });
+
+        it('past matches all dates strictly before today', () => {
+            expect(matchesInspectionFilter(makeInsp('2026-05-12'), 'past', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2025-12-01'), 'past', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-13'), 'past', now)).toBe(false);
+            expect(matchesInspectionFilter(makeInsp('2026-05-14'), 'past', now)).toBe(false);
+        });
+
+        it('this_week matches Sun-Sat of the current calendar week', () => {
+            // 2026-05-13 (Wed). Week = Sun 5/10 .. Sat 5/16.
+            expect(matchesInspectionFilter(makeInsp('2026-05-10'), 'this_week', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-13'), 'this_week', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-16'), 'this_week', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-09'), 'this_week', now)).toBe(false);
+            expect(matchesInspectionFilter(makeInsp('2026-05-17'), 'this_week', now)).toBe(false);
+        });
+
+        it('future matches dates beyond the end of this week', () => {
+            // After Sat 5/16.
+            expect(matchesInspectionFilter(makeInsp('2026-05-17'), 'future', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-06-01'), 'future', now)).toBe(true);
+            expect(matchesInspectionFilter(makeInsp('2026-05-16'), 'future', now)).toBe(false);
+            expect(matchesInspectionFilter(makeInsp('2026-05-13'), 'future', now)).toBe(false);
+        });
+
+        it('unconfirmed matches scheduled and draft, never in_progress / cancelled', () => {
+            expect(matchesInspectionFilter({ status: 'scheduled' }, 'unconfirmed', now)).toBe(true);
+            expect(matchesInspectionFilter({ status: 'draft' }, 'unconfirmed', now)).toBe(true);
+            expect(matchesInspectionFilter({ status: 'in_progress' }, 'unconfirmed', now)).toBe(false);
+            expect(matchesInspectionFilter({ status: 'completed' }, 'unconfirmed', now)).toBe(false);
+            expect(matchesInspectionFilter({ status: 'cancelled' }, 'unconfirmed', now)).toBe(false);
+        });
+
+        it('in_progress matches only in_progress status', () => {
+            expect(matchesInspectionFilter({ status: 'in_progress' }, 'in_progress', now)).toBe(true);
+            expect(matchesInspectionFilter({ status: 'IN_PROGRESS' }, 'in_progress', now)).toBe(true);
+            expect(matchesInspectionFilter({ status: 'scheduled' }, 'in_progress', now)).toBe(false);
+        });
+
+        it('non-status filters return false when date is missing', () => {
+            const noDate: FilterableInspection = { status: 'scheduled' };
+            expect(matchesInspectionFilter(noDate, 'today', now)).toBe(false);
+            expect(matchesInspectionFilter(noDate, 'past', now)).toBe(false);
+            expect(matchesInspectionFilter(noDate, 'this_week', now)).toBe(false);
+        });
+
+        it('accepts ISO timestamps and Date objects', () => {
+            expect(matchesInspectionFilter({ date: new Date(2026, 4, 13, 9, 0) }, 'today', now)).toBe(true);
+            expect(matchesInspectionFilter({ date: '2026-05-13T15:30:00Z' }, 'today', now)).toBe(true);
+        });
+    });
+
+    describe('countByFilter', () => {
+        it('returns correct counts across all buckets', () => {
+            const list: FilterableInspection[] = [
+                makeInsp('2026-05-13', 'scheduled'),    // today, unconfirmed
+                makeInsp('2026-05-13', 'in_progress'),  // today, in_progress
+                makeInsp('2026-05-12', 'scheduled'),    // yesterday, past, unconfirmed
+                makeInsp('2026-05-14', 'scheduled'),    // tomorrow, this_week, unconfirmed
+                makeInsp('2026-06-01', 'scheduled'),    // future, unconfirmed
+            ];
+            const counts = countByFilter(list, now);
+            expect(counts.all).toBe(5);
+            expect(counts.today).toBe(2);
+            expect(counts.yesterday).toBe(1);
+            expect(counts.tomorrow).toBe(1);
+            expect(counts.past).toBe(1);
+            expect(counts.future).toBe(1);
+            expect(counts.in_progress).toBe(1);
+            expect(counts.unconfirmed).toBe(4);
+            // this_week covers Sun 5/10..Sat 5/16 → today×2, yesterday, tomorrow.
+            expect(counts.this_week).toBe(4);
+        });
+
+        it('returns zeros for an empty list', () => {
+            const counts = countByFilter([], now);
+            for (const f of INSPECTION_FILTERS) {
+                expect(counts[f.id]).toBe(0);
+            }
+        });
+    });
+
+    it('exposes filters in spec order', () => {
+        const ids = INSPECTION_FILTERS.map(f => f.id);
+        expect(ids).toEqual([
+            'all', 'past', 'yesterday', 'today', 'tomorrow',
+            'this_week', 'future', 'unconfirmed', 'in_progress',
+        ]);
+    });
+});

--- a/tests/unit/rating-button-labels.spec.ts
+++ b/tests/unit/rating-button-labels.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * R7-16 — Rating buttons render the full label on tablet+ (≥640px) and the
+ * abbreviation only on mobile, with `aria-label` always carrying the full
+ * name for assistive tech.
+ *
+ * The buttons are produced by an Alpine `x-for` over `ratingLevels`, so we
+ * cannot assert `toHaveAccessibleName('Satisfactory')` in Playwright without
+ * loading a real, fully-seeded inspection in a logged-in browser context —
+ * that's beyond the scope of this responsive labelling fix.
+ *
+ * Instead we statically verify the JSX template:
+ *   * each rating-row template renders TWO <span> siblings, one with
+ *     `class="hidden sm:inline"` + `x-text="level.label"` (full name on
+ *     tablet+) and one with `class="sm:hidden"` + `x-text="level.abbreviation"`
+ *     (abbrev on mobile)
+ *   * each <button> still binds `aria-label` to `level.label` so screen
+ *     readers always announce the full name regardless of viewport
+ *
+ * If a future refactor regresses the responsive label or drops aria-label,
+ * this spec fails before the regression reaches CI.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tsxPath = resolve(__dirname, '../../src/templates/pages/inspection-edit.tsx');
+const source  = readFileSync(tsxPath, 'utf8');
+
+describe('R7-16 — rating button responsive labels', () => {
+    it('renders both full-label (sm:inline) and abbreviation (sm:hidden) spans', () => {
+        // Both spans must appear at least twice: the desktop top-bar button
+        // row and the active-card row both render rating buttons.
+        const fullLabelMatches = source.match(/class="hidden sm:inline" x-text="level\.label"/g) ?? [];
+        const abbrevMatches    = source.match(/class="sm:hidden" x-text="level\.abbreviation"/g) ?? [];
+        expect(fullLabelMatches.length, 'full-label span (hidden sm:inline) should appear in at least 2 rating rows').toBeGreaterThanOrEqual(2);
+        expect(abbrevMatches.length,    'abbrev span (sm:hidden) should appear in at least 2 rating rows').toBeGreaterThanOrEqual(2);
+    });
+
+    it('keeps aria-label bound to level.label on every rating button', () => {
+        // x-bind:aria-label="level.label" — must remain on the rating buttons
+        // so AT users always hear the full rating name.
+        const aria = source.match(/x-bind:aria-label="level\.label"/g) ?? [];
+        expect(aria.length, 'aria-label="level.label" must be present on rating buttons').toBeGreaterThanOrEqual(2);
+    });
+
+    it('removes the old single x-text="level.abbreviation" attribute from rating buttons', () => {
+        // The previous code rendered the button as <button x-text="level.abbreviation">
+        // which left no room for a full-label fallback. Confirm we no longer
+        // attach x-text directly to the rating <button> tag (the spans inside
+        // each button are still allowed — that match is excluded by the
+        // negative lookbehind on `class="sm:hidden" `).
+        const lines = source.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i] ?? '';
+            // Only flag <button>-tag lines that use the old single-x-text
+            // pattern — span-tag lines are part of the new pattern and OK.
+            if (/^\s*x-text="level\.abbreviation"\s*$/.test(line)) {
+                // Walk up to find the enclosing tag start.
+                let opener = '';
+                for (let j = i; j >= 0 && j > i - 12; j--) {
+                    const lj = lines[j] ?? '';
+                    if (/^\s*<button\b/.test(lj)) { opener = '<button'; break; }
+                    if (/^\s*<span\b/.test(lj))   { opener = '<span';   break; }
+                }
+                expect(opener, `line ${i + 1} attaches x-text=level.abbreviation directly to a <button>`).not.toBe('<button');
+            }
+        }
+    });
+});

--- a/tests/unit/report-sidebar.spec.ts
+++ b/tests/unit/report-sidebar.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Competitor parity Feature C2 — section issue-count badges.
+ *
+ * Verifies the report viewer left sidebar renders a single combined defect
+ * count badge per section (Spectora App.F.2) in addition to the existing
+ * per-category breakdown. Anchor links must continue to point to the
+ * #section-{id} hash so clicking the section scrolls the report viewer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ReportSidebar, type ReportSidebarSection } from '../../src/templates/components/report-sidebar';
+
+function render(node: unknown): string {
+    return String(node);
+}
+
+const baseSection = (overrides: Partial<ReportSidebarSection> = {}): ReportSidebarSection => ({
+    id:    'roof',
+    title: 'Roof',
+    defects: { safety: 0, recommendation: 0, maintenance: 0 },
+    ...overrides,
+});
+
+describe('ReportSidebar — competitor C2 issue-count badges', () => {
+    it('renders a combined defect-count badge when section has any defect', () => {
+        const html = render(ReportSidebar({
+            sections: [baseSection({ defects: { safety: 2, recommendation: 1, maintenance: 0 } })],
+            role: 'client', inspectionId: 'i-1', siteName: 'Acme',
+        }));
+        // Combined badge — total (safety + recommendation + maintenance).
+        expect(html).toMatch(/data-test="section-defect-total"[^>]*>3<\/span>/);
+    });
+
+    it('omits the combined badge when section has zero defects', () => {
+        const html = render(ReportSidebar({
+            sections: [baseSection()],
+            role: 'client', inspectionId: 'i-1', siteName: 'Acme',
+        }));
+        expect(html).not.toContain('data-test="section-defect-total"');
+    });
+
+    it('renders an anchor link to #section-{id} for each section', () => {
+        const html = render(ReportSidebar({
+            sections: [baseSection({ id: 'plumbing', title: 'Plumbing' })],
+            role: 'client', inspectionId: 'i-1', siteName: 'Acme',
+        }));
+        expect(html).toContain('href="#section-plumbing"');
+    });
+
+    it('keeps the per-category breakdown badges for backwards compat', () => {
+        const html = render(ReportSidebar({
+            sections: [baseSection({ defects: { safety: 1, recommendation: 0, maintenance: 0 } })],
+            role: 'client', inspectionId: 'i-1', siteName: 'Acme',
+        }));
+        // Existing safety badge (rose-500 background) stays.
+        expect(html).toContain('Safety hazards');
+    });
+
+    it('uses red (rose) styling on the combined badge', () => {
+        const html = render(ReportSidebar({
+            sections: [baseSection({ defects: { safety: 0, recommendation: 0, maintenance: 5 } })],
+            role: 'client', inspectionId: 'i-1', siteName: 'Acme',
+        }));
+        // Spec calls for "small red badge" — verify rose color class on the
+        // combined badge wrapper.
+        expect(html).toMatch(/data-test="section-defect-total"[^>]*class="[^"]*bg-rose-500/);
+    });
+});


### PR DESCRIPTION
## Summary

Triple-track polish ride after Sprint 2 launch. Fixes 4 regressions found during live Chrome MCP testing, lands 2 long-pending UX issues, and ships 3 highest-ROI competitor parity features.

### Track A — Sprint 2 regression (5 commits)
- A1: rating-systems page wires `authFetch` via `auth.js`; root cause was `authFetch` defined as top-level const, not on `window` — broke all 4 inspection sub-page JS files
- A2: removes "SOON" badge from sidebar Rating Systems link
- A3: inspection sub-route shell wraps `/report` with sticky 5-tab nav
- A4: `/photos`, `/summary`, `/signatures`, `/settings` no longer hang (same root cause as A1)

### Track B — UX (3 commits)
- B1 (R7-06): `/book` date input changed from `type=text` to `type=date` for native iOS Safari + Chrome mobile picker
- B2 (R7-16): rating buttons show full label on tablet+ (`Satisfactory`/`Monitor`/`Defect`/`Not Inspected`/`Not Present`) with `aria-label` for screen readers; abbreviated label only on mobile

### Track C — Competitor Top 3 (4 commits)
- C1: time-based filter tabs (ALL / PAST / YESTERDAY / TODAY / TOMORROW / FUTURE / UNCONFIRMED / IN PROGRESS) on inspection list — Spectora App.E.7 parity
- C2: section issue-count badges in viewer sidebar — Spectora App.F.2 parity
- C3: per-defect "Edit with AI" rewriter with 5 instruction templates (`shorten` / `more specific` / `less alarming` / `more professional` / `add specific location detail`); guarded against empty-comment generation

## Stats

- **3 tracks**, ~1.5h total parallel run time across worktree-isolated agents
- **45 test files**, **338 unit tests pass**
- type-check 0 errors, lint 0 errors (26 pre-existing warnings)
- 2 merge conflicts resolved (`playwright.config.ts`, both project-list additions)

## Test plan

- [x] type-check 0 errors
- [x] lint 0 errors
- [x] 338/338 unit tests pass
- [x] Playwright `sprint2-regression` 12 source-level guards
- [x] Playwright `subroutes` 7/7
- [x] Playwright `multi-inspection` 3/3 (regression preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)