### PR TITLE
Sprint 2 polish round 2: editor search + section numbering + repair list + disclaimer

### DIFF
--- a/migrations/0044_repair_list_toggle.sql
+++ b/migrations/0044_repair_list_toggle.sql
@@ -1,0 +1,12 @@
+-- Track E1 (ITB §11, UC-ITB-07) — opt-in Repair List view.
+--
+-- When enable_repair_list = 1, the published report sub-nav exposes an
+-- additional "Repair List" tab that aggregates every defect-rated item
+-- across the inspection into a clean punch-list (item label + comment +
+-- contractor recommendation tag + estimate range + photos). Distinct from
+-- the narrative report — this is what realtors hand to contractors.
+--
+-- Defaults to 0 so existing tenants don't see the new tab until they
+-- explicitly opt in via Settings → Workspace → Reports.
+
+ALTER TABLE tenant_configs ADD COLUMN enable_repair_list INTEGER NOT NULL DEFAULT 0;

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -95,6 +95,11 @@ function inspectionEditor(inspectionId) {
     aiSuggestions: [],
     aiTargetField: null,
     showAiPopover: false,
+    // Competitor parity App.E.3 (Spectora) — top-right "Search entire report…"
+    // input. Empty string = match all (no filter applied). The search helpers
+    // below scan section.title, item.label, and free-text fields in
+    // results[item.id] (notes / canned / custom comments).
+    searchQuery: '',
     // Spec 2026-05-07 — user snippets fetched from /api/admin/comments
     // (the same data source as the /comments page). Lets MY SNIPPETS show
     // bucket-classified user comments, so /comments + Library drawer agree.
@@ -601,6 +606,126 @@ function inspectionEditor(inspectionId) {
 
     getItemNotes(itemId) {
       return this.results[itemId]?.notes || '';
+    },
+
+    // ===== Editor full-text search (App.E.3) =================================
+    // Mirror of src/lib/editor-search.ts logic, kept inline here because
+    // public/js/* is plain JS loaded by the browser (no bundler step). The
+    // server-side TS file is the source of truth and carries the unit
+    // tests; if you change matching behavior here, change it there too.
+
+    _searchNeedle() {
+      var q = this.searchQuery;
+      if (!q) return '';
+      return String(q).trim().toLowerCase();
+    },
+
+    _searchContains(haystack, needle) {
+      if (!haystack) return false;
+      return String(haystack).toLowerCase().indexOf(needle) !== -1;
+    },
+
+    _searchResultMatches(itemId, needle) {
+      var r = this.results[itemId];
+      if (!r) return false;
+      if (this._searchContains(r.notes, needle)) return true;
+      if (this._searchContains(r.recommendation, needle)) return true;
+      var canned = r.cannedComments;
+      if (canned) {
+        var tabs = ['information', 'limitations', 'defects'];
+        for (var t = 0; t < tabs.length; t++) {
+          var list = canned[tabs[t]];
+          if (!list) continue;
+          for (var i = 0; i < list.length; i++) {
+            var entry = list[i] || {};
+            if (this._searchContains(entry.title, needle)) return true;
+            if (this._searchContains(entry.comment, needle)) return true;
+            if (this._searchContains(entry.effectiveComment, needle)) return true;
+          }
+        }
+      }
+      var custom = r.customComments;
+      if (custom) {
+        var ctabs = ['information', 'limitations', 'defects'];
+        for (var ct = 0; ct < ctabs.length; ct++) {
+          var clist = custom[ctabs[ct]];
+          if (!clist) continue;
+          for (var ci = 0; ci < clist.length; ci++) {
+            var centry = clist[ci] || {};
+            if (this._searchContains(centry.title, needle)) return true;
+            if (this._searchContains(centry.comment, needle)) return true;
+            if (this._searchContains(centry.location, needle)) return true;
+          }
+        }
+      }
+      return false;
+    },
+
+    /** True if the section's title matches OR any of its items matches. */
+    sectionMatchesSearch(section) {
+      var needle = this._searchNeedle();
+      if (!needle) return true;
+      if (!section) return false;
+      if (this._searchContains(section.title, needle)) return true;
+      var items = section.items || [];
+      for (var i = 0; i < items.length; i++) {
+        if (this.itemMatchesSearch(section, items[i])) return true;
+      }
+      return false;
+    },
+
+    /** True if section.title matches (whole section kept) OR
+     *  item.label / its result row matches the query. */
+    itemMatchesSearch(section, item) {
+      var needle = this._searchNeedle();
+      if (!needle) return true;
+      if (!item) return false;
+      if (section && this._searchContains(section.title, needle)) return true;
+      if (this._searchContains(item.label, needle)) return true;
+      return this._searchResultMatches(item.id, needle);
+    },
+
+    /** True when the user has typed something — used to swap "no results"
+     *  empty-state messages and to show the clear (×) button. */
+    get hasSearchQuery() {
+      return this._searchNeedle() !== '';
+    },
+
+    /** Total number of items matching the current query across all sections.
+     *  Drives the live "N matches" hint next to the search input. */
+    get searchMatchCount() {
+      var needle = this._searchNeedle();
+      if (!needle) return 0;
+      var count = 0;
+      for (var s = 0; s < this.sections.length; s++) {
+        var sec = this.sections[s];
+        var items = sec.items || [];
+        if (this._searchContains(sec.title, needle)) {
+          count += items.length;
+          continue;
+        }
+        for (var i = 0; i < items.length; i++) {
+          if (this.itemMatchesSearch(sec, items[i])) count++;
+        }
+      }
+      return count;
+    },
+
+    clearSearch() {
+      this.searchQuery = '';
+    },
+
+    /** Wrap matched substrings inside `text` with <mark>. Result is
+     *  HTML-escaped so it's safe to bind via x-html on a known item label
+     *  / section title (no other HTML in those fields). */
+    highlightSearchMatch(text) {
+      var src = text == null ? '' : String(text);
+      var safe = src.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      var needle = this._searchNeedle();
+      if (!needle) return safe;
+      var escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      var re = new RegExp(escaped, 'gi');
+      return safe.replace(re, function (m) { return '<mark>' + m + '</mark>'; });
     },
 
     getPhotoCount(itemId) {

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -1230,6 +1230,70 @@ inspectionsRoutes.openapi(getReportDataRoute, async (c) => {
 });
 
 /**
+ * GET /api/inspections/:id/repair-list
+ *
+ * Track E1 (ITB §11, UC-ITB-07) — flat punch-list of every defect-rated
+ * item across the inspection, suitable for handing to a contractor or
+ * realtor. Authenticated route; the public viewer page hits the same
+ * service via a server-side render at /inspections/:id/repair-list.
+ */
+const RepairListEntrySchema = z.object({
+    sectionId:           z.string(),
+    sectionTitle:        z.string(),
+    itemId:              z.string(),
+    itemLabel:           z.string(),
+    comment:             z.string(),
+    location:            z.string().nullable(),
+    category:            z.enum(['safety', 'recommendation', 'maintenance']),
+    recommendationId:    z.string().nullable(),
+    recommendationLabel: z.string().nullable(),
+    estimateLow:         z.number().nullable(),
+    estimateHigh:        z.number().nullable(),
+    photos:              z.array(z.object({ key: z.string(), url: z.string() })),
+    source:              z.enum(['canned', 'custom']),
+});
+const RepairListResponseSchema = z.object({
+    inspection: z.object({
+        id:              z.string(),
+        propertyAddress: z.string(),
+        date:            z.string().nullable(),
+        inspectorName:   z.string().nullable(),
+    }),
+    defects: z.array(RepairListEntrySchema),
+    totals: z.object({
+        count:           z.number(),
+        safety:          z.number(),
+        recommendation:  z.number(),
+        maintenance:     z.number(),
+        estimateLowSum:  z.number(),
+        estimateHighSum: z.number(),
+    }),
+    showEstimates: z.boolean(),
+});
+
+const getRepairListRoute = createRoute({
+    method: 'get',
+    path: '/{id}/repair-list',
+    tags: ['Inspections'],
+    summary: 'Get aggregated repair list (defects-only punch list)',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: z.object({ id: z.string() }) },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: createApiResponseSchema(RepairListResponseSchema) } },
+            description: 'Repair list',
+        },
+    },
+});
+
+inspectionsRoutes.openapi(getRepairListRoute, async (c) => {
+    const tenantId = c.get('tenantId') as string;
+    const { id } = c.req.valid('param');
+    const data = await c.var.services.inspection.getRepairList(id, tenantId);
+    return c.json({ success: true, data }, 200);
+});
+
+/**
  * POST /api/inspections/:id/confirm
  */
 inspectionsRoutes.openapi(createRoute({

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { InspectionPhotosPage } from './templates/pages/inspection/photos';
 import { InspectionSummaryPage } from './templates/pages/inspection/summary';
 import { InspectionSignaturesPage } from './templates/pages/inspection/signatures';
 import { InspectionSettingsPage } from './templates/pages/inspection/settings';
+import { RepairListPage } from './templates/pages/inspection/repair-list';
 import { SettingsAutomationsPage } from './templates/pages/settings-automations';
 import { SettingsWidgetPage } from './templates/pages/settings-widget';
 import { SettingsServicesPage } from './templates/pages/settings-services';
@@ -895,6 +896,19 @@ app.get('/report/:id', async (c) => {
 
         const data = await service.getReportData(id, tenantId as string);
 
+        // Track E1 — surface the per-tenant Repair List toggle so the report
+        // viewer can render the "View repair list" top-right link only when
+        // the workspace has opted in. Failure to read the column is treated
+        // as opt-out (e.g. legacy tenants pre-migration 0044).
+        let enableRepairList = false;
+        try {
+            const cfgRow = await drizzle(c.env.DB).select({ enableRepairList: schema.tenantConfigs.enableRepairList })
+                .from(schema.tenantConfigs)
+                .where(eq(schema.tenantConfigs.tenantId, tenantId as string))
+                .get();
+            enableRepairList = !!cfgRow?.enableRepairList;
+        } catch { /* default off */ }
+
         const rawDate = data.inspection.date || '';
         const formattedDate = rawDate ? new Date(rawDate).toLocaleDateString('en-US', {
             weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
@@ -913,6 +927,8 @@ app.get('/report/:id', async (c) => {
             summaryMode,
             // Sprint 2 S2-4 — gate "Estimated cost: $X – $Y" badges per tenant.
             showEstimates: data.showEstimates,
+            // Track E1 — show "View repair list" link only when opted in.
+            enableRepairList,
         }));
     } catch {
         return c.text('Report not found', 404);
@@ -960,8 +976,9 @@ app.get('/settings/workspace/reports', htmlAuthGuard(['owner', 'admin']), async 
         primaryColor: c.env.PRIMARY_COLOR || '#4f46e5',
         supportEmail: c.env.SENDER_EMAIL || 'support@example.com',
     });
-    const showEstimates = Boolean((cfg as { showEstimates?: boolean | number }).showEstimates);
-    return c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'reports', showEstimates }));
+    const showEstimates    = Boolean((cfg as { showEstimates?: boolean | number }).showEstimates);
+    const enableRepairList = Boolean((cfg as { enableRepairList?: boolean | number }).enableRepairList);
+    return c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'reports', showEstimates, enableRepairList }));
 });
 app.get('/settings/workspace/telemetry', htmlAuthGuard(['owner', 'admin']), (c) => c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'telemetry' })));
 
@@ -1085,7 +1102,18 @@ async function loadInspectionShellData(c: Context<HonoConfig>, inspectionId: str
                 status: i.status,
             }));
         }
-        return { propertyAddress, requestId, siblings };
+        // Track E1 — per-tenant Repair List toggle drives the 6th sub-nav
+        // tab. Failure to read defaults to false so the existing 5-tab nav
+        // stays the baseline.
+        let enableRepairList = false;
+        try {
+            const cfgRow = await drizzle(c.env.DB).select({ enableRepairList: schema.tenantConfigs.enableRepairList })
+                .from(schema.tenantConfigs)
+                .where(eq(schema.tenantConfigs.tenantId, tenantId))
+                .get();
+            enableRepairList = !!cfgRow?.enableRepairList;
+        } catch { /* default off */ }
+        return { propertyAddress, requestId, siblings, enableRepairList };
     } catch {
         return null;
     }
@@ -1097,10 +1125,23 @@ app.get('/inspections/:id/edit', htmlAuthGuard(['owner', 'admin', 'inspector']),
     return c.redirect(`/inspections/${id}/report`, 302);
 });
 
-app.get('/inspections/:id/report', htmlAuthGuard(['owner', 'admin', 'inspector']), (c) => {
+app.get('/inspections/:id/report', htmlAuthGuard(['owner', 'admin', 'inspector']), async (c) => {
     const id = c.req.param('id');
     if (!id) return c.redirect('/dashboard');
-    return c.html(InspectionEditPage({ inspectionId: id, branding: c.get('branding') }));
+    // Track E1 — surface the per-tenant Repair List toggle so the editor's
+    // sub-nav optionally renders the 6th tab.
+    const tenantId = c.get('tenantId');
+    let enableRepairList = false;
+    if (tenantId) {
+        try {
+            const cfgRow = await drizzle(c.env.DB).select({ enableRepairList: schema.tenantConfigs.enableRepairList })
+                .from(schema.tenantConfigs)
+                .where(eq(schema.tenantConfigs.tenantId, tenantId))
+                .get();
+            enableRepairList = !!cfgRow?.enableRepairList;
+        } catch { /* default off */ }
+    }
+    return c.html(InspectionEditPage({ inspectionId: id, branding: c.get('branding'), enableRepairList }));
 });
 
 app.get('/inspections/:id/photos', htmlAuthGuard(['owner', 'admin', 'inspector']), async (c) => {
@@ -1111,6 +1152,7 @@ app.get('/inspections/:id/photos', htmlAuthGuard(['owner', 'admin', 'inspector']
         inspectionId: id,
         propertyAddress: shell?.propertyAddress ?? 'Inspection',
         branding: c.get('branding'),
+        enableRepairList: !!shell?.enableRepairList,
         ...(shell?.requestId ? { requestId: shell.requestId } : {}),
         ...(shell?.siblings  ? { siblings: shell.siblings  } : {}),
     }));
@@ -1124,6 +1166,7 @@ app.get('/inspections/:id/summary', htmlAuthGuard(['owner', 'admin', 'inspector'
         inspectionId: id,
         propertyAddress: shell?.propertyAddress ?? 'Inspection',
         branding: c.get('branding'),
+        enableRepairList: !!shell?.enableRepairList,
         ...(shell?.requestId ? { requestId: shell.requestId } : {}),
         ...(shell?.siblings  ? { siblings: shell.siblings  } : {}),
     }));
@@ -1137,6 +1180,7 @@ app.get('/inspections/:id/signatures', htmlAuthGuard(['owner', 'admin', 'inspect
         inspectionId: id,
         propertyAddress: shell?.propertyAddress ?? 'Inspection',
         branding: c.get('branding'),
+        enableRepairList: !!shell?.enableRepairList,
         ...(shell?.requestId ? { requestId: shell.requestId } : {}),
         ...(shell?.siblings  ? { siblings: shell.siblings  } : {}),
     }));
@@ -1150,9 +1194,49 @@ app.get('/inspections/:id/settings', htmlAuthGuard(['owner', 'admin', 'inspector
         inspectionId: id,
         propertyAddress: shell?.propertyAddress ?? 'Inspection',
         branding: c.get('branding'),
+        enableRepairList: !!shell?.enableRepairList,
         ...(shell?.requestId ? { requestId: shell.requestId } : {}),
         ...(shell?.siblings  ? { siblings: shell.siblings  } : {}),
     }));
+});
+
+// Track E1 (ITB §11, UC-ITB-07) — Repair List sub-route. Server-renders
+// the punch-list of every flagged defect across the inspection. Available
+// only when the tenant has opted in via Settings → Workspace → Reports;
+// otherwise the route 404s so it cannot be deep-linked accidentally.
+app.get('/inspections/:id/repair-list', htmlAuthGuard(['owner', 'admin', 'inspector']), async (c) => {
+    const id = c.req.param('id');
+    if (!id) return c.redirect('/dashboard');
+    const tenantId = c.get('tenantId');
+    if (!tenantId) return c.redirect('/dashboard');
+
+    const shell = await loadInspectionShellData(c, id);
+
+    // Gate on the tenant toggle so an admin can't deep-link past the opt-in.
+    if (!shell?.enableRepairList) {
+        return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+    }
+    try {
+        const data = await c.var.services.inspection.getRepairList(id, tenantId);
+        const rawDate = data.inspection.date || '';
+        const formattedDate = rawDate ? new Date(rawDate).toLocaleDateString('en-US', {
+            weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        }) : null;
+        return c.html(RepairListPage({
+            inspectionId:    id,
+            propertyAddress: shell?.propertyAddress ?? data.inspection.propertyAddress ?? 'Inspection',
+            inspectionDate:  formattedDate,
+            inspectorName:   data.inspection.inspectorName,
+            defects:         data.defects,
+            totals:          data.totals,
+            showEstimates:   data.showEstimates,
+            branding:        c.get('branding'),
+            ...(shell?.requestId ? { requestId: shell.requestId } : {}),
+            ...(shell?.siblings  ? { siblings: shell.siblings  } : {}),
+        }));
+    } catch {
+        return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+    }
 });
 
 app.get('/', (c) => c.redirect('/dashboard'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -913,6 +913,9 @@ app.get('/report/:id', async (c) => {
             summaryMode,
             // Sprint 2 S2-4 — gate "Estimated cost: $X – $Y" badges per tenant.
             showEstimates: data.showEstimates,
+            // Competitor parity App.F.4 — drives the EDIT SECTION hover button.
+            // Public viewers (no JWT) get `null` and never see the affordance.
+            viewerRole: role,
         }));
     } catch {
         return c.text('Report not found', 404);

--- a/src/lib/db/schema/tenant.ts
+++ b/src/lib/db/schema/tenant.ts
@@ -67,6 +67,10 @@ export const tenantConfigs = sqliteTable('tenant_configs', {
     // Sprint 2 S2-4 — when true, published reports render the per-defect
     // "Estimated cost: $X – $Y" badge.
     showEstimates: integer('show_estimates', { mode: 'boolean' }).notNull().default(false),
+    // Track E1 (ITB §11, UC-ITB-07) — when true, the published report sub-nav
+    // exposes a "Repair List" tab. Default OFF — opt-in for realtors who want
+    // a separate punch-list view rather than the full narrative report.
+    enableRepairList: integer('enable_repair_list', { mode: 'boolean' }).notNull().default(false),
     updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 });
 

--- a/src/lib/editor-search.ts
+++ b/src/lib/editor-search.ts
@@ -1,0 +1,210 @@
+/**
+ * Editor full-text search helpers — Competitor parity App.E.3 (Spectora).
+ *
+ * Pure utility functions used by the inspection editor (`inspection-edit.tsx`
+ * + `public/js/inspection-edit.js`) to filter the rendered section/item tree
+ * against a free-form query string. Search is case-insensitive substring
+ * matching across:
+ *   - section titles (`section.title`)
+ *   - item labels (`item.label`)
+ *   - any text persisted in `results[itemId]` — `notes`, canned-comment
+ *     text, custom-comment text, recommendation labels.
+ *
+ * The editor-side caller passes `results` so we can match the inspector's
+ * own typing (a defect comment that says "rusted breaker") not just the
+ * static template labels. An empty / whitespace-only query short-circuits
+ * to "match everything".
+ *
+ * Kept as pure functions in `src/lib/` so they unit-test without a DOM /
+ * Alpine harness.
+ */
+
+/** A canned-comment entry as stored under `results[itemId].cannedComments`.
+ *  Only the fields we actually scan. */
+export interface SearchableCanned {
+    cannedId?: string;
+    title?: string;
+    comment?: string;
+    effectiveComment?: string;
+}
+
+/** A custom-comment entry as stored under `results[itemId].customComments`.
+ *  Only the fields we actually scan. */
+export interface SearchableCustom {
+    id?: string;
+    title?: string;
+    comment?: string;
+    location?: string;
+}
+
+/** Per-item editor state — shape matches the live `results` payload that
+ *  Alpine populates from `/api/inspections/:id/results`. */
+export interface SearchableResult {
+    notes?: string | null;
+    recommendation?: string | null;
+    cannedComments?: {
+        information?: SearchableCanned[];
+        limitations?: SearchableCanned[];
+        defects?: SearchableCanned[];
+    };
+    customComments?: {
+        information?: SearchableCustom[];
+        limitations?: SearchableCustom[];
+        defects?: SearchableCustom[];
+    };
+}
+
+/** Inspection item — only the fields we read. */
+export interface SearchableItem {
+    id: string;
+    label: string;
+}
+
+/** Inspection section — only the fields we read. */
+export interface SearchableSection {
+    id: string;
+    title: string;
+    items: SearchableItem[];
+}
+
+/** Map of itemId → result row. */
+export type SearchableResults = Record<string, SearchableResult | undefined>;
+
+/**
+ * Normalize a search query — lowercase + trim. Returns the empty string
+ * when the input is falsy, so callers can `if (!normalized) return all`.
+ */
+export function normalizeQuery(query: string | null | undefined): string {
+    if (!query) return '';
+    return query.trim().toLowerCase();
+}
+
+/** Case-insensitive substring test. Treats `null` / `undefined` haystack
+ *  as a non-match (avoids "" matching every query). */
+function contains(haystack: string | null | undefined, needle: string): boolean {
+    if (!haystack) return false;
+    return haystack.toLowerCase().includes(needle);
+}
+
+/** Walk a result row's free-text fields and return true if any contains
+ *  the (already-lowercased) needle. */
+function resultMatches(result: SearchableResult | undefined, needle: string): boolean {
+    if (!result) return false;
+    if (contains(result.notes ?? null, needle)) return true;
+    if (contains(result.recommendation ?? null, needle)) return true;
+
+    const canned = result.cannedComments;
+    if (canned) {
+        for (const tab of ['information', 'limitations', 'defects'] as const) {
+            const list = canned[tab];
+            if (!list) continue;
+            for (const entry of list) {
+                if (contains(entry.title, needle)) return true;
+                if (contains(entry.comment, needle)) return true;
+                if (contains(entry.effectiveComment, needle)) return true;
+            }
+        }
+    }
+
+    const custom = result.customComments;
+    if (custom) {
+        for (const tab of ['information', 'limitations', 'defects'] as const) {
+            const list = custom[tab];
+            if (!list) continue;
+            for (const entry of list) {
+                if (contains(entry.title, needle)) return true;
+                if (contains(entry.comment, needle)) return true;
+                if (contains(entry.location, needle)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Decide whether a single item matches the query. Match sources:
+ *   - section.title (so "Roof" surfaces every roof-section item)
+ *   - item.label
+ *   - result.notes / recommendation / canned + custom comments
+ */
+export function itemMatches(
+    section: SearchableSection,
+    item: SearchableItem,
+    results: SearchableResults,
+    query: string,
+): boolean {
+    const needle = normalizeQuery(query);
+    if (!needle) return true;
+    if (contains(section.title, needle)) return true;
+    if (contains(item.label, needle)) return true;
+    return resultMatches(results[item.id], needle);
+}
+
+/**
+ * Decide whether a section has at least one matching item (or matches
+ * directly via title). Used to hide whole sections when nothing matches.
+ */
+export function sectionMatches(
+    section: SearchableSection,
+    results: SearchableResults,
+    query: string,
+): boolean {
+    const needle = normalizeQuery(query);
+    if (!needle) return true;
+    if (contains(section.title, needle)) return true;
+    for (const item of section.items) {
+        if (itemMatches(section, item, results, needle)) return true;
+    }
+    return false;
+}
+
+/**
+ * Filter the section tree against a query. Empty query returns the input
+ * unchanged. Sections with zero matching items are dropped. Items inside
+ * a section-title hit are all kept (so "Roof" surfaces the whole Roof
+ * section, not just the items whose label contains "roof").
+ */
+export function filterSections<S extends SearchableSection>(
+    sections: ReadonlyArray<S>,
+    results: SearchableResults,
+    query: string,
+): S[] {
+    const needle = normalizeQuery(query);
+    if (!needle) return sections.slice();
+    const out: S[] = [];
+    for (const section of sections) {
+        if (contains(section.title, needle)) {
+            out.push(section);
+            continue;
+        }
+        const matchingItems = section.items.filter((it) =>
+            itemMatches(section, it, results, needle),
+        );
+        if (matchingItems.length === 0) continue;
+        out.push({ ...section, items: matchingItems });
+    }
+    return out;
+}
+
+/**
+ * Wrap every case-insensitive occurrence of `query` inside `text` with
+ * `<mark>` tags. Returns the original text if the query is empty.
+ *
+ * The result is **not** HTML-safe — callers must HTML-escape `text`
+ * upstream OR (preferable for Alpine) bind the highlighted markup
+ * via `x-html` only when the surrounding context is trusted. We
+ * escape `<`, `>`, `&` defensively here so an item label containing
+ * raw HTML can't break out of the `<mark>` wrapper.
+ */
+export function highlightMatches(text: string | null | undefined, query: string): string {
+    if (!text) return '';
+    const safe = String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const needle = normalizeQuery(query);
+    if (!needle) return safe;
+    // Escape regex meta-characters in the query so the user can search
+    // for "(GFCI)" without blowing up.
+    const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(escaped, 'gi');
+    return safe.replace(re, (match) => `<mark>${match}</mark>`);
+}

--- a/src/lib/report-section-numbering.ts
+++ b/src/lib/report-section-numbering.ts
@@ -1,0 +1,53 @@
+/**
+ * Report section numbering + edit-permission helpers — Competitor parity
+ * App.F.4 (Spectora).
+ *
+ * In the published report viewer (`/report/:id`), section headings render
+ * as `"3 - Roof"` (1-based, in visible-section order). On hover, an
+ * "EDIT SECTION" button surfaces — but only for viewers with an
+ * inspector / admin / owner role; public clients (no JWT, or `agent`
+ * role) never see the edit affordance.
+ *
+ * Kept as pure functions so they unit-test without a DOM or Alpine
+ * harness. The template (`report-card-stack.tsx`) calls these directly
+ * during render.
+ */
+
+/** Roles that may hop back into the editor from the published viewer. */
+const EDIT_ROLES = new Set(['owner', 'admin', 'inspector']);
+
+/** Decide whether the current viewer should see the EDIT SECTION button.
+ *  Accepts `null` / `undefined` (anonymous public viewer) and unknown
+ *  role strings — both fail-closed to `false`. */
+export function canEditSection(role: string | null | undefined): boolean {
+    if (!role) return false;
+    return EDIT_ROLES.has(role);
+}
+
+/**
+ * Build a Spectora-style numbered section title:
+ *   formatSectionHeading('Roof', 2)  ->  "3 - Roof"
+ *
+ * `index` is 0-based (matches the array index in the rendered list).
+ * A null / empty title falls back to the bare number — keeps the
+ * template safe if the SSR data layer ever produces a section with no
+ * title.
+ */
+export function formatSectionHeading(title: string | null | undefined, index: number): string {
+    const number = Math.max(0, Math.floor(index)) + 1;
+    const cleanTitle = (title || '').trim();
+    if (!cleanTitle) return String(number);
+    return `${number} - ${cleanTitle}`;
+}
+
+/**
+ * Build the deep-link the EDIT SECTION button should navigate to:
+ *   buildSectionEditHref('insp-123', 'roof')
+ *     ->  "/inspections/insp-123/report#section-roof"
+ *
+ * The fragment matches the section's DOM id in the editor — selecting
+ * it after the editor mounts scrolls the right section into view.
+ */
+export function buildSectionEditHref(inspectionId: string, sectionId: string): string {
+    return `/inspections/${inspectionId}/report#section-${sectionId}`;
+}

--- a/src/lib/validations/admin.schema.ts
+++ b/src/lib/validations/admin.schema.ts
@@ -13,6 +13,8 @@ export const UpdateBrandingSchema = z.object({
     reportTheme: z.enum(['modern', 'classic', 'minimal']).optional().openapi({ example: 'modern' }),
     // Sprint 2 S2-4 — gate the per-defect "Estimated cost: $X – $Y" badge.
     showEstimates: z.boolean().optional().openapi({ example: true }),
+    // Track E1 (ITB §11) — gate the "Repair List" tab on the published report.
+    enableRepairList: z.boolean().optional().openapi({ example: true }),
 }).openapi('UpdateBranding');
 
 /**

--- a/src/lib/validations/template.schema.ts
+++ b/src/lib/validations/template.schema.ts
@@ -59,6 +59,16 @@ const TemplateSectionSchema = z.object({
     title: z.string().min(1),
     icon:  z.string().optional(),
     items: z.array(TemplateItemSchema),
+    // Track E2 (Spectora App.A) — per-section legal disclaimer rendered at
+    // the bottom of the section in the published report. Null/empty when
+    // unset. Free-form text (≤ 4 KB) so tenants can paste boilerplate.
+    disclaimerText: z.string().max(4000).nullable().optional(),
+    // Track E2 — when true, the published report forces a page break BEFORE
+    // this section in PDF output. Used for cover-letter style sections that
+    // must start on a fresh sheet. Defaults to false (the existing CSS
+    // already breaks per-section by default — this flag is an explicit
+    // marker so future "no-break" overrides have a clean signal to honor).
+    alwaysPageBreak: z.boolean().optional(),
 }).strict();
 
 const RatingLevelSchema = z.object({

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -821,6 +821,161 @@ export class InspectionService {
     }
 
     /**
+     * Track E1 (ITB §11, UC-ITB-07) — Repair List aggregation.
+     *
+     * Walks every section of the published report (via getReportData so we
+     * stay aligned with the rating-system snapshot resolution + photo
+     * surfacing logic) and returns a flat list of defect-rated items only.
+     * Each row is a contractor punch-list entry: section breadcrumb + item
+     * label + the effective comment + contractor recommendation tag +
+     * estimate range + photo URLs.
+     *
+     * Custom (per-inspection) defects added by the inspector are also
+     * surfaced — they live under inspection_results.data[itemId].customComments
+     * and are not exposed by getReportData yet, so we pull them separately.
+     */
+    async getRepairList(inspectionId: string, tenantId: string) {
+        const report = await this.getReportData(inspectionId, tenantId);
+
+        // Pull custom defects directly from inspection_results since
+        // getReportData only resolves the template canned tabs.
+        interface CustomDefect {
+            id?:        string;
+            title?:     string;
+            comment?:   string;
+            included?:  boolean;
+            category?:  'safety' | 'recommendation' | 'maintenance';
+            location?:  string | null;
+            recommendationId?: string | null;
+            estimateLow?:      number | null;
+            estimateHigh?:     number | null;
+        }
+        const resultsRow = await this.getDrizzle()
+            .select({ data: inspectionResults.data })
+            .from(inspectionResults)
+            .where(and(
+                eq(inspectionResults.inspectionId, inspectionId),
+                eq(inspectionResults.tenantId, tenantId),
+            ))
+            .get();
+        const customByItem = new Map<string, CustomDefect[]>();
+        if (resultsRow?.data) {
+            const rawData = typeof resultsRow.data === 'string'
+                ? JSON.parse(resultsRow.data) as Record<string, unknown>
+                : resultsRow.data as Record<string, unknown>;
+            for (const itemId of Object.keys(rawData)) {
+                const entry = rawData[itemId] as { customComments?: { defects?: CustomDefect[] } } | null;
+                const customDefects = entry?.customComments?.defects ?? [];
+                if (customDefects.length > 0) customByItem.set(itemId, customDefects);
+            }
+        }
+
+        // Resolve recommendation slug → label once.
+        const labelBySlug = new Map<string, string>(
+            RECOMMENDATION_CATEGORIES.map(c => [c.id, c.label]),
+        );
+
+        interface RepairListEntry {
+            sectionId:           string;
+            sectionTitle:        string;
+            itemId:              string;
+            itemLabel:           string;
+            comment:             string;
+            location:            string | null;
+            category:            'safety' | 'recommendation' | 'maintenance';
+            recommendationId:    string | null;
+            recommendationLabel: string | null;
+            estimateLow:         number | null;
+            estimateHigh:        number | null;
+            photos:              Array<{ key: string; url: string }>;
+            // Source — distinguishes canned (template-driven) vs custom
+            // (per-inspection ad-hoc) defects so realtors can see the mix.
+            source:              'canned' | 'custom';
+        }
+        const entries: RepairListEntry[] = [];
+
+        for (const section of report.sections) {
+            for (const item of section.items) {
+                // Canned defects from the resolved tabs.
+                const cannedDefects = item.resolvedTabs?.defects ?? [];
+                for (const d of cannedDefects) {
+                    if (!d.included) continue;
+                    const cat = (d.effectiveCategory ?? 'maintenance') as RepairListEntry['category'];
+                    const slug = d.recommendationId ?? null;
+                    entries.push({
+                        sectionId:    section.id,
+                        sectionTitle: section.title,
+                        itemId:       item.id,
+                        itemLabel:    item.label,
+                        comment:      d.effectiveComment ?? '',
+                        location:     (typeof d.effectiveLocation === 'string' && d.effectiveLocation.length > 0)
+                            ? d.effectiveLocation
+                            : null,
+                        category:            cat,
+                        recommendationId:    slug,
+                        recommendationLabel: slug ? (labelBySlug.get(slug) ?? slug) : null,
+                        estimateLow:         d.estimateLow ?? null,
+                        estimateHigh:        d.estimateHigh ?? null,
+                        photos:              (d.defectPhotos ?? []).map(p => ({ key: p.key, url: p.url })),
+                        source:              'canned',
+                    });
+                }
+                // Custom defects (ad-hoc additions by the inspector).
+                const customs = customByItem.get(item.id) ?? [];
+                for (const c of customs) {
+                    if (c.included === false) continue;
+                    const cat = (c.category ?? 'maintenance') as RepairListEntry['category'];
+                    const slug = c.recommendationId ?? null;
+                    entries.push({
+                        sectionId:    section.id,
+                        sectionTitle: section.title,
+                        itemId:       item.id,
+                        itemLabel:    c.title || item.label,
+                        comment:      c.comment ?? '',
+                        location:     (typeof c.location === 'string' && c.location.length > 0)
+                            ? c.location
+                            : null,
+                        category:            cat,
+                        recommendationId:    slug,
+                        recommendationLabel: slug ? (labelBySlug.get(slug) ?? slug) : null,
+                        estimateLow:         c.estimateLow ?? null,
+                        estimateHigh:        c.estimateHigh ?? null,
+                        // Custom defect photos are not currently aggregated by
+                        // getReportData — the canned defect photo path stays
+                        // authoritative for now. A future iteration may pull
+                        // custom defect photos straight off the JSON payload.
+                        photos:              [],
+                        source:              'custom',
+                    });
+                }
+            }
+        }
+
+        const totals = entries.reduce(
+            (acc, e) => {
+                acc.count++;
+                acc[e.category]++;
+                if (typeof e.estimateLow  === 'number') acc.estimateLowSum  += e.estimateLow;
+                if (typeof e.estimateHigh === 'number') acc.estimateHighSum += e.estimateHigh;
+                return acc;
+            },
+            { count: 0, safety: 0, recommendation: 0, maintenance: 0, estimateLowSum: 0, estimateHighSum: 0 },
+        );
+
+        return {
+            inspection: {
+                id:              report.inspection.id as string,
+                propertyAddress: report.inspection.propertyAddress as string,
+                date:            report.inspection.date as string | null,
+                inspectorName:   report.inspection.inspectorName,
+            },
+            defects: entries,
+            totals,
+            showEstimates: report.showEstimates,
+        };
+    }
+
+    /**
      * Returns tab counts for the inspection list UI.
      * Single query with 6 conditional aggregates to avoid N+1.
      */

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -560,7 +560,11 @@ export class InspectionService {
         interface CannedDefect      { id: string; title: string; category: 'maintenance' | 'recommendation' | 'safety'; location: string; comment: string; photos: string[]; default: boolean }
         interface ItemTabs          { information: CannedInfoComment[]; limitations: CannedInfoComment[]; defects: CannedDefect[] }
         interface SchemaItem        { id: string; label: string; icon?: string; type?: string; ratingOptions?: string[]; tabs?: ItemTabs; number?: string }
-        interface SchemaSection     { id: string; title: string; icon?: string; items: SchemaItem[] }
+        // Track E2 (Spectora App.A) — per-section disclaimer + force-page-break
+        // are stored on the schema's section node so the editor can author
+        // them and the published report can honor them. Both are optional —
+        // legacy templates without these fields render unchanged.
+        interface SchemaSection     { id: string; title: string; icon?: string; items: SchemaItem[]; disclaimerText?: string | null; alwaysPageBreak?: boolean }
         interface SchemaData        { schemaVersion?: number; sections: SchemaSection[]; ratingSystem?: { levels: RatingLevel[] } }
         interface PhotoEntry        { key: string; annotatedKey?: string; annotationsJson?: string }
         // Sprint 2 S2-3 / S2-4 — per-defect recommendation slug + repair
@@ -652,6 +656,13 @@ export class InspectionService {
             title: sec.title || (sec as unknown as Record<string, string>).name || 'Untitled',
             icon: sec.icon ?? null,
             defectCount: stats.sectionDefects[sec.id] ?? 0,
+            // Track E2 — surface per-section flags so the report viewer can
+            // render the disclaimer + apply the page-break attribute. Null
+            // when unset so the renderer can short-circuit cleanly.
+            disclaimerText:  (typeof sec.disclaimerText === 'string' && sec.disclaimerText.trim().length > 0)
+                ? sec.disclaimerText.trim()
+                : null,
+            alwaysPageBreak: sec.alwaysPageBreak === true,
             items: sec.items.map((item: SchemaItem) => {
                 const res = resultData[item.id] || {};
                 const ratingId = res.rating ?? null;

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -333,6 +333,13 @@ details[open] > summary > .details-chevron { transform: rotate(180deg); }
     /* Each section starts on a new page in PDF output. */
     .report-section { page-break-before: always; break-before: page; }
     .report-section:first-of-type { page-break-before: auto; break-before: auto; }
+    /* Track E2 (Spectora App.A) — sections marked alwaysPageBreak override
+       the first-of-type carve-out so they always force a fresh sheet, even
+       when authored as the first section. */
+    .report-section[data-page-break="always"] {
+        page-break-before: always !important;
+        break-before: page !important;
+    }
 
     img { max-height: 250px; object-fit: contain; }
     .grid { display: flex !important; flex-wrap: wrap; gap: 1rem; }

--- a/src/templates/components/inspection-shell.tsx
+++ b/src/templates/components/inspection-shell.tsx
@@ -16,7 +16,7 @@
 
 import { PageHeader } from './page-header';
 
-export type InspectionSubRoute = 'report' | 'photos' | 'summary' | 'signatures' | 'settings';
+export type InspectionSubRoute = 'report' | 'photos' | 'summary' | 'signatures' | 'settings' | 'repair-list';
 
 interface SubInspectionInfo {
     id:           string;
@@ -31,15 +31,18 @@ export interface InspectionShellProps {
     /** When set, the page header shows a "Part X of Y" badge with switcher. */
     requestId?:      string;
     siblings?:       SubInspectionInfo[];
+    /** Track E1 — when true, the sub-nav exposes a 6th "Repair List" tab. */
+    enableRepairList?: boolean;
     children:        unknown;
 }
 
 const TABS: Array<{ id: InspectionSubRoute; label: string }> = [
-    { id: 'report',     label: 'Report' },
-    { id: 'photos',     label: 'Photos' },
-    { id: 'summary',    label: 'Summary' },
-    { id: 'signatures', label: 'Signatures' },
-    { id: 'settings',   label: 'Settings' },
+    { id: 'report',      label: 'Report' },
+    { id: 'photos',      label: 'Photos' },
+    { id: 'summary',     label: 'Summary' },
+    { id: 'repair-list', label: 'Repair List' },
+    { id: 'signatures',  label: 'Signatures' },
+    { id: 'settings',    label: 'Settings' },
 ];
 
 export const InspectionShell = ({
@@ -48,8 +51,12 @@ export const InspectionShell = ({
     current,
     requestId,
     siblings,
+    enableRepairList = false,
     children,
 }: InspectionShellProps): JSX.Element => {
+    // Track E1 — Repair List tab is opt-in per tenant. Filter it out when
+    // disabled so the sub-nav stays at its 5-tab Sprint 2 baseline.
+    const visibleTabs = enableRepairList ? TABS : TABS.filter(t => t.id !== 'repair-list');
     const hasMultipleSiblings = !!siblings && siblings.length > 1;
     const partIndex = hasMultipleSiblings && siblings
         ? siblings.findIndex(s => s.id === inspectionId) + 1
@@ -114,7 +121,7 @@ export const InspectionShell = ({
                 class="border-b border-slate-200 sticky top-0 z-20 bg-[#f8fafc]"
             >
                 <div class="flex items-center gap-1 overflow-x-auto hide-scrollbar">
-                    {TABS.map((t) => {
+                    {visibleTabs.map((t) => {
                         const active = t.id === current;
                         return (
                             <a

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -167,6 +167,7 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
               <template x-for="(sec, idx) in sections" x-bind:key="sec.id">
                 <button
                   x-on:click="selectSection(idx)"
+                  x-show="sectionMatchesSearch(sec)"
                   class="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all whitespace-nowrap"
                   x-bind:class="currentSectionIdx === idx ? 'text-white' : 'bg-white/60 text-gray-600'"
                   x-bind:style="currentSectionIdx === idx ? 'background: var(--ih-primary, #6366f1)' : ''"
@@ -231,6 +232,7 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
             <template x-for="item in currentSectionItems" x-bind:key="item.id">
               <div
                 x-bind:data-item-id="item.id"
+                x-show="itemMatchesSearch(currentSection, item)"
                 class="rounded-md p-4 transition-all cursor-pointer"
                 style="background: rgba(255,255,255,0.85); backdrop-filter: blur(16px) saturate(1.5); border: 1px solid rgba(255,255,255,0.7); border-left: 3px solid transparent; touch-action: manipulation;"
                 x-bind:style="(activeItemId === item.id ? 'border-color: #6366f1; ' : '') + 'border-left-color: ' + getRatingColor(getItemRating(item.id))"
@@ -242,7 +244,7 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
               >
                 <div class="flex items-start justify-between mb-3">
                   <div>
-                    <h3 class="font-bold text-sm" style="color: #0f172a" x-text="item.label"></h3>
+                    <h3 class="font-bold text-sm" style="color: #0f172a" x-html="highlightSearchMatch(item.label)"></h3>
                     <span class="text-[10px] font-mono" style="color: #cbd5e1" x-text="item.number"></span>
                   </div>
                   <span class="w-3 h-3 rounded-full" x-bind:style="'background:' + getRatingColor(getItemRating(item.id))"></span>
@@ -462,6 +464,17 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                 </div>
               </div>
             </template>
+            {/* Competitor parity App.E.3 — no-results state when search filters
+                out every item in the current section. */}
+            <div
+              x-show="hasSearchQuery && searchMatchCount === 0"
+              style="display:none"
+              data-testid="editor-search-empty"
+              class="mt-4 rounded-md bg-white border border-dashed border-slate-200 p-6 text-center"
+            >
+              <p class="text-sm text-slate-500">No matches for &ldquo;<span class="font-semibold text-slate-700" x-text="searchQuery"></span>&rdquo;.</p>
+              <button x-on:click="clearSearch()" class="mt-2 text-xs font-semibold text-indigo-600 hover:underline">Clear search</button>
+            </div>
           </div>
 
           {/* Spec 4D mobile — Inspection Events compact list */}
@@ -726,6 +739,7 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
               <template x-for="(sec, idx) in sections" x-bind:key="sec.id">
                 <button
                   x-on:click="selectSection(idx)"
+                  x-show="sectionMatchesSearch(sec)"
                   class="w-full flex items-center gap-2 px-3 py-2.5 rounded-xl text-left text-sm transition-all"
                   x-bind:style="currentSectionIdx === idx ? 'background: #eef2ff; color: var(--ih-primary, #6366f1)' : 'color: #64748b'"
                 >
@@ -800,6 +814,45 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                 >Batch</button>
               </div>
               <div class="flex items-center gap-2">
+                {/* Competitor parity App.E.3 (Spectora) — full-text search box.
+                    Filters every visible section + item live as the user
+                    types. Empty query restores the normal section/item tree. */}
+                <div class="relative" data-testid="editor-search">
+                  <span class="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 105.5 5.5a7.5 7.5 0 0011.15 11.15z" />
+                    </svg>
+                  </span>
+                  <input
+                    type="search"
+                    x-model="searchQuery"
+                    placeholder="Search entire report…"
+                    aria-label="Search the entire report"
+                    data-testid="editor-search-input"
+                    class="w-56 pl-8 pr-7 py-1.5 text-xs rounded-lg border bg-white text-slate-700 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400 transition-all"
+                    style="border-color: #e2e8f0"
+                  />
+                  <button
+                    type="button"
+                    x-show="hasSearchQuery"
+                    style="display:none"
+                    x-on:click="clearSearch()"
+                    aria-label="Clear search"
+                    data-testid="editor-search-clear"
+                    class="absolute right-1.5 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full text-slate-400 hover:text-slate-700 hover:bg-slate-100 flex items-center justify-center"
+                  >
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                <span
+                  x-show="hasSearchQuery"
+                  style="display:none"
+                  data-testid="editor-search-count"
+                  class="text-[11px] font-mono text-slate-500"
+                  x-text="searchMatchCount + ' match' + (searchMatchCount === 1 ? '' : 'es')"
+                ></span>
                 <button x-on:click="previewReport()" class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl" style="color: #64748b">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
                   Preview
@@ -985,6 +1038,7 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
               <template x-for="item in currentSectionItems" x-bind:key="item.id">
                 <div
                   x-bind:data-item-id="item.id"
+                  x-show="itemMatchesSearch(currentSection, item)"
                   class="rounded-md p-4 transition-all cursor-pointer group"
                   style="background: rgba(255,255,255,0.85); backdrop-filter: blur(16px) saturate(1.5); border: 1px solid rgba(255,255,255,0.7);"
                   x-bind:style="(activeItemId === item.id ? 'border-color: #6366f1; ' : '') + 'border-top: 4px solid ' + getRatingColor(getItemRating(item.id))"
@@ -996,7 +1050,7 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                   </div>
                   <div class="flex items-start justify-between mb-3">
                     <div>
-                      <h3 class="font-bold text-sm group-hover:text-indigo-600 transition-colors" style="color: #0f172a" x-text="item.label"></h3>
+                      <h3 class="font-bold text-sm group-hover:text-indigo-600 transition-colors" style="color: #0f172a" x-html="highlightSearchMatch(item.label)"></h3>
                       <span class="text-[10px] font-mono" style="color: #cbd5e1" x-text="item.number"></span>
                     </div>
                     <span
@@ -1352,6 +1406,16 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
                   </div>
                 </div>
               </template>
+              {/* Competitor parity App.E.3 — desktop no-results state. */}
+              <div
+                x-show="hasSearchQuery && searchMatchCount === 0"
+                style="display:none"
+                data-testid="editor-search-empty-desktop"
+                class="col-span-2 xl:col-span-3 rounded-md bg-white border border-dashed border-slate-200 p-8 text-center"
+              >
+                <p class="text-sm text-slate-500">No matches for &ldquo;<span class="font-semibold text-slate-700" x-text="searchQuery"></span>&rdquo;.</p>
+                <button x-on:click="clearSearch()" class="mt-2 text-xs font-semibold text-indigo-600 hover:underline">Clear search</button>
+              </div>
             </div>
           </main>
 

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -7,6 +7,9 @@ import { RECOMMENDATION_CATEGORIES } from '../../lib/recommendation-categories';
 interface InspectionEditProps {
   inspectionId: string;
   branding?: BrandingConfig | undefined;
+  // Track E1 — when true, the editor's sub-nav exposes the "Repair List"
+  // 6th tab. Default off so existing tenants keep the 5-tab layout.
+  enableRepairList?: boolean;
 }
 
 /**
@@ -27,7 +30,7 @@ function buildRecoGroups(): Array<{ group: string; items: Array<{ id: string; la
     return Array.from(groups.entries()).map(([group, items]) => ({ group, items }));
 }
 
-export function InspectionEditPage({ inspectionId, branding }: InspectionEditProps) {
+export function InspectionEditPage({ inspectionId, branding, enableRepairList = false }: InspectionEditProps) {
   const siteName = branding?.siteName || 'OpenInspection';
   const recoGroups = buildRecoGroups();
 
@@ -80,6 +83,16 @@ export function InspectionEditPage({ inspectionId, branding }: InspectionEditPro
             aria-selected="false"
             class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
           >Summary</a>
+          {/* Track E1 (ITB §11) — opt-in 6th tab. */}
+          {enableRepairList && (
+            <a
+              href={`/inspections/${inspectionId}/repair-list`}
+              role="tab"
+              aria-selected="false"
+              data-testid="inspection-edit-repair-list-tab"
+              class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+            >Repair List</a>
+          )}
           <a
             href={`/inspections/${inspectionId}/signatures`}
             role="tab"

--- a/src/templates/pages/inspection/photos.tsx
+++ b/src/templates/pages/inspection/photos.tsx
@@ -13,11 +13,12 @@ import { InspectionShell } from '../../components/inspection-shell';
 import type { BrandingConfig } from '../../../types/auth';
 
 export interface InspectionPhotosPageProps {
-    inspectionId:    string;
-    propertyAddress: string;
-    branding?:       BrandingConfig | undefined;
-    requestId?:      string | undefined;
-    siblings?:       Array<{ id: string; templateName: string; status: string }> | undefined;
+    inspectionId:     string;
+    propertyAddress:  string;
+    branding?:        BrandingConfig | undefined;
+    requestId?:       string | undefined;
+    siblings?:        Array<{ id: string; templateName: string; status: string }> | undefined;
+    enableRepairList?: boolean;
 }
 
 export const InspectionPhotosPage = ({
@@ -26,6 +27,7 @@ export const InspectionPhotosPage = ({
     branding,
     requestId,
     siblings,
+    enableRepairList,
 }: InspectionPhotosPageProps): JSX.Element => {
     const siteName = branding?.siteName || 'OpenInspection';
     return (
@@ -43,6 +45,7 @@ export const InspectionPhotosPage = ({
                 inspectionId={inspectionId}
                 propertyAddress={propertyAddress}
                 current="photos"
+                enableRepairList={!!enableRepairList}
                 {...(requestId ? { requestId } : {})}
                 {...(siblings  ? { siblings  } : {})}
             >

--- a/src/templates/pages/inspection/repair-list.tsx
+++ b/src/templates/pages/inspection/repair-list.tsx
@@ -1,0 +1,264 @@
+/**
+ * Track E1 (ITB §11, UC-ITB-07) — `/inspections/:id/repair-list` sub-page.
+ *
+ * Server-rendered punch-list of every defect-rated item across the
+ * inspection. Distinct from the narrative report — this is what realtors
+ * hand to contractors. Renders cleanly under print (`window.print()`),
+ * with each defect as a card grouped by section.
+ *
+ * Reaches the data via the authenticated InspectionService.getRepairList()
+ * directly at render time — no client-side fetch needed for the static
+ * print-friendly layout.
+ */
+
+import { MainLayout } from '../../layouts/main-layout';
+import { InspectionShell } from '../../components/inspection-shell';
+import type { BrandingConfig } from '../../../types/auth';
+
+export interface RepairListEntry {
+    sectionId:           string;
+    sectionTitle:        string;
+    itemId:              string;
+    itemLabel:           string;
+    comment:             string;
+    location:            string | null;
+    category:            'safety' | 'recommendation' | 'maintenance';
+    recommendationId:    string | null;
+    recommendationLabel: string | null;
+    estimateLow:         number | null;
+    estimateHigh:        number | null;
+    photos:              Array<{ key: string; url: string }>;
+    source:              'canned' | 'custom';
+}
+
+export interface RepairListPageProps {
+    inspectionId:    string;
+    propertyAddress: string;
+    inspectionDate:  string | null;
+    inspectorName:   string | null;
+    defects:         RepairListEntry[];
+    totals: {
+        count:           number;
+        safety:          number;
+        recommendation:  number;
+        maintenance:     number;
+        estimateLowSum:  number;
+        estimateHighSum: number;
+    };
+    showEstimates:   boolean;
+    branding?:       BrandingConfig | undefined;
+    requestId?:      string | undefined;
+    siblings?:       Array<{ id: string; templateName: string; status: string }> | undefined;
+}
+
+const CATEGORY_TONE: Record<RepairListEntry['category'], { bg: string; text: string; ring: string; label: string }> = {
+    safety:         { bg: 'bg-rose-50',    text: 'text-rose-700',    ring: 'ring-rose-200',    label: 'Safety' },
+    recommendation: { bg: 'bg-amber-50',   text: 'text-amber-700',   ring: 'ring-amber-200',   label: 'Recommend' },
+    maintenance:    { bg: 'bg-slate-50',   text: 'text-slate-700',   ring: 'ring-slate-200',   label: 'Maintain' },
+};
+
+function formatMoney(cents: number | null): string {
+    if (cents == null || cents <= 0) return '';
+    // Estimates are stored as cents — render the dollar component.
+    return `$${Math.round(cents / 100).toLocaleString()}`;
+}
+
+function groupBySection(entries: RepairListEntry[]): Array<{ sectionId: string; sectionTitle: string; items: RepairListEntry[] }> {
+    const order: string[] = [];
+    const map = new Map<string, { sectionId: string; sectionTitle: string; items: RepairListEntry[] }>();
+    for (const e of entries) {
+        if (!map.has(e.sectionId)) {
+            map.set(e.sectionId, { sectionId: e.sectionId, sectionTitle: e.sectionTitle, items: [] });
+            order.push(e.sectionId);
+        }
+        map.get(e.sectionId)!.items.push(e);
+    }
+    return order.map(id => map.get(id)!);
+}
+
+const REPAIR_LIST_CSS = `
+@media print {
+    .no-print { display: none !important; }
+    body { background: white !important; }
+    .repair-list-card { page-break-inside: avoid; break-inside: avoid; }
+    .repair-list-section { page-break-inside: avoid; }
+    .repair-list-section + .repair-list-section { page-break-before: auto; }
+}
+`;
+
+export const RepairListPage = ({
+    inspectionId,
+    propertyAddress,
+    inspectionDate,
+    inspectorName,
+    defects,
+    totals,
+    showEstimates,
+    branding,
+    requestId,
+    siblings,
+}: RepairListPageProps): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
+    const grouped = groupBySection(defects);
+
+    return (
+        <MainLayout
+            title={`${siteName} | Repair List`}
+            {...(branding ? { branding } : {})}
+            extraHead={<style dangerouslySetInnerHTML={{ __html: REPAIR_LIST_CSS }} />}
+        >
+            <InspectionShell
+                inspectionId={inspectionId}
+                propertyAddress={propertyAddress}
+                current="repair-list"
+                enableRepairList={true}
+                {...(requestId ? { requestId } : {})}
+                {...(siblings  ? { siblings  } : {})}
+            >
+                <div class="space-y-6">
+                    {/* Header summary + Print button */}
+                    <div class="flex flex-wrap items-end justify-between gap-3">
+                        <div>
+                            <h2 class="text-[18px] font-semibold tracking-tight text-slate-900">Repair list</h2>
+                            <p class="text-[12px] text-slate-500">
+                                Aggregated punch list of all flagged items. Printable for contractor handoff.
+                            </p>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <a
+                                href={`/inspections/${inspectionId}/report`}
+                                class="no-print inline-flex items-center gap-1.5 px-3 h-9 rounded-md bg-white border border-slate-200 text-slate-700 text-[12px] font-bold hover:bg-slate-50 transition-colors"
+                            >
+                                Edit in report tab
+                            </a>
+                            <button
+                                type="button"
+                                onclick="window.print()"
+                                data-testid="repair-list-print"
+                                class="no-print inline-flex items-center gap-1.5 px-3 h-9 rounded-md bg-slate-900 text-white text-[12px] font-bold hover:bg-slate-700 transition-colors"
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
+                                </svg>
+                                Print
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Property summary header (visible in print) */}
+                    <div class="rounded-md border border-slate-200 bg-white px-5 py-4 repair-list-section">
+                        <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 mb-1">Property</div>
+                        <div class="text-[16px] font-semibold text-slate-900">{propertyAddress}</div>
+                        <div class="text-[12px] text-slate-500 mt-1">
+                            {inspectionDate ? <span>Inspected <strong class="text-slate-700">{inspectionDate}</strong></span> : null}
+                            {inspectorName ? <span> &middot; By <strong class="text-slate-700">{inspectorName}</strong></span> : null}
+                        </div>
+                    </div>
+
+                    {/* Totals strip */}
+                    <div class="grid grid-cols-3 gap-3 repair-list-section">
+                        <div class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3">
+                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-rose-600">Safety</div>
+                            <div class="text-[22px] font-bold text-rose-700 tabular-nums" data-testid="repair-list-total-safety">{totals.safety}</div>
+                        </div>
+                        <div class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
+                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-600">Recommend</div>
+                            <div class="text-[22px] font-bold text-amber-700 tabular-nums" data-testid="repair-list-total-recommend">{totals.recommendation}</div>
+                        </div>
+                        <div class="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
+                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600">Maintenance</div>
+                            <div class="text-[22px] font-bold text-slate-700 tabular-nums" data-testid="repair-list-total-maintenance">{totals.maintenance}</div>
+                        </div>
+                    </div>
+
+                    {showEstimates && (totals.estimateLowSum > 0 || totals.estimateHighSum > 0) ? (
+                        <div class="rounded-md border border-emerald-200 bg-emerald-50 px-5 py-4 flex items-center justify-between">
+                            <div>
+                                <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-emerald-600">Estimated total repair range</div>
+                                <div class="text-[12px] text-emerald-700 mt-1">Sum of all per-defect estimates supplied by the inspector.</div>
+                            </div>
+                            <div class="text-[20px] font-bold text-emerald-800 tabular-nums" data-testid="repair-list-estimate-total">
+                                {formatMoney(totals.estimateLowSum)} – {formatMoney(totals.estimateHighSum)}
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {/* Empty state */}
+                    {defects.length === 0 ? (
+                        <div class="text-center py-12 px-6 rounded-lg bg-emerald-50 border border-emerald-200" data-testid="repair-list-empty">
+                            <p class="text-[13px] text-emerald-700 font-semibold">No defects flagged. The repair list is empty.</p>
+                        </div>
+                    ) : null}
+
+                    {/* Defect cards grouped by section */}
+                    {grouped.map(group => (
+                        <section class="space-y-3 repair-list-section">
+                            <header class="flex items-baseline justify-between border-b border-slate-200 pb-2">
+                                <h3 class="text-[14px] font-bold text-slate-900">{group.sectionTitle}</h3>
+                                <span class="text-[11px] text-slate-400 font-mono">{group.items.length} item{group.items.length === 1 ? '' : 's'}</span>
+                            </header>
+                            <ul class="space-y-3">
+                                {group.items.map(d => {
+                                    const tone = CATEGORY_TONE[d.category];
+                                    const lo = formatMoney(d.estimateLow);
+                                    const hi = formatMoney(d.estimateHigh);
+                                    const showEstimateBadge = showEstimates && (lo || hi);
+                                    return (
+                                        <li
+                                            class="repair-list-card rounded-md border border-slate-200 bg-white px-5 py-4"
+                                            data-testid="repair-list-card"
+                                            data-category={d.category}
+                                        >
+                                            <div class="flex items-start justify-between gap-3 mb-2">
+                                                <div class="flex-1 min-w-0">
+                                                    <div class="flex flex-wrap items-center gap-2 mb-1">
+                                                        <span class={`inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide ring-1 ring-inset ${tone.bg} ${tone.text} ${tone.ring}`}>
+                                                            {tone.label}
+                                                        </span>
+                                                        <span class="text-[11px] font-mono text-slate-400">{group.sectionTitle} &rsaquo; {d.itemLabel}</span>
+                                                    </div>
+                                                    <p class="text-[14px] font-semibold text-slate-900 leading-snug">{d.itemLabel}</p>
+                                                    {d.location ? (
+                                                        <p class="text-[12px] text-slate-500 mt-0.5">Location: {d.location}</p>
+                                                    ) : null}
+                                                </div>
+                                                {d.recommendationLabel ? (
+                                                    <span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200">
+                                                        {d.recommendationLabel}
+                                                    </span>
+                                                ) : null}
+                                            </div>
+
+                                            {d.comment ? (
+                                                <p class="text-[13px] text-slate-700 leading-relaxed whitespace-pre-line">{d.comment}</p>
+                                            ) : null}
+
+                                            {showEstimateBadge ? (
+                                                <div class="mt-3 inline-flex items-center px-2 py-1 rounded-md text-[12px] font-semibold bg-emerald-50 text-emerald-700 tabular-nums" data-testid="repair-list-card-estimate">
+                                                    Estimated cost: {lo || '$?'} – {hi || '$?'}
+                                                </div>
+                                            ) : null}
+
+                                            {d.photos.length > 0 ? (
+                                                <div class="mt-3 grid grid-cols-3 gap-2">
+                                                    {d.photos.slice(0, 6).map((p, idx) => (
+                                                        <img
+                                                            src={p.url}
+                                                            alt={`${d.itemLabel} photo ${idx + 1}`}
+                                                            class="w-full h-24 object-cover rounded border border-slate-200"
+                                                            loading="lazy"
+                                                        />
+                                                    ))}
+                                                </div>
+                                            ) : null}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+            </InspectionShell>
+        </MainLayout>
+    );
+};

--- a/src/templates/pages/inspection/settings.tsx
+++ b/src/templates/pages/inspection/settings.tsx
@@ -16,11 +16,12 @@ import { InspectionShell } from '../../components/inspection-shell';
 import type { BrandingConfig } from '../../../types/auth';
 
 export interface InspectionSettingsPageProps {
-    inspectionId:    string;
-    propertyAddress: string;
-    branding?:       BrandingConfig | undefined;
-    requestId?:      string | undefined;
-    siblings?:       Array<{ id: string; templateName: string; status: string }> | undefined;
+    inspectionId:     string;
+    propertyAddress:  string;
+    branding?:        BrandingConfig | undefined;
+    requestId?:       string | undefined;
+    siblings?:        Array<{ id: string; templateName: string; status: string }> | undefined;
+    enableRepairList?: boolean;
 }
 
 export const InspectionSettingsPage = ({
@@ -29,6 +30,7 @@ export const InspectionSettingsPage = ({
     branding,
     requestId,
     siblings,
+    enableRepairList,
 }: InspectionSettingsPageProps): JSX.Element => {
     const siteName = branding?.siteName || 'OpenInspection';
     return (
@@ -40,6 +42,7 @@ export const InspectionSettingsPage = ({
                 inspectionId={inspectionId}
                 propertyAddress={propertyAddress}
                 current="settings"
+                enableRepairList={!!enableRepairList}
                 {...(requestId ? { requestId } : {})}
                 {...(siblings  ? { siblings  } : {})}
             >

--- a/src/templates/pages/inspection/signatures.tsx
+++ b/src/templates/pages/inspection/signatures.tsx
@@ -12,11 +12,12 @@ import { InspectionShell } from '../../components/inspection-shell';
 import type { BrandingConfig } from '../../../types/auth';
 
 export interface InspectionSignaturesPageProps {
-    inspectionId:    string;
-    propertyAddress: string;
-    branding?:       BrandingConfig | undefined;
-    requestId?:      string | undefined;
-    siblings?:       Array<{ id: string; templateName: string; status: string }> | undefined;
+    inspectionId:     string;
+    propertyAddress:  string;
+    branding?:        BrandingConfig | undefined;
+    requestId?:       string | undefined;
+    siblings?:        Array<{ id: string; templateName: string; status: string }> | undefined;
+    enableRepairList?: boolean;
 }
 
 export const InspectionSignaturesPage = ({
@@ -25,6 +26,7 @@ export const InspectionSignaturesPage = ({
     branding,
     requestId,
     siblings,
+    enableRepairList,
 }: InspectionSignaturesPageProps): JSX.Element => {
     const siteName = branding?.siteName || 'OpenInspection';
     return (
@@ -36,6 +38,7 @@ export const InspectionSignaturesPage = ({
                 inspectionId={inspectionId}
                 propertyAddress={propertyAddress}
                 current="signatures"
+                enableRepairList={!!enableRepairList}
                 {...(requestId ? { requestId } : {})}
                 {...(siblings  ? { siblings  } : {})}
             >

--- a/src/templates/pages/inspection/summary.tsx
+++ b/src/templates/pages/inspection/summary.tsx
@@ -11,11 +11,12 @@ import { InspectionShell } from '../../components/inspection-shell';
 import type { BrandingConfig } from '../../../types/auth';
 
 export interface InspectionSummaryPageProps {
-    inspectionId:    string;
-    propertyAddress: string;
-    branding?:       BrandingConfig | undefined;
-    requestId?:      string | undefined;
-    siblings?:       Array<{ id: string; templateName: string; status: string }> | undefined;
+    inspectionId:     string;
+    propertyAddress:  string;
+    branding?:        BrandingConfig | undefined;
+    requestId?:       string | undefined;
+    siblings?:        Array<{ id: string; templateName: string; status: string }> | undefined;
+    enableRepairList?: boolean;
 }
 
 export const InspectionSummaryPage = ({
@@ -24,6 +25,7 @@ export const InspectionSummaryPage = ({
     branding,
     requestId,
     siblings,
+    enableRepairList,
 }: InspectionSummaryPageProps): JSX.Element => {
     const siteName = branding?.siteName || 'OpenInspection';
     return (
@@ -35,6 +37,7 @@ export const InspectionSummaryPage = ({
                 inspectionId={inspectionId}
                 propertyAddress={propertyAddress}
                 current="summary"
+                enableRepairList={!!enableRepairList}
                 {...(requestId ? { requestId } : {})}
                 {...(siblings  ? { siblings  } : {})}
             >

--- a/src/templates/pages/report-card-stack.tsx
+++ b/src/templates/pages/report-card-stack.tsx
@@ -24,6 +24,10 @@ interface ReportSection {
   icon?: string | null;
   defectCount: number;
   items: ReportItem[];
+  // Track E2 (Spectora App.A) — per-section legal disclaimer + force page
+  // break. Both are optional; legacy templates render unchanged.
+  disclaimerText?: string | null;
+  alwaysPageBreak?: boolean;
 }
 
 interface ReportPageProps {
@@ -216,7 +220,11 @@ export function ReportCardStackPage(props: ReportPageProps) {
         {/* Sections */}
         <div class="max-w-4xl mx-auto px-4 sm:px-6" {...{'x-bind:class': "showRepairPanel ? 'pb-[65vh]' : 'pb-32'"}}>
           {sections.map((section) => (
-            <div class="mb-6 report-section" x-show={`filter === 'all' || filter === 'summary' || sectionHasDefects('${section.id}')`}>
+            <div
+              class="mb-6 report-section"
+              {...(section.alwaysPageBreak ? { 'data-page-break': 'always' } : {})}
+              x-show={`filter === 'all' || filter === 'summary' || sectionHasDefects('${section.id}')`}
+            >
               <div class="flex items-center gap-3 mb-4">
                 <span class="text-2xl">{getSectionIcon(section.title)}</span>
                 <h2 class="text-2xl font-bold theme-font-display italic">{section.title}</h2>
@@ -294,6 +302,20 @@ export function ReportCardStackPage(props: ReportPageProps) {
                   </span>
                 </div>
               </div>
+
+              {/* Track E2 (Spectora App.A) — per-section disclaimer rendered
+                  beneath the items list. Hidden in summary filter to keep the
+                  preview pane clean. */}
+              {section.disclaimerText && (
+                <div
+                  data-testid="section-disclaimer"
+                  class="mt-4 px-4 py-3 rounded-md border theme-border bg-amber-50/40 text-[12px] leading-relaxed text-slate-700"
+                  x-show="filter !== 'summary'"
+                >
+                  <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-700 mb-1">Disclaimer</div>
+                  <p class="whitespace-pre-line">{section.disclaimerText}</p>
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/src/templates/pages/report-card-stack.tsx
+++ b/src/templates/pages/report-card-stack.tsx
@@ -49,6 +49,9 @@ interface ReportPageProps {
   // $X – $Y" badge underneath the recommendation pill. Tenant-controlled
   // via Settings → Workspace → Reports.
   showEstimates?: boolean;
+  // Track E1 (ITB §11) — when true, surface a "View repair list" link in
+  // the report header so realtors can jump to the contractor punch-list.
+  enableRepairList?: boolean;
 }
 
 const SECTION_ICONS: Record<string, string> = {
@@ -67,6 +70,7 @@ function getSectionIcon(title: string): string {
 export function ReportCardStackPage(props: ReportPageProps) {
   const { inspectionId, address, date, inspectorName, theme, stats, branding, summaryMode } = props;
   const showEstimates = props.showEstimates ?? false;
+  const enableRepairList = props.enableRepairList ?? false;
   // Server-side defect filter for ?summary=1 (PDF Summary mode).
   // Keeps only sections with at least one defect, and within each kept
   // section, only items whose severityBucket maps to defect.
@@ -187,6 +191,17 @@ export function ReportCardStackPage(props: ReportPageProps) {
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" /></svg>
                 PDF
               </button>
+              {/* Track E1 (ITB §11) — opt-in jump link to the aggregated repair list. */}
+              {enableRepairList && (
+                <a
+                  href={`/inspections/${inspectionId}/repair-list`}
+                  data-testid="report-repair-list-link"
+                  class="no-print px-4 py-2 text-sm font-medium rounded-lg theme-border border theme-text-secondary flex items-center gap-2 hover:bg-slate-50 transition-colors"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" /></svg>
+                  View Repair List
+                </a>
+              )}
               <button x-on:click="showRepairPanel = !showRepairPanel" class="px-4 py-2 text-sm font-semibold rounded-lg text-white flex items-center gap-2 theme-accent">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
                 Repair Request

--- a/src/templates/pages/report-card-stack.tsx
+++ b/src/templates/pages/report-card-stack.tsx
@@ -3,6 +3,11 @@ import { BareLayout } from '../layouts/main-layout';
 import { StatsCards } from '../components/stats-cards';
 import type { RatingLevel } from '../../lib/report-utils';
 import type { BrandingConfig } from '../../types/auth';
+import {
+  canEditSection,
+  formatSectionHeading,
+  buildSectionEditHref,
+} from '../../lib/report-section-numbering';
 
 interface ReportItem {
   id: string;
@@ -45,6 +50,10 @@ interface ReportPageProps {
   // $X – $Y" badge underneath the recommendation pill. Tenant-controlled
   // via Settings → Workspace → Reports.
   showEstimates?: boolean;
+  // Competitor parity App.F.4 (Spectora) — JWT role of the user viewing
+  // the published report. Drives the EDIT SECTION hover button: only
+  // owner / admin / inspector see it; public clients (no token) do not.
+  viewerRole?: string | null | undefined;
 }
 
 const SECTION_ICONS: Record<string, string> = {
@@ -63,6 +72,10 @@ function getSectionIcon(title: string): string {
 export function ReportCardStackPage(props: ReportPageProps) {
   const { inspectionId, address, date, inspectorName, theme, stats, branding, summaryMode } = props;
   const showEstimates = props.showEstimates ?? false;
+  // Competitor parity App.F.4 — only inspectors / admins / owners see the
+  // EDIT SECTION button on hover. Public clients never get a way back into
+  // the editor from the published view.
+  const showEditAffordance = canEditSection(props.viewerRole ?? null);
   // Server-side defect filter for ?summary=1 (PDF Summary mode).
   // Keeps only sections with at least one defect, and within each kept
   // section, only items whose severityBucket maps to defect.
@@ -215,12 +228,48 @@ export function ReportCardStackPage(props: ReportPageProps) {
 
         {/* Sections */}
         <div class="max-w-4xl mx-auto px-4 sm:px-6" {...{'x-bind:class': "showRepairPanel ? 'pb-[65vh]' : 'pb-32'"}}>
-          {sections.map((section) => (
-            <div class="mb-6 report-section" x-show={`filter === 'all' || filter === 'summary' || sectionHasDefects('${section.id}')`}>
+          {sections.map((section, sectionIdx) => (
+            <div
+              id={`section-${section.id}`}
+              data-testid="report-section"
+              class="mb-6 report-section group/section relative"
+              x-show={`filter === 'all' || filter === 'summary' || sectionHasDefects('${section.id}')`}
+            >
               <div class="flex items-center gap-3 mb-4">
                 <span class="text-2xl">{getSectionIcon(section.title)}</span>
-                <h2 class="text-2xl font-bold theme-font-display italic">{section.title}</h2>
+                {/* Competitor parity App.F.4 — auto-numbered heading
+                    ("3 - Roof"). Index follows visible-section order.
+                    aria-label uses the full numbered string so screen
+                    readers announce "3 - Roof"; the visual H2 splits
+                    the number into its own monospace span for design. */}
+                <h2
+                  data-testid="report-section-heading"
+                  aria-label={formatSectionHeading(section.title, sectionIdx)}
+                  class="text-2xl font-bold theme-font-display italic"
+                >
+                  <span data-testid="report-section-number" class="font-mono not-italic mr-1 theme-text-muted">{sectionIdx + 1} -</span>
+                  {section.title}
+                </h2>
                 <div class="flex-1 h-px theme-border border-t" />
+                {/* Competitor parity App.F.4 — EDIT SECTION button surfaces
+                    on hover. Inspector / admin / owner only; hidden for
+                    public viewers (clients, agents, anonymous). Print
+                    output never includes it. Renders as a deep-link to
+                    the editor with a #section-{id} fragment so the
+                    editor scrolls the right section into view. */}
+                {showEditAffordance && (
+                  <a
+                    href={buildSectionEditHref(inspectionId, section.id)}
+                    data-testid="report-section-edit"
+                    class="no-print opacity-0 group-hover/section:opacity-100 focus:opacity-100 transition-opacity duration-150 inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-bold uppercase tracking-widest theme-border border theme-text-secondary hover:bg-slate-50"
+                    aria-label={`Edit ${section.title} section`}
+                  >
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                    Edit Section
+                  </a>
+                )}
                 <span class="text-xs font-mono theme-text-muted">{section.items.length} items</span>
               </div>
 

--- a/src/templates/pages/settings-workspace.tsx
+++ b/src/templates/pages/settings-workspace.tsx
@@ -3,9 +3,12 @@ import type { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig | undefined; }
 
-// Sprint 2 S2-4 — extra prop only used by the new Reports sub-page so the
-// toggle reflects persisted state on first paint.
-interface ReportsProps extends Props { showEstimates?: boolean }
+// Sprint 2 S2-4 + Track E1 — extra props only used by the new Reports
+// sub-page so the toggles reflect persisted state on first paint.
+interface ReportsProps extends Props {
+    showEstimates?:    boolean;
+    enableRepairList?: boolean;
+}
 
 type WorkspaceSubPage = 'branding' | 'theme' | 'reports' | 'telemetry';
 
@@ -174,8 +177,9 @@ export const SettingsWorkspaceTelemetryPage = ({ branding }: Props): JSX.Element
  * each defect item. Defaults to off so existing tenants don't suddenly
  * start showing dollar figures.
  */
-export const SettingsWorkspaceReportsPage = ({ branding, showEstimates }: ReportsProps): JSX.Element => {
-    const initial = showEstimates ? 'true' : 'false';
+export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRepairList }: ReportsProps): JSX.Element => {
+    const initialEstimates    = showEstimates ? 'true' : 'false';
+    const initialRepairList   = enableRepairList ? 'true' : 'false';
     return (
         <SettingsLayout
             branding={branding}
@@ -183,20 +187,21 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates }: Report
             group="workspace"
             subPage="reports"
             pageTitle="Reports"
-            pageSubtitle="Control how published reports surface optional defect annotations such as repair estimate ranges."
+            pageSubtitle="Control how published reports surface optional defect annotations such as repair estimate ranges and the contractor punch-list."
         >
             <section
-                class="bg-white rounded-lg border border-surface-200 p-6 space-y-5"
+                class="bg-white rounded-lg border border-surface-200 p-6 space-y-6"
                 x-data={`{
-                    showEstimates: ${initial},
+                    showEstimates: ${initialEstimates},
+                    enableRepairList: ${initialRepairList},
                     saving: false,
-                    async save() {
+                    async save(payload) {
                         this.saving = true;
                         try {
                             const r = await authFetch('/api/admin/branding', {
                                 method: 'POST',
                                 headers: { 'content-type': 'application/json' },
-                                body: JSON.stringify({ showEstimates: this.showEstimates })
+                                body: JSON.stringify(payload)
                             });
                             if (!r.ok) {
                                 if (typeof showToast === 'function') showToast('Failed to save', true);
@@ -224,7 +229,30 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates }: Report
                         type="checkbox"
                         data-testid="settings-show-estimates-toggle"
                         x-model="showEstimates"
-                        x-on:change="save()"
+                        x-on:change="save({ showEstimates: showEstimates })"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        style="background-position: left center; background-repeat: no-repeat;"
+                    />
+                </label>
+
+                {/* Track E1 (ITB §11) — Repair List toggle. */}
+                <div class="border-t border-surface-200" />
+                <label class="flex items-start justify-between gap-6 cursor-pointer">
+                    <div class="flex-1">
+                        <div class="text-sm font-bold text-ink-900">Enable Repair List</div>
+                        <div class="text-xs text-ink-500 mt-1 leading-relaxed">
+                            Opt-in punch-list view that aggregates every flagged defect across
+                            the inspection into a clean, contractor-ready document. When on,
+                            the published report exposes a "View Repair List" link in the
+                            top-right and inspectors get a "Repair List" sub-tab in the
+                            inspection editor.
+                        </div>
+                    </div>
+                    <input
+                        type="checkbox"
+                        data-testid="settings-enable-repair-list-toggle"
+                        x-model="enableRepairList"
+                        x-on:change="save({ enableRepairList: enableRepairList })"
                         class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                     />
@@ -242,12 +270,13 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates }: Report
  * Dispatcher used by the route handler — picks the right component based on the
  * `subPage` URL segment. Keeps `index.ts` route registrations short.
  */
-export const SettingsWorkspacePage = ({ branding, subPage, showEstimates }: ReportsProps & { subPage: WorkspaceSubPage }): JSX.Element => {
+export const SettingsWorkspacePage = ({ branding, subPage, showEstimates, enableRepairList }: ReportsProps & { subPage: WorkspaceSubPage }): JSX.Element => {
     if (subPage === 'theme') return SettingsWorkspaceThemePage({ branding });
     if (subPage === 'telemetry') return SettingsWorkspaceTelemetryPage({ branding });
     if (subPage === 'reports') {
         const props: ReportsProps = { branding };
-        if (typeof showEstimates === 'boolean') props.showEstimates = showEstimates;
+        if (typeof showEstimates    === 'boolean') props.showEstimates    = showEstimates;
+        if (typeof enableRepairList === 'boolean') props.enableRepairList = enableRepairList;
         return SettingsWorkspaceReportsPage(props);
     }
     return SettingsWorkspaceBrandingPage({ branding });

--- a/src/templates/pages/template-editor.tsx
+++ b/src/templates/pages/template-editor.tsx
@@ -239,7 +239,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                     </div>
                                 </div>
 
-                                <div x-show="selectedSection" class="px-8 pb-6">
+                                <div x-show="selectedSection" class="px-8 pb-6 space-y-3">
                                     <details class="group">
                                         <summary class="text-[11px] font-700 uppercase tracking-[0.1em] text-ink-400 cursor-pointer hover:text-ink-600 transition-colors select-none flex items-center gap-2">
                                             <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" d="M9 5l7 7-7 7"/></svg>
@@ -249,6 +249,14 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                             class="mt-3 w-full text-sm bg-amber-50/50 border border-amber-200/50 rounded-xl px-4 py-3 resize-none font-body text-ink-600 placeholder:text-ink-300"
                                             placeholder="Optional legal disclaimer text shown at bottom of this section..."></textarea>
                                     </details>
+                                    {/* Track E2 (Spectora App.A) — force a fresh PDF page before this section. */}
+                                    <label class="flex items-center gap-3 cursor-pointer group select-none">
+                                        <input type="checkbox" x-model="selectedSection.alwaysPageBreak"
+                                            class="w-4 h-4 rounded border-surface-200 text-blueprint-600 focus:ring-blueprint-500" />
+                                        <span class="text-[11px] font-700 uppercase tracking-[0.1em] text-ink-500 group-hover:text-ink-700 transition-colors">
+                                            Always start on a new page (PDF)
+                                        </span>
+                                    </label>
                                 </div>
                             </div>
                         </template>

--- a/tests/repair-list.spec.ts
+++ b/tests/repair-list.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Track E1 (ITB §11, UC-ITB-07) — Repair List route smoke.
+ *
+ * Router-level guard: verify the new `/inspections/:id/repair-list` route
+ * is mounted and gated by htmlAuthGuard. Without a session the route
+ * 302s to /login (proves the route is registered + auth runs first); with
+ * an opted-in session the route either renders the punch-list or 404s
+ * when the tenant has the toggle off.
+ *
+ * Full UI flow (toggle on → see tab → click → see card list → print) is
+ * exercised by the Chrome MCP smoke separately.
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:8789';
+const FAKE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+test.describe('Track E1 — repair-list route', () => {
+    test('/repair-list sub-route is mounted', async ({ request }) => {
+        const res = await request.get(`${BASE_URL}/inspections/${FAKE_ID}/repair-list`, {
+            maxRedirects: 0,
+            failOnStatusCode: false,
+        });
+        // Either a 302 to /login (unauth) or a 200/404 (auth + opt-in/out).
+        // A 500 or anything else means the route blew up.
+        expect([200, 301, 302, 303, 307, 308, 404]).toContain(res.status());
+        if ([301, 302, 303, 307, 308].includes(res.status())) {
+            const location = res.headers()['location'] || '';
+            expect(location).toMatch(/\/login/);
+        }
+    });
+
+    test('GET /api/inspections/:id/repair-list responds', async ({ request }) => {
+        const res = await request.get(`${BASE_URL}/api/inspections/${FAKE_ID}/repair-list`, {
+            failOnStatusCode: false,
+        });
+        // Auth middleware on /api/* returns 401 without a token; the route
+        // should be mounted (not 404 from the catch-all).
+        expect(res.status()).not.toBe(404);
+        expect([401, 403, 200]).toContain(res.status());
+    });
+});

--- a/tests/unit/editor-search.spec.ts
+++ b/tests/unit/editor-search.spec.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeQuery,
+    itemMatches,
+    sectionMatches,
+    filterSections,
+    highlightMatches,
+    type SearchableSection,
+    type SearchableResults,
+} from '../../src/lib/editor-search';
+
+/**
+ * Competitor parity App.E.3 (Spectora) — editor full-text search.
+ * Pure-function tests for the filter helpers used by inspection-edit.tsx.
+ */
+describe('editor-search', () => {
+    const sections: SearchableSection[] = [
+        {
+            id: 'roof',
+            title: 'Roof',
+            items: [
+                { id: 'cover',  label: 'Roof Covering' },
+                { id: 'flash',  label: 'Roof Flashing' },
+            ],
+        },
+        {
+            id: 'elec',
+            title: 'Electrical',
+            items: [
+                { id: 'panel',  label: 'Main Panel' },
+                { id: 'gfci',   label: 'GFCI Outlets' },
+            ],
+        },
+        {
+            id: 'plumb',
+            title: 'Plumbing',
+            items: [
+                { id: 'wh',     label: 'Water Heater' },
+            ],
+        },
+    ];
+
+    const results: SearchableResults = {
+        cover: { notes: 'Asphalt shingles in good shape' },
+        flash: { notes: 'Cracked at chimney; needs sealant' },
+        panel: { notes: 'Federal Pacific panel — recommend replacement' },
+        gfci:  {
+            notes: '',
+            cannedComments: {
+                defects: [
+                    { cannedId: 'd1', title: 'Reverse polarity', comment: 'Outlet wired in reverse' },
+                ],
+            },
+        },
+        wh:    {
+            notes: '',
+            customComments: {
+                defects: [
+                    { id: 'c1', title: 'Rusted base', comment: 'Visible corrosion at tank base', location: 'Garage' },
+                ],
+            },
+        },
+    };
+
+    describe('normalizeQuery', () => {
+        it('lowercases and trims', () => {
+            expect(normalizeQuery('  Roof  ')).toBe('roof');
+        });
+        it('returns empty for nullish input', () => {
+            expect(normalizeQuery(null)).toBe('');
+            expect(normalizeQuery(undefined)).toBe('');
+            expect(normalizeQuery('')).toBe('');
+            expect(normalizeQuery('   ')).toBe('');
+        });
+    });
+
+    describe('itemMatches', () => {
+        const roof = sections[0]!;
+        const cover = roof.items[0]!;
+        const flash = roof.items[1]!;
+
+        it('empty query matches everything', () => {
+            expect(itemMatches(roof, cover, results, '')).toBe(true);
+            expect(itemMatches(roof, cover, results, '   ')).toBe(true);
+        });
+        it('matches on item label (case-insensitive)', () => {
+            expect(itemMatches(roof, cover, results, 'covering')).toBe(true);
+            expect(itemMatches(roof, cover, results, 'COVERING')).toBe(true);
+        });
+        it('matches on section title (so the whole section surfaces)', () => {
+            expect(itemMatches(roof, cover, results, 'roof')).toBe(true);
+        });
+        it('matches on result notes', () => {
+            expect(itemMatches(roof, flash, results, 'chimney')).toBe(true);
+            expect(itemMatches(roof, cover, results, 'asphalt')).toBe(true);
+        });
+        it('matches on canned-comment title and comment text', () => {
+            const elec = sections[1]!;
+            const gfci = elec.items[1]!;
+            expect(itemMatches(elec, gfci, results, 'reverse polarity')).toBe(true);
+            expect(itemMatches(elec, gfci, results, 'wired in reverse')).toBe(true);
+        });
+        it('matches on custom-comment title, comment, location', () => {
+            const plumb = sections[2]!;
+            const wh = plumb.items[0]!;
+            expect(itemMatches(plumb, wh, results, 'rusted')).toBe(true);
+            expect(itemMatches(plumb, wh, results, 'corrosion')).toBe(true);
+            expect(itemMatches(plumb, wh, results, 'garage')).toBe(true);
+        });
+        it('returns false when nothing matches', () => {
+            expect(itemMatches(roof, cover, results, 'asbestos')).toBe(false);
+        });
+    });
+
+    describe('sectionMatches', () => {
+        it('matches when section title contains query', () => {
+            expect(sectionMatches(sections[0]!, results, 'roof')).toBe(true);
+        });
+        it('matches when any item matches', () => {
+            expect(sectionMatches(sections[1]!, results, 'gfci')).toBe(true);
+            expect(sectionMatches(sections[1]!, results, 'federal pacific')).toBe(true);
+        });
+        it('returns false when no item matches', () => {
+            expect(sectionMatches(sections[2]!, results, 'asbestos')).toBe(false);
+        });
+        it('empty query matches every section', () => {
+            for (const s of sections) {
+                expect(sectionMatches(s, results, '')).toBe(true);
+            }
+        });
+    });
+
+    describe('filterSections', () => {
+        it('empty query returns all sections (with all items)', () => {
+            const out = filterSections(sections, results, '');
+            expect(out.length).toBe(3);
+            expect(out[0]!.items.length).toBe(2);
+        });
+
+        it('section-title hit keeps every item in that section', () => {
+            const out = filterSections(sections, results, 'electrical');
+            expect(out.length).toBe(1);
+            expect(out[0]!.id).toBe('elec');
+            expect(out[0]!.items.length).toBe(2); // both items kept
+        });
+
+        it('item-label hit keeps only matching items in their section', () => {
+            const out = filterSections(sections, results, 'gfci');
+            expect(out.length).toBe(1);
+            expect(out[0]!.items.length).toBe(1);
+            expect(out[0]!.items[0]!.id).toBe('gfci');
+        });
+
+        it('notes hit surfaces the right item', () => {
+            const out = filterSections(sections, results, 'chimney');
+            expect(out.length).toBe(1);
+            expect(out[0]!.id).toBe('roof');
+            expect(out[0]!.items.length).toBe(1);
+            expect(out[0]!.items[0]!.id).toBe('flash');
+        });
+
+        it('drops sections with zero matches', () => {
+            const out = filterSections(sections, results, 'asbestos');
+            expect(out.length).toBe(0);
+        });
+
+        it('does not mutate input', () => {
+            const before = JSON.stringify(sections);
+            filterSections(sections, results, 'roof');
+            filterSections(sections, results, 'gfci');
+            expect(JSON.stringify(sections)).toBe(before);
+        });
+    });
+
+    describe('highlightMatches', () => {
+        it('wraps the matched substring in <mark>', () => {
+            expect(highlightMatches('Roof Covering', 'roof')).toBe('<mark>Roof</mark> Covering');
+        });
+        it('preserves original casing of the source text', () => {
+            expect(highlightMatches('Roof Covering', 'COV')).toBe('Roof <mark>Cov</mark>ering');
+        });
+        it('escapes HTML metacharacters in source text', () => {
+            expect(highlightMatches('A&B<C>', 'b')).toBe('A&amp;<mark>B</mark>&lt;C&gt;');
+        });
+        it('returns the (escaped) text unchanged when query is empty', () => {
+            expect(highlightMatches('Roof', '')).toBe('Roof');
+            expect(highlightMatches('A&B', '')).toBe('A&amp;B');
+        });
+        it('returns empty string for null / undefined', () => {
+            expect(highlightMatches(null, 'roof')).toBe('');
+            expect(highlightMatches(undefined, 'roof')).toBe('');
+        });
+        it('handles regex meta characters in query', () => {
+            // Should not throw, and should literal-match the parens.
+            expect(highlightMatches('GFCI (Bath)', '(bath)')).toBe('GFCI <mark>(Bath)</mark>');
+        });
+        it('matches multiple occurrences (global flag)', () => {
+            expect(highlightMatches('Roof and Roof again', 'roof'))
+                .toBe('<mark>Roof</mark> and <mark>Roof</mark> again');
+        });
+    });
+});

--- a/tests/unit/repair-list.service.spec.ts
+++ b/tests/unit/repair-list.service.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * Track E1 (ITB §11, UC-ITB-07) — Repair List aggregation.
+ *
+ * Covers:
+ *   - getRepairList aggregates ONLY included canned defects from the
+ *     resolved tabs of every section/item.
+ *   - Custom (per-inspection) defects are also surfaced.
+ *   - Default-on canned defects with no per-inspection state still appear.
+ *   - Excluded defects (state.included === false) are dropped.
+ *   - Recommendation slug → label resolution.
+ *   - Estimate range surfaced per defect; totals sum across all entries.
+ *   - showEstimates flag passes through from tenant_configs.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InspectionService } from '../../src/services/inspection.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT = '00000000-0000-0000-0000-000000000123';
+const INSPECTION_ID = '55555555-5555-5555-5555-555555555555';
+const TEMPLATE_ID = '66666666-6666-6666-6666-666666666666';
+
+const TEMPLATE_SCHEMA = {
+    schemaVersion: 2,
+    sections: [
+        {
+            id: 'roof',
+            title: 'Roof',
+            items: [
+                {
+                    id: 'roof-shingles',
+                    label: 'Shingles',
+                    type: 'rich',
+                    ratingOptions: ['Defect'],
+                    tabs: {
+                        information: [],
+                        limitations: [],
+                        defects: [
+                            // default-on, no estimate, no recommendation
+                            { id: 'def-default-on', title: 'Worn shingles', category: 'maintenance', location: 'Front slope', comment: 'Worn surface granules.', photos: [], default: true },
+                            // default-off — should NOT appear unless toggled
+                            { id: 'def-default-off', title: 'Active leak', category: 'safety', location: '', comment: 'Active leak detected.', photos: [], default: false },
+                        ],
+                    },
+                },
+            ],
+        },
+        {
+            id: 'electrical',
+            title: 'Electrical',
+            items: [
+                {
+                    id: 'elec-panel',
+                    label: 'Main Panel',
+                    type: 'rich',
+                    ratingOptions: ['Defect'],
+                    tabs: {
+                        information: [],
+                        limitations: [],
+                        defects: [
+                            { id: 'def-double-tap', title: 'Double-tap breaker', category: 'safety', location: '', comment: 'Double-tap on breaker 4.', photos: [], default: false },
+                        ],
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+async function seedFixture(testDb: BetterSQLite3Database<typeof schema>) {
+    await testDb.insert(schema.tenants).values({
+        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+    });
+    await testDb.insert(schema.templates).values({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: TEMPLATE_ID, tenantId: TENANT, name: 'Standard', schema: TEMPLATE_SCHEMA as any, version: 1, createdAt: new Date(),
+    });
+    await testDb.insert(schema.inspections).values({
+        id: INSPECTION_ID, tenantId: TENANT, templateId: TEMPLATE_ID,
+        propertyAddress: '1 Main St', clientName: 'C', clientEmail: 'c@example.com',
+        date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+        paymentRequired: false, agreementRequired: false, createdAt: new Date(),
+    });
+}
+
+describe('Track E1 — InspectionService.getRepairList', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let svc: InspectionService;
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        await setupSchema(fixture.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InspectionService({} as D1Database);
+        await seedFixture(testDb);
+    });
+
+    it('returns the default-on canned defect with no inspector state', async () => {
+        const result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        expect(result.defects).toHaveLength(1);
+        expect(result.defects[0]!.itemLabel).toBe('Shingles');
+        expect(result.defects[0]!.sectionTitle).toBe('Roof');
+        expect(result.defects[0]!.category).toBe('maintenance');
+        expect(result.defects[0]!.location).toBe('Front slope');
+        expect(result.defects[0]!.source).toBe('canned');
+        // No estimate / recommendation supplied, so totals stay zero.
+        expect(result.totals.maintenance).toBe(1);
+        expect(result.totals.safety).toBe(0);
+        expect(result.totals.estimateLowSum).toBe(0);
+        expect(result.totals.estimateHighSum).toBe(0);
+    });
+
+    it('drops a default-on defect when the inspector toggled it off', async () => {
+        await svc.updateResults(INSPECTION_ID, TENANT, {
+            'roof-shingles': {
+                tabs: {
+                    defects: [
+                        { cannedId: 'def-default-on', included: false },
+                    ],
+                },
+            },
+        });
+        const result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        expect(result.defects).toHaveLength(0);
+        expect(result.totals.count).toBe(0);
+    });
+
+    it('includes a default-off defect when the inspector toggled it on', async () => {
+        await svc.updateResults(INSPECTION_ID, TENANT, {
+            'roof-shingles': {
+                tabs: {
+                    defects: [
+                        { cannedId: 'def-default-off', included: true, recommendationId: 'roof-leak', estimateLow: 50000, estimateHigh: 150000 },
+                    ],
+                },
+            },
+        });
+        const result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        // Default-on (worn shingles) + the toggled-on leak.
+        expect(result.defects.length).toBe(2);
+        const leak = result.defects.find(d => d.itemLabel === 'Shingles' && d.category === 'safety');
+        expect(leak).toBeDefined();
+        expect(leak!.recommendationId).toBe('roof-leak');
+        expect(leak!.recommendationLabel).not.toBe('roof-leak'); // resolved to human-readable label
+        expect(leak!.estimateLow).toBe(50000);
+        expect(leak!.estimateHigh).toBe(150000);
+        expect(result.totals.safety).toBe(1);
+        expect(result.totals.estimateLowSum).toBe(50000);
+        expect(result.totals.estimateHighSum).toBe(150000);
+    });
+
+    it('aggregates defects across multiple sections + items', async () => {
+        await svc.updateResults(INSPECTION_ID, TENANT, {
+            'elec-panel': {
+                tabs: {
+                    defects: [
+                        { cannedId: 'def-double-tap', included: true },
+                    ],
+                },
+            },
+        });
+        const result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        // Roof default + elec toggled-on = 2 entries across 2 sections.
+        expect(result.defects.length).toBe(2);
+        const sections = new Set(result.defects.map(d => d.sectionTitle));
+        expect(sections.has('Roof')).toBe(true);
+        expect(sections.has('Electrical')).toBe(true);
+    });
+
+    it('surfaces custom (per-inspection) defects', async () => {
+        // Bypass updateResults' canned-only sanitizer and write directly so
+        // we can simulate a custom defect on the inspection_results.data
+        // payload.
+        await testDb.insert(schema.inspectionResults).values({
+            id: 'res-1',
+            inspectionId: INSPECTION_ID,
+            tenantId: TENANT,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            data: {
+                'roof-shingles': {
+                    customComments: {
+                        defects: [
+                            { id: 'cust-1', title: 'Loose flashing', comment: 'Flashing is loose at chimney base.', included: true, category: 'safety' },
+                            { id: 'cust-2', title: 'Excluded',       comment: 'should not appear',                  included: false, category: 'maintenance' },
+                        ],
+                    },
+                },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            lastSyncedAt: new Date(),
+        });
+        const result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        // Default canned (Worn shingles) + custom safety = 2.
+        expect(result.defects).toHaveLength(2);
+        const custom = result.defects.find(d => d.source === 'custom');
+        expect(custom).toBeDefined();
+        expect(custom!.itemLabel).toBe('Loose flashing');
+        expect(custom!.category).toBe('safety');
+        expect(result.totals.safety).toBe(1);
+        expect(result.totals.maintenance).toBe(1);
+    });
+
+    it('reflects showEstimates from tenant_configs', async () => {
+        // Default = false (no row).
+        let result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        expect(result.showEstimates).toBe(false);
+        // Insert config with show_estimates = 1.
+        await testDb.insert(schema.tenantConfigs).values({
+            tenantId: TENANT, showEstimates: true, updatedAt: new Date(),
+        });
+        result = await svc.getRepairList(INSPECTION_ID, TENANT);
+        expect(result.showEstimates).toBe(true);
+    });
+});

--- a/tests/unit/report-section-numbering.spec.ts
+++ b/tests/unit/report-section-numbering.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+    canEditSection,
+    formatSectionHeading,
+    buildSectionEditHref,
+} from '../../src/lib/report-section-numbering';
+
+/**
+ * Competitor parity App.F.4 (Spectora) — auto-numbered section headings
+ * + EDIT SECTION hover affordance in the published report viewer.
+ */
+describe('report-section-numbering', () => {
+    describe('canEditSection', () => {
+        it('grants edit to owner / admin / inspector', () => {
+            expect(canEditSection('owner')).toBe(true);
+            expect(canEditSection('admin')).toBe(true);
+            expect(canEditSection('inspector')).toBe(true);
+        });
+        it('denies edit to client / agent / unknown roles', () => {
+            expect(canEditSection('agent')).toBe(false);
+            expect(canEditSection('client')).toBe(false);
+            expect(canEditSection('viewer')).toBe(false);
+        });
+        it('denies edit when role is null / undefined / empty', () => {
+            expect(canEditSection(null)).toBe(false);
+            expect(canEditSection(undefined)).toBe(false);
+            expect(canEditSection('')).toBe(false);
+        });
+    });
+
+    describe('formatSectionHeading', () => {
+        it('produces 1-based numbering with em-dashed title', () => {
+            expect(formatSectionHeading('Roof', 0)).toBe('1 - Roof');
+            expect(formatSectionHeading('Heating', 4)).toBe('5 - Heating');
+            expect(formatSectionHeading('Electrical', 2)).toBe('3 - Electrical');
+        });
+        it('trims surrounding whitespace from the title', () => {
+            expect(formatSectionHeading('  Roof  ', 0)).toBe('1 - Roof');
+        });
+        it('falls back to bare number when title is missing', () => {
+            expect(formatSectionHeading('', 2)).toBe('3');
+            expect(formatSectionHeading(null, 0)).toBe('1');
+            expect(formatSectionHeading(undefined, 7)).toBe('8');
+            expect(formatSectionHeading('   ', 4)).toBe('5');
+        });
+        it('floors fractional indexes and clamps negatives to 0', () => {
+            expect(formatSectionHeading('Roof', 1.7)).toBe('2 - Roof');
+            expect(formatSectionHeading('Roof', -3)).toBe('1 - Roof');
+        });
+    });
+
+    describe('buildSectionEditHref', () => {
+        it('builds the editor deep-link with #section-{id} fragment', () => {
+            expect(buildSectionEditHref('insp-123', 'roof'))
+                .toBe('/inspections/insp-123/report#section-roof');
+            expect(buildSectionEditHref('abc', 'electrical-panel'))
+                .toBe('/inspections/abc/report#section-electrical-panel');
+        });
+    });
+});

--- a/tests/unit/report-section-viewer.spec.ts
+++ b/tests/unit/report-section-viewer.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * ReportCardStackPage render tests — Competitor parity App.F.4 (Spectora).
+ *
+ * Asserts the published-report viewer:
+ *   - numbers visible sections starting at 1 ("3 - Roof")
+ *   - shows the EDIT SECTION button only for inspector / admin / owner
+ *   - never shows EDIT SECTION for public viewers (no role) or agents
+ *   - emits a stable `id="section-{id}"` anchor so the editor deep-link
+ *     can scroll the right section into view
+ *
+ * Uses String(JSXNode) — hono/jsx materialises HTML server-side without
+ * needing a DOM.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ReportCardStackPage } from '../../src/templates/pages/report-card-stack';
+import type { RatingLevel } from '../../src/lib/report-utils';
+
+function render(node: unknown): string {
+    return String(node);
+}
+
+const ratingLevels: RatingLevel[] = [
+    { id: 'sat',    label: 'Satisfactory', abbreviation: 'Sat', color: '#22c55e', severity: 'good',        isDefect: false },
+    { id: 'mon',    label: 'Monitor',      abbreviation: 'Mon', color: '#f59e0b', severity: 'marginal',    isDefect: false },
+    { id: 'defect', label: 'Defect',       abbreviation: 'Def', color: '#f43f5e', severity: 'significant', isDefect: true  },
+];
+
+const baseProps = {
+    inspectionId: 'insp-abc',
+    address: '123 Main St',
+    date: 'May 8, 2026',
+    inspectorName: 'Jane Inspector',
+    theme: 'modern' as const,
+    stats: { total: 6, satisfactory: 3, monitor: 1, defect: 2 },
+    ratingLevels,
+    sections: [
+        {
+            id: 'roof',
+            title: 'Roof',
+            icon: null,
+            defectCount: 1,
+            items: [
+                { id: 'cover', label: 'Roof Covering', rating: 'sat',    ratingColor: '#22c55e', ratingLabel: 'Sat', severityBucket: 'satisfactory', notes: 'OK',     photos: [] },
+                { id: 'flash', label: 'Roof Flashing', rating: 'defect', ratingColor: '#f43f5e', ratingLabel: 'Def', severityBucket: 'defect',       notes: 'Cracked', photos: [] },
+            ],
+        },
+        {
+            id: 'elec',
+            title: 'Electrical',
+            icon: null,
+            defectCount: 0,
+            items: [
+                { id: 'panel', label: 'Main Panel', rating: 'sat', ratingColor: '#22c55e', ratingLabel: 'Sat', severityBucket: 'satisfactory', notes: 'OK', photos: [] },
+            ],
+        },
+        {
+            id: 'plumb',
+            title: 'Plumbing',
+            icon: null,
+            defectCount: 1,
+            items: [
+                { id: 'wh', label: 'Water Heater', rating: 'mon', ratingColor: '#f59e0b', ratingLabel: 'Mon', severityBucket: 'monitor', notes: 'Aging', photos: [] },
+            ],
+        },
+    ],
+};
+
+describe('ReportCardStackPage — section numbering (App.F.4)', () => {
+    it('numbers visible sections starting at 1', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps }));
+        // Each section heading carries a "{N} -" prefix.
+        expect(html).toContain('1 -');
+        expect(html).toContain('2 -');
+        expect(html).toContain('3 -');
+        expect(html).toContain('Roof');
+        expect(html).toContain('Electrical');
+        expect(html).toContain('Plumbing');
+    });
+
+    it('emits id="section-{id}" anchor on each section card', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps }));
+        expect(html).toContain('id="section-roof"');
+        expect(html).toContain('id="section-elec"');
+        expect(html).toContain('id="section-plumb"');
+    });
+
+    it('numbered <span> uses font-mono styling', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps }));
+        // The number span is monospace + theme-text-muted.
+        expect(html).toMatch(/font-mono[^>]*>1 -/);
+    });
+
+    it('aria-label on heading uses the full numbered string', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps }));
+        expect(html).toContain('aria-label="1 - Roof"');
+        expect(html).toContain('aria-label="3 - Plumbing"');
+    });
+});
+
+describe('ReportCardStackPage — EDIT SECTION hover button (App.F.4)', () => {
+    it('renders EDIT button for inspector role', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: 'inspector' }));
+        expect(html).toContain('data-testid="report-section-edit"');
+        expect(html).toContain('Edit Section');
+        // Each section gets its own deep-link.
+        expect(html).toContain('href="/inspections/insp-abc/report#section-roof"');
+        expect(html).toContain('href="/inspections/insp-abc/report#section-elec"');
+        expect(html).toContain('href="/inspections/insp-abc/report#section-plumb"');
+    });
+
+    it('renders EDIT button for admin role', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: 'admin' }));
+        expect(html).toContain('data-testid="report-section-edit"');
+    });
+
+    it('renders EDIT button for owner role', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: 'owner' }));
+        expect(html).toContain('data-testid="report-section-edit"');
+    });
+
+    it('hides EDIT button for agent role', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: 'agent' }));
+        expect(html).not.toContain('data-testid="report-section-edit"');
+        expect(html).not.toContain('Edit Section');
+    });
+
+    it('hides EDIT button for anonymous public viewer (null role)', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: null }));
+        expect(html).not.toContain('data-testid="report-section-edit"');
+    });
+
+    it('hides EDIT button when viewerRole prop is omitted entirely', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps }));
+        expect(html).not.toContain('data-testid="report-section-edit"');
+    });
+
+    it('EDIT button uses no-print class so it disappears in PDFs', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: 'inspector' }));
+        // Tailwind no-print utility — main-layout's print stylesheet hides it.
+        // Match the <a> opening tag that carries data-testid AND no-print
+        // (attribute order is not guaranteed by hono/jsx, so we check both).
+        const matches = html.match(/<a [^>]*data-testid="report-section-edit"[^>]*>/g) ?? [];
+        expect(matches.length).toBeGreaterThan(0);
+        for (const tag of matches) {
+            expect(tag).toContain('no-print');
+        }
+    });
+
+    it('EDIT button uses opacity-0 + group-hover for hover-only reveal', async () => {
+        const html = await render(ReportCardStackPage({ ...baseProps, viewerRole: 'inspector' }));
+        expect(html).toMatch(/opacity-0[^"]*group-hover\/section:opacity-100/);
+    });
+});

--- a/tests/unit/section-disclaimer-render.spec.ts
+++ b/tests/unit/section-disclaimer-render.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Track E2 (Spectora App.A) — getReportData surfaces per-section
+ * disclaimerText + alwaysPageBreak so the published report viewer can
+ * render the disclaimer block + apply the data-page-break attribute.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InspectionService } from '../../src/services/inspection.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT = '00000000-0000-0000-0000-000000000077';
+const INSPECTION_ID = '33333333-3333-3333-3333-333333333333';
+const TEMPLATE_ID = '44444444-4444-4444-4444-444444444444';
+
+function buildTemplateSchema() {
+    return {
+        schemaVersion: 2 as const,
+        sections: [
+            {
+                id: 'roof',
+                title: 'Roof',
+                disclaimerText: 'The inspector did not walk on the roof due to weather conditions.',
+                alwaysPageBreak: true,
+                items: [
+                    { id: 'roof-i', label: 'Shingles', type: 'text' },
+                ],
+            },
+            {
+                id: 'plumbing',
+                title: 'Plumbing',
+                // no disclaimer, no page-break
+                items: [
+                    { id: 'plumbing-i', label: 'Faucets', type: 'text' },
+                ],
+            },
+        ],
+    };
+}
+
+describe('Track E2 — section disclaimer + alwaysPageBreak surfacing', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let svc: InspectionService;
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        await setupSchema(fixture.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InspectionService({} as D1Database);
+
+        await testDb.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        await testDb.insert(schema.templates).values({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            id: TEMPLATE_ID, tenantId: TENANT, name: 'Standard', schema: buildTemplateSchema() as any, version: 1, createdAt: new Date(),
+        });
+        await testDb.insert(schema.inspections).values({
+            id: INSPECTION_ID, tenantId: TENANT, templateId: TEMPLATE_ID,
+            propertyAddress: '1 Main St', clientName: 'C', clientEmail: 'c@example.com',
+            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+            paymentRequired: false, agreementRequired: false, createdAt: new Date(),
+        });
+    });
+
+    it('surfaces disclaimerText and alwaysPageBreak on the section payload', async () => {
+        const report = await svc.getReportData(INSPECTION_ID, TENANT);
+        const roof = report.sections.find(s => s.id === 'roof');
+        const plumbing = report.sections.find(s => s.id === 'plumbing');
+        expect(roof).toBeDefined();
+        expect(roof!.disclaimerText).toBe('The inspector did not walk on the roof due to weather conditions.');
+        expect(roof!.alwaysPageBreak).toBe(true);
+        // Plumbing has no flags — defaults must come through cleanly.
+        expect(plumbing).toBeDefined();
+        expect(plumbing!.disclaimerText).toBeNull();
+        expect(plumbing!.alwaysPageBreak).toBe(false);
+    });
+
+    it('trims whitespace-only disclaimerText to null', async () => {
+        const tplWithEmpty = {
+            schemaVersion: 2 as const,
+            sections: [
+                { id: 's', title: 'S', disclaimerText: '   ', items: [{ id: 'i', label: 'I', type: 'text' }] },
+            ],
+        };
+        await testDb.update(schema.templates).set({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            schema: tplWithEmpty as any,
+        });
+        const report = await svc.getReportData(INSPECTION_ID, TENANT);
+        expect(report.sections[0]!.disclaimerText).toBeNull();
+    });
+});

--- a/tests/unit/template-section-flags.spec.ts
+++ b/tests/unit/template-section-flags.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Track E2 (Spectora App.A) — per-section disclaimer + always_page_break.
+ *
+ * Schema-level tests verify that the v2 template Zod validator accepts the
+ * new optional fields and rejects malformed ones. The renderer side is
+ * exercised by the report-utils + getReportData spec to ensure surfacing
+ * those fields onto the report data contract works end-to-end.
+ */
+import { describe, it, expect } from 'vitest';
+import { CreateTemplateSchema } from '../../src/lib/validations/template.schema';
+
+const baseItem = {
+    id: 'i1',
+    label: 'Item',
+    type: 'text' as const,
+};
+
+function buildPayload(section: Record<string, unknown>) {
+    return {
+        name: 'T',
+        schema: {
+            schemaVersion: 2 as const,
+            sections: [{ id: 's1', title: 'Section', items: [baseItem], ...section }],
+        },
+    };
+}
+
+describe('Track E2 — TemplateSectionSchema accepts new flags', () => {
+    it('accepts a section with disclaimerText + alwaysPageBreak set', () => {
+        const result = CreateTemplateSchema.safeParse(buildPayload({
+            disclaimerText: 'Roof not walked due to weather conditions.',
+            alwaysPageBreak: true,
+        }));
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts a legacy section without the new fields (backwards compat)', () => {
+        const result = CreateTemplateSchema.safeParse(buildPayload({}));
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts disclaimerText: null (explicit clear)', () => {
+        const result = CreateTemplateSchema.safeParse(buildPayload({
+            disclaimerText: null,
+        }));
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects disclaimerText longer than 4 KB', () => {
+        const tooLong = 'x'.repeat(4001);
+        const result = CreateTemplateSchema.safeParse(buildPayload({
+            disclaimerText: tooLong,
+        }));
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects alwaysPageBreak as a non-boolean value', () => {
+        const result = CreateTemplateSchema.safeParse(buildPayload({
+            alwaysPageBreak: 'yes',
+        }));
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Round 2 of competitor parity. Ships 4 more high-ROI features from the iter 1 Top 10 gap report.

### Track D (3 commits)
- **D1** Editor full-text search (Spectora App.E.3) — top-of-page search input filters items live; matches section title / item label / notes / canned + custom comments / recommendation; mark-tag highlights; mobile + desktop.
- **D2** Auto-numbered sections + EDIT SECTION hover (App.F.4) — `"3 - Roof"` numbered headings in published viewer; hover-only EDIT button gated to inspector/admin/owner.

### Track E (3 commits)
- **E1** Repair List (ITB §11) — new `/inspections/:id/repair-list` page aggregating defects into a contractor punch-list (item · recommendation tag · estimate range · photos). Tenant settings toggle to opt in. 6th sub-route tab.
- **E2** Per-section disclaimer + always_page_break (Spectora App.A) — template schema gains `disclaimerText` and `alwaysPageBreak` per section; renders below items in viewer; print CSS honors `data-page-break="always"`.

## Stats

- 6 commits across 2 worktree-isolated tracks
- **397 unit tests pass** (was 338 pre-round)
- type-check 0 errors, lint 0 errors
- 3 merge conflicts resolved (index.ts plumbing + report-card-stack.tsx interface + section heading)
- New migration: `0044_repair_list_toggle.sql`

## Test plan

- [x] type-check 0
- [x] lint 0
- [x] 397/397 unit tests
- [x] Editor search filters live (mobile + desktop)
- [x] Section numbering 1-based, visible-section order
- [x] EDIT SECTION button only for inspector/admin/owner
- [x] Repair list 404s when toggle off, renders when on
- [x] Disclaimer text appears below section items in published report
- [x] Always-page-break attribute honored in print CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)