### PR TITLE
Sprint 2 polish round 3: publish modal + list status icons + people card

### DIFF
--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -112,7 +112,14 @@ function inspectionEditor(inspectionId) {
       notifyAgent: true,
       requireSignature: false,
       requirePayment: false,
+      // Round-2 F1 — radio: 'report' (default) or 'agreement'.
+      payload: 'report',
     },
+
+    // Round-2 F1 — multi-recipient Publish modal state.
+    showLegacyPublishOptions: false,
+    loadingRecipients: false,
+    recipients: [],
 
     async init() {
       // Tell global KeyboardHUD (keyboard-hud.tsx) not to fire on ? — this
@@ -1823,13 +1830,71 @@ function inspectionEditor(inspectionId) {
       window.open('/api/inspections/' + this.inspectionId + '/report', '_blank');
     },
 
+    // Round-2 F1 — Fetch the recipient list for the multi-recipient publish
+    // modal. Each row gets a fresh { channels: { email: false, text: false } }
+    // so checkbox state starts unchecked. Sets `loadingRecipients` for the
+    // body's loading sentinel.
+    async loadRecipients() {
+      this.loadingRecipients = true;
+      try {
+        const res = await authFetch('/api/inspections/' + this.inspectionId + '/recipients');
+        if (res.ok) {
+          const json = await res.json();
+          const list = (json && json.data) || [];
+          this.recipients = list.map(function (r) {
+            return {
+              contactId: r.contactId,
+              name:      r.name,
+              role:      r.role,
+              email:     r.email,
+              phone:     r.phone,
+              channels:  { email: !!r.email, text: false },
+            };
+          });
+        } else {
+          this.recipients = [];
+        }
+      } catch (e) {
+        this.recipients = [];
+      } finally {
+        this.loadingRecipients = false;
+      }
+    },
+
+    // Round-2 F1 — count of {recipient × channel} checkboxes that are on.
+    // Used by Send All disabled binding.
+    selectedRecipientCount() {
+      let n = 0;
+      for (const r of this.recipients) {
+        if (r.channels && r.channels.email) n++;
+        if (r.channels && r.channels.text)  n++;
+      }
+      return n;
+    },
+
     async publish() {
       this.publishing = true;
       try {
+        // Round-2 F1 — collapse the per-recipient channel selections into the
+        // payload shape PublishInspectionSchema expects.
+        const recipientPayload = (this.recipients || [])
+          .map(function (r) {
+            const ch = [];
+            if (r.channels && r.channels.email) ch.push('email');
+            if (r.channels && r.channels.text)  ch.push('text');
+            return { contactId: r.contactId, channels: ch };
+          })
+          .filter(function (r) { return r.channels.length > 0; });
+
+        const body = Object.assign({}, this.publishOptions, {
+          recipients:        recipientPayload,
+          sendAgreementCopy: this.publishOptions.payload === 'agreement',
+        });
+
         var res = await authFetch('/api/inspections/' + this.inspectionId + '/publish', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(this.publishOptions),
+          body: JSON.stringify(body),
         });
         if (res.ok) {
           var json = await res.json();

--- a/public/js/inspection-settings.js
+++ b/public/js/inspection-settings.js
@@ -23,6 +23,17 @@ document.addEventListener('alpine:init', () => {
             agreementRequired: false,
         },
 
+        // Round-2 F3 — People card payload. Loaded from
+        // /api/inspections/:id/people; rendered by the PeopleCard component.
+        peopleCard: null,
+        get peopleCardCount() {
+            if (!this.peopleCard) return 0;
+            return (this.peopleCard.inspector ? 1 : 0)
+                 + (this.peopleCard.client    ? 1 : 0)
+                 + (this.peopleCard.buyerAgents?.length   || 0)
+                 + (this.peopleCard.listingAgents?.length || 0);
+        },
+
         get ratingSystemLabel() {
             // T1 will set rating_system_id + ratingSystem fields on templates.
             // Until merge we return null and the badge stays hidden.
@@ -34,10 +45,12 @@ document.addEventListener('alpine:init', () => {
 
         async load() {
             try {
-                const [inspRes, tplRes, teamRes] = await Promise.all([
+                const [inspRes, tplRes, teamRes, peopleRes] = await Promise.all([
                     window.authFetch('/api/inspections/' + this.inspectionId),
                     window.authFetch('/api/templates'),
                     window.authFetch('/api/team/members'),
+                    // Round-2 F3 — People card payload.
+                    window.authFetch('/api/inspections/' + this.inspectionId + '/people'),
                 ]);
                 const inspJson = inspRes.ok ? await inspRes.json() : { data: {} };
                 const insp = (inspJson.data && (inspJson.data.inspection || inspJson.data)) || {};
@@ -57,6 +70,10 @@ document.addEventListener('alpine:init', () => {
                     const teamJson = await teamRes.json();
                     const members = (teamJson.data && (teamJson.data.members || teamJson.data)) || [];
                     this.inspectors = members.filter(m => m.role === 'inspector' || m.role === 'admin' || m.role === 'owner');
+                }
+                if (peopleRes && peopleRes.ok) {
+                    const peopleJson = await peopleRes.json();
+                    this.peopleCard = (peopleJson && peopleJson.data) || null;
                 }
             } catch (e) {
                 console.error('settings.load failed', e);

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -18,6 +18,7 @@ import {
     InspectionListResponseSchema,
     InspectionCountsSchema,
     PublishInspectionSchema,
+    InspectionRecipientsResponseSchema,
     ReportDataResponseSchema,
     CancelInspectionSchema,
     DashboardResponseSchema,
@@ -1343,6 +1344,33 @@ inspectionsRoutes.openapi(createRoute({
     const { id } = c.req.valid('param');
     await c.var.services.inspection.uncancelInspection(tenantId, id);
     return c.json({ success: true });
+});
+
+/**
+ * Round-2 F1 — GET /api/inspections/:id/recipients
+ * Returns the multi-party list (client + buyer agent + listing agent) that
+ * the Publish modal renders per-recipient Email/Text checkboxes against.
+ */
+const recipientsRoute = createRoute({
+    method:  'get',
+    path:    '/{id}/recipients',
+    tags:    ['Inspections'],
+    summary: 'List the recipients eligible for the Publish modal',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: z.object({ id: z.string() }) },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: InspectionRecipientsResponseSchema } },
+            description: 'Recipient list',
+        },
+    },
+});
+
+inspectionsRoutes.openapi(recipientsRoute, async (c) => {
+    const tenantId = c.get('tenantId') as string;
+    const { id }   = c.req.valid('param');
+    const list     = await c.var.services.inspection.getRecipientList(id, tenantId);
+    return c.json({ success: true, data: list }, 200);
 });
 
 /**

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -19,6 +19,7 @@ import {
     InspectionCountsSchema,
     PublishInspectionSchema,
     InspectionRecipientsResponseSchema,
+    InspectionPeopleResponseSchema,
     ReportDataResponseSchema,
     CancelInspectionSchema,
     DashboardResponseSchema,
@@ -1371,6 +1372,32 @@ inspectionsRoutes.openapi(recipientsRoute, async (c) => {
     const { id }   = c.req.valid('param');
     const list     = await c.var.services.inspection.getRecipientList(id, tenantId);
     return c.json({ success: true, data: list }, 200);
+});
+
+/**
+ * Round-2 F3 — GET /api/inspections/:id/people
+ * People-card payload (inspector + client + buyer/listing agents).
+ */
+const peopleRoute = createRoute({
+    method:  'get',
+    path:    '/{id}/people',
+    tags:    ['Inspections'],
+    summary: 'People card payload (inspector, client, agents)',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: z.object({ id: z.string() }) },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: InspectionPeopleResponseSchema } },
+            description: 'People card',
+        },
+    },
+});
+
+inspectionsRoutes.openapi(peopleRoute, async (c) => {
+    const tenantId = c.get('tenantId') as string;
+    const { id }   = c.req.valid('param');
+    const card     = await c.var.services.inspection.getPeopleCard(id, tenantId);
+    return c.json({ success: true, data: card }, 200);
 });
 
 /**

--- a/src/lib/inspection-status.ts
+++ b/src/lib/inspection-status.ts
@@ -1,0 +1,55 @@
+/**
+ * Round-2 F2 — Inspection list status-icon helper.
+ *
+ * Translates the dashboard-bucket statusFlags shape into the four visual
+ * indicators rendered next to each inspection row:
+ *
+ *   - 📄 report ready      → status is `completed` or `delivered`
+ *   - 📋 agreement signed  → at least one signed inspection_agreements row
+ *   - ✈️ sent              → status is `delivered` (publish workflow ran)
+ *   - 🚩 flag              → row is in the "Needs Attention" bucket
+ *                            (e.g. agreement unsigned past threshold,
+ *                            invoice overdue, report unpublished too long)
+ *
+ * Pure function: input is the minimal subset of inspection-row fields the
+ * dashboard already loads, output is a 4-key boolean record. Easy to unit
+ * test with a state matrix and reuse anywhere a row needs the icons.
+ */
+
+export interface InspectionStatusInput {
+    /** Inspection lifecycle status (`draft`, `scheduled`, `confirmed`, `in_progress`, `completed`, `delivered`, `cancelled`). */
+    status?: string | null;
+    /** Has at least one signed agreement record. */
+    agreementSigned?: boolean;
+    /** Row currently sits in the Needs Attention bucket. */
+    flagged?: boolean;
+}
+
+export interface InspectionStatusIcons {
+    /** Report has been built (rated + published). */
+    reportReady: boolean;
+    /** Inspection agreement was signed by the client. */
+    agreementSigned: boolean;
+    /** Publish workflow completed — report has been delivered to recipients. */
+    sent: boolean;
+    /** Row needs attention (overdue or stale). */
+    flagged: boolean;
+}
+
+/**
+ * Computes the four status-icon states for one inspection row.
+ *
+ * Defensive: missing fields collapse to `false` so partial data (e.g. a row
+ * pulled before signed-agreements join lands) never throws.
+ */
+export function getInspectionStatusIcons(input: InspectionStatusInput): InspectionStatusIcons {
+    const status = (input.status ?? '').toLowerCase();
+    const completedOrDelivered = status === 'completed' || status === 'delivered';
+    const delivered            = status === 'delivered';
+    return {
+        reportReady:     completedOrDelivered,
+        agreementSigned: input.agreementSigned === true,
+        sent:            delivered,
+        flagged:         input.flagged === true,
+    };
+}

--- a/src/lib/validations/inspection.schema.ts
+++ b/src/lib/validations/inspection.schema.ts
@@ -142,13 +142,42 @@ export const InspectionStatsResponseSchema = createApiResponseSchema(InspectionS
 
 // --- Report Data ---
 
+// Round-2 F1 — per-recipient delivery selection. Each recipient row chooses
+// zero-or-more channels. Empty `channels` means "skip this recipient".
+export const PublishRecipientSchema = z.object({
+  contactId: z.string().nullable(),
+  channels:  z.array(z.enum(['email', 'text'])).default([]),
+}).openapi('PublishRecipient');
+
 export const PublishInspectionSchema = z.object({
   theme: z.enum(['modern', 'classic', 'minimal']).default('modern'),
   notifyClient: z.boolean().default(true),
   notifyAgent: z.boolean().default(true),
   requireSignature: z.boolean().default(false),
   requirePayment: z.boolean().default(false),
+  // Round-2 F1 — multi-recipient publish modal payload. Optional because
+  // legacy clients still post the flat shape above. When present, the
+  // server uses this list to drive per-recipient delivery (email + text)
+  // instead of the broad notifyClient/notifyAgent flags.
+  recipients: z.array(PublishRecipientSchema).optional(),
+  // Whether the modal sent a copy of the agreement alongside the report.
+  // Stored only for audit/notification fan-out — does not change how the
+  // report itself is built.
+  sendAgreementCopy: z.boolean().default(false),
 }).openapi('PublishInspection');
+
+// Round-2 F1 — recipient list returned by GET /api/inspections/:id/recipients.
+export const InspectionRecipientSchema = z.object({
+  contactId: z.string().nullable(),
+  name:      z.string(),
+  role:      z.enum(['client', 'agent_buyer', 'agent_listing']),
+  email:     z.string().nullable(),
+  phone:     z.string().nullable(),
+}).openapi('InspectionRecipient');
+
+export const InspectionRecipientsResponseSchema = createApiResponseSchema(
+  z.array(InspectionRecipientSchema)
+).openapi('InspectionRecipientsResponse');
 
 export const ReportItemSchema = z.object({
   id: z.string(),

--- a/src/lib/validations/inspection.schema.ts
+++ b/src/lib/validations/inspection.schema.ts
@@ -179,6 +179,33 @@ export const InspectionRecipientsResponseSchema = createApiResponseSchema(
   z.array(InspectionRecipientSchema)
 ).openapi('InspectionRecipientsResponse');
 
+// Round-2 F3 — People card payload (Spectora §E.2).
+const PeopleAgentSchema = z.object({
+  id:     z.string(),
+  name:   z.string(),
+  email:  z.string().nullable(),
+  phone:  z.string().nullable(),
+  agency: z.string().nullable(),
+});
+
+export const InspectionPeopleSchema = z.object({
+  inspector: z.object({
+    id:    z.string(),
+    name:  z.string().nullable(),
+    email: z.string(),
+    phone: z.string().nullable(),
+  }).nullable(),
+  client: z.object({
+    name:  z.string(),
+    email: z.string().nullable(),
+    phone: z.string().nullable(),
+  }).nullable(),
+  buyerAgents:   z.array(PeopleAgentSchema),
+  listingAgents: z.array(PeopleAgentSchema),
+}).openapi('InspectionPeople');
+
+export const InspectionPeopleResponseSchema = createApiResponseSchema(InspectionPeopleSchema).openapi('InspectionPeopleResponse');
+
 export const ReportItemSchema = z.object({
   id: z.string(),
   label: z.string(),

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -1008,6 +1008,90 @@ export class InspectionService {
     }
 
     /**
+     * Round-2 F1 — list every party associated with an inspection so the
+     * Publish modal can render per-recipient Email + Text checkboxes.
+     *
+     * Returned shape (`InspectionRecipient[]`):
+     *   - role: 'client' | 'agent_buyer' | 'agent_listing'
+     *   - contactId: contact row id (null for the inline client — clients are
+     *     stored as columns on `inspections`, not in `contacts`)
+     *   - name, email, phone
+     *
+     * Recipients without any contact info (no email AND no phone) are dropped
+     * because there is no way to deliver to them. Tenant-scoped via the
+     * compound `where(eq(id), eq(tenantId))` guard on the inspection lookup
+     * AND the contact lookup.
+     */
+    async getRecipientList(inspectionId: string, tenantId: string): Promise<Array<{
+        contactId: string | null;
+        name:      string;
+        role:      'client' | 'agent_buyer' | 'agent_listing';
+        email:     string | null;
+        phone:     string | null;
+    }>> {
+        const db = this.getDrizzle();
+
+        const inspection = await db.select().from(inspections)
+            .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)))
+            .get();
+        if (!inspection) throw Errors.NotFound('Inspection not found');
+
+        const recipients: Array<{
+            contactId: string | null;
+            name:      string;
+            role:      'client' | 'agent_buyer' | 'agent_listing';
+            email:     string | null;
+            phone:     string | null;
+        }> = [];
+
+        // Client — stored inline on inspections (not contacts table). Only
+        // include when there is at least a name AND at least one channel.
+        if ((inspection.clientName ?? '').trim() && (inspection.clientEmail || inspection.clientPhone)) {
+            recipients.push({
+                contactId: null,
+                name:      inspection.clientName as string,
+                role:      'client',
+                email:     (inspection.clientEmail as string | null) ?? null,
+                phone:     (inspection.clientPhone as string | null) ?? null,
+            });
+        }
+
+        // Agents — buyer's agent (referredByAgentId) + listing agent (sellingAgentId).
+        const agentIds = [inspection.referredByAgentId, inspection.sellingAgentId]
+            .filter((x): x is string => typeof x === 'string' && x.length > 0);
+        if (agentIds.length > 0) {
+            const agentRows = await db.select().from(contacts)
+                .where(and(eq(contacts.tenantId, tenantId), inArray(contacts.id, agentIds)));
+            const byId = new Map<string, typeof agentRows[number]>();
+            for (const row of agentRows) byId.set(row.id as string, row);
+
+            const buyerId   = inspection.referredByAgentId as string | null;
+            const listingId = inspection.sellingAgentId   as string | null;
+
+            for (const [id, role] of [
+                [buyerId,   'agent_buyer'  as const],
+                [listingId, 'agent_listing' as const],
+            ] as Array<[string | null, 'agent_buyer' | 'agent_listing']>) {
+                if (!id) continue;
+                const row = byId.get(id);
+                if (!row) continue;
+                const email = (row.email as string | null) ?? null;
+                const phone = (row.phone as string | null) ?? null;
+                if (!email && !phone) continue; // no delivery channel
+                recipients.push({
+                    contactId: row.id as string,
+                    name:      row.name as string,
+                    role,
+                    email,
+                    phone,
+                });
+            }
+        }
+
+        return recipients;
+    }
+
+    /**
      * Publishes an inspection report (transitions to delivered status).
      */
     async publishInspection(inspectionId: string, tenantId: string, _options: {
@@ -1016,6 +1100,10 @@ export class InspectionService {
         notifyAgent: boolean;
         requireSignature: boolean;
         requirePayment: boolean;
+        // Round-2 F1 — optional per-recipient delivery list. Older callers
+        // (legacy publish modal, AI agent flows) keep working without it.
+        recipients?: Array<{ contactId: string | null; channels: Array<'email' | 'text'> }>;
+        sendAgreementCopy?: boolean;
     }) {
         const db = this.getDrizzle();
 

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -1092,6 +1092,94 @@ export class InspectionService {
     }
 
     /**
+     * Round-2 F3 — People card payload (Spectora §E.2 / §4.1).
+     *
+     * Groups every party connected to an inspection by role so the inspection
+     * Settings page can render a contact card with role chips:
+     *
+     *   - Inspector  → users row referenced by inspectorId
+     *   - Client     → inline columns on inspections (clientName/email/phone)
+     *   - Buyer's Agent  → contacts row pointed at by referredByAgentId
+     *   - Listing Agent  → contacts row pointed at by sellingAgentId
+     *
+     * Schema currently allows ONE buyer agent + ONE listing agent per
+     * inspection. The result returns arrays for forward-compat (so the UI
+     * can render "Buyer's Agent · 2" if multi-agent ever ships) without a
+     * follow-up service refactor.
+     */
+    async getPeopleCard(inspectionId: string, tenantId: string): Promise<{
+        inspector:     { id: string; name: string | null; email: string; phone: string | null } | null;
+        client:        { name: string; email: string | null; phone: string | null } | null;
+        buyerAgents:   Array<{ id: string; name: string; email: string | null; phone: string | null; agency: string | null }>;
+        listingAgents: Array<{ id: string; name: string; email: string | null; phone: string | null; agency: string | null }>;
+    }> {
+        const db = this.getDrizzle();
+
+        const inspection = await db.select().from(inspections)
+            .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)))
+            .get();
+        if (!inspection) throw Errors.NotFound('Inspection not found');
+
+        // Inspector — users table (tenant-scoped).
+        let inspector: { id: string; name: string | null; email: string; phone: string | null } | null = null;
+        if (inspection.inspectorId) {
+            const u = await db.select().from(users)
+                .where(and(eq(users.id, inspection.inspectorId as string), eq(users.tenantId, tenantId)))
+                .get();
+            if (u) {
+                inspector = {
+                    id:    u.id as string,
+                    name:  (u.name  as string | null) ?? null,
+                    email: u.email as string,
+                    phone: (u.phone as string | null) ?? null,
+                };
+            }
+        }
+
+        // Client — inline on inspections. Only return when there's at least
+        // a name (otherwise nothing meaningful to render in the card).
+        const clientName = (inspection.clientName as string | null) ?? null;
+        const client = clientName && clientName.trim().length > 0
+            ? {
+                name:  clientName,
+                email: (inspection.clientEmail as string | null) ?? null,
+                phone: (inspection.clientPhone as string | null) ?? null,
+            }
+            : null;
+
+        // Agents — fetch both in one query.
+        const agentIds = [inspection.referredByAgentId, inspection.sellingAgentId]
+            .filter((x): x is string => typeof x === 'string' && x.length > 0);
+        const agentRowsById = new Map<string, typeof contacts.$inferSelect>();
+        if (agentIds.length > 0) {
+            const rows = await db.select().from(contacts)
+                .where(and(eq(contacts.tenantId, tenantId), inArray(contacts.id, agentIds)));
+            for (const row of rows) agentRowsById.set(row.id as string, row);
+        }
+        const toAgent = (id: string | null) => {
+            if (!id) return null;
+            const row = agentRowsById.get(id);
+            if (!row) return null;
+            return {
+                id:     row.id as string,
+                name:   row.name as string,
+                email:  (row.email  as string | null) ?? null,
+                phone:  (row.phone  as string | null) ?? null,
+                agency: (row.agency as string | null) ?? null,
+            };
+        };
+        const buyerAgent   = toAgent(inspection.referredByAgentId as string | null);
+        const listingAgent = toAgent(inspection.sellingAgentId   as string | null);
+
+        return {
+            inspector,
+            client,
+            buyerAgents:   buyerAgent   ? [buyerAgent]   : [],
+            listingAgents: listingAgent ? [listingAgent] : [],
+        };
+    }
+
+    /**
      * Publishes an inspection report (transitions to delivered status).
      */
     async publishInspection(inspectionId: string, tenantId: string, _options: {

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -1343,7 +1343,7 @@ export class InspectionService {
         const decorate = <T extends { id: unknown; status?: unknown; sellingAgentId?: unknown; referredByAgentId?: unknown; price?: unknown; requestId?: unknown }>(rows: T[]): Array<T & {
             defectStats:    { safety: number; recommendation: number; maintenance: number };
             agentName?:     string;
-            statusFlags:    { reportPublished: boolean; agreementSigned: boolean; paid: boolean; flagged: boolean; canceled: boolean };
+            statusFlags:    { reportPublished: boolean; reportReady: boolean; agreementSigned: boolean; paid: boolean; sent: boolean; flagged: boolean; canceled: boolean };
             requestId?:     string;
             siblingCount?:  number;
         }> =>
@@ -1354,14 +1354,22 @@ export class InspectionService {
                 const agentName = (sellingId && agentNameMap.get(sellingId)) || (referredById && agentNameMap.get(referredById)) || undefined;
                 const reqId = (r as { requestId?: unknown }).requestId as string | null | undefined;
                 const siblingCount = reqId ? (requestSiblingCounts.get(reqId) ?? 1) : 1;
+                // Round-2 F2 — split "report ready" (built/completed) from "sent"
+                // (delivered = publish workflow completed). Older clients still
+                // see `reportPublished` (alias of reportReady) for backward-
+                // compat; new dashboard JSX reads `sent` for the ✈️ icon.
+                const reportReady = r.status === 'completed' || r.status === 'delivered';
+                const sent        = r.status === 'delivered';
                 return {
                     ...r,
                     defectStats: statsMap.get(id) ?? { safety: 0, recommendation: 0, maintenance: 0 },
                     ...(agentName ? { agentName } : {}),
                     statusFlags: {
-                        reportPublished: r.status === 'completed' || r.status === 'delivered',
+                        reportPublished: reportReady,
+                        reportReady,
                         agreementSigned: signedSet.has(id),
                         paid:            paidIdSet.has(id),
+                        sent,
                         flagged:         overdueSet.has(id),
                         canceled:        r.status === 'cancelled',
                     },

--- a/src/templates/components/people-card.tsx
+++ b/src/templates/components/people-card.tsx
@@ -1,0 +1,148 @@
+/**
+ * Round-2 F3 — People card with role chips (Spectora §4.1 / §E.2).
+ *
+ * Renders the inspector + client + buyer's agent + listing agent for an
+ * inspection as a single card. Each row carries:
+ *
+ *   - role chip (Buyer / Buyer's Agent / Listing Agent / Inspector)
+ *   - name (avatar = initials)
+ *   - email → mailto: link
+ *   - phone → tel:   link
+ *
+ * Per-group counter ("Buyer's Agent · 2") is appended on the chip when the
+ * group has multiple entries — schema today allows only 1, but the
+ * component is forward-compatible.
+ *
+ * The card is driven by the Alpine state already loaded by the inspection
+ * Settings page: `peopleCard.inspector`, `peopleCard.client`,
+ * `peopleCard.buyerAgents`, `peopleCard.listingAgents`. The factory in
+ * inspection-settings.js fetches /api/inspections/:id/people on init.
+ */
+
+const CHIP: Record<string, { label: string; bg: string; fg: string }> = {
+    inspector:     { label: 'Inspector',     bg: '#eef2ff', fg: '#4338ca' },
+    client:        { label: 'Buyer',         bg: '#f0fdf4', fg: '#166534' },
+    agent_buyer:   { label: "Buyer's Agent", bg: '#ecfeff', fg: '#0e7490' },
+    agent_listing: { label: 'Listing Agent', bg: '#fef3c7', fg: '#92400e' },
+};
+
+function chipStyle(kind: keyof typeof CHIP): string {
+    const c = CHIP[kind]!;
+    return `background: ${c.bg}; color: ${c.fg}`;
+}
+
+/**
+ * One contact row inside the card. The kind drives the chip color/label.
+ * The Alpine binding consumes a row object with `name`, `email`, `phone`.
+ *
+ * `bind` is the Alpine variable holding the row (e.g. `peopleCard.client`
+ * for a single contact, or `a` inside a `<template x-for="a in ...">`
+ * loop). `extraChip` (optional) renders an extra inline chip (e.g.
+ * "Buyer's Agent · 2"). `wrapper` controls whether the row uses x-show
+ * (single contact) or x-for (collection).
+ */
+interface PeopleRowProps {
+    kind: keyof typeof CHIP;
+    bind: string;
+    show?: string;
+    extraChipExpr?: string;
+}
+
+function initialsExpr(nameExpr: string): string {
+    // Inline JS that returns at most 2 capitalised initials from a name.
+    return `(${nameExpr} || '').trim().split(/\\s+/).slice(0,2).map(s => s.charAt(0).toUpperCase()).join('')`;
+}
+
+const PeopleRow = ({ kind, bind, show, extraChipExpr }: PeopleRowProps): JSX.Element => {
+    const chip = CHIP[kind]!;
+    const wrapperAttrs: Record<string, unknown> = show ? { 'x-show': show, style: 'display:none' } : {};
+    return (
+        <div class="flex items-center gap-3 py-2.5" data-test="people-card-row" {...wrapperAttrs}>
+            <div
+                class="w-9 h-9 flex-shrink-0 rounded-full flex items-center justify-center text-xs font-bold ring-1 ring-inset"
+                style={`${chipStyle(kind)}; --tw-ring-color: ${chip.fg}33`}
+                x-text={initialsExpr(`${bind}.name`)}
+            ></div>
+            <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 flex-wrap">
+                    <span class="text-[14px] font-semibold text-slate-900 truncate" x-text={`${bind}.name`}></span>
+                    <span
+                        class="px-2 py-0.5 text-[10px] font-bold rounded-full whitespace-nowrap"
+                        style={chipStyle(kind)}
+                    >{chip.label}</span>
+                    {extraChipExpr ? (
+                        <span
+                            class="px-2 py-0.5 text-[10px] font-bold rounded-full whitespace-nowrap bg-slate-100 text-slate-600"
+                            x-text={extraChipExpr}
+                        ></span>
+                    ) : null}
+                </div>
+                <div class="text-[12px] mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5">
+                    <a
+                        x-show={`${bind}.email`}
+                        x-bind:href={`'mailto:' + ${bind}.email`}
+                        class="text-indigo-600 hover:underline"
+                        x-text={`${bind}.email`}
+                    ></a>
+                    <a
+                        x-show={`${bind}.phone`}
+                        x-bind:href={`'tel:' + ${bind}.phone`}
+                        class="text-indigo-600 hover:underline"
+                        x-text={`${bind}.phone`}
+                    ></a>
+                    <span x-show={`!${bind}.email && !${bind}.phone`} class="text-slate-400 italic">
+                        No contact info
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+/**
+ * The full card. Drop into a page that exposes a `peopleCard` Alpine
+ * object via x-data. The card auto-hides when nothing is loaded.
+ */
+export const PeopleCard = (): JSX.Element => (
+    <section
+        class="bg-white border border-slate-200 rounded-md p-5"
+        data-test="people-card"
+        x-show="peopleCard"
+        style="display:none"
+    >
+        <header class="flex items-center justify-between mb-3">
+            <h2 class="text-[14px] font-bold tracking-tight text-slate-900">People</h2>
+            <span class="text-[10px] font-mono text-slate-400" x-text="peopleCardCount + ' total'"></span>
+        </header>
+        <div class="divide-y divide-slate-100">
+            <PeopleRow kind="inspector"   bind="peopleCard.inspector" show="peopleCard.inspector" />
+            <PeopleRow kind="client"      bind="peopleCard.client"    show="peopleCard.client" />
+
+            {/* Buyer's Agents — schema allows 1 today, but component handles N. */}
+            <template x-for="(a, idx) in peopleCard.buyerAgents" {...{ 'x-bind:key': '"buyer-" + (a.id || idx)' }}>
+                <PeopleRow
+                    kind="agent_buyer"
+                    bind="a"
+                    extraChipExpr="peopleCard.buyerAgents.length > 1 ? ('· ' + (idx + 1) + '/' + peopleCard.buyerAgents.length) : ''"
+                />
+            </template>
+
+            {/* Listing Agents */}
+            <template x-for="(a, idx) in peopleCard.listingAgents" {...{ 'x-bind:key': '"listing-" + (a.id || idx)' }}>
+                <PeopleRow
+                    kind="agent_listing"
+                    bind="a"
+                    extraChipExpr="peopleCard.listingAgents.length > 1 ? ('· ' + (idx + 1) + '/' + peopleCard.listingAgents.length) : ''"
+                />
+            </template>
+
+            <div
+                x-show="peopleCardCount === 0"
+                style="display:none"
+                class="py-6 text-center text-[12px] text-slate-400"
+            >
+                No people linked to this inspection yet.
+            </div>
+        </div>
+    </section>
+);

--- a/src/templates/components/publish-modal.tsx
+++ b/src/templates/components/publish-modal.tsx
@@ -1,0 +1,198 @@
+/**
+ * Round-2 F1 — Multi-recipient Publish modal (Spectora §G.3).
+ *
+ * Replaces the old flat "Confirm Publish" button with a per-recipient
+ * delivery picker:
+ *
+ *   - Lists every party associated with the inspection (client, buyer's
+ *     agent, listing agent — pulled from GET /api/inspections/:id/recipients).
+ *   - Each recipient row carries two checkboxes: Email and Text. Greyed-out
+ *     when the recipient lacks that channel (e.g. no phone → no SMS).
+ *   - Top of body: radio group switching between "Send a copy of the report"
+ *     and "Send a copy of the agreement". Drives `publishOptions.sendAgreementCopy`.
+ *   - Empty state: when the recipient list is empty, body shows
+ *     "There aren't any contacts to publish to" and the footer shows only
+ *     [Cancel].
+ *   - Footer: [Cancel] [Send All]. Send All is disabled until at least one
+ *     channel checkbox is selected.
+ *
+ * Wires entirely into the existing inspection-edit.js Alpine data via:
+ *   - `loadRecipients()`     — fetches the list when modal opens
+ *   - `recipients[]`         — per-row { contactId, name, role, email, phone, channels: { email, text } }
+ *   - `selectedRecipientCount()` — reactive count of checked channels (gates Send All)
+ *   - `publish()`            — POSTs to /publish with `recipients` payload
+ *
+ * Driver mode: Alpine `name="showPublishModal"`. The custom footer is inlined
+ * because Send All needs an x-bind:disabled wired to the count getter.
+ */
+
+import { Modal } from './modal';
+
+const ROLE_CHIP: Record<string, { label: string; bg: string; fg: string }> = {
+    client:         { label: 'Buyer',         bg: '#eef2ff', fg: '#4338ca' },
+    agent_buyer:    { label: "Buyer's Agent", bg: '#ecfeff', fg: '#0e7490' },
+    agent_listing:  { label: 'Listing Agent', bg: '#fef3c7', fg: '#92400e' },
+};
+
+export const PublishModal = (): JSX.Element => (
+    <Modal
+        name="showPublishModal"
+        title="Publish Report"
+        size="md"
+        footer={
+            <>
+                <button
+                    type="button"
+                    x-on:click="showPublishModal = false"
+                    class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border bg-white hover:bg-slate-50 transition-all"
+                    style="border-color: #e2e8f0; color: #475569"
+                >
+                    Cancel
+                </button>
+                {/* Send All — only rendered when there is at least one
+                    recipient. Disabled until any channel checkbox is checked. */}
+                <button
+                    type="button"
+                    x-show="recipients.length > 0"
+                    x-on:click="publish()"
+                    x-bind:disabled="publishing || selectedRecipientCount() === 0"
+                    class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 transition-all"
+                    data-test="publish-send-all"
+                >
+                    <span x-text="publishing ? 'Sending…' : 'Send All'"></span>
+                </button>
+            </>
+        }
+    >
+        <div class="space-y-4" x-data="{}" x-init="if (typeof loadRecipients === 'function') loadRecipients()">
+            {/* Loading state */}
+            <div
+                x-show="loadingRecipients"
+                style="display:none"
+                class="text-center py-8 text-sm"
+                {...{ 'data-test': 'publish-loading' }}
+            >
+                Loading recipients…
+            </div>
+
+            {/* Empty state — no contacts to publish to */}
+            <div
+                x-show="!loadingRecipients && recipients.length === 0"
+                style="display:none"
+                class="text-center py-8"
+                data-test="publish-empty-state"
+            >
+                <p class="text-sm font-semibold text-slate-700">
+                    There aren't any contacts to publish to.
+                </p>
+                <p class="text-xs text-slate-500 mt-2">
+                    Add a client email/phone or link an agent under Settings to enable publish.
+                </p>
+            </div>
+
+            {/* Body — only when recipients are loaded */}
+            <div x-show="!loadingRecipients && recipients.length > 0" style="display:none" class="space-y-4">
+                {/* Report summary card (same as before) */}
+                <div class="p-3 rounded-xl" style="background: #f1f5f9">
+                    <div class="text-xs font-mono" style="color: #94a3b8">Report Summary</div>
+                    <div
+                        class="text-sm mt-1"
+                        style="color: #1e293b"
+                        x-text="reportStats.total + ' items  |  ' + reportStats.defect + ' defects  |  ' + reportStats.monitor + ' monitors'"
+                    ></div>
+                </div>
+
+                {/* Send a copy of … radio */}
+                <div class="space-y-2">
+                    <div class="text-[10px] font-bold uppercase tracking-[0.2em]" style="color: #94a3b8">
+                        Send a copy of
+                    </div>
+                    <div class="flex gap-2" data-test="publish-payload-radio">
+                        <label class="flex-1 cursor-pointer">
+                            <input
+                                type="radio"
+                                value="report"
+                                x-model="publishOptions.payload"
+                                class="peer sr-only"
+                            />
+                            <div class="px-3 py-2 rounded-xl border text-sm font-semibold text-slate-600 peer-checked:bg-indigo-50 peer-checked:text-indigo-700 peer-checked:border-indigo-300 transition-all" style="border-color: #e2e8f0">
+                                The report
+                            </div>
+                        </label>
+                        <label class="flex-1 cursor-pointer">
+                            <input
+                                type="radio"
+                                value="agreement"
+                                x-model="publishOptions.payload"
+                                class="peer sr-only"
+                            />
+                            <div class="px-3 py-2 rounded-xl border text-sm font-semibold text-slate-600 peer-checked:bg-indigo-50 peer-checked:text-indigo-700 peer-checked:border-indigo-300 transition-all" style="border-color: #e2e8f0">
+                                The agreement
+                            </div>
+                        </label>
+                    </div>
+                </div>
+
+                {/* Recipients list */}
+                <div class="space-y-2" data-test="publish-recipient-list">
+                    <div class="grid grid-cols-[1fr_auto_auto] gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.2em]" style="color: #94a3b8">
+                        <span>Recipient</span>
+                        <span class="w-12 text-center">Email</span>
+                        <span class="w-12 text-center">Text</span>
+                    </div>
+                    <template x-for="(r, idx) in recipients" {...{ 'x-bind:key': '(r.contactId || "client") + idx' }}>
+                        <div class="grid grid-cols-[1fr_auto_auto] gap-3 items-center px-3 py-2 rounded-xl border" style="border-color: rgba(226,232,240,0.7); background: rgba(248,250,252,0.5)">
+                            <div class="min-w-0">
+                                <div class="flex items-center gap-2">
+                                    <span class="text-sm font-semibold truncate" style="color: #0f172a" x-text="r.name"></span>
+                                    {Object.entries(ROLE_CHIP).map(([role, chip]) => (
+                                        <span
+                                            x-show={`r.role === '${role}'`}
+                                            class="px-1.5 py-0.5 text-[10px] font-bold rounded-full whitespace-nowrap"
+                                            style={`background: ${chip.bg}; color: ${chip.fg}`}
+                                        >
+                                            {chip.label}
+                                        </span>
+                                    ))}
+                                </div>
+                                <div class="text-[11px] mt-0.5 truncate" style="color: #64748b">
+                                    <span x-show="r.email" x-text="r.email"></span>
+                                    <span x-show="r.email && r.phone"> · </span>
+                                    <span x-show="r.phone" x-text="r.phone"></span>
+                                </div>
+                            </div>
+                            <label class="w-12 flex justify-center">
+                                <input
+                                    type="checkbox"
+                                    x-model="r.channels.email"
+                                    x-bind:disabled="!r.email"
+                                    class="rounded disabled:opacity-30"
+                                    {...{ 'data-test': 'publish-channel-email' }}
+                                />
+                            </label>
+                            <label class="w-12 flex justify-center">
+                                <input
+                                    type="checkbox"
+                                    x-model="r.channels.text"
+                                    x-bind:disabled="!r.phone"
+                                    class="rounded disabled:opacity-30"
+                                    {...{ 'data-test': 'publish-channel-text' }}
+                                />
+                            </label>
+                        </div>
+                    </template>
+                </div>
+
+                {/* Advanced options link — opens the legacy options modal */}
+                <button
+                    type="button"
+                    x-on:click="showLegacyPublishOptions = true"
+                    class="text-[11px] font-semibold underline"
+                    style="color: #6366f1"
+                >
+                    Advanced options (theme, signature, payment) →
+                </button>
+            </div>
+        </div>
+    </Modal>
+);

--- a/src/templates/components/row-status-icons.tsx
+++ b/src/templates/components/row-status-icons.tsx
@@ -1,0 +1,79 @@
+/**
+ * Round-2 F2 — Inspection list status-icon column.
+ *
+ * Compact row of 4 status indicators rendered in the dashboard / inspections
+ * list. Each icon is 14px, grayed when its state is `false`, semantic-colored
+ * when `true`, and carries a tooltip via `title`.
+ *
+ * Driven by `i.statusFlags` (from InspectionService.getDashboardBuckets):
+ *   - 📄 reportReady     — report is built (status `completed` or `delivered`)
+ *   - 📋 agreementSigned — at least one signed agreement
+ *   - ✈️ sent           — publish workflow finished (status `delivered`)
+ *   - 🚩 flagged         — sits in Needs Attention bucket
+ *
+ * The component is JSX-only (no script) so it inlines cleanly inside the
+ * Alpine `<template x-for>` row loops in dashboard.tsx. The shape was
+ * intentionally kept identical to the previous inline block to minimise
+ * visual churn.
+ */
+export const RowStatusIcons = (): JSX.Element => (
+    <div class="flex items-center gap-1 text-slate-300" data-test="row-status-icons">
+        {/* 📄 Report ready — completed or delivered */}
+        <span
+            class="w-5 h-5 inline-flex items-center justify-center"
+            x-bind:class="i.statusFlags?.reportReady ? 'text-emerald-500' : ''"
+            x-bind:title="i.statusFlags?.reportReady ? 'Report ready' : 'Report not yet ready'"
+            x-bind:aria-label="i.statusFlags?.reportReady ? 'Report ready' : 'Report not yet ready'"
+        >
+            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
+                <path
+                    fill-rule="evenodd"
+                    d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z"
+                    clip-rule="evenodd"
+                />
+            </svg>
+        </span>
+        {/* 📋 Agreement signed */}
+        <span
+            class="w-5 h-5 inline-flex items-center justify-center"
+            x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''"
+            x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'"
+            x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'"
+        >
+            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path
+                    fill-rule="evenodd"
+                    d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clip-rule="evenodd"
+                />
+            </svg>
+        </span>
+        {/* ✈️ Sent — publish completed (delivered) */}
+        <span
+            class="w-5 h-5 inline-flex items-center justify-center"
+            x-bind:class="i.statusFlags?.sent ? 'text-sky-500' : ''"
+            x-bind:title="i.statusFlags?.sent ? 'Report sent' : 'Report not yet sent'"
+            x-bind:aria-label="i.statusFlags?.sent ? 'Report sent' : 'Report not yet sent'"
+        >
+            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z" />
+            </svg>
+        </span>
+        {/* 🚩 Flagged — Needs Attention bucket */}
+        <span
+            x-show="i.statusFlags?.flagged"
+            class="w-5 h-5 inline-flex items-center justify-center text-rose-500"
+            title="Flagged: invoice overdue or other attention needed"
+            aria-label="Flagged"
+        >
+            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path
+                    fill-rule="evenodd"
+                    d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z"
+                    clip-rule="evenodd"
+                />
+            </svg>
+        </span>
+    </div>
+);

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -3,6 +3,7 @@ import { BrandingConfig } from '../../types/auth';
 import { CancelModal } from '../components/cancel-modal';
 import { Modal } from '../components/modal';
 import { PageHeader } from '../components/page-header';
+import { RowStatusIcons } from '../components/row-status-icons';
 
 export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefined } = {}): JSX.Element => {
     const siteName = branding?.siteName || 'OpenInspection';
@@ -222,21 +223,8 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                     </a>
                                     {/* Sub-spec B Task 7 (B-6) — price (right-aligned, monospace) */}
                                     <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
-                                    {/* Status icons — slate-300 default, semantic color when active */}
-                                    <div class="flex items-center gap-1 text-slate-300">
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.reportPublished ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'" x-bind:aria-label="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'" x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.paid ? 'text-emerald-500' : (i.price > 0 ? 'text-amber-500' : '')" x-bind:title="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')" x-bind:aria-label="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm12 4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4a2 2 0 012-2h10zm-7 5a2 2 0 100-4 2 2 0 000 4z"/></svg>
-                                        </span>
-                                        <span x-show="i.statusFlags?.flagged" class="w-5 h-5 inline-flex items-center justify-center text-rose-500" title="Flagged: invoice overdue or other attention needed" aria-label="Flagged">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                    </div>
+                                    {/* Round-2 F2 — status icons (📄 ready · 📋 signed · ✈️ sent · 🚩 flag) */}
+                                    <RowStatusIcons />
                                     <div x-data="actionMenu({ id: i.id, status: i.status })" class="relative ml-3">
                                         <button type="button" x-on:click="open = !open" class="text-slate-400 hover:text-slate-700 px-2 text-lg font-bold">•••</button>
                                         <div x-show="open" {...{ 'x-cloak': true, 'x-on:click.outside': 'open = false' }} class="absolute right-0 top-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-10 min-w-[140px]">
@@ -285,21 +273,8 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                     </a>
                                     {/* Sub-spec B Task 7 (B-6) — price (right-aligned, monospace) */}
                                     <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
-                                    {/* Status icons — slate-300 default, semantic color when active */}
-                                    <div class="flex items-center gap-1 text-slate-300">
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.reportPublished ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'" x-bind:aria-label="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'" x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.paid ? 'text-emerald-500' : (i.price > 0 ? 'text-amber-500' : '')" x-bind:title="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')" x-bind:aria-label="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm12 4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4a2 2 0 012-2h10zm-7 5a2 2 0 100-4 2 2 0 000 4z"/></svg>
-                                        </span>
-                                        <span x-show="i.statusFlags?.flagged" class="w-5 h-5 inline-flex items-center justify-center text-rose-500" title="Flagged: invoice overdue or other attention needed" aria-label="Flagged">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                    </div>
+                                    {/* Round-2 F2 — status icons (📄 ready · 📋 signed · ✈️ sent · 🚩 flag) */}
+                                    <RowStatusIcons />
                                     <div x-data="actionMenu({ id: i.id, status: i.status })" class="relative ml-3">
                                         <button type="button" x-on:click="open = !open" class="text-slate-400 hover:text-slate-700 px-2 text-lg font-bold">•••</button>
                                         <div x-show="open" {...{ 'x-cloak': true, 'x-on:click.outside': 'open = false' }} class="absolute right-0 top-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-10 min-w-[140px]">
@@ -371,21 +346,8 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                     </a>
                                     {/* Sub-spec B Task 7 (B-6) — price (right-aligned, monospace) */}
                                     <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
-                                    {/* Status icons — slate-300 default, semantic color when active */}
-                                    <div class="flex items-center gap-1 text-slate-300">
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.reportPublished ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'" x-bind:aria-label="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'" x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.paid ? 'text-emerald-500' : (i.price > 0 ? 'text-amber-500' : '')" x-bind:title="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')" x-bind:aria-label="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm12 4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4a2 2 0 012-2h10zm-7 5a2 2 0 100-4 2 2 0 000 4z"/></svg>
-                                        </span>
-                                        <span x-show="i.statusFlags?.flagged" class="w-5 h-5 inline-flex items-center justify-center text-rose-500" title="Flagged: invoice overdue or other attention needed" aria-label="Flagged">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                    </div>
+                                    {/* Round-2 F2 — status icons (📄 ready · 📋 signed · ✈️ sent · 🚩 flag) */}
+                                    <RowStatusIcons />
                                     <div x-data="actionMenu({ id: i.id, status: i.status })" class="relative ml-3">
                                         <button type="button" x-on:click="open = !open" class="text-slate-400 hover:text-slate-700 px-2 text-lg font-bold">•••</button>
                                         <div x-show="open" {...{ 'x-cloak': true, 'x-on:click.outside': 'open = false' }} class="absolute right-0 top-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-10 min-w-[140px]">
@@ -434,21 +396,8 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                     </a>
                                     {/* Sub-spec B Task 7 (B-6) — price (right-aligned, monospace) */}
                                     <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
-                                    {/* Status icons — slate-300 default, semantic color when active */}
-                                    <div class="flex items-center gap-1 text-slate-300">
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.reportPublished ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'" x-bind:aria-label="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'" x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.paid ? 'text-emerald-500' : (i.price > 0 ? 'text-amber-500' : '')" x-bind:title="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')" x-bind:aria-label="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm12 4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4a2 2 0 012-2h10zm-7 5a2 2 0 100-4 2 2 0 000 4z"/></svg>
-                                        </span>
-                                        <span x-show="i.statusFlags?.flagged" class="w-5 h-5 inline-flex items-center justify-center text-rose-500" title="Flagged: invoice overdue or other attention needed" aria-label="Flagged">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                    </div>
+                                    {/* Round-2 F2 — status icons (📄 ready · 📋 signed · ✈️ sent · 🚩 flag) */}
+                                    <RowStatusIcons />
                                     <div x-data="actionMenu({ id: i.id, status: i.status })" class="relative ml-3">
                                         <button type="button" x-on:click="open = !open" class="text-slate-400 hover:text-slate-700 px-2 text-lg font-bold">•••</button>
                                         <div x-show="open" {...{ 'x-cloak': true, 'x-on:click.outside': 'open = false' }} class="absolute right-0 top-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-10 min-w-[140px]">
@@ -502,21 +451,8 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                     </a>
                                     {/* Sub-spec B Task 7 (B-6) — price (right-aligned, monospace) */}
                                     <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
-                                    {/* Status icons — slate-300 default, semantic color when active */}
-                                    <div class="flex items-center gap-1 text-slate-300">
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.reportPublished ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'" x-bind:aria-label="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'" x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.paid ? 'text-emerald-500' : (i.price > 0 ? 'text-amber-500' : '')" x-bind:title="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')" x-bind:aria-label="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm12 4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4a2 2 0 012-2h10zm-7 5a2 2 0 100-4 2 2 0 000 4z"/></svg>
-                                        </span>
-                                        <span x-show="i.statusFlags?.flagged" class="w-5 h-5 inline-flex items-center justify-center text-rose-500" title="Flagged: invoice overdue or other attention needed" aria-label="Flagged">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                    </div>
+                                    {/* Round-2 F2 — status icons (📄 ready · 📋 signed · ✈️ sent · 🚩 flag) */}
+                                    <RowStatusIcons />
                                     <div x-data="actionMenu({ id: i.id, status: i.status })" class="relative ml-3">
                                         <button type="button" x-on:click="open = !open" class="text-slate-400 hover:text-slate-700 px-2 text-lg font-bold">•••</button>
                                         <div x-show="open" {...{ 'x-cloak': true, 'x-on:click.outside': 'open = false' }} class="absolute right-0 top-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-10 min-w-[140px]">
@@ -565,21 +501,8 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                     </a>
                                     {/* Sub-spec B Task 7 (B-6) — price (right-aligned, monospace) */}
                                     <div x-show="i.price > 0" class="text-[13px] font-mono font-semibold text-slate-700 tabular-nums" x-text="'$' + ((i.price || 0) / 100).toFixed(0)"></div>
-                                    {/* Status icons — slate-300 default, semantic color when active */}
-                                    <div class="flex items-center gap-1 text-slate-300">
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.reportPublished ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'" x-bind:aria-label="i.statusFlags?.reportPublished ? 'Report published' : 'Report not yet published'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.agreementSigned ? 'text-emerald-500' : ''" x-bind:title="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'" x-bind:aria-label="i.statusFlags?.agreementSigned ? 'Agreement signed' : 'Agreement not yet signed'">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                        <span class="w-5 h-5 inline-flex items-center justify-center" x-bind:class="i.statusFlags?.paid ? 'text-emerald-500' : (i.price > 0 ? 'text-amber-500' : '')" x-bind:title="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')" x-bind:aria-label="i.statusFlags?.paid ? 'Paid' : (i.price > 0 ? 'Payment pending' : 'No payment required')">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm12 4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4a2 2 0 012-2h10zm-7 5a2 2 0 100-4 2 2 0 000 4z"/></svg>
-                                        </span>
-                                        <span x-show="i.statusFlags?.flagged" class="w-5 h-5 inline-flex items-center justify-center text-rose-500" title="Flagged: invoice overdue or other attention needed" aria-label="Flagged">
-                                            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/></svg>
-                                        </span>
-                                    </div>
+                                    {/* Round-2 F2 — status icons (📄 ready · 📋 signed · ✈️ sent · 🚩 flag) */}
+                                    <RowStatusIcons />
                                     <div x-data="actionMenu({ id: i.id, status: i.status })" class="relative ml-3">
                                         <button type="button" x-on:click="open = !open" class="text-slate-400 hover:text-slate-700 px-2 text-lg font-bold">•••</button>
                                         <div x-show="open" {...{ 'x-cloak': true, 'x-on:click.outside': 'open = false' }} class="absolute right-0 top-full mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-10 min-w-[140px]">

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -1,6 +1,7 @@
 // src/templates/pages/inspection-edit.tsx
 import { BareLayout } from '../layouts/main-layout';
 import { Modal, ModalFooter } from '../components/modal';
+import { PublishModal } from '../components/publish-modal';
 import type { BrandingConfig } from '../../types/auth';
 import { RECOMMENDATION_CATEGORIES } from '../../lib/recommendation-categories';
 
@@ -1504,66 +1505,40 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
           </aside>
         </div>
 
-        {/* ===== Publish Modal — 3 distinct buttons (Cancel, Send PDF [tertiary
-             emerald], Confirm Publish), so footer is inlined rather than using
-             ModalFooter. All three share the canonical h-10/rounded-xl shape. */}
+        {/* Round-2 F1 — Multi-recipient Publish modal (Spectora §G.3).
+             Lists every party (client, buyer's agent, listing agent) with
+             per-recipient Email + Text checkboxes, plus a radio that switches
+             between sending the report or the agreement. Footer:
+                [Cancel]   [Send All]
+             Send All disabled when nothing is checked. Empty-state shown
+             when the inspection has no contacts. */}
+        <PublishModal />
         <Modal
-            name="showPublishModal"
-            title="Publish Report"
+            name="showLegacyPublishOptions"
+            title="Publish options"
             size="md"
             footer={
                 <>
                     <button
                         type="button"
-                        x-on:click="showPublishModal = false"
+                        x-on:click="showLegacyPublishOptions = false"
                         class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border bg-white hover:bg-slate-50 transition-all"
                         style="border-color: #e2e8f0; color: #475569"
                     >
-                        Cancel
-                    </button>
-                    <button
-                        type="button"
-                        {...{ 'x-on:click': 'sendReportPdf()' }}
-                        {...{ 'x-bind:disabled': 'sendingPdf' }}
-                        class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 disabled:opacity-50 transition-all"
-                    >
-                        <span x-show="!sendingPdf">Send PDF</span>
-                        <span x-show="sendingPdf">Sending…</span>
-                    </button>
-                    <button
-                        type="button"
-                        x-on:click="publish()"
-                        x-bind:disabled="publishing"
-                        class="flex-1 h-10 px-4 rounded-xl text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-                    >
-                        <span x-text="publishing ? 'Publishing…' : 'Confirm Publish'"></span>
+                        Done
                     </button>
                 </>
             }
         >
-            <div class="space-y-4">
-                <div class="p-3 rounded-xl" style="background: #f1f5f9">
-                    <div class="text-xs font-mono" style="color: #94a3b8">Report Summary</div>
-                    <div class="text-sm mt-1" style="color: #1e293b" x-text="reportStats.total + ' items  |  ' + reportStats.defect + ' defects  |  ' + reportStats.monitor + ' monitors'"></div>
-                </div>
-                <div class="space-y-3">
-                    <label class="flex items-center justify-between">
-                        <span class="text-sm" style="color: #475569">Email client</span>
-                        <input type="checkbox" x-model="publishOptions.notifyClient" class="rounded" checked />
-                    </label>
-                    <label class="flex items-center justify-between">
-                        <span class="text-sm" style="color: #475569">Email agent</span>
-                        <input type="checkbox" x-model="publishOptions.notifyAgent" class="rounded" checked />
-                    </label>
-                    <label class="flex items-center justify-between">
-                        <span class="text-sm" style="color: #475569">Require signature</span>
-                        <input type="checkbox" x-model="publishOptions.requireSignature" class="rounded" />
-                    </label>
-                    <label class="flex items-center justify-between">
-                        <span class="text-sm" style="color: #475569">Require payment</span>
-                        <input type="checkbox" x-model="publishOptions.requirePayment" class="rounded" />
-                    </label>
-                </div>
+            <div class="space-y-3">
+                <label class="flex items-center justify-between">
+                    <span class="text-sm" style="color: #475569">Require signature</span>
+                    <input type="checkbox" x-model="publishOptions.requireSignature" class="rounded" />
+                </label>
+                <label class="flex items-center justify-between">
+                    <span class="text-sm" style="color: #475569">Require payment</span>
+                    <input type="checkbox" x-model="publishOptions.requirePayment" class="rounded" />
+                </label>
                 <div>
                     <div class="text-xs font-semibold mb-2" style="color: #94a3b8">THEME</div>
                     <div class="flex gap-2">

--- a/src/templates/pages/inspection/settings.tsx
+++ b/src/templates/pages/inspection/settings.tsx
@@ -13,6 +13,7 @@
 
 import { MainLayout } from '../../layouts/main-layout';
 import { InspectionShell } from '../../components/inspection-shell';
+import { PeopleCard } from '../../components/people-card';
 import type { BrandingConfig } from '../../../types/auth';
 
 export interface InspectionSettingsPageProps {
@@ -48,6 +49,11 @@ export const InspectionSettingsPage = ({
             >
                 <div x-data={`inspectionSettingsPage('${inspectionId}')`} x-init="load()" class="space-y-8 max-w-2xl">
                     <div x-show="loading" class="text-center py-12 text-slate-400 text-[13px]">Loading…</div>
+
+                    {/* Round-2 F3 — People card with role chips. Auto-loads
+                        from /api/inspections/:id/people via the settings
+                        Alpine factory; auto-hides when nothing returned. */}
+                    <PeopleCard />
 
                     <form x-show="!loading" style="display:none" {...{ 'x-on:submit.prevent': 'save()' }} class="space-y-6">
                         <fieldset class="space-y-4">

--- a/tests/unit/inspection-people-card.spec.ts
+++ b/tests/unit/inspection-people-card.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InspectionService } from '../../src/services/inspection.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT = '00000000-0000-0000-0000-000000000001';
+
+describe('Round-2 F3 — InspectionService.getPeopleCard', () => {
+    let svc: InspectionService;
+    let testDb: BetterSQLite3Database<typeof schema>;
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        await setupSchema(fixture.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InspectionService({} as D1Database);
+
+        await testDb.insert(schema.tenants).values([
+            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        ]);
+    });
+
+    it('returns inspector + client + agents grouped by role', async () => {
+        await testDb.insert(schema.users).values({
+            id:           'user-insp',
+            tenantId:     TENANT,
+            email:        'inspector@acme.com',
+            passwordHash: 'x',
+            name:         'Sam Inspector',
+            phone:        '+15550009999',
+            role:         'inspector',
+            createdAt:    new Date(),
+        });
+        await testDb.insert(schema.contacts).values([
+            { id: 'agent-buyer-1',   tenantId: TENANT, type: 'agent', name: 'Bob Buyer-Agent',    email: 'bob@bba.com',  phone: '+15550001111', createdAt: new Date() },
+            { id: 'agent-listing-1', tenantId: TENANT, type: 'agent', name: 'Lisa Listing-Agent', email: 'lisa@lla.com', phone: null,            createdAt: new Date() },
+        ]);
+        await testDb.insert(schema.inspections).values({
+            id:                'insp-people-1',
+            tenantId:          TENANT,
+            inspectorId:       'user-insp',
+            propertyAddress:   '1 Main St',
+            clientName:        'Jane Buyer',
+            clientEmail:       'jane@example.com',
+            clientPhone:       '+15551234567',
+            referredByAgentId: 'agent-buyer-1',
+            sellingAgentId:    'agent-listing-1',
+            date:              '2026-06-01',
+            status:            'completed',
+            paymentStatus:     'unpaid',
+            price:             0,
+            paymentRequired:   false,
+            agreementRequired: false,
+            createdAt:         new Date(),
+        });
+
+        const card = await svc.getPeopleCard('insp-people-1', TENANT);
+
+        expect(card.inspector).toMatchObject({
+            name: 'Sam Inspector', email: 'inspector@acme.com', phone: '+15550009999',
+        });
+        expect(card.client).toMatchObject({
+            name: 'Jane Buyer', email: 'jane@example.com', phone: '+15551234567',
+        });
+        expect(card.buyerAgents).toHaveLength(1);
+        expect(card.buyerAgents[0]).toMatchObject({ name: 'Bob Buyer-Agent', email: 'bob@bba.com' });
+        expect(card.listingAgents).toHaveLength(1);
+        expect(card.listingAgents[0]).toMatchObject({ name: 'Lisa Listing-Agent', email: 'lisa@lla.com' });
+    });
+
+    it('returns nulls / empty arrays when nothing is linked', async () => {
+        await testDb.insert(schema.inspections).values({
+            id:                'insp-bare',
+            tenantId:          TENANT,
+            propertyAddress:   '1 Main St',
+            clientName:        null,
+            clientEmail:       null,
+            clientPhone:       null,
+            date:              '2026-06-01',
+            status:            'draft',
+            paymentStatus:     'unpaid',
+            price:             0,
+            paymentRequired:   false,
+            agreementRequired: false,
+            createdAt:         new Date(),
+        });
+
+        const card = await svc.getPeopleCard('insp-bare', TENANT);
+        expect(card.inspector).toBeNull();
+        expect(card.client).toBeNull();
+        expect(card.buyerAgents).toEqual([]);
+        expect(card.listingAgents).toEqual([]);
+    });
+
+    it('throws NotFound for cross-tenant access', async () => {
+        const OTHER = '00000000-0000-0000-0000-0000000000ff';
+        await testDb.insert(schema.tenants).values({
+            id: OTHER, name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        await testDb.insert(schema.inspections).values({
+            id: 'insp-other', tenantId: OTHER,
+            propertyAddress: 'X', clientName: null, clientEmail: null, clientPhone: null,
+            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+            price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date(),
+        });
+
+        await expect(svc.getPeopleCard('insp-other', TENANT)).rejects.toThrow();
+    });
+
+    it('returns counts per role group for templating', async () => {
+        await testDb.insert(schema.contacts).values([
+            { id: 'agent-buyer-1', tenantId: TENANT, type: 'agent', name: 'Bob', email: 'b@b.com', phone: null, createdAt: new Date() },
+        ]);
+        await testDb.insert(schema.inspections).values({
+            id:                'insp-counts',
+            tenantId:          TENANT,
+            propertyAddress:   '1 Main St',
+            clientName:        'Jane',
+            clientEmail:       'jane@example.com',
+            clientPhone:       null,
+            referredByAgentId: 'agent-buyer-1',
+            date:              '2026-06-01',
+            status:            'draft',
+            paymentStatus:     'unpaid',
+            price:             0,
+            paymentRequired:   false,
+            agreementRequired: false,
+            createdAt:         new Date(),
+        });
+
+        const card = await svc.getPeopleCard('insp-counts', TENANT);
+        expect(card.buyerAgents).toHaveLength(1);
+        expect(card.listingAgents).toHaveLength(0);
+        // Only 1 agent exists — counter should be 1 (component renders "Buyer's Agent" without ·N).
+        expect(card.buyerAgents[0]?.name).toBe('Bob');
+    });
+});

--- a/tests/unit/inspection-recipients.spec.ts
+++ b/tests/unit/inspection-recipients.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InspectionService } from '../../src/services/inspection.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT = '00000000-0000-0000-0000-000000000001';
+
+describe('Round-2 F1 — InspectionService.getRecipientList', () => {
+    let svc: InspectionService;
+    let testDb: BetterSQLite3Database<typeof schema>;
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        await setupSchema(fixture.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InspectionService({} as D1Database);
+
+        await testDb.insert(schema.tenants).values([
+            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        ]);
+    });
+
+    it('returns empty list when inspection has no contacts', async () => {
+        await testDb.insert(schema.inspections).values({
+            id:              'insp-empty',
+            tenantId:        TENANT,
+            propertyAddress: '1 Main St',
+            clientName:      null,
+            clientEmail:     null,
+            clientPhone:     null,
+            date:            '2026-06-01',
+            status:          'completed',
+            paymentStatus:   'unpaid',
+            price:           0,
+            paymentRequired: false,
+            agreementRequired: false,
+            createdAt:       new Date(),
+        });
+
+        const list = await svc.getRecipientList('insp-empty', TENANT);
+        expect(list).toEqual([]);
+    });
+
+    it('returns just the client when no agents linked', async () => {
+        await testDb.insert(schema.inspections).values({
+            id:              'insp-client-only',
+            tenantId:        TENANT,
+            propertyAddress: '1 Main St',
+            clientName:      'Jane Buyer',
+            clientEmail:     'jane@example.com',
+            clientPhone:     '+15551234567',
+            date:            '2026-06-01',
+            status:          'completed',
+            paymentStatus:   'unpaid',
+            price:           0,
+            paymentRequired: false,
+            agreementRequired: false,
+            createdAt:       new Date(),
+        });
+
+        const list = await svc.getRecipientList('insp-client-only', TENANT);
+        expect(list).toHaveLength(1);
+        expect(list[0]).toMatchObject({
+            role: 'client',
+            name: 'Jane Buyer',
+            email: 'jane@example.com',
+            phone: '+15551234567',
+        });
+    });
+
+    it('returns client + buyer agent + listing agent when all linked', async () => {
+        // Buyer's Agent (referredByAgentId)
+        await testDb.insert(schema.contacts).values([
+            {
+                id:        'agent-buyer-1',
+                tenantId:  TENANT,
+                type:      'agent',
+                name:      'Bob Buyer-Agent',
+                email:     'bob@bba.com',
+                phone:     '+15550001111',
+                createdAt: new Date(),
+            },
+            {
+                id:        'agent-listing-1',
+                tenantId:  TENANT,
+                type:      'agent',
+                name:      'Lisa Listing-Agent',
+                email:     'lisa@lla.com',
+                phone:     null,
+                createdAt: new Date(),
+            },
+        ]);
+
+        await testDb.insert(schema.inspections).values({
+            id:                'insp-3-people',
+            tenantId:          TENANT,
+            propertyAddress:   '1 Main St',
+            clientName:        'Jane Buyer',
+            clientEmail:       'jane@example.com',
+            clientPhone:       '+15551234567',
+            referredByAgentId: 'agent-buyer-1',
+            sellingAgentId:    'agent-listing-1',
+            date:              '2026-06-01',
+            status:            'completed',
+            paymentStatus:     'unpaid',
+            price:             0,
+            paymentRequired:   false,
+            agreementRequired: false,
+            createdAt:         new Date(),
+        });
+
+        const list = await svc.getRecipientList('insp-3-people', TENANT);
+        expect(list).toHaveLength(3);
+
+        const client  = list.find(p => p.role === 'client');
+        const buyer   = list.find(p => p.role === 'agent_buyer');
+        const listing = list.find(p => p.role === 'agent_listing');
+
+        expect(client).toMatchObject({  name: 'Jane Buyer',         email: 'jane@example.com', phone: '+15551234567' });
+        expect(buyer).toMatchObject({   name: 'Bob Buyer-Agent',    email: 'bob@bba.com',      contactId: 'agent-buyer-1' });
+        expect(listing).toMatchObject({ name: 'Lisa Listing-Agent', email: 'lisa@lla.com',     phone: null });
+    });
+
+    it('throws NotFound for an inspection in another tenant', async () => {
+        const OTHER = '00000000-0000-0000-0000-0000000000ff';
+        await testDb.insert(schema.tenants).values({
+            id: OTHER, name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        await testDb.insert(schema.inspections).values({
+            id: 'insp-other', tenantId: OTHER,
+            propertyAddress: 'X', clientName: null, clientEmail: null, clientPhone: null,
+            date: '2026-06-01', status: 'completed', paymentStatus: 'unpaid',
+            price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date(),
+        });
+
+        await expect(svc.getRecipientList('insp-other', TENANT)).rejects.toThrow();
+    });
+
+    it('drops contacts that have neither email nor phone', async () => {
+        await testDb.insert(schema.contacts).values({
+            id:        'agent-noinfo',
+            tenantId:  TENANT,
+            type:      'agent',
+            name:      'No Contact Info',
+            email:     null,
+            phone:     null,
+            createdAt: new Date(),
+        });
+        await testDb.insert(schema.inspections).values({
+            id:                'insp-noinfo',
+            tenantId:          TENANT,
+            propertyAddress:   '1 Main St',
+            clientName:        'Has Email',
+            clientEmail:       'real@example.com',
+            clientPhone:       null,
+            referredByAgentId: 'agent-noinfo',
+            date:              '2026-06-01',
+            status:            'completed',
+            paymentStatus:     'unpaid',
+            price:             0,
+            paymentRequired:   false,
+            agreementRequired: false,
+            createdAt:         new Date(),
+        });
+
+        const list = await svc.getRecipientList('insp-noinfo', TENANT);
+        // Client kept (has email), agent dropped (no email and no phone).
+        expect(list).toHaveLength(1);
+        expect(list[0]?.role).toBe('client');
+    });
+});

--- a/tests/unit/inspection-status.spec.ts
+++ b/tests/unit/inspection-status.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { getInspectionStatusIcons } from '../../src/lib/inspection-status';
+
+describe('Round-2 F2 — getInspectionStatusIcons', () => {
+    it('returns all-false for a draft inspection with no flags', () => {
+        const icons = getInspectionStatusIcons({ status: 'draft' });
+        expect(icons).toEqual({
+            reportReady:     false,
+            agreementSigned: false,
+            sent:            false,
+            flagged:         false,
+        });
+    });
+
+    it('marks reportReady when status is completed (not yet sent)', () => {
+        const icons = getInspectionStatusIcons({ status: 'completed' });
+        expect(icons.reportReady).toBe(true);
+        expect(icons.sent).toBe(false);
+    });
+
+    it('marks both reportReady and sent when status is delivered', () => {
+        const icons = getInspectionStatusIcons({ status: 'delivered' });
+        expect(icons.reportReady).toBe(true);
+        expect(icons.sent).toBe(true);
+    });
+
+    it('agreementSigned + flagged independent of status', () => {
+        const icons = getInspectionStatusIcons({
+            status: 'in_progress',
+            agreementSigned: true,
+            flagged: true,
+        });
+        expect(icons.agreementSigned).toBe(true);
+        expect(icons.flagged).toBe(true);
+        expect(icons.reportReady).toBe(false);
+        expect(icons.sent).toBe(false);
+    });
+
+    it('treats missing fields as false (defensive)', () => {
+        const icons = getInspectionStatusIcons({});
+        expect(icons).toEqual({
+            reportReady:     false,
+            agreementSigned: false,
+            sent:            false,
+            flagged:         false,
+        });
+    });
+
+    it('handles cancelled status — no green flags', () => {
+        const icons = getInspectionStatusIcons({ status: 'cancelled' });
+        expect(icons.reportReady).toBe(false);
+        expect(icons.sent).toBe(false);
+    });
+
+    it('case-insensitive status matching', () => {
+        const icons = getInspectionStatusIcons({ status: 'DELIVERED' });
+        expect(icons.reportReady).toBe(true);
+        expect(icons.sent).toBe(true);
+    });
+
+    it('matrix — every status combination', () => {
+        const cases: Array<[string, boolean, boolean]> = [
+            // status, expected reportReady, expected sent
+            ['draft',       false, false],
+            ['scheduled',   false, false],
+            ['confirmed',   false, false],
+            ['in_progress', false, false],
+            ['completed',   true,  false],
+            ['delivered',   true,  true ],
+            ['cancelled',   false, false],
+        ];
+        for (const [status, ready, sent] of cases) {
+            const icons = getInspectionStatusIcons({ status });
+            expect(icons.reportReady, `${status} reportReady`).toBe(ready);
+            expect(icons.sent, `${status} sent`).toBe(sent);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Round 3 of competitor parity (round-2 analysis Top 3, all S effort).

- **F1** Multi-recipient Publish modal (Spectora §G.3) — replaces flat publish button with proper modal: per-recipient Email/Text checkboxes, "Send a copy of report/agreement" radio, empty-state guard, [Cancel][Send All] footer with disabled state.
- **F2** Inspection list status-icon column (Spectora §4.3 + §5.1) — 4 compact icons per row (📄 report ready / 📋 agreement signed / ✈️ sent / 🚩 flagged) with tooltips.
- **F3** People card with role chips (Spectora §E.2) — inspection settings sub-route now shows grouped Inspector + Buyer + Buyer's Agent + Listing Agent with avatar, role chips, mailto/tel click-actions.

## Stats

- 4 commits, single worktree-isolated track
- **414 unit tests pass** (was 397; +17 new)
- type-check 0 errors, lint 0 errors
- 0 merge conflicts

## Notes

- F1 server-side fan-out for per-recipient SMS/email dispatch is a follow-up; schema + request shape are in place
- No Playwright additions (data-layer unit coverage prioritized over component snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)