### PR TITLE
Sprint 2 polish round 4: property facts + closing date + order ID + referral

### DIFF
--- a/migrations/0045_property_facts.sql
+++ b/migrations/0045_property_facts.sql
@@ -1,0 +1,21 @@
+-- Round-2 backlog G1 / G2 / G3 — competitor parity (Spectora §E.2 + ITB UC-ITB-10).
+--
+-- G1 Property Facts strip — six numeric / textual property attributes shown
+-- on the inspection settings page and as a banner above the published
+-- report. Most fields already live as dedicated columns from migration
+-- 0016_parity_schema (year_built, sqft, foundation_type, bedrooms, bathrooms).
+-- We add `lot_size` (free-text — "0.25 acres" / "10,000 sqft") and a JSON
+-- `property_facts` envelope so future facts can land without further DDL.
+--
+-- G2 Closing Date — already added in 0016 as `closing_date TEXT` (ISO date).
+-- No DDL needed, but a comment line keeps the intent visible alongside G1.
+--
+-- G3 Order ID + Referral Source — `order_id` and `referral_source` columns
+-- already exist on inspections. We add `custom_referral_sources` (JSON)
+-- to tenant_configs so each workspace can extend the seven seed sources
+-- (Realtor / Past Client / Google Search / Facebook / Yelp / Walk-in / Other).
+
+ALTER TABLE inspections ADD COLUMN lot_size       TEXT;
+ALTER TABLE inspections ADD COLUMN property_facts TEXT;
+
+ALTER TABLE tenant_configs ADD COLUMN custom_referral_sources TEXT;

--- a/public/js/inspection-settings.js
+++ b/public/js/inspection-settings.js
@@ -1,6 +1,11 @@
 // Sprint 2 S2-5 — Settings sub-page Alpine data factory.
 // Edits inspection-level config: schedule, inspector, template, gates.
 //
+// Round-2 backlog G1 / G2 / G3 — Property Facts strip (six inline-editable
+// fields), Closing Date and Order ID + Referral Source. Property Facts
+// persists via PATCH /api/inspections/:id/property-facts on input change
+// (single-field saves), the rest piggy-backs on the existing form save.
+//
 // Note on T1 coordination: when T1 ships rating_system_id on templates,
 // the `ratingSystemLabel` getter picks it up from the template object
 // without any code change. Until then it returns null and the badge stays
@@ -21,7 +26,27 @@ document.addEventListener('alpine:init', () => {
             price: 0,
             paymentRequired: false,
             agreementRequired: false,
+            // Round-2 backlog G2 — Closing Date (ISO YYYY-MM-DD) for CRM follow-ups.
+            closingDate: '',
+            // Round-2 backlog G3 — Order ID + Referral Source.
+            orderId: '',
+            referralSource: '',
         },
+
+        // Round-2 backlog G1 — Property Facts strip. Loaded once on init,
+        // then each input persists individually via saveFact() on change so
+        // the inspector doesn't need to hit "Save" to see the banner update
+        // on the published report.
+        facts: {
+            yearBuilt:      null,
+            sqft:           null,
+            foundationType: '',
+            lotSize:        '',
+            bedrooms:       null,
+            bathrooms:      null,
+        },
+        factsState: 'idle', // 'idle' | 'saving' | 'saved' | 'error'
+        factsTimer: null,
 
         // Round-2 F3 — People card payload. Loaded from
         // /api/inspections/:id/people; rendered by the PeopleCard component.
@@ -45,12 +70,14 @@ document.addEventListener('alpine:init', () => {
 
         async load() {
             try {
-                const [inspRes, tplRes, teamRes, peopleRes] = await Promise.all([
+                const [inspRes, tplRes, teamRes, peopleRes, factsRes] = await Promise.all([
                     window.authFetch('/api/inspections/' + this.inspectionId),
                     window.authFetch('/api/templates'),
                     window.authFetch('/api/team/members'),
                     // Round-2 F3 — People card payload.
                     window.authFetch('/api/inspections/' + this.inspectionId + '/people'),
+                    // Round-2 backlog G1 — Property Facts strip.
+                    window.authFetch('/api/inspections/' + this.inspectionId + '/property-facts'),
                 ]);
                 const inspJson = inspRes.ok ? await inspRes.json() : { data: {} };
                 const insp = (inspJson.data && (inspJson.data.inspection || inspJson.data)) || {};
@@ -60,6 +87,10 @@ document.addEventListener('alpine:init', () => {
                 this.form.price = Number(insp.price || 0);
                 this.form.paymentRequired = !!insp.paymentRequired;
                 this.form.agreementRequired = !!insp.agreementRequired;
+                // G2 / G3 round-trip — fields may be null on legacy rows.
+                this.form.closingDate    = insp.closingDate    || '';
+                this.form.orderId        = insp.orderId        || '';
+                this.form.referralSource = insp.referralSource || '';
 
                 if (tplRes && tplRes.ok) {
                     const tplJson = await tplRes.json();
@@ -75,10 +106,68 @@ document.addEventListener('alpine:init', () => {
                     const peopleJson = await peopleRes.json();
                     this.peopleCard = (peopleJson && peopleJson.data) || null;
                 }
+                if (factsRes && factsRes.ok) {
+                    const factsJson = await factsRes.json();
+                    const f = (factsJson && factsJson.data) || {};
+                    this.facts.yearBuilt      = f.yearBuilt      ?? null;
+                    this.facts.sqft           = f.sqft           ?? null;
+                    this.facts.foundationType = f.foundationType ?? '';
+                    this.facts.lotSize        = f.lotSize        ?? '';
+                    this.facts.bedrooms       = f.bedrooms       ?? null;
+                    this.facts.bathrooms      = f.bathrooms      ?? null;
+                }
             } catch (e) {
                 console.error('settings.load failed', e);
             } finally {
                 this.loading = false;
+            }
+        },
+
+        // Round-2 backlog G1 — single-field property-facts save. Coerces
+        // empty strings to null (clear the field) and string numerics to
+        // numbers for the integer/float columns.
+        async saveFact(field, raw) {
+            const value = (() => {
+                const trimmed = (typeof raw === 'string') ? raw.trim() : raw;
+                if (trimmed === '' || trimmed === null || trimmed === undefined) return null;
+                if (field === 'foundationType') return trimmed;
+                if (field === 'lotSize')        return String(trimmed).slice(0, 50);
+                if (field === 'bathrooms') {
+                    const n = Number(trimmed);
+                    return Number.isFinite(n) ? n : null;
+                }
+                // yearBuilt / sqft / bedrooms — integer
+                const n = Number(trimmed);
+                if (!Number.isFinite(n)) return null;
+                return Math.round(n);
+            })();
+
+            this.factsState = 'saving';
+            try {
+                const res = await window.authFetch('/api/inspections/' + this.inspectionId + '/property-facts', {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ [field]: value }),
+                });
+                if (!res.ok) throw new Error('save failed');
+                const json = await res.json();
+                const f = (json && json.data) || {};
+                // Re-sync local state from the server so the strip reflects
+                // canonical values (e.g. integer coercion).
+                this.facts.yearBuilt      = f.yearBuilt      ?? null;
+                this.facts.sqft           = f.sqft           ?? null;
+                this.facts.foundationType = f.foundationType ?? '';
+                this.facts.lotSize        = f.lotSize        ?? '';
+                this.facts.bedrooms       = f.bedrooms       ?? null;
+                this.facts.bathrooms      = f.bathrooms      ?? null;
+                this.factsState = 'saved';
+                if (this.factsTimer) clearTimeout(this.factsTimer);
+                this.factsTimer = setTimeout(() => {
+                    if (this.factsState === 'saved') this.factsState = 'idle';
+                }, 1500);
+            } catch (e) {
+                console.error('saveFact failed', e);
+                this.factsState = 'error';
             }
         },
 
@@ -91,10 +180,16 @@ document.addEventListener('alpine:init', () => {
                     price: Number(this.form.price || 0),
                     paymentRequired: !!this.form.paymentRequired,
                     agreementRequired: !!this.form.agreementRequired,
+                    // Round-2 backlog G2 / G3 — null clears, undefined leaves
+                    // existing value untouched. Empty string from the date /
+                    // text inputs is treated as "clear".
+                    closingDate:    this.form.closingDate    || null,
+                    orderId:        this.form.orderId        || null,
+                    referralSource: this.form.referralSource || null,
                 };
                 Object.keys(body).forEach(k => body[k] === undefined && delete body[k]);
                 const res = await window.authFetch('/api/inspections/' + this.inspectionId, {
-                    method: 'PUT',
+                    method: 'PATCH',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(body),
                 });

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -23,6 +23,8 @@ import {
     ReportDataResponseSchema,
     CancelInspectionSchema,
     DashboardResponseSchema,
+    PropertyFactsSchema,
+    PropertyFactsResponseSchema,
 } from '../lib/validations/inspection.schema';
 import { CreateTemplateSchema, UpdateTemplateSchema } from '../lib/validations/template.schema';
 import { createApiResponseSchema, SuccessResponseSchema } from '../lib/validations/shared.schema';
@@ -578,6 +580,71 @@ inspectionsRoutes.openapi(updateInspectionRoute, async (c) => {
         });
     }
     return c.json({ success: true, data: { success: true } }, 200);
+});
+
+/**
+ * Round-2 backlog G1 (Spectora §E.2) — GET /api/inspections/:id/property-facts
+ * Returns the six Property Facts columns for the strip + report banner.
+ */
+const getPropertyFactsRoute = createRoute({
+    method: 'get',
+    path: '/{id}/property-facts',
+    tags: ['Inspections'],
+    summary: 'Get property facts',
+    description: 'Returns the Property Facts strip payload (year built, sqft, foundation, lot, beds, baths).',
+    request: {
+        params: z.object({ id: z.string().uuid() }),
+    },
+    middleware: [requireRole(['owner', 'admin', 'inspector'])],
+    responses: {
+        200: {
+            content: { 'application/json': { schema: PropertyFactsResponseSchema } },
+            description: 'Success',
+        },
+    },
+});
+
+inspectionsRoutes.openapi(getPropertyFactsRoute, async (c) => {
+    const { id } = c.req.valid('param');
+    const tenantId = c.get('tenantId');
+    const facts = await c.var.services.inspection.getPropertyFacts(id, tenantId);
+    return c.json({ success: true, data: facts }, 200);
+});
+
+/**
+ * Round-2 backlog G1 (Spectora §E.2) — PATCH /api/inspections/:id/property-facts
+ * Inline-edit handler for the Property Facts card. Accepts a partial payload
+ * so a single-field save round-trips without touching the other columns.
+ */
+const updatePropertyFactsRoute = createRoute({
+    method: 'patch',
+    path: '/{id}/property-facts',
+    tags: ['Inspections'],
+    summary: 'Update property facts',
+    description: 'Patches the Property Facts strip. Omitted keys are unchanged; null clears a field.',
+    request: {
+        params: z.object({ id: z.string().uuid() }),
+        body: { content: { 'application/json': { schema: PropertyFactsSchema } } },
+    },
+    middleware: [requireRole(['owner', 'admin', 'inspector'])],
+    responses: {
+        200: {
+            content: { 'application/json': { schema: PropertyFactsResponseSchema } },
+            description: 'Success',
+        },
+    },
+});
+
+inspectionsRoutes.openapi(updatePropertyFactsRoute, async (c) => {
+    const { id } = c.req.valid('param');
+    const tenantId = c.get('tenantId');
+    const body = c.req.valid('json');
+    const facts = await c.var.services.inspection.updatePropertyFacts(id, tenantId, body);
+    auditFromContext(c, 'inspection.property_facts.update', 'inspection', {
+        entityId: id,
+        metadata: { fields: Object.keys(body) },
+    });
+    return c.json({ success: true, data: facts }, 200);
 });
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -932,6 +932,9 @@ app.get('/report/:id', async (c) => {
             viewerRole: role,
             // Track E1 — show "View repair list" link only when opted in.
             enableRepairList,
+            // Round-2 backlog G1 — Property Facts banner above the report
+            // header. Auto-hidden when every field is empty.
+            propertyFacts: data.propertyFacts,
         }));
     } catch {
         return c.text('Report not found', 404);
@@ -982,6 +985,26 @@ app.get('/settings/workspace/reports', htmlAuthGuard(['owner', 'admin']), async 
     const showEstimates    = Boolean((cfg as { showEstimates?: boolean | number }).showEstimates);
     const enableRepairList = Boolean((cfg as { enableRepairList?: boolean | number }).enableRepairList);
     return c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'reports', showEstimates, enableRepairList }));
+});
+// Round-2 backlog G3 — Custom referral sources sub-page. Reads
+// tenant_configs.custom_referral_sources via the BrandingService so the
+// textarea hydrates with the saved values on first paint.
+app.get('/settings/workspace/referral', htmlAuthGuard(['owner', 'admin']), async (c) => {
+    const tenantId = c.get('tenantId');
+    let customReferralSources: string[] | undefined;
+    try {
+        const cfg = await drizzle(c.env.DB).select({ customReferralSources: schema.tenantConfigs.customReferralSources })
+            .from(schema.tenantConfigs)
+            .where(eq(schema.tenantConfigs.tenantId, tenantId))
+            .get();
+        const raw = cfg?.customReferralSources;
+        if (Array.isArray(raw)) customReferralSources = raw as string[];
+    } catch { /* default empty */ }
+    return c.html(SettingsWorkspacePage({
+        branding: c.get('branding'),
+        subPage: 'referral',
+        ...(customReferralSources ? { customReferralSources } : {}),
+    }));
 });
 app.get('/settings/workspace/telemetry', htmlAuthGuard(['owner', 'admin']), (c) => c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'telemetry' })));
 
@@ -1108,15 +1131,22 @@ async function loadInspectionShellData(c: Context<HonoConfig>, inspectionId: str
         // Track E1 — per-tenant Repair List toggle drives the 6th sub-nav
         // tab. Failure to read defaults to false so the existing 5-tab nav
         // stays the baseline.
+        // Round-2 backlog G3 — `customReferralSources` extends the seven
+        // seed referral labels on the inspection settings dropdown.
         let enableRepairList = false;
+        let customReferralSources: string[] | undefined;
         try {
-            const cfgRow = await drizzle(c.env.DB).select({ enableRepairList: schema.tenantConfigs.enableRepairList })
-                .from(schema.tenantConfigs)
-                .where(eq(schema.tenantConfigs.tenantId, tenantId))
-                .get();
+            const cfgRow = await drizzle(c.env.DB).select({
+                enableRepairList:      schema.tenantConfigs.enableRepairList,
+                customReferralSources: schema.tenantConfigs.customReferralSources,
+            }).from(schema.tenantConfigs)
+              .where(eq(schema.tenantConfigs.tenantId, tenantId))
+              .get();
             enableRepairList = !!cfgRow?.enableRepairList;
+            const raw = cfgRow?.customReferralSources;
+            if (Array.isArray(raw)) customReferralSources = raw as string[];
         } catch { /* default off */ }
-        return { propertyAddress, requestId, siblings, enableRepairList };
+        return { propertyAddress, requestId, siblings, enableRepairList, customReferralSources };
     } catch {
         return null;
     }
@@ -1200,6 +1230,7 @@ app.get('/inspections/:id/settings', htmlAuthGuard(['owner', 'admin', 'inspector
         enableRepairList: !!shell?.enableRepairList,
         ...(shell?.requestId ? { requestId: shell.requestId } : {}),
         ...(shell?.siblings  ? { siblings: shell.siblings  } : {}),
+        ...(shell?.customReferralSources ? { customReferralSources: shell.customReferralSources } : {}),
     }));
 });
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -18,6 +18,7 @@ export type AuditAction =
     | 'inspection.results_merged'
     | 'inspection.sync_conflict_resolved'
     | 'inspection.share_agent'
+    | 'inspection.property_facts.update'
     | 'persistence.granted'
     | 'persistence.denied'
     | 'template.create'

--- a/src/lib/db/schema/inspection.ts
+++ b/src/lib/db/schema/inspection.ts
@@ -74,6 +74,13 @@ export const inspections = sqliteTable('inspections', {
     foundationType:      text('foundation_type'),
     bedrooms:            integer('bedrooms'),
     bathrooms:           real('bathrooms'),
+    // Round-2 backlog G1 (Spectora §E.2) — free-text lot size so inspectors
+    // can enter "0.25 acres", "10,000 sqft", etc. without a parser.
+    lotSize:             text('lot_size'),
+    // Round-2 backlog G1 — JSON envelope for future property facts that
+    // don't warrant their own column. Reads/writes go through
+    // updatePropertyFacts() which merges with the dedicated columns.
+    propertyFacts:       text('property_facts', { mode: 'json' }).$type<Record<string, unknown>>(),
     unit:                text('unit'),
     county:              text('county'),
     sellingAgentId:      text('selling_agent_id'),

--- a/src/lib/db/schema/tenant.ts
+++ b/src/lib/db/schema/tenant.ts
@@ -71,6 +71,10 @@ export const tenantConfigs = sqliteTable('tenant_configs', {
     // exposes a "Repair List" tab. Default OFF — opt-in for realtors who want
     // a separate punch-list view rather than the full narrative report.
     enableRepairList: integer('enable_repair_list', { mode: 'boolean' }).notNull().default(false),
+    // Round-2 backlog G3 (Spectora §4.1, ITB UC-ITB-10) — tenant-defined
+    // referral sources that extend the seven seeds (Realtor / Past Client /
+    // Google Search / Facebook / Yelp / Walk-in / Other). NULL = no extras.
+    customReferralSources: text('custom_referral_sources', { mode: 'json' }).$type<string[]>(),
     updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 });
 

--- a/src/lib/referral-sources.ts
+++ b/src/lib/referral-sources.ts
@@ -1,0 +1,41 @@
+/**
+ * Round-2 backlog G3 (Spectora §4.1, ITB UC-ITB-10) — referral source list.
+ *
+ * Seven seed values that ship with every workspace. Tenants can append
+ * additional labels via Settings → Workspace → Referral Sources, persisted
+ * to `tenant_configs.custom_referral_sources`.
+ *
+ * Keeping the seed list in a shared module avoids drifting copies between
+ * the dropdown, the validation layer and the audit-export columns.
+ */
+
+export const SEED_REFERRAL_SOURCES = [
+    'Realtor',
+    'Past Client',
+    'Google Search',
+    'Facebook',
+    'Yelp',
+    'Walk-in',
+    'Other',
+] as const;
+
+export type SeedReferralSource = typeof SEED_REFERRAL_SOURCES[number];
+
+/**
+ * Returns the effective referral-source list for a tenant: seeds first,
+ * then any custom labels (de-duplicated, case-insensitive) appended in the
+ * order the workspace configured them.
+ */
+export function resolveReferralSources(custom?: string[] | null | undefined): string[] {
+    const seen = new Set<string>(SEED_REFERRAL_SOURCES.map(s => s.toLowerCase()));
+    const out: string[] = [...SEED_REFERRAL_SOURCES];
+    for (const raw of custom ?? []) {
+        const v = (raw ?? '').trim();
+        if (!v) continue;
+        const k = v.toLowerCase();
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push(v);
+    }
+    return out;
+}

--- a/src/lib/validations/admin.schema.ts
+++ b/src/lib/validations/admin.schema.ts
@@ -15,6 +15,11 @@ export const UpdateBrandingSchema = z.object({
     showEstimates: z.boolean().optional().openapi({ example: true }),
     // Track E1 (ITB §11) — gate the "Repair List" tab on the published report.
     enableRepairList: z.boolean().optional().openapi({ example: true }),
+    // Round-2 backlog G3 (Spectora §4.1) — extra referral-source labels the
+    // tenant wants on the inspection settings dropdown. The seed list of
+    // seven values (Realtor / Past Client / …) is hardcoded; this array
+    // appends to it. Trimmed entries; max 32 to keep the dropdown usable.
+    customReferralSources: z.array(z.string().min(1).max(50)).max(32).optional().openapi({ example: ['Magazine ad', 'Trade show'] }),
 }).openapi('UpdateBranding');
 
 /**

--- a/src/lib/validations/inspection.schema.ts
+++ b/src/lib/validations/inspection.schema.ts
@@ -77,10 +77,42 @@ export const UpdateInspectionSchema = z.object({
     foundationType: z.enum(['basement', 'slab', 'crawlspace', 'other']).nullable().optional(),
     bedrooms:       z.number().int().min(0).nullable().optional().openapi({ example: 3 }),
     bathrooms:      z.number().min(0).max(20).nullable().optional().openapi({ example: 2.5 }),
+    // Round-2 backlog G1 — free-text lot size ("0.25 acres", "10,000 sqft").
+    lotSize:        z.string().max(50).nullable().optional().openapi({ example: '0.25 acres' }),
     unit:           z.string().max(50).nullable().optional(),
     county:         z.string().max(100).nullable().optional(),
+    // Round-2 backlog G2 (Spectora §7.10) — when does the buyer close on
+    // the property. Used for follow-up CRM signals. ISO YYYY-MM-DD.
+    closingDate:    z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date (YYYY-MM-DD)').nullable().optional().openapi({ example: '2026-07-15' }),
+    // Round-2 backlog G3 (Spectora §4.1) — free-text Order ID for ISN-style
+    // integrations. Surfaced in PMS exports.
+    orderId:        z.string().max(64).nullable().optional().openapi({ example: 'ORD-2026-0142' }),
+    // Round-2 backlog G3 — referral source label. Free-text so the seed
+    // list ("Realtor", "Past Client", ...) plus tenant custom values both
+    // round-trip without a separate enum.
+    referralSource: z.string().max(100).nullable().optional().openapi({ example: 'Realtor' }),
     reportThemeOverride: z.enum(['modern', 'classic', 'minimal']).nullable().optional().openapi({ example: 'classic' }),
 }).openapi('UpdateInspection');
+
+/**
+ * Round-2 backlog G1 (Spectora §E.2) — Property Facts strip payload.
+ * Six structured fields. All optional so inspectors can fill them in over
+ * time. `null` clears a field; omitted = leave existing value untouched.
+ *
+ * `yearBuilt`, `sqft`, `bedrooms`, `bathrooms` and `foundationType` map to
+ * dedicated columns on `inspections`. `lotSize` maps to the new `lot_size`
+ * column added in migration 0045.
+ */
+export const PropertyFactsSchema = z.object({
+    yearBuilt:      z.number().int().min(1800).max(2100).nullable().optional().openapi({ example: 1990 }),
+    sqft:           z.number().int().min(0).max(1_000_000).nullable().optional().openapi({ example: 1800 }),
+    foundationType: z.enum(['basement', 'slab', 'crawlspace', 'other']).nullable().optional().openapi({ example: 'basement' }),
+    lotSize:        z.string().max(50).nullable().optional().openapi({ example: '0.25 acres' }),
+    bedrooms:       z.number().int().min(0).max(50).nullable().optional().openapi({ example: 3 }),
+    bathrooms:      z.number().min(0).max(50).nullable().optional().openapi({ example: 2.5 }),
+}).openapi('PropertyFacts');
+
+export const PropertyFactsResponseSchema = createApiResponseSchema(PropertyFactsSchema).openapi('PropertyFactsResponse');
 
 export const CancellationReasonSchema = z.enum([
     'client_cancelled',

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -107,6 +107,18 @@ type Inspection = z.infer<typeof InspectionSchema>;
 type InspectionListParams = z.infer<typeof InspectionListQuerySchema>;
 type CreateInspectionData = z.infer<typeof CreateInspectionSchema>;
 
+/** Round-2 backlog G1 — Property Facts strip payload. Mirrors the canonical
+ *  Zod shape declared in inspection.schema.ts (PropertyFactsSchema). */
+type PropertyFactFoundation = 'basement' | 'slab' | 'crawlspace' | 'other';
+export interface PropertyFacts {
+    yearBuilt:      number | null;
+    sqft:           number | null;
+    foundationType: PropertyFactFoundation | null;
+    lotSize:        string | null;
+    bedrooms:       number | null;
+    bathrooms:      number | null;
+}
+
 /**
  * Service to handle all inspection-related business logic.
  */
@@ -396,6 +408,79 @@ export class InspectionService {
             ...clone,
             createdAt: safeISODate(clone.createdAt)
         };
+    }
+
+    /**
+     * Round-2 backlog G1 (Spectora §E.2) — return the Property Facts strip
+     * payload for a single inspection. Each field is null when the inspector
+     * hasn't filled it in yet so the UI can show its "—" placeholder.
+     */
+    async getPropertyFacts(id: string, tenantId: string): Promise<PropertyFacts> {
+        const db = this.getDrizzle();
+        const row = await db.select({
+            yearBuilt:      inspections.yearBuilt,
+            sqft:           inspections.sqft,
+            foundationType: inspections.foundationType,
+            lotSize:        inspections.lotSize,
+            bedrooms:       inspections.bedrooms,
+            bathrooms:      inspections.bathrooms,
+        }).from(inspections)
+          .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
+          .get();
+        if (!row) throw Errors.NotFound('Inspection not found');
+        // Foundation column is free-text in SQLite; coerce to the canonical
+        // four-value enum so the API response schema validates. Anything
+        // unexpected falls back to 'other'.
+        const allowedFoundations: ReadonlyArray<PropertyFactFoundation> =
+            ['basement', 'slab', 'crawlspace', 'other'] as const;
+        const ft = row.foundationType ?? null;
+        const foundationType: PropertyFactFoundation | null = ft === null
+            ? null
+            : (allowedFoundations.includes(ft as PropertyFactFoundation) ? (ft as PropertyFactFoundation) : 'other');
+        return {
+            yearBuilt:      row.yearBuilt      ?? null,
+            sqft:           row.sqft           ?? null,
+            foundationType,
+            lotSize:        row.lotSize        ?? null,
+            bedrooms:       row.bedrooms       ?? null,
+            bathrooms:      row.bathrooms      ?? null,
+        };
+    }
+
+    /**
+     * Round-2 backlog G1 — patch the six Property Facts columns in a single
+     * write. Undefined keys are skipped (so the caller can save one field at
+     * a time without clobbering the others). Null values clear the field.
+     * Returns the resulting facts row so the UI doesn't need a re-fetch.
+     */
+    async updatePropertyFacts(id: string, tenantId: string, facts: {
+        yearBuilt?:      number | null | undefined;
+        sqft?:           number | null | undefined;
+        foundationType?: PropertyFactFoundation | null | undefined;
+        lotSize?:        string | null | undefined;
+        bedrooms?:       number | null | undefined;
+        bathrooms?:      number | null | undefined;
+    }): Promise<PropertyFacts> {
+        const db = this.getDrizzle();
+        const existing = await db.select({ id: inspections.id }).from(inspections)
+            .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
+            .get();
+        if (!existing) throw Errors.NotFound('Inspection not found');
+
+        const update: Partial<typeof inspections.$inferInsert> = {};
+        if (facts.yearBuilt      !== undefined) update.yearBuilt      = facts.yearBuilt;
+        if (facts.sqft           !== undefined) update.sqft           = facts.sqft;
+        if (facts.foundationType !== undefined) update.foundationType = facts.foundationType;
+        if (facts.lotSize        !== undefined) update.lotSize        = facts.lotSize;
+        if (facts.bedrooms       !== undefined) update.bedrooms       = facts.bedrooms;
+        if (facts.bathrooms      !== undefined) update.bathrooms      = facts.bathrooms;
+
+        if (Object.keys(update).length > 0) {
+            await db.update(inspections).set(update)
+                .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));
+        }
+
+        return this.getPropertyFacts(id, tenantId);
     }
 
     /**
@@ -805,6 +890,19 @@ export class InspectionService {
             // defaults the column to 0 anyway, so this is just paranoia).
         }
 
+        // Round-2 backlog G1 (Spectora §E.2) — Property Facts banner rendered
+        // at the top of the published report. Surface the six dedicated
+        // columns; the report layer decides whether to render the strip
+        // when at least one field is populated.
+        const propertyFacts = {
+            yearBuilt:      (inspection as { yearBuilt?: number | null }).yearBuilt           ?? null,
+            sqft:           (inspection as { sqft?: number | null }).sqft                     ?? null,
+            foundationType: (inspection as { foundationType?: string | null }).foundationType ?? null,
+            lotSize:        (inspection as { lotSize?: string | null }).lotSize               ?? null,
+            bedrooms:       (inspection as { bedrooms?: number | null }).bedrooms             ?? null,
+            bathrooms:      (inspection as { bathrooms?: number | null }).bathrooms           ?? null,
+        };
+
         return {
             inspection: { ...inspection, inspectorName },
             theme: 'modern' as const,
@@ -817,6 +915,7 @@ export class InspectionService {
                 { id: 'Not Inspected', label: 'Not Inspected', abbreviation: 'NI', color: '#3b82f6', severity: 'minor', isDefect: false },
             ],
             showEstimates,
+            propertyFacts,
         };
     }
 

--- a/src/templates/components/property-facts-card.tsx
+++ b/src/templates/components/property-facts-card.tsx
@@ -1,0 +1,202 @@
+/**
+ * Round-2 backlog G1 (Spectora §E.2 / §4.1) — Property Facts strip.
+ *
+ * Six inline-editable property attributes shown on the inspection settings
+ * page and (read-only) at the top of the published report:
+ *
+ *   Year Built · SqFt · Foundation · Lot Size · Bedrooms · Bathrooms
+ *
+ * Card variant — driven by Alpine state declared in inspection-settings.js
+ * (`facts.*`, `factsState`, `saveFact`). Each cell is a single input that
+ * persists on `change` via PATCH /api/inspections/:id/property-facts.
+ *
+ * Banner variant — server-rendered from `getReportData`'s `propertyFacts`
+ * payload. No Alpine; just a static row of label / value pairs.
+ */
+
+const FOUNDATION_OPTIONS: Array<{ value: string; label: string }> = [
+    { value: '',            label: '—' },
+    { value: 'basement',    label: 'Basement' },
+    { value: 'slab',        label: 'Slab' },
+    { value: 'crawlspace',  label: 'Crawlspace' },
+    { value: 'other',       label: 'Other' },
+];
+
+/**
+ * Editable card placed in inspection/settings.tsx. Each input binds to the
+ * `facts` Alpine reactive object and saves on change via the
+ * /api/inspections/:id/property-facts endpoint.
+ */
+export const PropertyFactsCard = (): JSX.Element => (
+    <fieldset
+        class="space-y-4"
+        data-testid="property-facts-card"
+    >
+        <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Property facts</legend>
+        <p class="text-[12px] text-slate-500">
+            Surfaced as a banner on the published report. Leave blank for fields you didn't capture —
+            the report renders only the facts you fill in.
+        </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {/* Year Built */}
+            <label class="block">
+                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Year Built</span>
+                <input
+                    type="number"
+                    min="1800"
+                    max="2100"
+                    step="1"
+                    placeholder="—"
+                    data-testid="property-facts-year-built"
+                    {...{ 'x-model.number': 'facts.yearBuilt' }}
+                    {...{ 'x-on:change': "saveFact('yearBuilt', $event.target.value)" }}
+                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium tabular-nums focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                />
+            </label>
+
+            {/* SqFt */}
+            <label class="block">
+                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">SqFt</span>
+                <input
+                    type="number"
+                    min="0"
+                    step="1"
+                    placeholder="—"
+                    data-testid="property-facts-sqft"
+                    {...{ 'x-model.number': 'facts.sqft' }}
+                    {...{ 'x-on:change': "saveFact('sqft', $event.target.value)" }}
+                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium tabular-nums focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                />
+            </label>
+
+            {/* Foundation Type */}
+            <label class="block">
+                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Foundation Type</span>
+                <select
+                    data-testid="property-facts-foundation"
+                    x-model="facts.foundationType"
+                    {...{ 'x-on:change': "saveFact('foundationType', $event.target.value)" }}
+                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                >
+                    {FOUNDATION_OPTIONS.map(o => (
+                        <option value={o.value}>{o.label}</option>
+                    ))}
+                </select>
+            </label>
+
+            {/* Lot Size — free text ("0.25 acres") */}
+            <label class="block">
+                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Lot Size</span>
+                <input
+                    type="text"
+                    maxLength={50}
+                    placeholder="—"
+                    data-testid="property-facts-lot-size"
+                    x-model="facts.lotSize"
+                    {...{ 'x-on:change': "saveFact('lotSize', $event.target.value)" }}
+                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                />
+            </label>
+
+            {/* Bedrooms */}
+            <label class="block">
+                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Bedrooms</span>
+                <input
+                    type="number"
+                    min="0"
+                    step="1"
+                    placeholder="—"
+                    data-testid="property-facts-bedrooms"
+                    {...{ 'x-model.number': 'facts.bedrooms' }}
+                    {...{ 'x-on:change': "saveFact('bedrooms', $event.target.value)" }}
+                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium tabular-nums focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                />
+            </label>
+
+            {/* Bathrooms */}
+            <label class="block">
+                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Bathrooms</span>
+                <input
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    placeholder="—"
+                    data-testid="property-facts-bathrooms"
+                    {...{ 'x-model.number': 'facts.bathrooms' }}
+                    {...{ 'x-on:change': "saveFact('bathrooms', $event.target.value)" }}
+                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium tabular-nums focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                />
+            </label>
+        </div>
+
+        <div class="text-[12px] text-slate-500" aria-live="polite">
+            <span x-show="factsState === 'saving'" style="display:none" class="text-amber-600 font-bold">Saving…</span>
+            <span x-show="factsState === 'saved'"  style="display:none" class="text-emerald-600 font-bold">Saved</span>
+            <span x-show="factsState === 'error'"  style="display:none" class="text-rose-600 font-bold">Couldn't save — try again</span>
+        </div>
+    </fieldset>
+);
+
+/**
+ * Read-only banner rendered above the published report (Spectora §E.2).
+ * Renders nothing when no facts are populated.
+ */
+export interface PropertyFactsBannerProps {
+    facts: {
+        yearBuilt:      number | null;
+        sqft:           number | null;
+        foundationType: string | null;
+        lotSize:        string | null;
+        bedrooms:       number | null;
+        bathrooms:      number | null;
+    };
+}
+
+const FOUNDATION_LABELS: Record<string, string> = {
+    basement:   'Basement',
+    slab:       'Slab',
+    crawlspace: 'Crawlspace',
+    other:      'Other',
+};
+
+function formatBathrooms(n: number): string {
+    // Match Spectora's "2.5 / 2.0 / 3" — drop trailing zeroes; integer baths
+    // render without decimals.
+    const trimmed = Number(n.toFixed(2));
+    return Number.isInteger(trimmed) ? String(trimmed) : trimmed.toFixed(1);
+}
+
+function formatSqft(n: number): string {
+    return new Intl.NumberFormat('en-US').format(n);
+}
+
+export const PropertyFactsBanner = ({ facts }: PropertyFactsBannerProps): JSX.Element | null => {
+    const cells: Array<{ label: string; value: string }> = [];
+    if (facts.yearBuilt != null)       cells.push({ label: 'Year Built',  value: String(facts.yearBuilt) });
+    if (facts.sqft      != null)       cells.push({ label: 'Sq Ft',       value: formatSqft(facts.sqft) });
+    if (facts.foundationType)          cells.push({ label: 'Foundation',  value: FOUNDATION_LABELS[facts.foundationType] ?? facts.foundationType });
+    if (facts.lotSize && facts.lotSize.trim() !== '')
+                                       cells.push({ label: 'Lot Size',    value: facts.lotSize });
+    if (facts.bedrooms  != null)       cells.push({ label: 'Bedrooms',    value: String(facts.bedrooms) });
+    if (facts.bathrooms != null)       cells.push({ label: 'Bathrooms',   value: formatBathrooms(facts.bathrooms) });
+
+    if (cells.length === 0) return null;
+
+    return (
+        <section
+            data-testid="report-property-facts-banner"
+            class="max-w-4xl mx-auto px-4 sm:px-6 mb-6"
+            aria-label="Property facts"
+        >
+            <div class="theme-card grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 px-4 py-3">
+                {cells.map(c => (
+                    <div class="text-center sm:text-left">
+                        <div class="text-[10px] font-bold uppercase tracking-[0.18em] theme-text-muted">{c.label}</div>
+                        <div class="text-sm font-semibold theme-font-display tabular-nums">{c.value}</div>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+};

--- a/src/templates/components/settings-layout.tsx
+++ b/src/templates/components/settings-layout.tsx
@@ -52,6 +52,7 @@ export const SETTINGS_GROUPS: readonly GroupConfig[] = [
             { slug: 'branding', label: 'Branding', href: '/settings/workspace/branding', description: 'Site name, color, logo' },
             { slug: 'theme', label: 'Report Theme', href: '/settings/workspace/theme', description: 'Modern / classic / minimal' },
             { slug: 'reports', label: 'Reports', href: '/settings/workspace/reports', description: 'Estimate display, defect badges' },
+            { slug: 'referral', label: 'Referral Sources', href: '/settings/workspace/referral', description: 'Custom referral labels' },
             { slug: 'telemetry', label: 'Telemetry', href: '/settings/workspace/telemetry', description: 'Google Analytics' },
         ],
     },

--- a/src/templates/pages/inspection/settings.tsx
+++ b/src/templates/pages/inspection/settings.tsx
@@ -14,6 +14,8 @@
 import { MainLayout } from '../../layouts/main-layout';
 import { InspectionShell } from '../../components/inspection-shell';
 import { PeopleCard } from '../../components/people-card';
+import { PropertyFactsCard } from '../../components/property-facts-card';
+import { SEED_REFERRAL_SOURCES, resolveReferralSources } from '../../../lib/referral-sources';
 import type { BrandingConfig } from '../../../types/auth';
 
 export interface InspectionSettingsPageProps {
@@ -23,6 +25,9 @@ export interface InspectionSettingsPageProps {
     requestId?:       string | undefined;
     siblings?:        Array<{ id: string; templateName: string; status: string }> | undefined;
     enableRepairList?: boolean;
+    // Round-2 backlog G3 — tenant-defined referral sources are appended to
+    // the seven seeds. Server resolves the merged list before render.
+    customReferralSources?: string[] | undefined;
 }
 
 export const InspectionSettingsPage = ({
@@ -32,7 +37,12 @@ export const InspectionSettingsPage = ({
     requestId,
     siblings,
     enableRepairList,
+    customReferralSources,
 }: InspectionSettingsPageProps): JSX.Element => {
+    const referralSources = resolveReferralSources(customReferralSources);
+    // Backstop in case the resolver shape changes — the seven seeds always
+    // need to be available.
+    const sources = referralSources.length > 0 ? referralSources : [...SEED_REFERRAL_SOURCES];
     const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout
@@ -80,6 +90,64 @@ export const InspectionSettingsPage = ({
                                     </select>
                                 </label>
                             </div>
+                            {/* Round-2 backlog G2 (Spectora §7.10) — Closing
+                                Date single picker. Used for follow-up CRM
+                                signals; never gates the report. */}
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <label class="block">
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Closing Date</span>
+                                    <input
+                                        type="date"
+                                        data-testid="inspection-closing-date"
+                                        x-model="form.closingDate"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                    />
+                                </label>
+                            </div>
+                        </fieldset>
+
+                        {/* Round-2 backlog G1 (Spectora §E.2) — Property
+                            Facts strip. Six inline-editable fields. Saves
+                            via /api/inspections/:id/property-facts on
+                            change rather than waiting for the form submit. */}
+                        <PropertyFactsCard />
+
+                        {/* Round-2 backlog G3 (Spectora §4.1, ITB UC-ITB-10)
+                            — Order ID + Referral Source. Both optional.
+                            Order ID is free-text up to 64 chars (ISN-style
+                            identifier). Referral Source is the merged
+                            seed + tenant custom list. */}
+                        <fieldset class="space-y-4">
+                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Order &amp; referral</legend>
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <label class="block">
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Order ID</span>
+                                    <input
+                                        type="text"
+                                        maxLength={64}
+                                        placeholder="—"
+                                        data-testid="inspection-order-id"
+                                        x-model="form.orderId"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                                    />
+                                </label>
+                                <label class="block">
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Referral Source</span>
+                                    <select
+                                        data-testid="inspection-referral-source"
+                                        x-model="form.referralSource"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                    >
+                                        <option value="">— Select source —</option>
+                                        {sources.map(s => (
+                                            <option value={s}>{s}</option>
+                                        ))}
+                                    </select>
+                                </label>
+                            </div>
+                            <p class="text-[12px] text-slate-500">
+                                Add custom referral sources at <a href="/settings/workspace/referral" class="text-indigo-600 hover:underline">Settings → Workspace → Referral Sources</a>.
+                            </p>
                         </fieldset>
 
                         <fieldset class="space-y-4">

--- a/src/templates/pages/report-card-stack.tsx
+++ b/src/templates/pages/report-card-stack.tsx
@@ -1,6 +1,7 @@
 // src/templates/pages/report-card-stack.tsx
 import { BareLayout } from '../layouts/main-layout';
 import { StatsCards } from '../components/stats-cards';
+import { PropertyFactsBanner, type PropertyFactsBannerProps } from '../components/property-facts-card';
 import type { RatingLevel } from '../../lib/report-utils';
 import type { BrandingConfig } from '../../types/auth';
 import {
@@ -61,6 +62,9 @@ interface ReportPageProps {
   // Track E1 (ITB §11) — when true, surface a "View repair list" link in
   // the report header so realtors can jump to the contractor punch-list.
   enableRepairList?: boolean;
+  // Round-2 backlog G1 (Spectora §E.2) — Property Facts banner payload.
+  // Renders nothing when every field is null/empty.
+  propertyFacts?: PropertyFactsBannerProps['facts'] | undefined;
 }
 
 const SECTION_ICONS: Record<string, string> = {
@@ -224,6 +228,11 @@ export function ReportCardStackPage(props: ReportPageProps) {
           <h1 class="text-2xl sm:text-3xl font-bold theme-font-display leading-tight mb-2">{address}</h1>
           <p class="theme-text-secondary text-sm">{date} · Inspector: {inspectorName || 'N/A'}</p>
         </div>
+
+        {/* Round-2 backlog G1 (Spectora §E.2) — Property Facts banner.
+            Renders nothing when no facts are populated, so legacy reports
+            with bare metadata stay visually unchanged. */}
+        {props.propertyFacts && <PropertyFactsBanner facts={props.propertyFacts} />}
 
         {/* Stats */}
         <div class="max-w-4xl mx-auto px-4 sm:px-6 mb-6">

--- a/src/templates/pages/settings-workspace.tsx
+++ b/src/templates/pages/settings-workspace.tsx
@@ -1,4 +1,5 @@
 import { SettingsLayout } from '../components/settings-layout';
+import { SEED_REFERRAL_SOURCES } from '../../lib/referral-sources';
 import type { BrandingConfig } from '../../types/auth';
 
 interface Props { branding?: BrandingConfig | undefined; }
@@ -10,7 +11,13 @@ interface ReportsProps extends Props {
     enableRepairList?: boolean;
 }
 
-type WorkspaceSubPage = 'branding' | 'theme' | 'reports' | 'telemetry';
+// Round-2 backlog G3 — extra prop only used by the new Referral sub-page
+// so the textarea hydrates with the workspace's saved custom labels.
+interface ReferralProps extends Props {
+    customReferralSources?: string[];
+}
+
+type WorkspaceSubPage = 'branding' | 'theme' | 'reports' | 'referral' | 'telemetry';
 
 /* ─────────────────────────────  Branding  ───────────────────────────── */
 
@@ -266,11 +273,106 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
     );
 };
 
+/* ─────────────────────────────  Referral Sources (G3)  ───────────────────────────── */
+
+/**
+ * Round-2 backlog G3 (Spectora §4.1, ITB UC-ITB-10) — custom referral
+ * sources. Tenants can append to the seven seeded values
+ * (Realtor / Past Client / Google Search / Facebook / Yelp / Walk-in /
+ * Other) by entering one label per line. We keep the form deliberately
+ * MVP — no drag-reorder, no per-row delete — so a single textarea + Save
+ * round-trips to `tenant_configs.custom_referral_sources` (JSON).
+ */
+export const SettingsWorkspaceReferralPage = ({ branding, customReferralSources }: ReferralProps): JSX.Element => {
+    const initial = (customReferralSources ?? []).join('\n');
+    return (
+        <SettingsLayout
+            branding={branding}
+            title="Settings | Referral Sources"
+            group="workspace"
+            subPage="referral"
+            pageTitle="Referral Sources"
+            pageSubtitle="Extend the built-in referral source list shown on every inspection. One label per line."
+        >
+            <section
+                class="bg-white rounded-lg border border-surface-200 p-6 space-y-5"
+                x-data={`{
+                    raw: ${JSON.stringify(initial)},
+                    saving: false,
+                    parse() {
+                        return this.raw.split('\\n').map(s => s.trim()).filter(Boolean);
+                    },
+                    async save() {
+                        this.saving = true;
+                        try {
+                            const r = await authFetch('/api/admin/branding', {
+                                method: 'POST',
+                                headers: { 'content-type': 'application/json' },
+                                body: JSON.stringify({ customReferralSources: this.parse() })
+                            });
+                            if (!r.ok) {
+                                if (typeof showToast === 'function') showToast('Failed to save', true);
+                            } else {
+                                if (typeof showToast === 'function') showToast('Saved');
+                            }
+                        } catch (e) {
+                            if (typeof showToast === 'function') showToast('Failed to save', true);
+                        }
+                        finally { this.saving = false; }
+                    }
+                }`}
+            >
+                <div class="space-y-3">
+                    <div class="text-xs font-bold uppercase tracking-[0.2em] text-ink-700">Built-in sources</div>
+                    <ul class="flex flex-wrap gap-2">
+                        {SEED_REFERRAL_SOURCES.map(s => (
+                            <li class="px-2.5 py-1 rounded-md text-[11px] font-bold bg-surface-100 text-ink-700">{s}</li>
+                        ))}
+                    </ul>
+                </div>
+
+                <div class="space-y-2">
+                    <label for="customReferralSources" class="block text-xs font-bold text-ink-700 uppercase tracking-[0.2em]">Custom labels</label>
+                    <textarea
+                        id="customReferralSources"
+                        data-testid="settings-referral-textarea"
+                        x-model="raw"
+                        rows={8}
+                        placeholder="Magazine ad
+Trade show
+Referral partner"
+                        class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none transition-all font-medium text-sm placeholder:text-ink-300"
+                    ></textarea>
+                    <p class="text-[11px] text-ink-500">One label per line. Maximum 32 entries; duplicates are ignored.</p>
+                </div>
+
+                <div class="flex items-center justify-end gap-3 pt-2 border-t border-surface-200">
+                    <span x-show="saving" class="text-xs text-ink-500">Saving…</span>
+                    <button
+                        x-on:click="save()"
+                        x-bind:disabled="saving"
+                        data-testid="settings-referral-save"
+                        class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all disabled:bg-surface-200"
+                    >
+                        Save
+                    </button>
+                </div>
+            </section>
+
+            <script src="/js/auth.js"></script>
+            <script src="/js/toast.js"></script>
+        </SettingsLayout>
+    );
+};
+
 /**
  * Dispatcher used by the route handler — picks the right component based on the
  * `subPage` URL segment. Keeps `index.ts` route registrations short.
  */
-export const SettingsWorkspacePage = ({ branding, subPage, showEstimates, enableRepairList }: ReportsProps & { subPage: WorkspaceSubPage }): JSX.Element => {
+export const SettingsWorkspacePage = (
+    { branding, subPage, showEstimates, enableRepairList, customReferralSources }:
+    ReportsProps & ReferralProps & { subPage: WorkspaceSubPage }
+): JSX.Element => {
     if (subPage === 'theme') return SettingsWorkspaceThemePage({ branding });
     if (subPage === 'telemetry') return SettingsWorkspaceTelemetryPage({ branding });
     if (subPage === 'reports') {
@@ -278,6 +380,11 @@ export const SettingsWorkspacePage = ({ branding, subPage, showEstimates, enable
         if (typeof showEstimates    === 'boolean') props.showEstimates    = showEstimates;
         if (typeof enableRepairList === 'boolean') props.enableRepairList = enableRepairList;
         return SettingsWorkspaceReportsPage(props);
+    }
+    if (subPage === 'referral') {
+        const props: ReferralProps = { branding };
+        if (Array.isArray(customReferralSources)) props.customReferralSources = customReferralSources;
+        return SettingsWorkspaceReferralPage(props);
     }
     return SettingsWorkspaceBrandingPage({ branding });
 };

--- a/tests/unit/property-facts-banner.spec.ts
+++ b/tests/unit/property-facts-banner.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Round-2 backlog G1 (Spectora §E.2) — PropertyFactsBanner render coverage.
+ *
+ * Asserts:
+ *   - Renders nothing when every fact is null/empty.
+ *   - Renders a card with each populated cell + label/value pair.
+ *   - SqFt is comma-formatted (1,800).
+ *   - Bathrooms formatted with at most one decimal; integer baths stay
+ *     decimal-free.
+ *   - Foundation enum maps to a friendly label.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PropertyFactsBanner } from '../../src/templates/components/property-facts-card';
+
+function render(node: unknown): string {
+    if (node === null || node === undefined) return '';
+    return String(node);
+}
+
+const EMPTY = {
+    yearBuilt:      null,
+    sqft:           null,
+    foundationType: null,
+    lotSize:        null,
+    bedrooms:       null,
+    bathrooms:      null,
+};
+
+describe('PropertyFactsBanner', () => {
+    it('renders null when every fact is empty', () => {
+        const out = PropertyFactsBanner({ facts: EMPTY });
+        expect(out).toBeNull();
+    });
+
+    it('renders a banner with populated cells only', () => {
+        const html = render(PropertyFactsBanner({ facts: {
+            yearBuilt: 1990, sqft: 1800, foundationType: 'basement',
+            lotSize: '0.25 acres', bedrooms: 3, bathrooms: 2.5,
+        }}));
+        expect(html).toContain('report-property-facts-banner');
+        expect(html).toContain('Year Built');
+        expect(html).toContain('1990');
+        expect(html).toContain('Sq Ft');
+        expect(html).toContain('1,800'); // comma-formatted
+        expect(html).toContain('Foundation');
+        expect(html).toContain('Basement'); // friendly label
+        expect(html).toContain('Lot Size');
+        expect(html).toContain('0.25 acres');
+        expect(html).toContain('Bedrooms');
+        expect(html).toContain('Bathrooms');
+        expect(html).toContain('2.5');
+    });
+
+    it('omits cells whose value is null or empty', () => {
+        const html = render(PropertyFactsBanner({ facts: {
+            ...EMPTY,
+            yearBuilt: 2010,
+        }}));
+        expect(html).toContain('Year Built');
+        expect(html).toContain('2010');
+        // Other labels must NOT be present.
+        expect(html).not.toContain('Sq Ft');
+        expect(html).not.toContain('Foundation');
+        expect(html).not.toContain('Bedrooms');
+    });
+
+    it('renders integer bathrooms without decimals', () => {
+        const html = render(PropertyFactsBanner({ facts: {
+            ...EMPTY,
+            bathrooms: 3,
+        }}));
+        expect(html).toContain('Bathrooms');
+        // Must NOT render "3.0"
+        expect(html).not.toMatch(/3\.0/);
+    });
+
+    it('treats whitespace-only lotSize as empty', () => {
+        const html = render(PropertyFactsBanner({ facts: {
+            ...EMPTY,
+            lotSize: '   ',
+        }}));
+        // banner suppressed entirely because no other fact set
+        expect(html).toBe('');
+    });
+});

--- a/tests/unit/property-facts.spec.ts
+++ b/tests/unit/property-facts.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * Round-2 backlog G1 (Spectora §E.2) — InspectionService.updatePropertyFacts
+ * + getPropertyFacts unit coverage.
+ *
+ * Asserts:
+ *   - Six dedicated columns round-trip in/out.
+ *   - Partial patches leave un-named fields untouched.
+ *   - Null clears a field.
+ *   - Cross-tenant calls are rejected.
+ *   - Zod parse on the new PATCH payload.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InspectionService } from '../../src/services/inspection.service';
+import { PropertyFactsSchema, UpdateInspectionSchema } from '../../src/lib/validations/inspection.schema';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT_A = '00000000-0000-0000-0000-000000000001';
+const TENANT_B = '00000000-0000-0000-0000-000000000002';
+
+describe('InspectionService.updatePropertyFacts (G1)', () => {
+    let svc: InspectionService;
+    let testDb: BetterSQLite3Database<typeof schema>;
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        await setupSchema(fixture.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InspectionService({} as D1Database);
+
+        await testDb.insert(schema.tenants).values([
+            { id: TENANT_A, name: 'Acme',   subdomain: 'acme',   status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_B, name: 'Globex', subdomain: 'globex', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        ]);
+        await testDb.insert(schema.inspections).values([
+            { id: 'insp-A', tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'A', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },
+            { id: 'insp-B', tenantId: TENANT_B, propertyAddress: '2 Elm Rd',  clientName: 'B', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },
+        ]);
+    });
+
+    it('round-trips all six fields', async () => {
+        const out = await svc.updatePropertyFacts('insp-A', TENANT_A, {
+            yearBuilt:      1990,
+            sqft:           1800,
+            foundationType: 'basement',
+            lotSize:        '0.25 acres',
+            bedrooms:       3,
+            bathrooms:      2.5,
+        });
+        expect(out).toEqual({
+            yearBuilt:      1990,
+            sqft:           1800,
+            foundationType: 'basement',
+            lotSize:        '0.25 acres',
+            bedrooms:       3,
+            bathrooms:      2.5,
+        });
+    });
+
+    it('partial patch keeps unrelated columns intact', async () => {
+        await svc.updatePropertyFacts('insp-A', TENANT_A, {
+            yearBuilt: 1990,
+            sqft: 1800,
+        });
+        const after = await svc.updatePropertyFacts('insp-A', TENANT_A, {
+            // Only bathrooms — yearBuilt + sqft must survive.
+            bathrooms: 2,
+        });
+        expect(after.yearBuilt).toBe(1990);
+        expect(after.sqft).toBe(1800);
+        expect(after.bathrooms).toBe(2);
+        expect(after.bedrooms).toBeNull();
+    });
+
+    it('null clears a previously set value', async () => {
+        await svc.updatePropertyFacts('insp-A', TENANT_A, {
+            lotSize: '0.5 acres',
+            yearBuilt: 1985,
+        });
+        const cleared = await svc.updatePropertyFacts('insp-A', TENANT_A, {
+            lotSize: null,
+        });
+        expect(cleared.lotSize).toBeNull();
+        // yearBuilt untouched.
+        expect(cleared.yearBuilt).toBe(1985);
+    });
+
+    it('rejects cross-tenant access', async () => {
+        await expect(
+            svc.updatePropertyFacts('insp-B', TENANT_A, { yearBuilt: 2000 })
+        ).rejects.toThrow(/not found/i);
+    });
+
+    it('getPropertyFacts returns nulls when never set', async () => {
+        const facts = await svc.getPropertyFacts('insp-A', TENANT_A);
+        expect(facts).toEqual({
+            yearBuilt:      null,
+            sqft:           null,
+            foundationType: null,
+            lotSize:        null,
+            bedrooms:       null,
+            bathrooms:      null,
+        });
+    });
+});
+
+describe('PropertyFactsSchema (Zod)', () => {
+    it('accepts a complete payload', () => {
+        const parsed = PropertyFactsSchema.parse({
+            yearBuilt: 1990, sqft: 1800, foundationType: 'slab',
+            lotSize: '0.5 acres', bedrooms: 3, bathrooms: 2.5,
+        });
+        expect(parsed.yearBuilt).toBe(1990);
+        expect(parsed.foundationType).toBe('slab');
+    });
+
+    it('accepts an empty payload (partial patch)', () => {
+        const parsed = PropertyFactsSchema.parse({});
+        expect(parsed).toEqual({});
+    });
+
+    it('accepts null to clear a field', () => {
+        const parsed = PropertyFactsSchema.parse({ lotSize: null, yearBuilt: null });
+        expect(parsed.lotSize).toBeNull();
+        expect(parsed.yearBuilt).toBeNull();
+    });
+
+    it('rejects out-of-range yearBuilt', () => {
+        expect(() => PropertyFactsSchema.parse({ yearBuilt: 1500 })).toThrow();
+        expect(() => PropertyFactsSchema.parse({ yearBuilt: 3000 })).toThrow();
+    });
+
+    it('rejects unknown foundationType', () => {
+        expect(() => PropertyFactsSchema.parse({ foundationType: 'pier' })).toThrow();
+    });
+
+    it('rejects negative sqft', () => {
+        expect(() => PropertyFactsSchema.parse({ sqft: -1 })).toThrow();
+    });
+});
+
+describe('UpdateInspectionSchema — G2 closingDate / G3 orderId / G3 referralSource', () => {
+    it('accepts all three new fields', () => {
+        const parsed = UpdateInspectionSchema.parse({
+            closingDate:    '2026-07-15',
+            orderId:        'ORD-2026-0142',
+            referralSource: 'Realtor',
+        });
+        expect(parsed.closingDate).toBe('2026-07-15');
+        expect(parsed.orderId).toBe('ORD-2026-0142');
+        expect(parsed.referralSource).toBe('Realtor');
+    });
+
+    it('null clears each new field', () => {
+        const parsed = UpdateInspectionSchema.parse({
+            closingDate:    null,
+            orderId:        null,
+            referralSource: null,
+        });
+        expect(parsed.closingDate).toBeNull();
+        expect(parsed.orderId).toBeNull();
+        expect(parsed.referralSource).toBeNull();
+    });
+
+    it('rejects malformed closingDate', () => {
+        expect(() => UpdateInspectionSchema.parse({ closingDate: '07/15/2026' })).toThrow();
+        expect(() => UpdateInspectionSchema.parse({ closingDate: '2026-7-15' })).toThrow();
+    });
+
+    it('rejects orderId longer than 64 chars', () => {
+        expect(() => UpdateInspectionSchema.parse({ orderId: 'X'.repeat(65) })).toThrow();
+    });
+});

--- a/tests/unit/referral-sources.spec.ts
+++ b/tests/unit/referral-sources.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Round-2 backlog G3 (Spectora §4.1, ITB UC-ITB-10) — referral source list
+ * resolver. Asserts:
+ *   - Seed list is always returned.
+ *   - Custom labels are appended in order.
+ *   - Empty / whitespace entries are dropped.
+ *   - Case-insensitive de-duplication against seed + earlier custom values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SEED_REFERRAL_SOURCES, resolveReferralSources } from '../../src/lib/referral-sources';
+import { UpdateBrandingSchema } from '../../src/lib/validations/admin.schema';
+
+describe('resolveReferralSources', () => {
+    it('returns the seven seed values when no custom list', () => {
+        const out = resolveReferralSources();
+        expect(out).toEqual([...SEED_REFERRAL_SOURCES]);
+        // Sanity: list contains the canonical seven labels.
+        expect(out).toContain('Realtor');
+        expect(out).toContain('Past Client');
+        expect(out).toContain('Google Search');
+        expect(out).toContain('Facebook');
+        expect(out).toContain('Yelp');
+        expect(out).toContain('Walk-in');
+        expect(out).toContain('Other');
+        expect(out).toHaveLength(7);
+    });
+
+    it('handles null / undefined gracefully', () => {
+        expect(resolveReferralSources(null)).toHaveLength(7);
+        expect(resolveReferralSources(undefined)).toHaveLength(7);
+    });
+
+    it('appends custom values after the seeds', () => {
+        const out = resolveReferralSources(['Magazine ad', 'Trade show']);
+        expect(out.slice(0, 7)).toEqual([...SEED_REFERRAL_SOURCES]);
+        expect(out.slice(7)).toEqual(['Magazine ad', 'Trade show']);
+    });
+
+    it('drops empty / whitespace-only entries', () => {
+        const out = resolveReferralSources(['', '   ', 'Trade show', '  ']);
+        expect(out).toEqual([...SEED_REFERRAL_SOURCES, 'Trade show']);
+    });
+
+    it('de-dupes against seeds case-insensitively', () => {
+        // "REALTOR" must not double up — it matches the seed "Realtor".
+        const out = resolveReferralSources(['REALTOR', 'realtor', 'New label']);
+        expect(out).toEqual([...SEED_REFERRAL_SOURCES, 'New label']);
+    });
+
+    it('de-dupes within the custom list itself', () => {
+        const out = resolveReferralSources(['Magazine ad', 'magazine AD', 'Trade show']);
+        expect(out).toEqual([...SEED_REFERRAL_SOURCES, 'Magazine ad', 'Trade show']);
+    });
+});
+
+describe('UpdateBrandingSchema — customReferralSources (G3)', () => {
+    it('accepts an array of labels', () => {
+        const parsed = UpdateBrandingSchema.parse({
+            customReferralSources: ['Magazine ad', 'Trade show'],
+        });
+        expect(parsed.customReferralSources).toEqual(['Magazine ad', 'Trade show']);
+    });
+
+    it('rejects more than 32 entries', () => {
+        const tooMany = Array.from({ length: 33 }, (_, i) => `label-${i}`);
+        expect(() => UpdateBrandingSchema.parse({ customReferralSources: tooMany })).toThrow();
+    });
+
+    it('rejects entries longer than 50 chars', () => {
+        expect(() => UpdateBrandingSchema.parse({
+            customReferralSources: ['X'.repeat(51)],
+        })).toThrow();
+    });
+
+    it('rejects empty-string entries', () => {
+        expect(() => UpdateBrandingSchema.parse({
+            customReferralSources: [''],
+        })).toThrow();
+    });
+});


### PR DESCRIPTION
## Summary

Round 4 of competitor parity. Three round-2 backlog Top 3 S items, single migration.

- **G1** Property Facts banner (Spectora §E.2) — 6-field strip on inspection settings + report header (Year Built / SqFt / Foundation / Lot / Bedrooms / Bathrooms). Inline-saving per-input with "Saving / Saved / Couldn't save" affordance.
- **G2** Closing Date (Spectora §7.10) — date picker on inspection settings; round-trips through `PATCH /api/inspections/:id`.
- **G3** Order ID + Referral Source (Spectora §4.1, ITB UC-ITB-10) — free-text Order ID, dropdown with 7 seed labels (`Realtor` / `Past Client` / `Google Search` / `Facebook` / `Yelp` / `Walk-in` / `Other`), tenant-extensible custom list via new `/settings/workspace/referral` sub-page.

## Stats

- 5 commits, 1 worktree-isolated track
- **444 unit tests pass** (was 414; +30 new)
- type-check 0 errors, lint 0 errors
- Migration `0045_property_facts.sql`: adds `lot_size`, `property_facts`, `custom_referral_sources` columns
- Latent bug fix: `inspection-settings.js` was using stale `method: 'PUT'`; corrected to `PATCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)