### PR TITLE
Sprint 3: tag system + property auto-fill + customer export + tablet + InterNACHI + burst photo + calendar DnD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ npm run deploy       # Deploy to Cloudflare Workers
 | `STRIPE_WEBHOOK_SECRET` | No | Stripe webhook HMAC verification |
 | `GA_MEASUREMENT_ID` | No | Google Analytics tracking ID |
 | `GOOGLE_PLACES_API_KEY` | No | Google Places API key powering address autocomplete on the dashboard new-inspection wizard and the public `/book` page (proxied via `/api/places/*` and `/api/public/geocode`). When unset, both endpoints return `{ data: [], reason: 'NO_API_KEY' }` and the address inputs degrade gracefully to plain text — the customer can still type a free-form address and submit. |
+| `ESTATED_API_KEY` | No | Sprint 3 S3-1 — Estated.io public-records key for the `POST /api/inspections/:id/property-facts/autofill` endpoint. Resolves year built / sqft / foundation / lot size / bedrooms / bathrooms by address. When unset, the endpoint returns `{ data: null, reason: 'NO_API_KEY' }` and the Property Facts card displays a polite "auto-fill not configured" hint while still accepting manual entry. Same graceful-degrade pattern as `GOOGLE_PLACES_API_KEY`. |
 
 ---
 

--- a/migrations/0049_tags.sql
+++ b/migrations/0049_tags.sql
@@ -1,0 +1,35 @@
+-- Sprint 3 S3-3 — T-key Tag system.
+--
+-- Two new tables:
+--   tags                       — tenant-scoped tag library (name + colour, seedable).
+--   inspection_item_tag_links  — many-to-many link between an inspection-item
+--                                position (inspection_id + item_id) and a tag.
+--
+-- Tags are internal-only — they never render on the customer-facing report.
+-- Inspector workflow: T hotkey on inspection-edit opens a picker popover;
+-- multi-select links/unlinks tags onto the active item.
+--
+-- See docs/superpowers/plans/2026-05-08-sprint3-polish-ga.md § S3-3 for the
+-- full design.
+CREATE TABLE tags (
+  id          TEXT    PRIMARY KEY,
+  tenant_id   TEXT    NOT NULL,
+  name        TEXT    NOT NULL,
+  color       TEXT,
+  is_seed     INTEGER NOT NULL DEFAULT 0,
+  created_at  INTEGER NOT NULL,
+  UNIQUE (tenant_id, name)
+);
+CREATE INDEX idx_tags_tenant ON tags(tenant_id);
+
+CREATE TABLE inspection_item_tag_links (
+  inspection_id TEXT    NOT NULL,
+  item_id       TEXT    NOT NULL,
+  tag_id        TEXT    NOT NULL,
+  tenant_id     TEXT    NOT NULL,
+  created_at    INTEGER NOT NULL,
+  PRIMARY KEY (inspection_id, item_id, tag_id)
+);
+CREATE INDEX idx_tag_links_tenant            ON inspection_item_tag_links(tenant_id);
+CREATE INDEX idx_tag_links_inspection_item   ON inspection_item_tag_links(inspection_id, item_id);
+CREATE INDEX idx_tag_links_tag               ON inspection_item_tag_links(tag_id);

--- a/migrations/0051_customer_repair_export.sql
+++ b/migrations/0051_customer_repair_export.sql
@@ -1,0 +1,13 @@
+-- Sprint 3 Track B (S3-2) — Customer-driven Repair Request export.
+--
+-- When enable_customer_repair_export = 1, the public report viewer surfaces
+-- a "Generate repair request" link that takes the customer (the recipient
+-- of the report) to a print-friendly repair-request page they can hand off
+-- to a contractor or email back to themselves. Distinct from the inspector-
+-- facing repair list (Track E1, migration 0044): that list is for inspectors
+-- and realtors, this list is for the homeowner/buyer.
+--
+-- Defaults to 0 so existing tenants don't surface the new affordance until
+-- they explicitly opt in via Settings → Workspace → Reports.
+
+ALTER TABLE tenant_configs ADD COLUMN enable_customer_repair_export INTEGER NOT NULL DEFAULT 0;

--- a/public/js/burst-camera.d.ts
+++ b/public/js/burst-camera.d.ts
@@ -1,0 +1,12 @@
+/**
+ * S3-6 — burst-camera helpers re-exported for unit tests.
+ *
+ * The actual file is plain JS (loaded as a <script> in the browser);
+ * this declaration surfaces the timing constants + pure helper used
+ * by `tests/unit/burst-camera-timing.spec.ts`.
+ */
+export declare const LONG_PRESS_MS: number;
+export declare const BURST_FPS: number;
+export declare const MAX_BURST_FRAMES: number;
+export declare const BURST_INTERVAL_MS: number;
+export declare function burstFrameCount(heldMs: number): number;

--- a/public/js/burst-camera.js
+++ b/public/js/burst-camera.js
@@ -1,0 +1,298 @@
+// S3-6 — AI burst photo capture (Alpine factory + getUserMedia logic).
+//
+// Long-press shutter: distinguishes a single tap (`< LONG_PRESS_MS`)
+// from a sustained press (`>= LONG_PRESS_MS`). Single tap = one
+// frame, hold = burst capped at MAX_BURST_FRAMES @ ~BURST_FPS.
+//
+// Captures live in-memory only; "Done" uploads them via the existing
+// inspectionEditor._uploadBlobAsPhoto path so retry/IDB-queue is honored.
+//
+// Graceful degrade: if `navigator.mediaDevices.getUserMedia` is missing
+// or the user denies the permission, openFor() short-circuits to the
+// existing `#hotkey-photo-input` file picker.
+
+(function () {
+    var LONG_PRESS_MS = 200;        // hold threshold before burst kicks in
+    var BURST_FPS     = 10;         // capped 10 fps so we never exceed 30
+    var MAX_BURST_FRAMES = 30;
+    var BURST_INTERVAL_MS = Math.round(1000 / BURST_FPS);
+
+    /**
+     * Pure timing helper exported for unit tests. Given the ms a press
+     * has been held, returns the count of frames a burst should have
+     * produced (capped at MAX_BURST_FRAMES). Frame N fires at
+     * t = (N-1) * BURST_INTERVAL_MS — i.e. frame 1 immediately, frame 2
+     * at 100 ms, etc. (when BURST_FPS is 10).
+     */
+    function burstFrameCount(heldMs) {
+        if (typeof heldMs !== 'number' || heldMs < 0) return 0;
+        if (heldMs < LONG_PRESS_MS) return 1; // a quick tap is a single shot
+        var frames = 1 + Math.floor(heldMs / BURST_INTERVAL_MS);
+        if (frames > MAX_BURST_FRAMES) frames = MAX_BURST_FRAMES;
+        return frames;
+    }
+
+    // Expose constants + helper so Vitest can import without DOM.
+    if (typeof window !== 'undefined') {
+        window.__BURST_CAMERA = {
+            LONG_PRESS_MS: LONG_PRESS_MS,
+            BURST_FPS: BURST_FPS,
+            MAX_BURST_FRAMES: MAX_BURST_FRAMES,
+            BURST_INTERVAL_MS: BURST_INTERVAL_MS,
+            burstFrameCount: burstFrameCount,
+        };
+    }
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            LONG_PRESS_MS: LONG_PRESS_MS,
+            BURST_FPS: BURST_FPS,
+            MAX_BURST_FRAMES: MAX_BURST_FRAMES,
+            BURST_INTERVAL_MS: BURST_INTERVAL_MS,
+            burstFrameCount: burstFrameCount,
+        };
+    }
+
+    function nextId() {
+        return 'b_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 8);
+    }
+
+    function burstCameraFactory() {
+        return {
+            // ── reactive state (Alpine) ────────────────────────────────
+            open: false,
+            stream: null,
+            burstActive: false,
+            burstCount: 0,
+            captures: [],            // [{ id, blob, url }]
+            facing: 'environment',
+            uploading: false,
+
+            // ── private (don't include in template bindings) ───────────
+            _itemId: null,
+            _pressedAt: 0,
+            _burstTimer: null,
+            _shotCount: 0,
+            _lastUrl: null,
+
+            init() {
+                // Listen for the editor opening the camera. The inspection-edit
+                // page dispatches { detail: { itemId } } when the user wants
+                // to capture for a specific item.
+                window.addEventListener('burst-camera:open', (e) => {
+                    var id = e && e.detail && e.detail.itemId;
+                    if (id) this.openFor(id);
+                });
+            },
+
+            async openFor(itemId) {
+                this._itemId = itemId;
+                if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+                    this._fallback('Camera API unavailable');
+                    return;
+                }
+                try {
+                    // Prefer rear camera; fall back to default if exact-match fails.
+                    let stream;
+                    try {
+                        stream = await navigator.mediaDevices.getUserMedia({
+                            video: { facingMode: { exact: this.facing }, width: { ideal: 1920 }, height: { ideal: 1080 } },
+                            audio: false,
+                        });
+                    } catch (_) {
+                        stream = await navigator.mediaDevices.getUserMedia({
+                            video: { facingMode: this.facing, width: { ideal: 1920 }, height: { ideal: 1080 } },
+                            audio: false,
+                        });
+                    }
+                    this.stream = stream;
+                    this.$refs.video.srcObject = stream;
+                    this.captures = [];
+                    this._shotCount = 0;
+                    this.open = true;
+                } catch (e) {
+                    this._fallback('Camera permission denied');
+                }
+            },
+
+            close() {
+                this._stopBurst();
+                if (this.stream) {
+                    try { this.stream.getTracks().forEach(function (t) { t.stop(); }); } catch (_) { /* ignore */ }
+                    this.stream = null;
+                }
+                if (this.$refs && this.$refs.video) {
+                    try { this.$refs.video.srcObject = null; } catch (_) { /* ignore */ }
+                }
+                // Revoke object URLs so we don't leak preview blobs.
+                this.captures.forEach(function (c) { try { URL.revokeObjectURL(c.url); } catch (_) {} });
+                this.captures = [];
+                this._itemId = null;
+                this.uploading = false;
+                this.open = false;
+            },
+
+            async switchFacing() {
+                this.facing = this.facing === 'environment' ? 'user' : 'environment';
+                if (!this.open) return;
+                if (this.stream) {
+                    try { this.stream.getTracks().forEach(function (t) { t.stop(); }); } catch (_) {}
+                }
+                try {
+                    var stream = await navigator.mediaDevices.getUserMedia({
+                        video: { facingMode: this.facing, width: { ideal: 1920 }, height: { ideal: 1080 } },
+                        audio: false,
+                    });
+                    this.stream = stream;
+                    this.$refs.video.srcObject = stream;
+                } catch (_) { /* keep prior stream alive — user can close */ }
+            },
+
+            // ── shutter handlers ───────────────────────────────────────
+            onShutterDown() {
+                this._pressedAt = Date.now();
+                // Start a "long-press intent" timer: if still pressed at
+                // LONG_PRESS_MS, switch into burst mode.
+                this._longPressTimer = setTimeout(() => { this._beginBurst(); }, LONG_PRESS_MS);
+            },
+
+            onShutterUp() {
+                var heldMs = Date.now() - this._pressedAt;
+                if (this._longPressTimer) { clearTimeout(this._longPressTimer); this._longPressTimer = null; }
+                if (this.burstActive) {
+                    this._stopBurst();
+                } else if (heldMs < LONG_PRESS_MS) {
+                    this._captureFrame();
+                }
+                this._pressedAt = 0;
+            },
+
+            onShutterCancel() {
+                if (this._longPressTimer) { clearTimeout(this._longPressTimer); this._longPressTimer = null; }
+                if (this.burstActive) this._stopBurst();
+                this._pressedAt = 0;
+            },
+
+            _beginBurst() {
+                if (this.burstActive) return;
+                this.burstActive = true;
+                this.burstCount = 0;
+                this._captureFrame();         // first frame immediately
+                this._burstTimer = setInterval(() => {
+                    if (this._shotCount >= MAX_BURST_FRAMES || this.captures.length >= MAX_BURST_FRAMES) {
+                        this._stopBurst();
+                        return;
+                    }
+                    this._captureFrame();
+                }, BURST_INTERVAL_MS);
+            },
+
+            _stopBurst() {
+                if (this._burstTimer) { clearInterval(this._burstTimer); this._burstTimer = null; }
+                this.burstActive = false;
+            },
+
+            _captureFrame() {
+                var video = this.$refs && this.$refs.video;
+                var canvas = this.$refs && this.$refs.canvas;
+                if (!video || !canvas || !video.videoWidth) return;
+                canvas.width = video.videoWidth;
+                canvas.height = video.videoHeight;
+                var ctx = canvas.getContext('2d');
+                if (!ctx) return;
+                ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+                var self = this;
+                canvas.toBlob(function (blob) {
+                    if (!blob) return;
+                    var id = nextId();
+                    var url = URL.createObjectURL(blob);
+                    self.captures.push({ id: id, blob: blob, url: url });
+                    self._shotCount++;
+                    self.burstCount = self._shotCount;
+                }, 'image/jpeg', 0.85);
+            },
+
+            discardOne(id) {
+                var idx = -1;
+                for (var i = 0; i < this.captures.length; i++) {
+                    if (this.captures[i].id === id) { idx = i; break; }
+                }
+                if (idx === -1) return;
+                try { URL.revokeObjectURL(this.captures[idx].url); } catch (_) { /* ignore */ }
+                this.captures.splice(idx, 1);
+            },
+
+            discardAll() {
+                this.captures.forEach(function (c) { try { URL.revokeObjectURL(c.url); } catch (_) {} });
+                this.captures = [];
+                this._shotCount = 0;
+                this.burstCount = 0;
+            },
+
+            async commit() {
+                if (this.uploading || this.captures.length === 0 || !this._itemId) return;
+                this.uploading = true;
+                var editor = null;
+                try {
+                    var host = document.querySelector('[x-data*="inspectionEditor"]');
+                    if (host && window.Alpine && typeof window.Alpine.$data === 'function') {
+                        editor = window.Alpine.$data(host);
+                    }
+                } catch (_) { /* fall through */ }
+
+                for (var i = 0; i < this.captures.length; i++) {
+                    var cap = this.captures[i];
+                    try {
+                        if (editor && typeof editor._uploadBlobAsPhoto === 'function') {
+                            await editor._uploadBlobAsPhoto(this._itemId, cap.blob);
+                        } else {
+                            await this._uploadDirect(this._itemId, cap.blob);
+                        }
+                    } catch (e) {
+                        console.error('Burst upload failed:', e);
+                        if (typeof showToast === 'function') showToast('Upload failed for one frame.', true);
+                    }
+                }
+                this.close();
+            },
+
+            async _uploadDirect(itemId, blob) {
+                // Fallback path when the inspectionEditor instance is not
+                // reachable. Hits the same endpoint inspection-edit.js uses.
+                var fd = new FormData();
+                var fileName = 'burst-' + Date.now() + '.jpg';
+                fd.append('file', blob, fileName);
+                fd.append('itemId', itemId);
+                var fetcher = (typeof window !== 'undefined' && typeof window.authFetch === 'function')
+                    ? window.authFetch
+                    : (typeof authFetch === 'function' ? authFetch : window.fetch.bind(window));
+                var inspectionId = (window.__OI_INSPECTION_ID || (document.body && document.body.getAttribute('data-inspection-id')) || '').toString();
+                if (!inspectionId) return;
+                await fetcher('/api/inspections/' + encodeURIComponent(inspectionId) + '/upload', {
+                    method: 'POST',
+                    body: fd,
+                });
+            },
+
+            _fallback(reason) {
+                this.open = false;
+                if (typeof showToast === 'function') showToast('Camera unavailable — opening file picker.');
+                var input = document.getElementById('hotkey-photo-input');
+                if (input) input.click();
+            },
+        };
+    }
+
+    function register() {
+        if (typeof window === 'undefined' || !window.Alpine) return;
+        try {
+            window.Alpine.data('burstCamera', burstCameraFactory);
+        } catch (_) { /* already registered */ }
+    }
+    // Guard so unit-test env (node, no document) can `import` this file.
+    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+        document.addEventListener('alpine:init', register);
+    }
+    if (typeof window !== 'undefined' && window.Alpine && typeof window.Alpine.data === 'function') {
+        register();
+    }
+})();

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -27,12 +27,175 @@ function calendarMeta() {
 document.addEventListener('alpine:init', () => window.Alpine.data('calendarMeta', calendarMeta));
 window.calendarMeta = calendarMeta;
 
+// ─── Sprint 3 · S3-9 — Drag-drop reschedule helpers ─────────────────────────
+//
+// Pure helpers mirrored from src/lib/calendar-conflict.ts so the browser can
+// run them without bundling. The TS unit tests cover the canonical version;
+// keep this in sync when changing the algorithm.
+//
+// `sameDayHour` matches if both inputs fall on the same UTC calendar day and
+// the same UTC hour. YYYY-MM-DD inputs are treated as full-day occupants.
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function calendarSameDayHour(a, b) {
+    if (!a || !b) return false;
+    const aDateOnly = DATE_ONLY_RE.test(a);
+    const bDateOnly = DATE_ONLY_RE.test(b);
+    const aDate = aDateOnly ? new Date(a + 'T00:00:00Z') : new Date(a);
+    const bDate = bDateOnly ? new Date(b + 'T00:00:00Z') : new Date(b);
+    if (Number.isNaN(aDate.getTime()) || Number.isNaN(bDate.getTime())) return false;
+    const sameDay = aDate.getUTCFullYear() === bDate.getUTCFullYear()
+        && aDate.getUTCMonth() === bDate.getUTCMonth()
+        && aDate.getUTCDate()  === bDate.getUTCDate();
+    if (!sameDay) return false;
+    if (aDateOnly || bDateOnly) return true;
+    return aDate.getUTCHours() === bDate.getUTCHours();
+}
+
+function findConflict(events, targetIso, ignoreId) {
+    for (const ev of events) {
+        if (!ev || ev.id === ignoreId) continue;
+        // Skip Google read-only events — they aren't ours to bump.
+        if (ev.extendedProps && ev.extendedProps.source === 'google') continue;
+        const evIso = typeof ev.startStr === 'string' && ev.startStr
+            ? ev.startStr
+            : (ev.start instanceof Date ? ev.start.toISOString() : ev.start);
+        if (calendarSameDayHour(evIso, targetIso)) return ev;
+    }
+    return null;
+}
+
+function formatSlotLabel(iso) {
+    if (!iso) return '';
+    const d = DATE_ONLY_RE.test(iso) ? new Date(iso + 'T00:00:00Z') : new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    if (DATE_ONLY_RE.test(iso)) {
+        return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    }
+    return d.toLocaleString(undefined, {
+        weekday: 'short', month: 'short', day: 'numeric',
+        hour: 'numeric', minute: '2-digit',
+    });
+}
+
+// PATCH helper. Returns {ok: boolean, status: number}
+async function patchInspectionDate(id, newIso) {
+    try {
+        const res = await authFetch('/api/inspections/' + encodeURIComponent(id), {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ date: newIso }),
+        });
+        return { ok: res.ok, status: res.status };
+    } catch (err) {
+        return { ok: false, status: 0 };
+    }
+}
+
+// ─── Sprint 3 · S3-9 — Conflict modal Alpine data ───────────────────────────
+function calendarConflict() {
+    return {
+        open:          false,
+        busy:          false,
+        conflictTitle: '',
+        targetLabel:   '',
+        // Pending drop context — populated when the modal opens.
+        _draggedId:    null,
+        _draggedOldIso:null,
+        _draggedNewIso:null,
+        _conflictId:   null,
+        _conflictIso:  null,
+        _revert:       null,
+        _onResolved:   null,
+
+        prompt(payload) {
+            this._draggedId     = payload.draggedId;
+            this._draggedOldIso = payload.draggedOldIso;
+            this._draggedNewIso = payload.draggedNewIso;
+            this._conflictId    = payload.conflictId;
+            this._conflictIso   = payload.conflictIso;
+            this._revert        = payload.revert;
+            this._onResolved    = payload.onResolved;
+            this.conflictTitle  = payload.conflictTitle || 'Another inspection';
+            this.targetLabel    = formatSlotLabel(payload.draggedNewIso);
+            this.busy           = false;
+            this.open           = true;
+        },
+
+        cancel() {
+            if (this.busy) return;
+            try { if (this._revert) this._revert(); } catch {}
+            this._reset();
+            this.open = false;
+        },
+
+        async resolve(action) {
+            if (this.busy) return;
+            this.busy = true;
+
+            // Replace = move conflict back to dragged's old slot.
+            // Swap    = move dragged to new slot AND conflict to dragged's old slot.
+            // The dragged event has already been visually moved by FullCalendar
+            // before eventDrop fires; both branches PATCH it to confirm the move
+            // and PATCH the conflict to its new slot.
+            const patchDragged  = patchInspectionDate(this._draggedId,  this._draggedNewIso);
+            const patchConflict = patchInspectionDate(this._conflictId, this._draggedOldIso);
+            const [a, b] = await Promise.all([patchDragged, patchConflict]);
+
+            this.busy = false;
+            if (!a.ok || !b.ok) {
+                // Roll back: revert the drag. The conflict event's position is
+                // controlled by the underlying data, not the drag, so a refetch
+                // restores it.
+                try { if (this._revert) this._revert(); } catch {}
+                if (typeof showToast === 'function') showToast('Reschedule failed', true);
+                if (this._onResolved) this._onResolved({ ok: false });
+                this._reset();
+                this.open = false;
+                return;
+            }
+
+            if (typeof showToast === 'function') {
+                showToast(action === 'swap' ? 'Inspections swapped' : 'Inspection rescheduled');
+            }
+            if (this._onResolved) this._onResolved({ ok: true, action });
+            this._reset();
+            this.open = false;
+        },
+
+        _reset() {
+            this._draggedId = this._draggedOldIso = this._draggedNewIso = null;
+            this._conflictId = this._conflictIso = null;
+            this._revert = this._onResolved = null;
+        },
+    };
+}
+document.addEventListener('alpine:init', () => window.Alpine.data('calendarConflict', calendarConflict));
+window.calendarConflict = calendarConflict;
+
+// Export pure helpers on window so the FullCalendar handler (which runs
+// outside Alpine) can reuse them, and so manual smoke tests can call them
+// from the browser console.
+window._calendar = window._calendar || {};
+window._calendar.sameDayHour     = calendarSameDayHour;
+window._calendar.findConflict    = findConflict;
+window._calendar.formatSlotLabel = formatSlotLabel;
+window._calendar.patchInspectionDate = patchInspectionDate;
+
 document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
     if (!calendarEl) return;
     if (typeof FullCalendar === 'undefined') {
         console.error('FullCalendar not loaded');
         return;
+    }
+
+    // Reach into the conflict modal Alpine data once the modal is mounted.
+    function getConflictModal() {
+        var el = document.querySelector('[x-data="calendarConflict"]');
+        if (!el || !window.Alpine) return null;
+        return window.Alpine.$data(el);
     }
 
     var calendar = new FullCalendar.Calendar(calendarEl, {
@@ -45,6 +208,21 @@ document.addEventListener('DOMContentLoaded', function() {
         },
         height: 'auto',
         nowIndicator: true,
+
+        // Sprint 3 · S3-9 — drag-drop reschedule.
+        editable:              true,
+        eventDurationEditable: false,
+        // Allow dragging local inspection events; Google events stay read-only.
+        eventAllow: function(_dropInfo, draggedEvent) {
+            const src = draggedEvent.extendedProps && draggedEvent.extendedProps.source;
+            return src !== 'google';
+        },
+        // Mobile: long-press to start drag. FullCalendar uses Pointer Events
+        // under the hood; `longPressDelay` enables press-and-hold drag start
+        // on touch devices, matching the iOS/Android home-screen mental model.
+        longPressDelay: 500,
+        selectLongPressDelay: 500,
+
         events: function(info, successCallback, failureCallback) {
             authFetch('/api/calendar/events?start=' + encodeURIComponent(info.startStr) + '&end=' + encodeURIComponent(info.endStr))
                 .then(function(res) {
@@ -55,6 +233,59 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (data) successCallback(data);
                 })
                 .catch(failureCallback);
+        },
+        eventDrop: async function(info) {
+            // Don't accept drops on read-only Google events (also blocked by eventAllow).
+            if (info.event.extendedProps && info.event.extendedProps.source === 'google') {
+                info.revert();
+                return;
+            }
+
+            const draggedId      = info.event.id;
+            const draggedNewIso  = info.event.start ? info.event.start.toISOString() : null;
+            const draggedOldIso  = info.oldEvent && info.oldEvent.start ? info.oldEvent.start.toISOString() : null;
+
+            if (!draggedNewIso) {
+                info.revert();
+                if (typeof showToast === 'function') showToast('Could not parse new date', true);
+                return;
+            }
+
+            // Conflict check across currently-rendered events (excluding the
+            // dragged event itself).
+            const allEvents = calendar.getEvents();
+            const conflict  = findConflict(allEvents, draggedNewIso, draggedId);
+
+            if (conflict) {
+                const modal = getConflictModal();
+                if (!modal) {
+                    // Modal markup not present — fall back to revert + toast.
+                    info.revert();
+                    if (typeof showToast === 'function') showToast('Time slot taken', true);
+                    return;
+                }
+                modal.prompt({
+                    draggedId:      draggedId,
+                    draggedOldIso:  draggedOldIso,
+                    draggedNewIso:  draggedNewIso,
+                    conflictId:     conflict.id,
+                    conflictIso:    conflict.startStr || (conflict.start && conflict.start.toISOString()),
+                    conflictTitle:  conflict.title,
+                    revert:         function() { info.revert(); },
+                    onResolved:     function(_result) { calendar.refetchEvents(); },
+                });
+                return;
+            }
+
+            // No conflict — optimistic UI: card has already moved. PATCH and
+            // snap back on error.
+            const result = await patchInspectionDate(draggedId, draggedNewIso);
+            if (!result.ok) {
+                info.revert();
+                if (typeof showToast === 'function') showToast('Reschedule failed', true);
+                return;
+            }
+            if (typeof showToast === 'function') showToast('Inspection rescheduled');
         },
         eventClick: function(info) {
             // Google events are read-only — no navigation

--- a/public/js/customer-repair-request.js
+++ b/public/js/customer-repair-request.js
@@ -1,0 +1,95 @@
+/**
+ * Sprint 3 Track B (S3-2) — Customer Repair Request page (Alpine factory).
+ *
+ * Owns the state for the public `/inspections/:id/customer-repair-request`
+ * export page:
+ *   - per-item textarea notes (collected into a single payload before send)
+ *   - recipient email input + submit
+ *   - toast-style status feedback (success / error)
+ *
+ * Posts to POST /api/public/repair-request/email; the endpoint mirrors the
+ * gating used by `/report/:id` (shared subdomain → same tenant resolution
+ * → payment + agreement gate). No JWT required — the page is public.
+ */
+document.addEventListener('alpine:init', function () {
+    window.Alpine.data('customerRepairRequest', function (initial) {
+        return {
+            inspectionId: initial.inspectionId,
+            recipientEmail: initial.recipientEmail || '',
+            items: initial.items || [],
+            itemNotes: {},
+            sending: false,
+            toast: '',
+            toastError: false,
+
+            init() {
+                // Pre-seed itemNotes keys so the payload always contains the
+                // same shape (one entry per defect, possibly empty string).
+                for (const it of this.items) {
+                    if (!Object.prototype.hasOwnProperty.call(this.itemNotes, it.itemId)) {
+                        this.itemNotes[it.itemId] = '';
+                    }
+                }
+            },
+
+            buildCustomerComments() {
+                // Concatenate the per-item textarea notes into a single
+                // human-readable string the backend can attach to the email.
+                // Skips empty entries.
+                const lines = [];
+                for (const it of this.items) {
+                    const note = (this.itemNotes[it.itemId] || '').trim();
+                    if (!note) continue;
+                    const heading = (it.sectionTitle || '') + ' › ' + (it.itemLabel || '');
+                    lines.push(heading + ': ' + note);
+                }
+                return lines.join('\n');
+            },
+
+            isValidEmail(s) {
+                if (!s) return false;
+                // Lightweight client-side check; the server uses Zod email().
+                return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s));
+            },
+
+            async sendEmail() {
+                if (this.sending) return;
+                if (!this.isValidEmail(this.recipientEmail)) {
+                    this.toast = 'Please enter a valid email address.';
+                    this.toastError = true;
+                    return;
+                }
+                this.sending = true;
+                this.toast = '';
+                this.toastError = false;
+                try {
+                    const body = {
+                        inspectionId: this.inspectionId,
+                        recipientEmail: this.recipientEmail,
+                        customerComments: this.buildCustomerComments(),
+                    };
+                    const res = await fetch('/api/public/repair-request/email', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(body),
+                    });
+                    const json = await res.json().catch(function () { return null; });
+                    if (!res.ok || !json || json.success !== true) {
+                        const msg = (json && json.error && json.error.message) || 'Email could not be sent.';
+                        this.toast = msg;
+                        this.toastError = true;
+                        return;
+                    }
+                    this.toast = 'Repair request sent. Check your inbox.';
+                    this.toastError = false;
+                } catch (err) {
+                    this.toast = 'Network error. Please try again.';
+                    this.toastError = true;
+                } finally {
+                    this.sending = false;
+                }
+            },
+        };
+    });
+});

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -700,6 +700,14 @@ function dashboardFactory() {
         // collapses to a single flat list filtered in-memory.
         activeFilter: 'all',
         filterOptions: INSPECTION_FILTERS,
+        // Sprint 3 S3-3 — secondary tag filter. Combines with `activeFilter`
+        // (intersection) so the inspector can scope to "today + Critical".
+        // `tagFilterIds` is the resolved set of inspection ids that have at
+        // least one item linked to the active tag — populated lazily by
+        // onTagFilterChange().
+        activeTagFilter: '',
+        availableTags: [],
+        tagFilterIds: null, // null when no tag selected; Set<string> when active
         // Spec 4D.T10 — Today's events bucket
         todayEvents: [],
         eventTypes: [],
@@ -709,6 +717,42 @@ function dashboardFactory() {
         async init() {
             await this.reload();
             window.addEventListener('inspection-updated', () => this.reload());
+            // Sprint 3 S3-3 — populate the tag filter dropdown. Best-effort —
+            // a 4xx response (no permission) leaves the dropdown empty.
+            try {
+                const tagsRes = await fetch('/api/tags', { credentials: 'include' });
+                if (tagsRes.ok) {
+                    const json = await tagsRes.json().catch(function () { return null; });
+                    this.availableTags = (json && json.data) || [];
+                }
+            } catch (_) { /* silent */ }
+        },
+
+        async onTagFilterChange() {
+            const tagId = this.activeTagFilter || '';
+            if (!tagId) { this.tagFilterIds = null; return; }
+            try {
+                const res = await fetch('/api/tags/' + encodeURIComponent(tagId) + '/inspections', { credentials: 'include' });
+                if (!res.ok) { this.tagFilterIds = new Set(); return; }
+                const json = await res.json().catch(function () { return null; });
+                const ids = (json && json.data && json.data.inspectionIds) || [];
+                this.tagFilterIds = new Set(ids);
+                // If user is on the 'all' filter, switch to a flat list view so
+                // the tag-filtered set is actually visible.
+                if (this.activeFilter === 'all') this.activeFilter = 'today';
+            } catch (_) {
+                this.tagFilterIds = new Set();
+            }
+        },
+
+        /** True when the inspection passes BOTH the active time filter and
+         *  the tag filter (when set). Used by filteredInspections + counts. */
+        _passesAllActiveFilters(insp, timeFilter, now) {
+            if (!matchesInspectionFilter(insp, timeFilter, now)) return false;
+            if (this.tagFilterIds) {
+                if (!insp || !insp.id || !this.tagFilterIds.has(insp.id)) return false;
+            }
+            return true;
         },
 
         async reload() {
@@ -854,10 +898,13 @@ function dashboardFactory() {
         // Inspections matching the currently active non-'all' filter, sorted
         // by inspection date ascending (closest first). Stable enough that
         // re-renders don't shuffle rows when the same data reloads.
+        // Sprint 3 S3-3 — also intersects with the active tag filter when set.
+        // When only the tag filter is active (time = all), return the tag set.
         get filteredInspections() {
-            if (this.activeFilter === 'all') return [];
+            const tagActive = !!this.tagFilterIds;
+            if (this.activeFilter === 'all' && !tagActive) return [];
             const now = new Date();
-            const list = this._allInspections.filter(i => matchesInspectionFilter(i, this.activeFilter, now));
+            const list = this._allInspections.filter((i) => this._passesAllActiveFilters(i, this.activeFilter, now));
             list.sort((a, b) => {
                 const da = a && a.date ? new Date(a.date).getTime() : 0;
                 const db = b && b.date ? new Date(b.date).getTime() : 0;

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -75,6 +75,12 @@ function inspectionEditor(inspectionId) {
     publishing: false,
     sendingPdf: false,
     isDesktop: window.innerWidth >= 1024,
+    // Sprint 3 S3-4 — drawer state for the 1024-1279 tablet zone. The
+    // persistent right ACTIVE ITEM pane only renders at xl (≥1280); on a
+    // tablet the inspector taps the "Inspector" button in the toolbar to
+    // slide this drawer in. Defaults closed; auto-closes when the viewport
+    // grows past xl (no need for the drawer + persistent pane to coexist).
+    tabletInspectorOpen: false,
     saveTimer: null,
     saveState: 'idle',
     // Round 32 — one-time mobile gesture-discovery hint for R23 swipe nav
@@ -135,6 +141,13 @@ function inspectionEditor(inspectionId) {
 
       window.addEventListener('resize', () => {
         this.isDesktop = window.innerWidth >= 1024;
+        // Sprint 3 S3-4 — auto-close the tablet drawer when the viewport
+        // grows past xl (≥1280). At that width the persistent right pane
+        // takes over; keeping the drawer open would double-render its
+        // content over top of the persistent pane.
+        if (window.innerWidth >= 1280 && this.tabletInspectorOpen) {
+          this.tabletInspectorOpen = false;
+        }
       });
 
       // Spec 5G M1.1 mobile — horizontal swipe between sections (analog of

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -1765,11 +1765,21 @@ function inspectionEditor(inspectionId) {
     async uploadPhoto(itemId, event) {
       var file = event.target.files && event.target.files[0];
       if (!file) return;
+      await this._uploadBlobAsPhoto(itemId, file);
+    },
+
+    // S3-6 — shared upload path used by both <input type=file> and the
+    // burst camera modal. Accepts a Blob (or File) and resolves once the
+    // POST completes. On success, appends `{ key }` to results[itemId]
+    // .photos and triggers the debounced save. Errors are swallowed and
+    // logged — the surrounding caller surfaces a toast.
+    async _uploadBlobAsPhoto(itemId, blob) {
+      if (!blob || !itemId) return;
       var formData = new FormData();
-      // Server endpoint is POST /api/inspections/:id/upload with form field
-      // 'file' + 'itemId' (see src/api/inspections.ts:760). Earlier client
-      // versions used /photos + 'photo' which 404'd silently.
-      formData.append('file', file);
+      // Server endpoint is POST /api/inspections/:id/upload with form
+      // field 'file' + 'itemId' (see src/api/inspections.ts:760).
+      var fileName = (blob && blob.name) || ('photo-' + Date.now() + '.jpg');
+      formData.append('file', blob, fileName);
       formData.append('itemId', itemId);
       try {
         var res = await authFetch('/api/inspections/' + this.inspectionId + '/upload', {
@@ -1778,12 +1788,31 @@ function inspectionEditor(inspectionId) {
         });
         if (res.ok) {
           var json = await res.json();
+          if (!this.results[itemId]) this.results[itemId] = {};
           if (!this.results[itemId].photos) this.results[itemId].photos = [];
           this.results[itemId].photos.push({ key: json.data.key });
           this.debounceSave();
+        } else {
+          if (typeof showToast === 'function') showToast('Photo upload failed.', true);
         }
       } catch (e) {
         console.error('Photo upload failed:', e);
+        if (typeof showToast === 'function') showToast('Photo upload network error.', true);
+      }
+    },
+
+    // S3-6 — open the burst-camera modal for this item. Dispatches a
+    // window event the burstCamera factory listens for. If camera APIs
+    // are missing or denied, the modal itself falls back to the native
+    // <input capture> picker.
+    openBurstCamera(itemId) {
+      try {
+        window.dispatchEvent(new CustomEvent('burst-camera:open', { detail: { itemId: itemId } }));
+      } catch (e) {
+        // Older browsers without CustomEvent constructor — fall back to
+        // the file picker directly.
+        var input = document.getElementById('hotkey-photo-input');
+        if (input) input.click();
       }
     },
 

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -88,6 +88,18 @@ function inspectionEditor(inspectionId) {
     quickRatingItemId: null, // when long-press fires, target item id
     showQuickRating: false,  // bottom-sheet visibility
     showCheatsheet: false,   // ? HUD visibility (mobile menu button + desktop ?)
+    // Sprint 3 S3-3 — T-key tag picker state. `tagsLibrary` holds all tenant
+    // tags (lazy-loaded once via loadTagsIfNeeded). `tagsByItem` is a map
+    // of itemId → Tag[] hydrated by the bulk /api/inspections/:id/tags
+    // endpoint when the editor mounts. The picker popover toggles via
+    // `tagPickerOpen`; `tagPickerItemId` is the active target.
+    tagsLibrary: [],
+    tagsLibraryLoaded: false,
+    tagsByItem: {},
+    tagPickerOpen: false,
+    tagPickerItemId: null,
+    tagPickerQuery: '',
+    tagSavingId: null, // tag id currently being toggled (loading indicator)
     slashPickerOpen: false,  // slash-trigger inline popover state — used to
                              // hide the right ACTIVE ITEM pane while open
                              // (avoids duplicate canned-comment list).
@@ -313,10 +325,16 @@ function inspectionEditor(inspectionId) {
           this.openCommentLibrary('my-snippets');
           return;
         }
-        // T = tag (stub — no tag schema yet)
+        // T = open tag picker for the active item (Sprint 3 S3-3).
+        // The picker is an Alpine popover registered alongside this editor;
+        // we drive it via the shared `tagPicker*` state on this same scope.
         if (e.key === 't' || e.key === 'T') {
           e.preventDefault();
-          if (typeof showToast === 'function') showToast('Tags coming soon');
+          if (!this.activeItemId) {
+            if (typeof showToast === 'function') showToast('Select an item first to add a tag');
+            return;
+          }
+          this.openTagPicker(this.activeItemId);
           return;
         }
         // Navigation: ArrowUp / ArrowDown move active item up/down,
@@ -485,6 +503,18 @@ function inspectionEditor(inspectionId) {
             }
           }
         }
+
+        // Sprint 3 S3-3 — hydrate tag chips alongside results so each item
+        // card renders with its existing labels. Best-effort: a 4xx response
+        // (rare — happens on unauthenticated edge cases) leaves the chips
+        // empty, and the T-key picker re-fetches when first opened.
+        try {
+          var tagsRes = await authFetch('/api/inspections/' + this.inspectionId + '/tags');
+          if (tagsRes.ok) {
+            var tJson = await tagsRes.json();
+            this.tagsByItem = (tJson && tJson.data) || {};
+          }
+        } catch (_) { /* swallow — picker will retry on open */ }
       } catch (e) {
         console.error('Failed to load inspection data:', e);
       }
@@ -1350,7 +1380,143 @@ function inspectionEditor(inspectionId) {
       if (typeof showToast === 'function') showToast('Section: ' + (sec.title || sec.name || ('#' + idx)));
     },
 
-    // Sprint 1 A-9: Fuzzy section picker. Opens via G then S leader-keys.
+    // ─── Sprint 3 S3-3 — Tag picker ────────────────────────────────
+    async loadTagsIfNeeded() {
+      if (this.tagsLibraryLoaded) return;
+      try {
+        const [libRes, mapRes] = await Promise.all([
+          authFetch('/api/tags'),
+          authFetch('/api/inspections/' + encodeURIComponent(this.inspectionId) + '/tags'),
+        ]);
+        if (libRes.ok) {
+          const j = await libRes.json();
+          this.tagsLibrary = (j && j.data) || [];
+        }
+        if (mapRes.ok) {
+          const j = await mapRes.json();
+          this.tagsByItem = (j && j.data) || {};
+        }
+        this.tagsLibraryLoaded = true;
+      } catch (e) {
+        console.error('Failed to load tags', e);
+      }
+    },
+
+    openTagPicker(itemId) {
+      this.tagPickerItemId = itemId;
+      this.tagPickerQuery = '';
+      this.tagPickerOpen = true;
+      this.loadTagsIfNeeded();
+      const self = this;
+      setTimeout(function () {
+        const input = document.getElementById('tag-picker-input');
+        if (input) input.focus();
+      }, 50);
+    },
+
+    closeTagPicker() {
+      this.tagPickerOpen = false;
+      this.tagPickerItemId = null;
+      this.tagPickerQuery = '';
+    },
+
+    /** Tags currently linked to a single item (defensive copy via spread). */
+    getItemTags(itemId) {
+      if (!itemId) return [];
+      return (this.tagsByItem && this.tagsByItem[itemId]) || [];
+    },
+
+    /** True when `tag` is linked to the active picker item. */
+    isTagLinked(tag) {
+      if (!this.tagPickerItemId || !tag) return false;
+      const links = this.getItemTags(this.tagPickerItemId);
+      return links.some(function (t) { return t.id === tag.id; });
+    },
+
+    /** Filter tag library by the picker query (case-insensitive substring). */
+    get filteredTagsForPicker() {
+      const q = (this.tagPickerQuery || '').toLowerCase().trim();
+      const src = this.tagsLibrary || [];
+      if (!q) return src;
+      return src.filter(function (t) {
+        return (t.name || '').toLowerCase().indexOf(q) !== -1;
+      });
+    },
+
+    async toggleTag(tag) {
+      if (!this.tagPickerItemId || !tag || this.tagSavingId) return;
+      this.tagSavingId = tag.id;
+      const itemId = this.tagPickerItemId;
+      const inspectionId = this.inspectionId;
+      const linked = this.isTagLinked(tag);
+      try {
+        let res;
+        if (linked) {
+          res = await authFetch(
+            '/api/inspections/' + encodeURIComponent(inspectionId)
+            + '/items/' + encodeURIComponent(itemId)
+            + '/tags/' + encodeURIComponent(tag.id),
+            { method: 'DELETE' }
+          );
+        } else {
+          res = await authFetch(
+            '/api/inspections/' + encodeURIComponent(inspectionId)
+            + '/items/' + encodeURIComponent(itemId)
+            + '/tags',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ tagId: tag.id }),
+            }
+          );
+        }
+        if (!res.ok) {
+          if (typeof showToast === 'function') showToast('Tag update failed', true);
+          return;
+        }
+        // Optimistic local update — keep tagsByItem in sync.
+        const current = this.getItemTags(itemId).slice();
+        if (linked) {
+          this.tagsByItem[itemId] = current.filter(function (t) { return t.id !== tag.id; });
+        } else {
+          this.tagsByItem[itemId] = current.concat([tag]).sort(function (a, b) { return (a.name || '').localeCompare(b.name || ''); });
+        }
+      } catch (e) {
+        if (typeof showToast === 'function') showToast('Network error', true);
+      } finally {
+        this.tagSavingId = null;
+      }
+    },
+
+    /** Inline removal of a chip on an item card. */
+    async removeItemTag(itemId, tagId) {
+      if (!itemId || !tagId) return;
+      try {
+        const res = await authFetch(
+          '/api/inspections/' + encodeURIComponent(this.inspectionId)
+          + '/items/' + encodeURIComponent(itemId)
+          + '/tags/' + encodeURIComponent(tagId),
+          { method: 'DELETE' }
+        );
+        if (!res.ok) {
+          if (typeof showToast === 'function') showToast('Failed to remove tag', true);
+          return;
+        }
+        const current = (this.tagsByItem[itemId] || []).slice();
+        this.tagsByItem[itemId] = current.filter(function (t) { return t.id !== tagId; });
+      } catch (e) {
+        if (typeof showToast === 'function') showToast('Network error', true);
+      }
+    },
+
+    onTagPickerKeydown(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        this.closeTagPicker();
+      }
+    },
+
+    /** Sprint 1 A-9: Fuzzy section picker. Opens via G then S leader-keys. */
     openSectionPicker() {
       this.sectionPickerOpen = true;
       this.sectionPickerQuery = '';

--- a/public/js/inspection-settings.js
+++ b/public/js/inspection-settings.js
@@ -47,6 +47,12 @@ document.addEventListener('alpine:init', () => {
         },
         factsState: 'idle', // 'idle' | 'saving' | 'saved' | 'error'
         factsTimer: null,
+        // Sprint 3 S3-1 — Property auto-fill. `propertyAddress` is hydrated
+        // from the inspection on load() so the autofill button can pass it
+        // to the server-side proxy. `autofillState` drives the spinner.
+        propertyAddress: '',
+        autofillState: 'idle', // 'idle' | 'pending' | 'success' | 'no_key' | 'not_found' | 'error'
+        autofillMessage: '',
 
         // Round-2 F3 — People card payload. Loaded from
         // /api/inspections/:id/people; rendered by the PeopleCard component.
@@ -84,6 +90,7 @@ document.addEventListener('alpine:init', () => {
                 this.form.date = (insp.date || '').slice(0, 10);
                 this.form.inspectorId = insp.inspectorId || '';
                 this.form.templateId = insp.templateId || '';
+                this.propertyAddress = insp.propertyAddress || '';
                 this.form.price = Number(insp.price || 0);
                 this.form.paymentRequired = !!insp.paymentRequired;
                 this.form.agreementRequired = !!insp.agreementRequired;
@@ -168,6 +175,85 @@ document.addEventListener('alpine:init', () => {
             } catch (e) {
                 console.error('saveFact failed', e);
                 this.factsState = 'error';
+            }
+        },
+
+        // Sprint 3 S3-1 — Auto-fill from public records (Estated.io proxy).
+        // Calls /api/inspections/:id/property-facts/autofill with the saved
+        // property address. The server returns mapped facts or a
+        // graceful-degrade reason. Each non-empty incoming field is patched
+        // via the existing PATCH /property-facts handler — preserving any
+        // values the inspector has already typed (we never overwrite a
+        // non-empty manual entry).
+        async autofillFromAddress() {
+            if (!this.propertyAddress || this.propertyAddress.length < 5) {
+                this.autofillState = 'error';
+                this.autofillMessage = 'No address on file. Edit it first.';
+                return;
+            }
+            this.autofillState = 'pending';
+            this.autofillMessage = '';
+            try {
+                const res = await window.authFetch(
+                    '/api/inspections/' + this.inspectionId + '/property-facts/autofill',
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ addressString: this.propertyAddress }),
+                    },
+                );
+                const json = await res.json().catch(function () { return null; });
+                if (!res.ok) {
+                    this.autofillState = 'error';
+                    this.autofillMessage = (json && json.error && json.error.message) || ('HTTP ' + res.status);
+                    return;
+                }
+                const data = (json && json.data) || {};
+                if (!data.facts) {
+                    if (data.reason === 'NO_API_KEY') {
+                        this.autofillState = 'no_key';
+                        this.autofillMessage = 'Auto-fill is not configured on this server. Enter facts manually.';
+                    } else if (data.reason === 'NOT_FOUND') {
+                        this.autofillState = 'not_found';
+                        this.autofillMessage = "Couldn't find property in public records. Enter facts manually.";
+                    } else {
+                        this.autofillState = 'error';
+                        this.autofillMessage = "Provider couldn't supply data. Enter facts manually.";
+                    }
+                    return;
+                }
+                // Patch each non-empty field, preserving manual overrides.
+                const facts = data.facts || {};
+                let filled = 0;
+                if (this.facts.yearBuilt == null && typeof facts.yearBuilt === 'number') {
+                    await this.saveFact('yearBuilt', facts.yearBuilt); filled++;
+                }
+                if (this.facts.sqft == null && typeof facts.sqft === 'number') {
+                    await this.saveFact('sqft', facts.sqft); filled++;
+                }
+                if (!this.facts.foundationType && typeof facts.foundationType === 'string' && facts.foundationType) {
+                    await this.saveFact('foundationType', facts.foundationType); filled++;
+                }
+                if (!this.facts.lotSize && typeof facts.lotSize === 'string' && facts.lotSize) {
+                    await this.saveFact('lotSize', facts.lotSize); filled++;
+                }
+                if (this.facts.bedrooms == null && typeof facts.bedrooms === 'number') {
+                    await this.saveFact('bedrooms', facts.bedrooms); filled++;
+                }
+                if (this.facts.bathrooms == null && typeof facts.bathrooms === 'number') {
+                    await this.saveFact('bathrooms', facts.bathrooms); filled++;
+                }
+                this.autofillState = 'success';
+                this.autofillMessage = filled > 0
+                    ? ('Auto-filled ' + filled + ' field' + (filled === 1 ? '' : 's') + '.')
+                    : 'Property already fully filled — no fields updated.';
+                if (typeof window.showToast === 'function') {
+                    window.showToast(this.autofillMessage);
+                }
+            } catch (e) {
+                console.error('autofill failed', e);
+                this.autofillState = 'error';
+                this.autofillMessage = (e && e.message) || 'Auto-fill failed';
             }
         },
 

--- a/public/js/tags.js
+++ b/public/js/tags.js
@@ -1,0 +1,164 @@
+/**
+ * Sprint 3 S3-3 — Tags library page Alpine handler.
+ *
+ * Implements list / create / edit / delete on /library/tags. Five seed tags
+ * appear lazily on first load (server-side seedDefaults via GET /api/tags).
+ *
+ * Hard rule: never browser prompt() / confirm() — delete uses an inline
+ * confirmation modal.
+ */
+(function () {
+    function register() {
+        if (!window.Alpine || typeof window.Alpine.data !== 'function') return;
+        window.Alpine.data('tagsLibrary', function () {
+            return {
+                tags: [],
+                loading: true,
+                error: '',
+
+                editing: null,
+                form: { name: '', color: 'slate' },
+                formError: '',
+                showEditModal: false,
+                saving: false,
+
+                deleteTarget: null,
+                showDeleteModal: false,
+
+                async init() {
+                    await this.load();
+                },
+
+                async load() {
+                    this.loading = true;
+                    this.error = '';
+                    try {
+                        const res = await authFetch('/api/tags');
+                        const json = await res.json().catch(function () { return null; });
+                        if (!res.ok) {
+                            this.error = (json && json.error && json.error.message) || ('HTTP ' + res.status);
+                            this.tags = [];
+                        } else {
+                            this.tags = (json && json.data) || [];
+                        }
+                    } catch (e) {
+                        this.error = (e && e.message) || 'Failed to load tags';
+                        this.tags = [];
+                    } finally {
+                        this.loading = false;
+                    }
+                },
+
+                colorClass(color) {
+                    const map = {
+                        slate:    'bg-slate-100 text-slate-700 ring-slate-200',
+                        amber:    'bg-amber-100 text-amber-700 ring-amber-200',
+                        rose:     'bg-rose-100 text-rose-700 ring-rose-200',
+                        indigo:   'bg-indigo-100 text-indigo-700 ring-indigo-200',
+                        emerald:  'bg-emerald-100 text-emerald-700 ring-emerald-200',
+                        sky:      'bg-sky-100 text-sky-700 ring-sky-200',
+                        fuchsia:  'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200',
+                        lime:     'bg-lime-100 text-lime-700 ring-lime-200',
+                    };
+                    return map[color] || map.slate;
+                },
+
+                openCreate() {
+                    this.editing = null;
+                    this.form = { name: '', color: 'slate' };
+                    this.formError = '';
+                    this.showEditModal = true;
+                },
+
+                openEdit(tag) {
+                    this.editing = tag;
+                    this.form = { name: tag.name || '', color: tag.color || 'slate' };
+                    this.formError = '';
+                    this.showEditModal = true;
+                },
+
+                async save() {
+                    const name = (this.form.name || '').trim();
+                    if (!name) { this.formError = 'Name is required'; return; }
+                    this.saving = true;
+                    this.formError = '';
+                    try {
+                        const url = this.editing
+                            ? '/api/tags/' + encodeURIComponent(this.editing.id)
+                            : '/api/tags';
+                        const method = this.editing ? 'PUT' : 'POST';
+                        const body = JSON.stringify({ name: name, color: this.form.color || 'slate' });
+                        const res = await authFetch(url, { method, headers: { 'Content-Type': 'application/json' }, body });
+                        const json = await res.json().catch(function () { return null; });
+                        if (!res.ok) {
+                            // @hono/zod-openapi returns { success: false, error: { message: '...' } }
+                            // or for validation errors, an array shape — surface the first message.
+                            let msg = 'HTTP ' + res.status;
+                            if (json && json.error) {
+                                if (typeof json.error.message === 'string') msg = json.error.message;
+                                else if (Array.isArray(json.error)) msg = json.error[0]?.message || msg;
+                            }
+                            this.formError = msg;
+                            return;
+                        }
+                        this.showEditModal = false;
+                        await this.load();
+                        if (typeof showToast === 'function') showToast(this.editing ? 'Tag updated' : 'Tag created');
+                    } catch (e) {
+                        this.formError = (e && e.message) || 'Save failed';
+                    } finally {
+                        this.saving = false;
+                    }
+                },
+
+                confirmDelete(tag) {
+                    if (tag.isSeed) return; // UI also disables the button
+                    this.deleteTarget = tag;
+                    this.showDeleteModal = true;
+                    // Inline modal not yet rendered on this page — perform optimistic
+                    // delete after a small native window.confirm is BANNED. Open an
+                    // inline confirm via the global modal-dialog if available.
+                    const self = this;
+                    if (window.OIConfirm && typeof window.OIConfirm.open === 'function') {
+                        window.OIConfirm.open({
+                            title: 'Delete tag',
+                            message: 'Delete "' + tag.name + '"? This will also remove it from any inspection items it is linked to.',
+                            confirmLabel: 'Delete',
+                            danger: true,
+                            onConfirm: function () { self.performDelete(); },
+                        });
+                    } else {
+                        // Fallback inline confirm — render a tiny inline UI panel using
+                        // the existing showEditModal slot would conflict; we simply
+                        // perform the delete after a 0ms tick to keep the call site
+                        // synchronous-feeling. Hard rule prohibits browser confirm(),
+                        // so we trust the explicit click + the seed-disable guard.
+                        self.performDelete();
+                    }
+                },
+
+                async performDelete() {
+                    if (!this.deleteTarget) return;
+                    try {
+                        const res = await authFetch('/api/tags/' + encodeURIComponent(this.deleteTarget.id), { method: 'DELETE' });
+                        const json = await res.json().catch(function () { return null; });
+                        if (!res.ok) {
+                            this.error = (json && json.error && json.error.message) || ('HTTP ' + res.status);
+                        } else if (typeof showToast === 'function') {
+                            showToast('Tag deleted');
+                        }
+                    } catch (e) {
+                        this.error = (e && e.message) || 'Delete failed';
+                    } finally {
+                        this.deleteTarget = null;
+                        this.showDeleteModal = false;
+                        await this.load();
+                    }
+                },
+            };
+        });
+    }
+
+    if (window.Alpine) register();
+    else document.addEventListener('alpine:init', register);
+})();

--- a/scripts/seed-marketplace.js
+++ b/scripts/seed-marketplace.js
@@ -38,7 +38,9 @@ try {
 const SEED_DIR = join(__dirname, '../src/data/seed-templates');
 
 // Spec 4F — `featured: 1` flags Spectora-parity defaults for marketplace top-sort + auto-seed on tenant init.
+// S3-5 — `internachi-13.json` is a standards-aligned 13-section template covering the InterNACHI Standards of Practice. Featured under category `standards_aligned`.
 const TEMPLATES = [
+  { file: 'internachi-13.json',     name: 'InterNACHI 13-Section Standard',          category: 'standards_aligned', featured: 1, changelog: 'S3-5: Standards-aligned 13-section template covering the InterNACHI Standards of Practice. Each section ships with a built-in legal disclaimer.' },
   { file: 'residential.json',       name: 'Standard Residential Inspection',         category: 'residential',       featured: 1, changelog: 'Initial release: standard US residential home inspection template.' },
   { file: 'pre-listing.json',       name: 'Pre-Listing Inspection',                  category: 'residential',       featured: 1, changelog: 'Spec 4F: seller-focused pre-listing inspection.' },
   { file: 'trec-rei-7-6.json',      name: 'TREC REI 7-6 Inspection Report',          category: 'trec',              featured: 0, changelog: 'Initial release: Texas Real Estate Commission REI 7-6 compliant template.' },

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -25,6 +25,8 @@ import {
     DashboardResponseSchema,
     PropertyFactsSchema,
     PropertyFactsResponseSchema,
+    PropertyFactsAutofillRequestSchema,
+    PropertyFactsAutofillResponseSchema,
     MediaCenterResponseSchema,
     MediaPoolUploadResponseSchema,
     MediaAttachRequestSchema,
@@ -649,6 +651,63 @@ inspectionsRoutes.openapi(updatePropertyFactsRoute, async (c) => {
         metadata: { fields: Object.keys(body) },
     });
     return c.json({ success: true, data: facts }, 200);
+});
+
+/**
+ * Sprint 3 S3-1 — POST /api/inspections/:id/property-facts/autofill
+ *
+ * Resolve property facts from an external public-records provider
+ * (Estated.io). Body: { addressString }. Response: { facts, source }.
+ * When no provider key is configured, returns
+ * `{ facts: null, source: 'manual_required', reason: 'NO_API_KEY' }`
+ * so the UI can show a polite "couldn't auto-fill" hint.
+ *
+ * Tenant ownership is verified via the inspection lookup. The endpoint
+ * does NOT persist the facts — the inline-save flow already in
+ * inspection-settings.js patches each field via the existing PATCH
+ * /property-facts endpoint, preserving the inspector's manual overrides.
+ */
+const autofillPropertyFactsRoute = createRoute({
+    method: 'post',
+    path: '/{id}/property-facts/autofill',
+    tags: ['Inspections'],
+    summary: 'Auto-fill property facts from public records (Estated.io)',
+    description: 'Returns mapped Property Facts payload or null + reason code. Inspector remains free to override fields manually after auto-fill.',
+    request: {
+        params: z.object({ id: z.string().uuid() }),
+        body: { content: { 'application/json': { schema: PropertyFactsAutofillRequestSchema } } },
+    },
+    middleware: [requireRole(['owner', 'admin'])],
+    responses: {
+        200: {
+            content: { 'application/json': { schema: PropertyFactsAutofillResponseSchema } },
+            description: 'Auto-fill result',
+        },
+    },
+});
+
+inspectionsRoutes.openapi(autofillPropertyFactsRoute, async (c) => {
+    const { id } = c.req.valid('param');
+    const tenantId = c.get('tenantId');
+    const { addressString } = c.req.valid('json');
+
+    // Tenant ownership guard — refuses cross-tenant lookups.
+    await c.var.services.inspection.getInspection(id, tenantId);
+
+    const result = await c.var.services.propertyLookup.lookup(addressString);
+    auditFromContext(c, 'inspection.property_facts.autofill', 'inspection', {
+        entityId: id,
+        metadata: { source: result.source ?? 'manual_required', reason: result.reason },
+    });
+
+    return c.json({
+        success: true as const,
+        data: {
+            facts:  result.data,
+            source: result.source ?? ('manual_required' as const),
+            ...(result.reason ? { reason: result.reason } : {}),
+        },
+    }, 200);
 });
 
 /**

--- a/src/api/repair-requests.ts
+++ b/src/api/repair-requests.ts
@@ -1,0 +1,202 @@
+/**
+ * Sprint 3 Track B (S3-2) — Public Customer Repair Request email endpoint.
+ *
+ * POST /api/public/repair-request/email
+ *
+ * Public, no JWT — the customer who received the inspection report can
+ * email a copy of the customer-facing repair-request export to themselves
+ * (or to a contractor). Same gates as `/r/:id/repair-request`:
+ *   - Tenant must opt in via tenant_configs.enable_customer_repair_export
+ *   - Inspection's payment + agreement requirements must be satisfied
+ *   - Tenant resolved from subdomain (or single-tenant default in standalone)
+ *
+ * Audit log: writes 'repair_request.exported' on success.
+ *
+ * Rate-limited by IP via the existing booking rate-limit bucket — the same
+ * abuse profile applies (public, unauthenticated, sends email to a user-
+ * supplied address).
+ */
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import { drizzle } from 'drizzle-orm/d1';
+import { eq, and } from 'drizzle-orm';
+import { inspections, agreementRequests, tenantConfigs, users } from '../lib/db/schema';
+import { HonoConfig } from '../types/hono';
+import { Errors } from '../lib/errors';
+import { checkRateLimit } from '../lib/rate-limit';
+import { logger } from '../lib/logger';
+import { writeAuditLog } from '../lib/audit';
+
+const repairRequestRoutes = new OpenAPIHono<HonoConfig>();
+
+const EmailRequestSchema = z.object({
+    inspectionId:     z.string().uuid().openapi({ example: '550e8400-e29b-41d4-a716-446655440000' }),
+    recipientEmail:   z.string().email('Invalid email address').openapi({ example: 'buyer@example.com' }),
+    customerComments: z.string().max(5000).optional().openapi({ example: 'Roof › Shingles: please replace by end of June.' }),
+}).openapi('CustomerRepairRequestEmail');
+
+const EmailResponseSchema = z.object({
+    success: z.literal(true),
+    data: z.object({
+        sent: z.literal(true),
+    }),
+});
+
+const sendEmailRoute = createRoute({
+    method: 'post',
+    path: '/repair-request/email',
+    tags: ['Public'],
+    summary: 'Email a copy of the repair-request export to the supplied address',
+    request: {
+        body: {
+            content: {
+                'application/json': {
+                    schema: EmailRequestSchema,
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: EmailResponseSchema } },
+            description: 'Email queued for delivery',
+        },
+    },
+});
+
+repairRequestRoutes.openapi(sendEmailRoute, async (c) => {
+    await checkRateLimit(c, 'book');
+
+    const body = c.req.valid('json');
+    const tenantId = c.get('tenantId') || c.get('resolvedTenantId');
+    if (!tenantId) throw Errors.Forbidden('Tenant context missing.');
+
+    const db = drizzle(c.env.DB);
+
+    // Tenant opt-in check.
+    const cfg = await db.select({
+        enableCustomerRepairExport: tenantConfigs.enableCustomerRepairExport,
+    }).from(tenantConfigs)
+        .where(eq(tenantConfigs.tenantId, tenantId as string))
+        .get();
+    if (!cfg?.enableCustomerRepairExport) {
+        throw Errors.Forbidden('Customer repair-request export is not enabled for this workspace.');
+    }
+
+    // Inspection lookup + tenant scoping in a single query.
+    const insp = await db.select({
+        id:                inspections.id,
+        propertyAddress:   inspections.propertyAddress,
+        date:              inspections.date,
+        inspectorId:       inspections.inspectorId,
+        paymentRequired:   inspections.paymentRequired,
+        paymentStatus:     inspections.paymentStatus,
+        agreementRequired: inspections.agreementRequired,
+    }).from(inspections)
+        .where(and(eq(inspections.id, body.inspectionId), eq(inspections.tenantId, tenantId as string)))
+        .get();
+    if (!insp) throw Errors.NotFound('Inspection');
+
+    // Same gating as /report/:id and /r/:id/repair-request.
+    if (insp.paymentRequired === true && insp.paymentStatus !== 'paid') {
+        throw Errors.Forbidden('Payment is required before this report can be exported.');
+    }
+    if (insp.agreementRequired === true) {
+        const signed = await db.select({ id: agreementRequests.id })
+            .from(agreementRequests)
+            .where(and(
+                eq(agreementRequests.inspectionId, body.inspectionId),
+                eq(agreementRequests.tenantId, tenantId as string),
+                eq(agreementRequests.status, 'signed'),
+            ))
+            .limit(1);
+        if (signed.length === 0) {
+            throw Errors.Forbidden('Inspection agreement must be signed before this report can be exported.');
+        }
+    }
+
+    // Inspector name for the email body footer.
+    let inspectorName: string | null = null;
+    if (insp.inspectorId) {
+        const insRow = await db.select({ name: users.name })
+            .from(users)
+            .where(and(eq(users.id, insp.inspectorId), eq(users.tenantId, tenantId as string)))
+            .get();
+        inspectorName = insRow?.name ?? null;
+    }
+
+    // Build the email body. The report-export link drives the recipient
+    // back to the same page they exported from for the rich (printable)
+    // version; the email body shows the inline comments only.
+    const baseUrl = (c.env.APP_BASE_URL || '').replace(/\/$/, '')
+        || (c.req.header('host') ? `https://${c.req.header('host')}` : '');
+    const exportUrl = `${baseUrl}/r/${body.inspectionId}/repair-request`;
+    const branding = c.get('branding');
+    const siteName = branding?.siteName || c.env.APP_NAME || 'OpenInspection';
+
+    const safeAddress = escapeHtml(insp.propertyAddress || 'your property');
+    const safeComments = body.customerComments
+        ? escapeHtml(body.customerComments).replace(/\n/g, '<br/>')
+        : '';
+    const safeInspector = inspectorName ? escapeHtml(inspectorName) : '';
+
+    const html = `
+        <div style="font-family: -apple-system, system-ui, Segoe UI, Roboto, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #0f172a;">
+            <p style="font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: #64748b; margin: 0 0 4px;">Repair Request</p>
+            <h1 style="font-size: 22px; line-height: 1.25; font-weight: 600; margin: 0 0 16px;">${safeAddress}</h1>
+            <p style="font-size: 14px; line-height: 1.5; color: #475569;">
+                Here is your repair-request list, generated from the inspection report${safeInspector ? ` by <strong>${safeInspector}</strong>` : ''}. You can hand this list to your contractor or share it with the seller.
+            </p>
+            ${safeComments ? `
+            <div style="margin-top: 20px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px;">
+                <p style="font-size: 11px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: #64748b; margin: 0 0 8px;">Your notes</p>
+                <p style="font-size: 14px; line-height: 1.6; margin: 0; white-space: pre-wrap;">${safeComments}</p>
+            </div>` : ''}
+            <p style="margin-top: 24px;">
+                <a href="${exportUrl}" style="display: inline-block; padding: 10px 16px; background: #0f172a; color: white; text-decoration: none; border-radius: 6px; font-size: 13px; font-weight: 700;">Open the printable list</a>
+            </p>
+            <hr style="border: 0; border-top: 1px solid #e2e8f0; margin: 32px 0;" />
+            <p style="font-size: 11px; color: #94a3b8;">
+                Sent by ${escapeHtml(siteName)}. This list reflects items flagged in your inspection report and does not constitute a legally binding contract or repair scope.
+            </p>
+        </div>
+    `;
+
+    try {
+        await c.var.services.email.sendEmail(
+            [body.recipientEmail],
+            `Repair request — ${insp.propertyAddress || 'your property'}`,
+            html,
+        );
+    } catch (err) {
+        logger.error('[repair-request.email] send failed', { tenantId, inspectionId: body.inspectionId },
+            err instanceof Error ? err : undefined);
+        throw Errors.ServiceUnavailable('Email delivery failed. Please try again later.');
+    }
+
+    writeAuditLog({
+        db: c.env.DB,
+        tenantId: tenantId as string,
+        action: 'repair_request.exported',
+        entityType: 'inspection',
+        entityId: body.inspectionId,
+        metadata: {
+            recipientEmail: body.recipientEmail,
+            hasComments: !!body.customerComments && body.customerComments.length > 0,
+        },
+        ipAddress: c.req.header('cf-connecting-ip') || c.req.header('x-forwarded-for') || undefined,
+        executionCtx: c.executionCtx,
+    });
+
+    return c.json({ success: true as const, data: { sent: true as const } }, 200);
+});
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+export default repairRequestRoutes;

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -83,6 +83,40 @@ tagsRoutes.openapi(createRoute({
     return c.json({ success: true as const, data: tag }, 200);
 });
 
+/* ── GET /api/tags/:id/inspections ─────────────────────────────────────
+ *  Sprint 3 S3-3 — list filter. Returns the distinct inspection ids in the
+ *  tenant that have at least one item linked to this tag. The dashboard
+ *  uses this to scope its flat list view to "by tag".
+ */
+tagsRoutes.openapi(createRoute({
+    method: 'get', path: '/{id}/inspections',
+    tags: ['Tags'],
+    summary: 'List inspections that have any item tagged with this tag',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: IdParamSchema },
+    responses: {
+        200: {
+            content: {
+                'application/json': {
+                    schema: z.object({
+                        success: z.literal(true),
+                        data:    z.object({ inspectionIds: z.array(z.string()) }),
+                    }),
+                },
+            },
+            description: 'Inspection ids',
+        },
+    },
+}), async (c) => {
+    const { id } = c.req.valid('param');
+    const tenantId = c.get('tenantId') as string;
+    // Tenant-scope guard via lookup — refuses cross-tenant ids.
+    const tag = await c.var.services.tag.get(id, tenantId);
+    if (!tag) throw Errors.NotFound('Tag not found');
+    const inspectionIds = await c.var.services.tag.listInspectionsByTag(tenantId, id);
+    return c.json({ success: true as const, data: { inspectionIds } }, 200);
+});
+
 /* ── DELETE /api/tags/:id ─────────────────────────────────────────────── */
 tagsRoutes.openapi(createRoute({
     method: 'delete', path: '/{id}',

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,0 +1,233 @@
+/**
+ * Sprint 3 S3-3 — Tag API.
+ *
+ * Tenant-scoped CRUD over the `tags` table plus link/unlink endpoints
+ * for inspection items. Inspectors can create + link tags; only owners
+ * and admins can rename / delete them.
+ *
+ * Routes mounted at `/api/tags` (library) and a small parallel set under
+ * `/api/inspections/:id/items/:itemId/tags` (item links).
+ */
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import type { HonoConfig } from '../types/hono';
+import { requireRole } from '../lib/middleware/rbac';
+import { auditFromContext } from '../lib/audit';
+import { Errors } from '../lib/errors';
+import {
+    CreateTagSchema,
+    UpdateTagSchema,
+    TagListResponseSchema,
+    TagSingleResponseSchema,
+    TagDeleteResponseSchema,
+    TagLinkResponseSchema,
+    TagUnlinkResponseSchema,
+} from '../lib/validations/tag.schema';
+
+const tagsRoutes = new OpenAPIHono<HonoConfig>();
+
+const IdParamSchema = z.object({ id: z.string().min(1) });
+
+/* ── GET /api/tags ────────────────────────────────────────────────────── */
+tagsRoutes.openapi(createRoute({
+    method: 'get', path: '/',
+    tags: ['Tags'],
+    summary: 'List tags for the current tenant (seed + custom)',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    responses: {
+        200: { content: { 'application/json': { schema: TagListResponseSchema } }, description: 'List' },
+    },
+}), async (c) => {
+    const tenantId = c.get('tenantId') as string;
+    // Lazy-seed canonical tags so first-time tenants always see the five.
+    await c.var.services.tag.seedDefaults(tenantId);
+    const data = await c.var.services.tag.list(tenantId);
+    return c.json({ success: true as const, data }, 200);
+});
+
+/* ── POST /api/tags ───────────────────────────────────────────────────── */
+tagsRoutes.openapi(createRoute({
+    method: 'post', path: '/',
+    tags: ['Tags'],
+    summary: 'Create a custom tag',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { body: { content: { 'application/json': { schema: CreateTagSchema } } } },
+    responses: {
+        200: { content: { 'application/json': { schema: TagSingleResponseSchema } }, description: 'Created' },
+    },
+}), async (c) => {
+    const input = c.req.valid('json');
+    const tenantId = c.get('tenantId') as string;
+    const tag = await c.var.services.tag.create(tenantId, input);
+    auditFromContext(c, 'tag.created', 'tag', { entityId: tag.id, metadata: { name: tag.name } });
+    return c.json({ success: true as const, data: tag }, 200);
+});
+
+/* ── PUT /api/tags/:id ────────────────────────────────────────────────── */
+tagsRoutes.openapi(createRoute({
+    method: 'put', path: '/{id}',
+    tags: ['Tags'],
+    middleware: [requireRole(['owner', 'admin'])] as const,
+    request: {
+        params: IdParamSchema,
+        body: { content: { 'application/json': { schema: UpdateTagSchema } } },
+    },
+    responses: {
+        200: { content: { 'application/json': { schema: TagSingleResponseSchema } }, description: 'Updated' },
+    },
+}), async (c) => {
+    const { id } = c.req.valid('param');
+    const patch = c.req.valid('json');
+    const tenantId = c.get('tenantId') as string;
+    const tag = await c.var.services.tag.update(id, tenantId, patch);
+    auditFromContext(c, 'tag.updated', 'tag', { entityId: tag.id });
+    return c.json({ success: true as const, data: tag }, 200);
+});
+
+/* ── DELETE /api/tags/:id ─────────────────────────────────────────────── */
+tagsRoutes.openapi(createRoute({
+    method: 'delete', path: '/{id}',
+    tags: ['Tags'],
+    middleware: [requireRole(['owner', 'admin'])] as const,
+    request: { params: IdParamSchema },
+    responses: {
+        200: { content: { 'application/json': { schema: TagDeleteResponseSchema } }, description: 'Deleted' },
+    },
+}), async (c) => {
+    const { id } = c.req.valid('param');
+    const tenantId = c.get('tenantId') as string;
+    const result = await c.var.services.tag.delete(id, tenantId);
+    auditFromContext(c, 'tag.deleted', 'tag', { entityId: id });
+    return c.json({ success: true as const, data: result }, 200);
+});
+
+export default tagsRoutes;
+
+/* ─── Item-link sub-routes ────────────────────────────────────────────── */
+//
+// Mounted separately under /api/inspections so the path can carry the
+// inspection id + item id directly. We keep them in this file so all
+// tag endpoints live together.
+
+export const inspectionTagRoutes = new OpenAPIHono<HonoConfig>();
+
+const InspectionItemTagParamsSchema = z.object({
+    id:     z.string().min(1),
+    itemId: z.string().min(1),
+});
+
+const InspectionItemTagWithTagParamsSchema = z.object({
+    id:     z.string().min(1),
+    itemId: z.string().min(1),
+    tagId:  z.string().min(1),
+});
+
+const LinkBodySchema = z.object({ tagId: z.string().min(1) }).strict();
+
+/* ── GET /api/inspections/:id/items/:itemId/tags ──────────────────────── */
+inspectionTagRoutes.openapi(createRoute({
+    method: 'get', path: '/{id}/items/{itemId}/tags',
+    tags: ['Tags'],
+    summary: 'List tags linked to an inspection item',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: InspectionItemTagParamsSchema },
+    responses: {
+        200: { content: { 'application/json': { schema: TagListResponseSchema } }, description: 'Item tags' },
+    },
+}), async (c) => {
+    const { id, itemId } = c.req.valid('param');
+    const tenantId = c.get('tenantId') as string;
+    const data = await c.var.services.tag.getItemTags(tenantId, id, itemId);
+    return c.json({ success: true as const, data }, 200);
+});
+
+/* ── POST /api/inspections/:id/items/:itemId/tags ─────────────────────── */
+inspectionTagRoutes.openapi(createRoute({
+    method: 'post', path: '/{id}/items/{itemId}/tags',
+    tags: ['Tags'],
+    summary: 'Link a tag to an inspection item',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: {
+        params: InspectionItemTagParamsSchema,
+        body: { content: { 'application/json': { schema: LinkBodySchema } } },
+    },
+    responses: {
+        200: { content: { 'application/json': { schema: TagLinkResponseSchema } }, description: 'Linked' },
+    },
+}), async (c) => {
+    const { id, itemId } = c.req.valid('param');
+    const { tagId } = c.req.valid('json');
+    const tenantId = c.get('tenantId') as string;
+
+    // Verify the inspection belongs to this tenant before linking.
+    await c.var.services.inspection.getInspection(id, tenantId);
+    await c.var.services.tag.linkToItem(tenantId, id, itemId, tagId);
+    auditFromContext(c, 'tag.linked', 'inspection_item', {
+        entityId: id,
+        metadata: { itemId, tagId },
+    });
+    return c.json({ success: true as const, data: { linked: true as const } }, 200);
+});
+
+/* ── DELETE /api/inspections/:id/items/:itemId/tags/:tagId ────────────── */
+inspectionTagRoutes.openapi(createRoute({
+    method: 'delete', path: '/{id}/items/{itemId}/tags/{tagId}',
+    tags: ['Tags'],
+    summary: 'Unlink a tag from an inspection item',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: InspectionItemTagWithTagParamsSchema },
+    responses: {
+        200: { content: { 'application/json': { schema: TagUnlinkResponseSchema } }, description: 'Unlinked' },
+    },
+}), async (c) => {
+    const { id, itemId, tagId } = c.req.valid('param');
+    const tenantId = c.get('tenantId') as string;
+
+    // Tenant ownership guard via inspection lookup.
+    await c.var.services.inspection.getInspection(id, tenantId);
+    await c.var.services.tag.unlinkFromItem(tenantId, id, itemId, tagId);
+    auditFromContext(c, 'tag.unlinked', 'inspection_item', {
+        entityId: id,
+        metadata: { itemId, tagId },
+    });
+    return c.json({ success: true as const, data: { unlinked: true as const } }, 200);
+});
+
+/* ── GET /api/inspections/:id/tags ─────────────────────────────────────
+ *  Bulk fetch — returns a map of itemId → Tag[] for the entire inspection.
+ *  Used by inspection-edit to hydrate all chips on initial load.
+ */
+const InspectionIdParamSchema = z.object({ id: z.string().min(1) });
+
+inspectionTagRoutes.openapi(createRoute({
+    method: 'get', path: '/{id}/tags',
+    tags: ['Tags'],
+    summary: 'Map of itemId → tags for an inspection',
+    middleware: [requireRole(['owner', 'admin', 'inspector'])] as const,
+    request: { params: InspectionIdParamSchema },
+    responses: {
+        200: {
+            content: {
+                'application/json': {
+                    schema: z.object({
+                        success: z.literal(true),
+                        data:    z.record(z.string(), z.array(z.object({
+                            id:        z.string(),
+                            name:      z.string(),
+                            color:     z.string().nullable().optional(),
+                            isSeed:    z.boolean(),
+                            createdAt: z.number(),
+                        }))),
+                    }),
+                },
+            },
+            description: 'Item tag map',
+        },
+    },
+}), async (c) => {
+    const { id } = c.req.valid('param');
+    const tenantId = c.get('tenantId') as string;
+    await c.var.services.inspection.getInspection(id, tenantId);
+    const data = await c.var.services.tag.getInspectionTagMap(tenantId, id);
+    if (!data) throw Errors.Internal('Tag map unavailable');
+    return c.json({ success: true as const, data }, 200);
+});

--- a/src/data/seed-templates/internachi-13.json
+++ b/src/data/seed-templates/internachi-13.json
@@ -1,0 +1,925 @@
+{
+  "id": "seed_internachi_13_v1",
+  "name": "InterNACHI 13-Section Standard",
+  "description": "Standards-aligned residential inspection template covering the 13 systems described in the InterNACHI Standards of Practice. Each section has a built-in legal disclaimer and original Information / Limitations / Defects canned comments.",
+  "version": 2,
+  "featured": true,
+  "schema": {
+    "schemaVersion": 2,
+    "sections": [
+      {
+        "id": "s_inspection_details",
+        "title": "Inspection Details",
+        "disclaimerText": "This summary documents the conditions under which the inspection was performed. Items not present, not safely accessible, or outside the scope of a visual inspection are excluded from the report.",
+        "items": [
+          {
+            "id": "i_attendees",
+            "label": "Attendees",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_att_client", "title": "Client present", "comment": "Client was present during the inspection.", "default": true },
+                { "id": "ri_att_agent",  "title": "Agent present",  "comment": "Listing or buyer's agent was present during the inspection.", "default": false }
+              ],
+              "limitations": [],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_weather",
+            "label": "Weather Conditions",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_wx_clear", "title": "Clear / dry", "comment": "Weather was clear and dry at the time of inspection.", "default": true },
+                { "id": "ri_wx_rain",  "title": "Recent rain", "comment": "Significant rainfall occurred within 48 hours prior to inspection.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_wx_dry", "title": "Dry interior", "comment": "Active leakage indicators may not be visible during prolonged dry weather.", "default": false }
+              ],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_occupancy",
+            "label": "Occupancy",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_occ_occ",  "title": "Occupied",  "comment": "Property was occupied; furniture and personal belongings limited visibility in some areas.", "default": false },
+                { "id": "ri_occ_vac",  "title": "Vacant",    "comment": "Property was vacant at the time of inspection.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_occ_blocked", "title": "Items blocking access", "comment": "Areas concealed by stored items or furniture were not inspected.", "default": false }
+              ],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_utilities",
+            "label": "Utilities Status",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_util_on", "title": "All utilities on", "comment": "Electric, water, and gas utilities were operational at the time of inspection.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_util_off", "title": "Utility off", "comment": "One or more utilities were not operational; affected systems could not be tested.", "default": false }
+              ],
+              "defects": []
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_exterior",
+        "title": "Exterior",
+        "disclaimerText": "The exterior inspection is a visual assessment of readily accessible surfaces and components. Concealed damage behind siding, soil, or vegetation is excluded from the scope of this report.",
+        "items": [
+          {
+            "id": "i_ext_walls",
+            "label": "Wall Cladding",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ext_wall_type",   "title": "Material",  "comment": "Exterior wall cladding consists of fiber cement and brick veneer.", "default": true },
+                { "id": "ri_ext_wall_cond",   "title": "Condition", "comment": "Exterior wall cladding appears serviceable with no visible structural defects.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ext_wall_veg", "title": "Vegetation", "comment": "Sections of cladding behind vegetation or stored items were not inspected.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ext_wall_crack", "title": "Cracks", "category": "recommendation", "location": "", "comment": "Cracks observed in exterior cladding; recommend evaluation and sealing by a qualified contractor.", "photos": [], "default": false },
+                { "id": "rd_ext_wall_paint", "title": "Peeling paint", "category": "maintenance", "location": "", "comment": "Peeling or weathered paint observed; recommend repainting to protect substrate.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ext_trim",
+            "label": "Trim, Soffit & Fascia",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ext_trim_ok", "title": "Serviceable", "comment": "Trim, soffit, and fascia appear serviceable.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_ext_trim_rot", "title": "Rot observed", "category": "recommendation", "location": "", "comment": "Rot observed at trim or fascia; recommend repair to prevent further deterioration.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ext_grading",
+            "label": "Grading & Drainage",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ext_grade_ok", "title": "Slopes away", "comment": "Site grading slopes away from the foundation as expected.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ext_grade_snow", "title": "Snow / mulch", "comment": "Areas covered by snow, mulch, or hardscape were not directly evaluated for grade.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ext_grade_neg", "title": "Negative slope", "category": "recommendation", "location": "", "comment": "Negative slope observed at portions of the foundation; recommend regrading to direct surface water away.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ext_walkways",
+            "label": "Walkways, Driveway & Steps",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ext_walk_ok", "title": "Serviceable", "comment": "Walkways and driveway appear serviceable with no significant trip hazards.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_ext_walk_trip", "title": "Trip hazard", "category": "safety", "location": "", "comment": "Settlement or displacement creates a trip hazard; recommend repair.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ext_decks",
+            "label": "Decks, Porches & Railings",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ext_deck_ok", "title": "Serviceable", "comment": "Deck framing, fasteners, and railings appear serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ext_deck_skirt", "title": "Skirted", "comment": "Concealed deck framing behind skirting or stored items was not inspected.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ext_deck_rail", "title": "Loose railing", "category": "safety", "location": "", "comment": "Railing is loose or missing balusters at greater-than-30-inch heights; recommend repair for fall safety.", "photos": [], "default": false },
+                { "id": "rd_ext_deck_ledger", "title": "Ledger attachment", "category": "safety", "location": "", "comment": "Ledger attachment to home is not visible or improperly fastened; recommend evaluation by a qualified contractor.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_roof",
+        "title": "Roof",
+        "disclaimerText": "Roof inspection is a visual evaluation of accessible roof surfaces, flashing, and penetrations. Areas concealed by snow, debris, or stored items are excluded. Walking on the roof is at the inspector's discretion based on safety and condition.",
+        "items": [
+          {
+            "id": "i_roof_method",
+            "label": "Inspection Method",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_roof_walked", "title": "Walked", "comment": "Roof was walked and inspected from on top of the roof surfaces.", "default": false },
+                { "id": "ri_roof_eaves",  "title": "From eaves", "comment": "Roof was inspected from accessible eaves and a ladder.", "default": true },
+                { "id": "ri_roof_ground", "title": "Ground / drone", "comment": "Roof was inspected from ground level and / or drone imagery only.", "default": false }
+              ],
+              "limitations": [],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_roof_covering",
+            "label": "Roof Covering",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_rc_type", "title": "Material", "comment": "Roof covering is asphalt composition shingles.", "default": true },
+                { "id": "ri_rc_cond", "title": "Condition", "comment": "Roof covering appears serviceable with no significant defects observed at the time of inspection.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_rc_snow", "title": "Snow / debris", "comment": "Areas covered by snow, debris, or solar panels were not inspected.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_rc_missing", "title": "Missing or damaged shingles", "category": "recommendation", "location": "", "comment": "Missing, broken, or lifted shingles observed; recommend repair by a qualified roofing contractor.", "photos": [], "default": false },
+                { "id": "rd_rc_eol",     "title": "Near end of life", "category": "maintenance", "location": "", "comment": "Roof covering shows weathering consistent with the latter portion of its expected service life; recommend planning for replacement.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_roof_penetrations",
+            "label": "Penetrations & Flashing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_rp_ok", "title": "Properly sealed", "comment": "Visible flashing at penetrations and wall intersections appears properly sealed.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_rp_visual", "title": "Concealed", "comment": "Concealed flashing under roof covering was not directly inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_rp_seal",    "title": "Failed sealant", "category": "maintenance", "location": "", "comment": "Sealant at one or more roof penetrations is cracked or aged; recommend renewal.", "photos": [], "default": false },
+                { "id": "rd_rp_chimney", "title": "Chimney flashing", "category": "recommendation", "location": "", "comment": "Improper or deteriorated flashing observed at chimney; recommend correction by a qualified contractor.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_roof_gutters",
+            "label": "Gutters & Downspouts",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_rg_ok", "title": "Serviceable", "comment": "Gutters and downspouts are securely attached.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_rg_storm", "title": "Storm response", "comment": "Performance during heavy rainfall was not directly observed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_rg_dis",   "title": "Discharge at foundation", "category": "recommendation", "location": "", "comment": "Downspouts discharge against the foundation; extend at least 4 to 6 feet away to direct water from the foundation.", "photos": [], "default": false },
+                { "id": "rd_rg_loose", "title": "Loose / sagging", "category": "maintenance", "location": "", "comment": "Gutters are loose or sagging at attachment points; secure or replace damaged sections.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_basement_foundation",
+        "title": "Basement, Foundation, Crawlspace & Structure",
+        "disclaimerText": "Foundation evaluation is limited to readily visible portions. Concealed structural members behind finishes, insulation, or stored items are excluded. Inspectors are not engineers and do not certify load capacity.",
+        "items": [
+          {
+            "id": "i_fd_foundation",
+            "label": "Foundation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fd_type", "title": "Type", "comment": "Foundation is poured concrete with a finished basement.", "default": true },
+                { "id": "ri_fd_ok",   "title": "Serviceable", "comment": "Visible portions of the foundation appear serviceable with no significant structural concerns.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fd_finish", "title": "Finished", "comment": "Foundation walls are finished; concealed portions could not be evaluated.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_fd_crack", "title": "Cracks", "category": "recommendation", "location": "", "comment": "Cracks observed in foundation walls; recommend evaluation by a qualified contractor or structural engineer.", "photos": [], "default": false },
+                { "id": "rd_fd_water", "title": "Water staining", "category": "recommendation", "location": "", "comment": "Water staining observed; recommend monitoring and improving exterior drainage.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_fd_floor_structure",
+            "label": "Floor Structure",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fl_ok", "title": "Serviceable", "comment": "Visible floor framing appears serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fl_finish", "title": "Concealed", "comment": "Concealed floor framing was not inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_fl_sag", "title": "Sag observed", "category": "recommendation", "location": "", "comment": "Sag or deflection observed; recommend evaluation by a qualified contractor.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_fd_walls",
+            "label": "Walls (Structural)",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_wl_ok", "title": "Serviceable", "comment": "Visible structural wall framing appears serviceable.", "default": true }
+              ],
+              "limitations": [],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_fd_crawlspace",
+            "label": "Crawlspace",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_cs_present", "title": "Crawlspace present", "comment": "Crawlspace was entered and inspected.", "default": false },
+                { "id": "ri_cs_none",    "title": "Slab on grade",      "comment": "No crawlspace; home is built on a slab.",   "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_cs_access", "title": "Access limit", "comment": "Crawlspace access was limited by clearance, debris, or insulation.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_cs_moisture", "title": "Moisture", "category": "recommendation", "location": "", "comment": "Elevated moisture or standing water observed; recommend evaluation and remediation.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_heating",
+        "title": "Heating",
+        "disclaimerText": "Heating system evaluation is limited to normal operation in heating mode using accessible controls. Heat exchangers, boilers, and concealed components are not disassembled. Annual servicing by a qualified HVAC technician is recommended.",
+        "items": [
+          {
+            "id": "i_h_equipment",
+            "label": "Heating Equipment",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_h_furnace", "title": "Forced air furnace", "comment": "Heating system is a forced air gas furnace.", "default": true },
+                { "id": "ri_h_age",     "title": "Equipment age",      "comment": "Equipment age estimated based on data plate; remaining service life is at the discretion of a qualified technician.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_h_heatex", "title": "Heat exchanger", "comment": "Heat exchanger was not disassembled and was not directly inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_h_age", "title": "Past expected life", "category": "recommendation", "location": "", "comment": "Equipment is past its expected service life; recommend evaluation by a qualified technician and budget for replacement.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_h_distribution",
+            "label": "Distribution & Filters",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hd_ok",    "title": "Serviceable", "comment": "Visible duct distribution appears serviceable.", "default": true },
+                { "id": "ri_hd_filter","title": "Filter",      "comment": "Air filter was inspected; recommend regular replacement per manufacturer guidance.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_hd_concealed", "title": "Concealed", "comment": "Concealed duct runs were not inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_hd_filter", "title": "Dirty filter", "category": "maintenance", "location": "", "comment": "Air filter is heavily soiled; replace.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_h_thermostat",
+            "label": "Thermostat & Controls",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_th_ok", "title": "Operates", "comment": "Thermostat operated the heating system using normal controls.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_th_no", "title": "No response", "category": "recommendation", "location": "", "comment": "Thermostat did not call for heat using normal controls; recommend evaluation by a qualified technician.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_cooling",
+        "title": "Cooling",
+        "disclaimerText": "Cooling systems are not tested when ambient temperatures are below the manufacturer's recommended range, typically 65 degrees Fahrenheit. Refrigerant levels and pressure are not measured.",
+        "items": [
+          {
+            "id": "i_c_equipment",
+            "label": "Cooling Equipment",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_c_split", "title": "Split system", "comment": "Cooling system is a central split system with outdoor condensing unit.", "default": true },
+                { "id": "ri_c_age",   "title": "Equipment age", "comment": "Equipment age estimated from data plate.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_c_temp", "title": "Temperature", "comment": "Cooling system was not tested due to ambient temperatures below the manufacturer's recommended range.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_c_age", "title": "Past expected life", "category": "recommendation", "location": "", "comment": "Cooling equipment is past its expected service life; recommend evaluation by a qualified technician.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_c_lineset",
+            "label": "Lineset & Condensate",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_cl_ok", "title": "Serviceable", "comment": "Visible lineset insulation and condensate drain appear serviceable.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_cl_insul",  "title": "Damaged insulation", "category": "maintenance", "location": "", "comment": "Damaged or missing lineset insulation observed; recommend replacement.", "photos": [], "default": false },
+                { "id": "rd_cl_cond",   "title": "Condensate clog",    "category": "recommendation", "location": "", "comment": "Condensate drain shows signs of clog or backup; recommend cleaning by a qualified technician.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_c_split",
+            "label": "Temperature Differential",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_cs_ok", "title": "Within range", "comment": "Supply / return temperature differential measured within the expected 14 to 22 degree Fahrenheit range.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_cs_low", "title": "Low differential", "category": "recommendation", "location": "", "comment": "Supply / return differential below expected range; recommend evaluation by a qualified technician.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_plumbing",
+        "title": "Plumbing",
+        "disclaimerText": "Plumbing inspection is limited to readily visible supply, waste, and venting components. Concealed piping, septic systems, and underground lines are excluded. Hidden leaks may not be apparent during a visual inspection.",
+        "items": [
+          {
+            "id": "i_p_supply",
+            "label": "Water Supply",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_p_main", "title": "Main shutoff", "comment": "Main water shutoff was located and identified.", "default": true },
+                { "id": "ri_p_press","title": "Pressure",     "comment": "Functional water pressure observed at multiple fixtures.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_p_concealed", "title": "Concealed", "comment": "Concealed supply piping was not inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_p_leak", "title": "Active leak", "category": "safety", "location": "", "comment": "Active leak observed at supply piping; recommend immediate repair by a qualified plumber.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_p_dwv",
+            "label": "Drain, Waste & Vent",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dwv_ok", "title": "Serviceable", "comment": "Visible drain, waste, and vent piping appear serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_dwv_concealed", "title": "Concealed", "comment": "Concealed waste piping was not inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_dwv_slow", "title": "Slow drain", "category": "maintenance", "location": "", "comment": "Slow drainage observed at one or more fixtures; recommend clearing.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_p_water_heater",
+            "label": "Water Heater",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_wh_type", "title": "Type", "comment": "Water heater is a tank-type gas unit.", "default": true },
+                { "id": "ri_wh_age",  "title": "Age",  "comment": "Water heater age estimated from data plate.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_wh_tpr",  "title": "TPR discharge", "category": "safety", "location": "", "comment": "Temperature pressure relief discharge piping is missing or improperly terminated; recommend correction by a qualified plumber.", "photos": [], "default": false },
+                { "id": "rd_wh_age",  "title": "Past life",     "category": "recommendation", "location": "", "comment": "Water heater is past its expected service life; recommend planning for replacement.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_p_fixtures",
+            "label": "Fixtures & Faucets",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_pf_ok", "title": "Serviceable", "comment": "Visible plumbing fixtures and faucets operated normally during the inspection.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_pf_drip", "title": "Drip", "category": "maintenance", "location": "", "comment": "Drip observed at faucet; recommend repair.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_electrical",
+        "title": "Electrical",
+        "disclaimerText": "Electrical inspection is a visual evaluation of accessible service equipment, panels, and a representative sample of devices. Concealed wiring, junction boxes, and load calculations are excluded. Inspectors are not licensed electricians.",
+        "items": [
+          {
+            "id": "i_e_service",
+            "label": "Service Entrance & Meter",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_se_amp",   "title": "Capacity", "comment": "Service entrance is rated 200 amps based on visible labeling.", "default": true },
+                { "id": "ri_se_under", "title": "Underground", "comment": "Service is delivered via underground lateral conductors.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_se_meter", "title": "Meter sealed", "comment": "Utility meter and service drop interior were not opened.", "default": true }
+              ],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_e_main_panel",
+            "label": "Main Panel",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_mp_ok", "title": "Serviceable", "comment": "Main panel was opened and inspected. Bonding, grounding, and breaker labeling appear serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_mp_brand", "title": "Brand caution", "comment": "Panel brand is associated with documented industry concerns; further evaluation by a qualified electrician is recommended.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_mp_bond",  "title": "Bonding", "category": "safety", "location": "", "comment": "Improper bonding observed in main panel; recommend correction by a qualified electrician.", "photos": [], "default": false },
+                { "id": "rd_mp_double", "title": "Double-tap", "category": "safety", "location": "", "comment": "Double-tapped breaker observed; recommend correction by a qualified electrician.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_e_subpanels",
+            "label": "Subpanels",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_sub_none", "title": "None present", "comment": "No subpanel observed.", "default": true },
+                { "id": "ri_sub_ok",   "title": "Serviceable",  "comment": "Subpanel was inspected and appears serviceable.", "default": false }
+              ],
+              "limitations": [],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_e_devices",
+            "label": "Outlets, Switches & GFCI / AFCI",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dv_sample", "title": "Representative sample", "comment": "A representative sample of receptacles and switches was tested.", "default": true },
+                { "id": "ri_dv_gfci",   "title": "GFCI tested",            "comment": "GFCI protection was tested at accessible locations.",            "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_dv_furn",   "title": "Furniture", "comment": "Receptacles concealed by furniture or stored items were not tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dv_open_gnd", "title": "Open ground", "category": "safety", "location": "", "comment": "Open ground observed at one or more outlets; recommend correction by a qualified electrician.", "photos": [], "default": false },
+                { "id": "rd_dv_no_gfci",  "title": "No GFCI",     "category": "safety", "location": "", "comment": "GFCI protection is missing at locations now required (kitchen, bath, exterior, garage); recommend upgrade.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_e_smoke_co",
+            "label": "Smoke & CO Alarms",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_sm_present", "title": "Present", "comment": "Smoke and carbon monoxide alarms were observed at sleeping areas.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_sm_func", "title": "Function", "comment": "Functional testing of alarms was not performed; recommend testing monthly and replacing batteries annually.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_sm_missing", "title": "Missing", "category": "safety", "location": "", "comment": "Smoke or carbon monoxide alarms missing at required locations; recommend installation per local code.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_fireplace",
+        "title": "Fireplace",
+        "disclaimerText": "Fireplaces and chimneys are inspected visually. A Level II chimney inspection by a qualified sweep is recommended prior to use, especially when the home has been vacant or recently purchased.",
+        "items": [
+          {
+            "id": "i_fp_present",
+            "label": "Fireplace Type",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fp_none", "title": "Not present", "comment": "No fireplace observed at the property.", "default": false },
+                { "id": "ri_fp_wood", "title": "Wood-burning", "comment": "Wood-burning masonry fireplace observed.", "default": true },
+                { "id": "ri_fp_gas",  "title": "Gas",          "comment": "Gas fireplace insert observed.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_fp_no_burn", "title": "Not lit", "comment": "Fireplace was not lit during the inspection.", "default": true }
+              ],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_fp_chimney",
+            "label": "Chimney & Flue",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ch_ok", "title": "Visible portions", "comment": "Visible portions of the chimney appear serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ch_interior", "title": "Interior flue", "comment": "Interior flue and liner were not directly inspected; Level II evaluation by a qualified sweep is recommended.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_ch_cap", "title": "Missing cap", "category": "recommendation", "location": "", "comment": "Chimney cap is missing or damaged; recommend installation to prevent water and animal intrusion.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_fp_hearth",
+            "label": "Firebox & Hearth",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hr_ok", "title": "Serviceable", "comment": "Firebox and hearth appear serviceable with no visible defects.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_hr_crack", "title": "Cracks", "category": "safety", "location": "", "comment": "Cracks observed in firebox or hearth; recommend evaluation by a qualified mason or sweep before use.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_attic_insulation",
+        "title": "Attic, Insulation & Ventilation",
+        "disclaimerText": "Attic inspection is limited to areas safely accessible without disturbing insulation or stored items. Concealed framing, wiring, and ducts are excluded.",
+        "items": [
+          {
+            "id": "i_at_access",
+            "label": "Attic Access",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_at_walk", "title": "Walked", "comment": "Attic was entered and walked at accessible portions.", "default": false },
+                { "id": "ri_at_view", "title": "Viewed only", "comment": "Attic was viewed from the access opening only.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_at_blown", "title": "Blown-in insulation", "comment": "Walking on blown-in insulation conceals framing; portions were not inspected to avoid disturbing insulation.", "default": true }
+              ],
+              "defects": []
+            }
+          },
+          {
+            "id": "i_at_insulation",
+            "label": "Insulation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_in_type",  "title": "Type", "comment": "Attic insulation is blown-in cellulose or fiberglass.", "default": true },
+                { "id": "ri_in_depth", "title": "Depth", "comment": "Insulation depth measured within typical regional expectations.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_in_low", "title": "Low depth", "category": "recommendation", "location": "", "comment": "Attic insulation is below current regional recommendations; recommend supplementing for energy efficiency.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_at_ventilation",
+            "label": "Ventilation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_vt_ok", "title": "Adequate", "comment": "Soffit and ridge ventilation appear adequate.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_vt_block", "title": "Blocked soffits", "category": "recommendation", "location": "", "comment": "Soffit vents are blocked by insulation; recommend installation of baffles to maintain airflow.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_at_bath_fans",
+            "label": "Bath / Kitchen Fan Termination",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_bf_ok", "title": "Terminated to exterior", "comment": "Bath and kitchen exhaust fans terminate to the exterior as expected.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_bf_attic", "title": "Terminates in attic", "category": "recommendation", "location": "", "comment": "Bath fan exhausts into the attic; recommend extending termination to the exterior.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_doors_windows_interior",
+        "title": "Doors, Windows & Interior",
+        "disclaimerText": "Interior inspection is a visual evaluation of finishes and a representative sample of doors and windows. Cosmetic blemishes and conditions concealed by furnishings are excluded.",
+        "items": [
+          {
+            "id": "i_dw_doors",
+            "label": "Doors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_d_ok", "title": "Serviceable", "comment": "A representative sample of doors operated normally.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_d_stick", "title": "Sticks", "category": "maintenance", "location": "", "comment": "Door sticks or fails to latch; recommend adjustment.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_dw_windows",
+            "label": "Windows",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_w_sample", "title": "Sample", "comment": "A representative sample of windows was operated.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_w_furn",   "title": "Blocked by furnishings", "comment": "Windows blocked by drapery or furnishings were not operated.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_w_seal",   "title": "Failed seal", "category": "recommendation", "location": "", "comment": "Failed insulating glass seal observed; recommend replacement when convenient.", "photos": [], "default": false },
+                { "id": "rd_w_stuck",  "title": "Inoperable",  "category": "recommendation", "location": "", "comment": "Window is painted or fastened shut; recommend repair to allow normal egress operation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_dw_walls_ceil",
+            "label": "Walls, Ceilings & Floors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_wc_ok", "title": "Serviceable", "comment": "Visible wall, ceiling, and floor finishes appear serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_wc_furn", "title": "Concealed", "comment": "Concealed finishes behind furniture or wall coverings were not inspected.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_wc_stain", "title": "Stains", "category": "recommendation", "location": "", "comment": "Stains observed on ceiling or wall surfaces; source could not be confirmed at the time of inspection. Recommend further evaluation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_dw_stairs",
+            "label": "Stairs & Handrails",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_st_ok", "title": "Serviceable", "comment": "Stairs and handrails appear serviceable.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_st_handrail", "title": "Missing handrail", "category": "safety", "location": "", "comment": "Required handrail is missing on stairs with four or more risers; recommend installation.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_built_in_appliances",
+        "title": "Built-in Appliances",
+        "disclaimerText": "Built-in appliances are tested using normal operating controls only. Calibration, leveling, and concealed components are excluded. Portable appliances do not transfer with the home and are not inspected.",
+        "items": [
+          {
+            "id": "i_ap_range",
+            "label": "Range / Cooktop / Oven",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_rg_ok", "title": "Serviceable", "comment": "Range, cooktop, and oven operated normally using normal controls.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_rg_calib", "title": "Calibration", "comment": "Oven calibration was not measured.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_rg_anti", "title": "Anti-tip bracket", "category": "safety", "location": "", "comment": "Anti-tip bracket is missing; recommend installation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ap_dishwasher",
+            "label": "Dishwasher",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dw_ok", "title": "Serviceable", "comment": "Dishwasher cycled and operated normally.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_dw_airgap", "title": "No air gap / high loop", "category": "recommendation", "location": "", "comment": "Air gap or high loop is missing; recommend installation per local code.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ap_disposal",
+            "label": "Garbage Disposal",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_gd_ok",   "title": "Serviceable", "comment": "Garbage disposal operated normally.", "default": true },
+                { "id": "ri_gd_none", "title": "Not present", "comment": "No garbage disposal observed.", "default": false }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_gd_leak", "title": "Leak", "category": "maintenance", "location": "", "comment": "Leakage observed at disposal; recommend repair or replacement.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_ap_microwave",
+            "label": "Microwave / Vent Hood",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_mw_ok", "title": "Serviceable", "comment": "Built-in microwave or vent hood operated normally.", "default": true }
+              ],
+              "limitations": [],
+              "defects": []
+            }
+          }
+        ]
+      },
+      {
+        "id": "s_garage",
+        "title": "Garage",
+        "disclaimerText": "Garage inspection covers structure, vehicle door operation, and fire-rated separations. Stored items concealing portions of walls and ceilings limit visibility.",
+        "alwaysPageBreak": false,
+        "items": [
+          {
+            "id": "i_g_structure",
+            "label": "Garage Structure & Floor",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_gs_ok", "title": "Serviceable", "comment": "Garage structure and floor appear serviceable.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_gs_stored", "title": "Stored items", "comment": "Portions of garage walls and floor were concealed by stored items.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_gs_crack", "title": "Floor crack", "category": "maintenance", "location": "", "comment": "Cracks observed in garage floor; recommend monitoring and sealing as needed.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_g_door",
+            "label": "Vehicle Door & Opener",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_gd_ok", "title": "Serviceable", "comment": "Vehicle door and opener operated normally.", "default": true },
+                { "id": "ri_gd_safe","title": "Safety reverse", "comment": "Auto-reverse safety feature was tested and functioned correctly.", "default": true }
+              ],
+              "limitations": [],
+              "defects": [
+                { "id": "rd_gd_reverse", "title": "Reverse failed", "category": "safety", "location": "", "comment": "Auto-reverse safety feature failed to operate as expected; recommend service by a qualified technician.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "i_g_separation",
+            "label": "Fire Separation & Service Door",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fs_ok", "title": "Intact", "comment": "Garage / dwelling fire separation appears intact at visible locations.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fs_concealed", "title": "Concealed", "comment": "Concealed sections of garage / dwelling separation were not inspected.", "default": true }
+              ],
+              "defects": [
+                { "id": "rd_fs_door",  "title": "Service door not rated", "category": "safety", "location": "", "comment": "Garage service door does not appear to be self-closing or fire-rated; recommend evaluation by a qualified contractor.", "photos": [], "default": false },
+                { "id": "rd_fs_gap",   "title": "Penetration",            "category": "safety", "location": "", "comment": "Unsealed penetration through garage / dwelling separation observed; recommend fire-stopping by a qualified contractor.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { TemplatesPage } from './templates/pages/templates';
 import { TemplateEditorPage } from './templates/pages/template-editor';
 import { MarketplacePage } from './templates/pages/marketplace';
 import { RatingSystemsPage } from './templates/pages/rating-systems';
+import { TagsPage } from './templates/pages/tags';
 import { TeamPage } from './templates/pages/team';
 import { AgreementsPage } from './templates/pages/agreements';
 import { AgreementSignPage } from './templates/pages/agreement-sign';
@@ -968,6 +969,9 @@ app.get('/templates/:id/edit', htmlAuthGuard(['owner', 'admin']), (c) => {
 app.get('/marketplace', htmlAuthGuard(['owner', 'admin']), (c) => c.html(MarketplacePage({ branding: c.get('branding') })));
 // Sprint 2 S2-1 — Library / Rating Systems CRUD page replaces the Sprint 1 stub.
 app.get('/library/rating-systems', htmlAuthGuard(['owner', 'admin', 'inspector']), (c) => c.html(RatingSystemsPage({ branding: c.get('branding') })));
+// Sprint 3 S3-3 — Library → Tags CRUD page (mounts above the inspection-edit
+// T-key picker; both share the same /api/tags backend).
+app.get('/library/tags', htmlAuthGuard(['owner', 'admin', 'inspector']), (c) => c.html(TagsPage({ branding: c.get('branding') })));
 // Settings hub (group cards)
 app.get('/settings', htmlAuthGuard(['owner', 'admin']), (c) => c.html(SettingsPage({ branding: c.get('branding') })));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ import recommendationsRoutes from './api/recommendations';
 import ratingSystemsRoutes from './api/rating-systems';
 import eventsRoutes from './api/events';
 import inspectionRequestsRoutes from './api/inspection-requests';
+import tagsRoutes, { inspectionTagRoutes } from './api/tags';
 
 const app = new OpenAPIHono<HonoConfig>();
 
@@ -328,6 +329,11 @@ app.route('/api/auth', coreAuthRoutes);
 app.route('/', coreAuthRoutes);
 app.route('/api/inspections', inspectionsRoutes);
 app.route('/api/inspections', inspectionSyncRoutes);
+// Sprint 3 S3-3 — tag link/unlink endpoints share the /api/inspections root
+// so the URL carries inspection id + item id directly. Mounted before the
+// generic inspection routes finish registering so OpenAPI catches both.
+app.route('/api/inspections', inspectionTagRoutes);
+app.route('/api/tags', tagsRoutes);
 app.route('/api/inspection-requests', inspectionRequestsRoutes);
 app.route('/api/ai', aiRoutes);
 app.route('/api/public', bookingsRoutes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { InspectionSummaryPage } from './templates/pages/inspection/summary';
 import { InspectionSignaturesPage } from './templates/pages/inspection/signatures';
 import { InspectionSettingsPage } from './templates/pages/inspection/settings';
 import { RepairListPage } from './templates/pages/inspection/repair-list';
+import { CustomerRepairRequestPage } from './templates/pages/customer-repair-request';
 import { SettingsAutomationsPage } from './templates/pages/settings-automations';
 import { SettingsWidgetPage } from './templates/pages/settings-widget';
 import { SettingsServicesPage } from './templates/pages/settings-services';
@@ -98,6 +99,7 @@ import recommendationsRoutes from './api/recommendations';
 import ratingSystemsRoutes from './api/rating-systems';
 import eventsRoutes from './api/events';
 import inspectionRequestsRoutes from './api/inspection-requests';
+import repairRequestRoutes from './api/repair-requests';
 
 const app = new OpenAPIHono<HonoConfig>();
 
@@ -185,7 +187,7 @@ const STATIC_ASSET_EXT = /\.(css|js|mjs|map|png|jpe?g|gif|svg|ico|webp|woff2?|tt
 app.use('*', async (c, next) => {
     const path = c.req.path;
     const isAuthPublic = path === '/api/auth/login' || path === '/api/auth/register' || path === '/api/auth/setup' || path === '/api/auth/login/2fa';
-    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/ics/') || path.startsWith('/api/messages/public/') || path === '/book' || path === '/widget.js' || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/agreements/sign/') || path.startsWith('/messages/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || STATIC_ASSET_EXT.test(path);
+    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/ics/') || path.startsWith('/api/messages/public/') || path === '/book' || path === '/widget.js' || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/r/') || path.startsWith('/agreements/sign/') || path.startsWith('/messages/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || STATIC_ASSET_EXT.test(path);
 
     if (isAuthPublic || isPublic || path === '/setup' || path === '/login' || path === '/join' || path.startsWith('/agreements/sign/')) return next();
 
@@ -332,6 +334,11 @@ app.route('/api/inspection-requests', inspectionRequestsRoutes);
 app.route('/api/ai', aiRoutes);
 app.route('/api/public', bookingsRoutes);
 app.route('/api/public/widget', widgetRoutes);
+// Sprint 3 Track B (S3-2) — Customer-driven Repair Request export.
+// Public, token-gated like /report/:id; the email endpoint validates the
+// per-tenant enable_customer_repair_export flag + payment + agreement gates
+// before sending.
+app.route('/api/public', repairRequestRoutes);
 app.route('/api/admin', adminRoutes);
 app.route('/api/agent', agentRoutes);
 app.route('/api/places', placesRoutes);
@@ -900,13 +907,19 @@ app.get('/report/:id', async (c) => {
         // viewer can render the "View repair list" top-right link only when
         // the workspace has opted in. Failure to read the column is treated
         // as opt-out (e.g. legacy tenants pre-migration 0044).
+        // Sprint 3 S3-2 — same pattern for the customer repair-request export.
         let enableRepairList = false;
+        let enableCustomerRepairExport = false;
         try {
-            const cfgRow = await drizzle(c.env.DB).select({ enableRepairList: schema.tenantConfigs.enableRepairList })
+            const cfgRow = await drizzle(c.env.DB).select({
+                enableRepairList:           schema.tenantConfigs.enableRepairList,
+                enableCustomerRepairExport: schema.tenantConfigs.enableCustomerRepairExport,
+            })
                 .from(schema.tenantConfigs)
                 .where(eq(schema.tenantConfigs.tenantId, tenantId as string))
                 .get();
             enableRepairList = !!cfgRow?.enableRepairList;
+            enableCustomerRepairExport = !!cfgRow?.enableCustomerRepairExport;
         } catch { /* default off */ }
 
         const rawDate = data.inspection.date || '';
@@ -932,12 +945,180 @@ app.get('/report/:id', async (c) => {
             viewerRole: role,
             // Track E1 — show "View repair list" link only when opted in.
             enableRepairList,
+            // Sprint 3 S3-2 — show "Generate repair request" link only when
+            // the workspace has opted in to the customer-facing export.
+            enableCustomerRepairExport,
             // Round-2 backlog G1 — Property Facts banner above the report
             // header. Auto-hidden when every field is empty.
             propertyFacts: data.propertyFacts,
         }));
     } catch {
         return c.text('Report not found', 404);
+    }
+});
+
+// Sprint 3 Track B (S3-2) — Public Customer Repair Request export.
+//
+// Token-gated companion to the inspector-facing /inspections/:id/repair-list
+// (Track E1). Mirrors the same payment + agreement gates that protect the
+// report itself — the customer cannot bypass them by jumping straight to
+// the repair-request export. Tenant must opt in via the
+// enable_customer_repair_export tenant_configs flag.
+app.get('/r/:id/repair-request', async (c) => {
+    const id = c.req.param('id') as string;
+    const tenantId = c.get('tenantId') || c.get('resolvedTenantId');
+    if (!tenantId) return c.text('Not found', 404);
+
+    // Inspector / admin / owner bypass — same logic as /report/:id so a
+    // logged-in inspector can preview the export without the gate firing
+    // against them.
+    let role: string | null = null;
+    try {
+        const { getCookie } = await import('hono/cookie');
+        const { verify } = await import('hono/jwt');
+        const tok = getCookie(c, '__Host-inspector_token');
+        if (tok && c.env.JWT_SECRET) {
+            const payload = await verify(tok, c.env.JWT_SECRET, 'HS256');
+            role = (payload as { role?: string })?.role ?? null;
+        }
+    } catch { /* unauthenticated public view */ }
+    const isInspectorOrAdmin = role === 'owner' || role === 'admin' || role === 'inspector';
+
+    try {
+        // Per-tenant opt-in toggle. Failure to read = treat as off.
+        let enableCustomerRepairExport = false;
+        let enableRepairList = false;
+        try {
+            const cfgRow = await drizzle(c.env.DB).select({
+                enableCustomerRepairExport: schema.tenantConfigs.enableCustomerRepairExport,
+                enableRepairList:           schema.tenantConfigs.enableRepairList,
+            })
+                .from(schema.tenantConfigs)
+                .where(eq(schema.tenantConfigs.tenantId, tenantId as string))
+                .get();
+            enableCustomerRepairExport = !!cfgRow?.enableCustomerRepairExport;
+            enableRepairList = !!cfgRow?.enableRepairList;
+        } catch { /* default off */ }
+        if (!enableCustomerRepairExport) {
+            return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+        }
+        // Suppress unused-var lint — enableRepairList is read for symmetry
+        // with /report/:id but the customer view never surfaces the link.
+        void enableRepairList;
+
+        // Pre-fetch the inspection row so we can run the same payment +
+        // agreement gate as /report/:id before pulling the (more expensive)
+        // repair-list data set.
+        if (!isInspectorOrAdmin) {
+            const db = drizzle(c.env.DB);
+            const insp = await db.select({
+                id:                schema.inspections.id,
+                propertyAddress:   schema.inspections.propertyAddress,
+                date:              schema.inspections.date,
+                inspectorId:       schema.inspections.inspectorId,
+                paymentRequired:   schema.inspections.paymentRequired,
+                paymentStatus:     schema.inspections.paymentStatus,
+                agreementRequired: schema.inspections.agreementRequired,
+            }).from(schema.inspections)
+                .where(and(eq(schema.inspections.id, id), eq(schema.inspections.tenantId, tenantId as string)))
+                .get();
+            if (!insp) return c.text('Report not found', 404);
+
+            const branding = c.get('branding');
+            const companyName = branding?.siteName || c.env.APP_NAME || 'OpenInspection';
+            const primaryColor = branding?.primaryColor || c.env.PRIMARY_COLOR || '#6366f1';
+            const baseUrl = (c.env.APP_BASE_URL || '').replace(/\/$/, '') || (c.req.header('host') ? `https://${c.req.header('host')}` : '');
+
+            let inspectorName: string | null = null;
+            if (insp.inspectorId) {
+                const inspectorRow = await drizzle(c.env.DB).select({ name: users.name })
+                    .from(users)
+                    .where(and(eq(users.id, insp.inspectorId), eq(users.tenantId, tenantId as string)))
+                    .get();
+                inspectorName = inspectorRow?.name ?? null;
+            }
+
+            if (insp.paymentRequired === true && insp.paymentStatus !== 'paid') {
+                const { ReportGatePage } = await import('./templates/pages/report-gate');
+                return c.html(ReportGatePage({
+                    reason:          'payment',
+                    companyName,
+                    primaryColor,
+                    actionUrl:       `${baseUrl}/invoices?inspection=${id}`,
+                    actionLabel:     'View invoice & pay',
+                    propertyAddress: insp.propertyAddress ?? null,
+                    inspectorName,
+                    scheduledDate:   insp.date ?? null,
+                }) as string);
+            }
+
+            if (insp.agreementRequired === true) {
+                const signed = await drizzle(c.env.DB).select({ id: schema.agreementRequests.id })
+                    .from(schema.agreementRequests)
+                    .where(and(
+                        eq(schema.agreementRequests.inspectionId, id),
+                        eq(schema.agreementRequests.tenantId, tenantId as string),
+                        eq(schema.agreementRequests.status, 'signed'),
+                    ))
+                    .limit(1);
+                if (signed.length === 0) {
+                    const { ReportGatePage } = await import('./templates/pages/report-gate');
+                    return c.html(ReportGatePage({
+                        reason:          'agreement',
+                        companyName,
+                        primaryColor,
+                        actionUrl:       `${baseUrl}/sign/${id}`,
+                        actionLabel:     'Sign agreement',
+                        propertyAddress: insp.propertyAddress ?? null,
+                        inspectorName,
+                        scheduledDate:   insp.date ?? null,
+                    }) as string);
+                }
+            }
+        }
+
+        // Pull the repair-list data set + the inspection's clientEmail for
+        // the email pre-fill input. clientEmail is a separate cheap select —
+        // getRepairList() doesn't surface it.
+        const data = await c.var.services.inspection.getRepairList(id, tenantId as string);
+        const clientRow = await drizzle(c.env.DB).select({ clientEmail: schema.inspections.clientEmail })
+            .from(schema.inspections)
+            .where(and(eq(schema.inspections.id, id), eq(schema.inspections.tenantId, tenantId as string)))
+            .get();
+
+        const rawDate = data.inspection.date || '';
+        const formattedDate = rawDate ? new Date(rawDate).toLocaleDateString('en-US', {
+            weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        }) : null;
+
+        // Strip recommendationId from the cards — the customer doesn't need
+        // the slug, only the human-readable label.
+        const defects = data.defects.map(d => ({
+            sectionId:           d.sectionId,
+            sectionTitle:        d.sectionTitle,
+            itemId:              d.itemId,
+            itemLabel:           d.itemLabel,
+            comment:             d.comment,
+            location:            d.location,
+            category:            d.category,
+            recommendationLabel: d.recommendationLabel,
+            estimateLow:         d.estimateLow,
+            estimateHigh:        d.estimateHigh,
+            photos:              d.photos,
+        }));
+
+        return c.html(CustomerRepairRequestPage({
+            inspectionId:    id,
+            propertyAddress: data.inspection.propertyAddress || 'Inspection',
+            inspectionDate:  formattedDate,
+            inspectorName:   data.inspection.inspectorName,
+            clientEmail:     clientRow?.clientEmail ?? null,
+            defects,
+            showEstimates:   data.showEstimates,
+            branding:        c.get('branding'),
+        }));
+    } catch {
+        return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
     }
 });
 
@@ -982,13 +1163,14 @@ app.get('/settings/workspace/reports', htmlAuthGuard(['owner', 'admin']), async 
         primaryColor: c.env.PRIMARY_COLOR || '#4f46e5',
         supportEmail: c.env.SENDER_EMAIL || 'support@example.com',
     });
-    const showEstimates          = Boolean((cfg as { showEstimates?: boolean | number }).showEstimates);
-    const enableRepairList       = Boolean((cfg as { enableRepairList?: boolean | number }).enableRepairList);
+    const showEstimates              = Boolean((cfg as { showEstimates?: boolean | number }).showEstimates);
+    const enableRepairList           = Boolean((cfg as { enableRepairList?: boolean | number }).enableRepairList);
+    const enableCustomerRepairExport = Boolean((cfg as { enableCustomerRepairExport?: boolean | number }).enableCustomerRepairExport);
     // Round-2 #10 — surface tenant-wide block-report policy so the toggles
     // hydrate with persisted state on first paint (no off-then-on flash).
-    const blockUnpaid            = Boolean((cfg as { blockUnpaid?: boolean | number }).blockUnpaid);
-    const blockUnsignedAgreement = Boolean((cfg as { blockUnsignedAgreement?: boolean | number }).blockUnsignedAgreement);
-    return c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'reports', showEstimates, enableRepairList, blockUnpaid, blockUnsignedAgreement }));
+    const blockUnpaid                = Boolean((cfg as { blockUnpaid?: boolean | number }).blockUnpaid);
+    const blockUnsignedAgreement     = Boolean((cfg as { blockUnsignedAgreement?: boolean | number }).blockUnsignedAgreement);
+    return c.html(SettingsWorkspacePage({ branding: c.get('branding'), subPage: 'reports', showEstimates, enableRepairList, enableCustomerRepairExport, blockUnpaid, blockUnsignedAgreement }));
 });
 // Round-2 backlog G3 — Custom referral sources sub-page. Reads
 // tenant_configs.custom_referral_sources via the BrandingService so the

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -53,7 +53,13 @@ export type AuditAction =
     | 'config.integration.update'
     | 'config.secrets.update'
     | 'config.attention_thresholds.update'
-    | 'config.dashboard_columns.update';
+    | 'config.dashboard_columns.update'
+    | 'tag.created'
+    | 'tag.updated'
+    | 'tag.deleted'
+    | 'tag.linked'
+    | 'tag.unlinked'
+    | 'inspection.property_facts.autofill';
 
 export interface AuditParams {
     db: D1Database;

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -49,6 +49,7 @@ export type AuditAction =
     | 'data.import'
     | 'data.delete'
     | 'audit.view'
+    | 'repair_request.exported'
     | 'comment.updated'
     | 'config.integration.update'
     | 'config.secrets.update'

--- a/src/lib/calendar-conflict.ts
+++ b/src/lib/calendar-conflict.ts
@@ -1,0 +1,77 @@
+/**
+ * Sprint 3 · S3-9 — Calendar drag-drop reschedule conflict detection.
+ *
+ * Pure helpers (no DOM, no fetch) so they can run in Vitest and inside the
+ * browser-side `calendar.js` drag handler. The FullCalendar event list is
+ * already loaded in memory when a drop happens, so this runs synchronously
+ * in `eventAllow` / `eventDrop` without an extra round-trip.
+ *
+ * Time semantics:
+ *   - "same hour" = same UTC year-month-day-hour. We deliberately use UTC
+ *     (not local time) so the result is identical whether the test runs in
+ *     CI (UTC) or on a developer's machine (local TZ). FullCalendar feeds us
+ *     ISO strings produced by `Date#toISOString()` from the dragged event,
+ *     which are already UTC.
+ *   - YYYY-MM-DD strings (no time) are treated as full-day occupants — any
+ *     drop on that calendar day conflicts. The `/api/calendar/events`
+ *     endpoint returns inspections in this shape for the dayGridMonth view.
+ */
+
+export interface CalendarItem {
+    id:   string;
+    date: string;       // ISO 8601 datetime, or YYYY-MM-DD
+}
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Returns true when both timestamps fall on the same UTC calendar day AND
+ * the same UTC hour. If either side is a YYYY-MM-DD (no time), only the
+ * calendar day must match — the day-only entry is treated as an all-day
+ * occupant of the slot.
+ *
+ * Returns false on any unparsable input rather than throwing — the caller is
+ * a drag-drop hot path and a thrown error would silently break the UI.
+ */
+export function sameDayHour(a: string, b: string): boolean {
+    if (!a || !b) return false;
+
+    const aDateOnly = DATE_ONLY_RE.test(a);
+    const bDateOnly = DATE_ONLY_RE.test(b);
+
+    const aDate = aDateOnly ? new Date(`${a}T00:00:00Z`) : new Date(a);
+    const bDate = bDateOnly ? new Date(`${b}T00:00:00Z`) : new Date(b);
+
+    if (Number.isNaN(aDate.getTime()) || Number.isNaN(bDate.getTime())) return false;
+
+    const sameDay = aDate.getUTCFullYear() === bDate.getUTCFullYear()
+        && aDate.getUTCMonth() === bDate.getUTCMonth()
+        && aDate.getUTCDate()  === bDate.getUTCDate();
+
+    if (!sameDay) return false;
+
+    // If either side is day-only, the day match alone is a conflict.
+    if (aDateOnly || bDateOnly) return true;
+
+    return aDate.getUTCHours() === bDate.getUTCHours();
+}
+
+/**
+ * Returns the first inspection that occupies the same UTC day+hour slot as
+ * `targetDate`, or `null` when the slot is free. The inspection identified
+ * by `ignoreId` is skipped — that's the inspection currently being dragged.
+ *
+ * Pure function: the caller passes the cached calendar payload, so this is
+ * O(n) over inspections currently rendered in the FullCalendar viewport.
+ */
+export function detectSlotConflict<T extends CalendarItem>(
+    inspections: ReadonlyArray<T>,
+    targetDate:  string,
+    ignoreId:    string,
+): T | null {
+    for (const ins of inspections) {
+        if (ins.id === ignoreId) continue;
+        if (sameDayHour(ins.date, targetDate)) return ins;
+    }
+    return null;
+}

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -19,6 +19,8 @@ export {
     inspectionEvents,
     inspectionRequests,
     inspectionMediaPool,
+    tags,
+    inspectionItemTagLinks,
 } from './inspection';
 export { contacts } from './contact';
 export { recommendations } from './recommendation';

--- a/src/lib/db/schema/inspection.ts
+++ b/src/lib/db/schema/inspection.ts
@@ -139,6 +139,34 @@ export const inspectionAgreements = sqliteTable('inspection_agreements', {
     userAgent: text('user_agent'),
 });
 
+// Sprint 3 S3-3 — T-key Tag system. Tenant-scoped tag library + a
+// many-to-many link table connecting an inspection-item position to one or
+// more tags. Internal-only (never rendered on customer-facing report).
+//
+// Design notes:
+//   - `name` is unique per tenant.
+//   - `is_seed` marks the five default tags planted on first /tags visit.
+//   - The link table uses (inspection_id, item_id, tag_id) as a composite
+//     PK so re-linking the same tag is a no-op without DELETE-then-INSERT.
+export const tags = sqliteTable('tags', {
+    id:        text('id').primaryKey(),
+    tenantId:  text('tenant_id').notNull(),
+    name:      text('name').notNull(),
+    color:     text('color'),
+    isSeed:    integer('is_seed').notNull().default(0),
+    createdAt: integer('created_at').notNull(),
+}, (t) => ({
+    tenantNameUnique: uniqueIndex('idx_tags_tenant_name').on(t.tenantId, t.name),
+}));
+
+export const inspectionItemTagLinks = sqliteTable('inspection_item_tag_links', {
+    inspectionId: text('inspection_id').notNull(),
+    itemId:       text('item_id').notNull(),
+    tagId:        text('tag_id').notNull(),
+    tenantId:     text('tenant_id').notNull(),
+    createdAt:    integer('created_at').notNull(),
+});
+
 // Round-2 backlog #9 (Spectora §E.3) — Media Center pool. Photos uploaded
 // ahead of item placement live here until the inspector drags one onto an
 // item textarea, at which point InspectionService.attachPoolPhoto moves it

--- a/src/lib/db/schema/tenant.ts
+++ b/src/lib/db/schema/tenant.ts
@@ -71,6 +71,11 @@ export const tenantConfigs = sqliteTable('tenant_configs', {
     // exposes a "Repair List" tab. Default OFF — opt-in for realtors who want
     // a separate punch-list view rather than the full narrative report.
     enableRepairList: integer('enable_repair_list', { mode: 'boolean' }).notNull().default(false),
+    // Sprint 3 S3-2 — when true, the public report viewer surfaces a
+    // "Generate repair request" link that takes the customer to a print-
+    // friendly export they can hand off to a contractor (or email back to
+    // themselves). Defaults OFF so existing tenants opt in deliberately.
+    enableCustomerRepairExport: integer('enable_customer_repair_export', { mode: 'boolean' }).notNull().default(false),
     // Round-2 backlog #10 — when true, every NEW inspection inherits
     // paymentRequired = true at creation time. Per-inspection override
     // remains; Stripe webhook auto-flips paymentStatus to 'paid'.

--- a/src/lib/middleware/di.ts
+++ b/src/lib/middleware/di.ts
@@ -31,6 +31,8 @@ import { ImportHistoryService } from '../../services/import-history.service';
 import { InspectionRequestService } from '../../services/inspection-request.service';
 import { RatingSystemService } from '../../services/rating-system.service';
 import { DashboardPrefsService } from '../../services/dashboard-prefs.service';
+import { TagService } from '../../services/tag.service';
+import { PropertyLookupService } from '../../services/property-lookup.service';
 
 import { StandaloneProvider } from '../integration/standalone';
 import { PortalProvider } from '../integration/portal';
@@ -177,6 +179,14 @@ export async function diMiddleware(c: Context<HonoConfig>, next: Next) {
                     break;
                 case 'dashboardPrefs':
                     target.dashboardPrefs = new DashboardPrefsService(c.env.DB);
+                    break;
+                case 'tag':
+                    target.tag = new TagService(c.env.DB);
+                    break;
+                case 'propertyLookup':
+                    target.propertyLookup = new PropertyLookupService({
+                        ESTATED_API_KEY: c.env.ESTATED_API_KEY,
+                    });
                     break;
             }
             return target[prop];

--- a/src/lib/validations/admin.schema.ts
+++ b/src/lib/validations/admin.schema.ts
@@ -15,6 +15,9 @@ export const UpdateBrandingSchema = z.object({
     showEstimates: z.boolean().optional().openapi({ example: true }),
     // Track E1 (ITB §11) — gate the "Repair List" tab on the published report.
     enableRepairList: z.boolean().optional().openapi({ example: true }),
+    // Sprint 3 S3-2 — gate the customer-driven "Generate repair request"
+    // export link on the published report. Independent of enableRepairList.
+    enableCustomerRepairExport: z.boolean().optional().openapi({ example: true }),
     // Round-2 backlog #10 — tenant-wide default for the per-inspection
     // paywall introduced in Sprint 1 D-7 (ReportGatePage). When true, every
     // newly created inspection inherits paymentRequired=true. Per-inspection

--- a/src/lib/validations/inspection.schema.ts
+++ b/src/lib/validations/inspection.schema.ts
@@ -119,6 +119,25 @@ export const PropertyFactsSchema = z.object({
 
 export const PropertyFactsResponseSchema = createApiResponseSchema(PropertyFactsSchema).openapi('PropertyFactsResponse');
 
+/**
+ * Sprint 3 S3-1 — POST /api/inspections/:id/property-facts/autofill
+ * Body: free-text address. Server-side proxy hits Estated.io public-records
+ * API and returns a normalised PropertyFacts payload (or `null` + reason
+ * code when the provider can't supply data — graceful degrade pattern).
+ */
+export const PropertyFactsAutofillRequestSchema = z.object({
+    addressString: z.string().min(5, 'Address is too short').max(200),
+}).openapi('PropertyFactsAutofillRequest');
+
+export const PropertyFactsAutofillResponseSchema = z.object({
+    success: z.literal(true),
+    data: z.object({
+        facts:  PropertyFactsSchema.nullable(),
+        source: z.enum(['estated', 'manual_required']),
+        reason: z.enum(['NO_API_KEY', 'NOT_FOUND', 'PROVIDER_ERROR']).optional(),
+    }),
+}).openapi('PropertyFactsAutofillResponse');
+
 export const CancellationReasonSchema = z.enum([
     'client_cancelled',
     'weather',

--- a/src/lib/validations/tag.schema.ts
+++ b/src/lib/validations/tag.schema.ts
@@ -1,0 +1,56 @@
+/**
+ * Sprint 3 S3-3 — Tag validation schemas.
+ *
+ * Tags are tenant-scoped library entries that inspectors attach to
+ * inspection items via the T hotkey. Internal-only (never on report).
+ *
+ * Color is optional + free-form so the tag picker can reuse Sprint 1
+ * design tokens (slate / amber / rose / indigo / emerald).
+ */
+import { z } from '@hono/zod-openapi';
+import { createApiResponseSchema } from './shared.schema';
+
+const TAG_COLOR_PATTERN = /^[a-z]{3,20}$/;
+
+export const TagSchema = z.object({
+    id:        z.string().min(1),
+    name:      z.string().min(1).max(40),
+    color:     z.string().regex(TAG_COLOR_PATTERN).nullable().optional(),
+    isSeed:    z.boolean(),
+    createdAt: z.number(),
+}).openapi('Tag');
+export type TagRecord = z.infer<typeof TagSchema>;
+
+export const CreateTagSchema = z.object({
+    name:  z.string().trim().min(1, 'Name is required').max(40, 'Name is too long'),
+    color: z.string().regex(TAG_COLOR_PATTERN, 'Invalid color token').optional(),
+}).strict().openapi('CreateTag');
+export type CreateTagInput = z.infer<typeof CreateTagSchema>;
+
+export const UpdateTagSchema = z.object({
+    name:  z.string().trim().min(1).max(40).optional(),
+    color: z.string().regex(TAG_COLOR_PATTERN).nullable().optional(),
+}).strict().openapi('UpdateTag');
+export type UpdateTagInput = z.infer<typeof UpdateTagSchema>;
+
+export const TagListResponseSchema   = createApiResponseSchema(z.array(TagSchema)).openapi('TagListResponse');
+export const TagSingleResponseSchema = createApiResponseSchema(TagSchema).openapi('TagSingleResponse');
+
+export const TagDeleteResponseSchema = z.object({
+    success: z.literal(true),
+    data:    z.object({ deleted: z.literal(true) }),
+}).openapi('TagDeleteResponse');
+
+/** Itemised tag link — what /api/inspections/:id/items/:itemId/tags returns. */
+export const ItemTagsResponseSchema  = createApiResponseSchema(z.array(TagSchema)).openapi('ItemTagsResponse');
+
+/** Empty link/unlink response. */
+export const TagLinkResponseSchema   = z.object({
+    success: z.literal(true),
+    data:    z.object({ linked: z.literal(true) }),
+}).openapi('TagLinkResponse');
+
+export const TagUnlinkResponseSchema = z.object({
+    success: z.literal(true),
+    data:    z.object({ unlinked: z.literal(true) }),
+}).openapi('TagUnlinkResponse');

--- a/src/lib/validations/template.schema.ts
+++ b/src/lib/validations/template.schema.ts
@@ -34,9 +34,13 @@ const ItemTabsSchema = z.object({
     defects:     z.array(CannedDefectSchema),
 }).strict();
 
+// S3-5 — tighten item label / section title to surface obviously-bogus
+// imports (e.g. someone pasting an entire paragraph as a "label"). The
+// limits comfortably accommodate every shipped seed template; current
+// longest label is 47 chars and longest section title is 34 chars.
 const RichItemSchema = z.object({
     id:            z.string().min(1),
-    label:         z.string().min(1),
+    label:         z.string().min(1).max(100),
     type:          z.literal('rich'),
     ratingOptions: z.array(z.string().min(1)).min(1),
     tabs:          ItemTabsSchema,
@@ -46,7 +50,7 @@ const RichItemSchema = z.object({
 
 const TextItemSchema = z.object({
     id:     z.string().min(1),
-    label:  z.string().min(1),
+    label:  z.string().min(1).max(100),
     type:   z.literal('text'),
     icon:   z.string().optional(),
     number: z.string().optional(),
@@ -56,7 +60,7 @@ const TemplateItemSchema = z.discriminatedUnion('type', [RichItemSchema, TextIte
 
 const TemplateSectionSchema = z.object({
     id:    z.string().min(1),
-    title: z.string().min(1),
+    title: z.string().min(1).max(50),
     icon:  z.string().optional(),
     items: z.array(TemplateItemSchema),
     // Track E2 (Spectora App.A) — per-section legal disclaimer rendered at

--- a/src/services/property-lookup.service.ts
+++ b/src/services/property-lookup.service.ts
@@ -1,0 +1,144 @@
+/**
+ * Sprint 3 S3-1 — PropertyLookupService.
+ *
+ * Server-side proxy for Estated.io public-records API. Fetches property
+ * facts (year built, sqft, foundation, lot size, bedrooms, bathrooms)
+ * by address. Maps the provider response into the existing
+ * PropertyFactsSchema so the inline-save handler in
+ * inspection-settings.js can patch the inspection without translation.
+ *
+ * Graceful degrade pattern (matches GooglePlacesService): when
+ * `ESTATED_API_KEY` is absent, returns `{ data: null, reason: 'NO_API_KEY' }`
+ * and the UI prompts manual entry. We never bubble a 5xx — the user
+ * always sees a clean "couldn't auto-fill" state.
+ *
+ * Provider docs: https://estated.com/docs (Property API v4)
+ */
+import { Errors } from '../lib/errors';
+import { logger } from '../lib/logger';
+
+export type FoundationType = 'basement' | 'slab' | 'crawlspace' | 'other';
+
+export interface PropertyFacts {
+    yearBuilt?:      number;
+    sqft?:           number;
+    foundationType?: FoundationType;
+    lotSize?:        string;
+    bedrooms?:       number;
+    bathrooms?:      number;
+}
+
+export type LookupReason = 'NO_API_KEY' | 'NOT_FOUND' | 'PROVIDER_ERROR';
+
+export interface LookupResult {
+    data:   PropertyFacts | null;
+    reason?: LookupReason;
+    source?: 'estated';
+}
+
+interface PropertyLookupEnv {
+    ESTATED_API_KEY?: string | undefined;
+}
+
+const ESTATED_API_BASE = 'https://apis.estated.com/v4/property';
+
+const FOUNDATION_MAP: Record<string, FoundationType> = {
+    basement:    'basement',
+    slab:        'slab',
+    crawlspace:  'crawlspace',
+    'crawl space': 'crawlspace',
+    pier:        'other',
+    'pier and beam': 'other',
+    other:       'other',
+};
+
+function normaliseFoundation(raw: unknown): FoundationType | undefined {
+    if (typeof raw !== 'string' || !raw) return undefined;
+    const key = raw.trim().toLowerCase();
+    return FOUNDATION_MAP[key];
+}
+
+interface EstatedV4Response {
+    data?: {
+        structure?: {
+            year_built?:       number | null;
+            total_area_sq_ft?: number | null;
+            beds_count?:       number | null;
+            baths?:            number | null;
+            foundation_type?:  string | null;
+        };
+        parcel?: {
+            area_sq_ft?: number | null;
+        };
+    };
+}
+
+/** Format an Estated parcel area into the free-text "lot size" string. */
+function formatLotSize(parcelSqFt: number | null | undefined): string | undefined {
+    if (typeof parcelSqFt !== 'number' || parcelSqFt <= 0) return undefined;
+    // Single-decimal acre conversion when over ~10k sqft (matches inspector
+    // mental model — small lots stay in sqft, large lots flip to acres).
+    if (parcelSqFt >= 10000) {
+        const acres = parcelSqFt / 43560;
+        return `${acres.toFixed(2)} acres`;
+    }
+    return `${parcelSqFt} sqft`;
+}
+
+export class PropertyLookupService {
+    constructor(private env: PropertyLookupEnv) {}
+
+    /**
+     * Resolve property facts for a free-text address. Never throws on
+     * provider errors — failures surface via the `reason` field.
+     */
+    async lookup(addressString: string): Promise<LookupResult> {
+        const address = (addressString ?? '').trim();
+        if (address.length < 5) throw Errors.BadRequest('Address is too short');
+
+        const apiKey = this.env.ESTATED_API_KEY;
+        if (!apiKey) return { data: null, reason: 'NO_API_KEY' };
+
+        let res: Response;
+        try {
+            const url = `${ESTATED_API_BASE}?token=${encodeURIComponent(apiKey)}&combined_address=${encodeURIComponent(address)}`;
+            res = await fetch(url, { method: 'GET' });
+        } catch (e) {
+            logger.warn('property-lookup.fetch-failed', { error: (e as Error).message });
+            return { data: null, reason: 'PROVIDER_ERROR' };
+        }
+
+        if (res.status === 404) return { data: null, reason: 'NOT_FOUND' };
+        if (!res.ok) {
+            logger.warn('property-lookup.provider-error', { status: res.status });
+            return { data: null, reason: 'PROVIDER_ERROR' };
+        }
+
+        let body: EstatedV4Response;
+        try {
+            body = await res.json() as EstatedV4Response;
+        } catch (e) {
+            logger.warn('property-lookup.parse-failed', { error: (e as Error).message });
+            return { data: null, reason: 'PROVIDER_ERROR' };
+        }
+
+        const structure = body?.data?.structure;
+        if (!structure) return { data: null, reason: 'NOT_FOUND' };
+
+        const facts: PropertyFacts = {};
+        if (typeof structure.year_built       === 'number') facts.yearBuilt = structure.year_built;
+        if (typeof structure.total_area_sq_ft === 'number') facts.sqft      = structure.total_area_sq_ft;
+        if (typeof structure.beds_count       === 'number') facts.bedrooms  = structure.beds_count;
+        if (typeof structure.baths            === 'number') facts.bathrooms = structure.baths;
+        const foundation = normaliseFoundation(structure.foundation_type);
+        if (foundation) facts.foundationType = foundation;
+        const lotSize = formatLotSize(body.data?.parcel?.area_sq_ft ?? null);
+        if (lotSize) facts.lotSize = lotSize;
+
+        // If absolutely nothing was extractable, treat as NOT_FOUND so the
+        // UI doesn't claim success on an empty payload.
+        if (Object.keys(facts).length === 0) return { data: null, reason: 'NOT_FOUND' };
+
+        return { data: facts, source: 'estated' };
+    }
+}

--- a/src/services/tag.service.ts
+++ b/src/services/tag.service.ts
@@ -1,0 +1,283 @@
+/**
+ * Sprint 3 S3-3 — TagService.
+ *
+ * Tenant-scoped CRUD over the `tags` table plus link/unlink helpers
+ * for the `inspection_item_tag_links` join. Tags are internal-only —
+ * never rendered on the customer-facing report.
+ *
+ * Inspector workflow: T hotkey on inspection-edit opens a picker;
+ * multi-select toggles links/unlinks for the active item.
+ *
+ * Seed defaults: five canonical tags planted on first /tags visit
+ * via `seedDefaults`. Idempotent — re-runs are no-ops.
+ */
+import { drizzle } from 'drizzle-orm/d1';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { tags, inspectionItemTagLinks } from '../lib/db/schema';
+import { Errors } from '../lib/errors';
+import { logger } from '../lib/logger';
+import type { CreateTagInput, UpdateTagInput, TagRecord } from '../lib/validations/tag.schema';
+
+/** Five canonical tags planted on first-run via `seedDefaults`. */
+export const SEED_TAGS: ReadonlyArray<{ name: string; color: string }> = Object.freeze([
+    { name: 'Needs follow-up',    color: 'amber'   },
+    { name: 'Waiting for client', color: 'slate'   },
+    { name: 'Critical',           color: 'rose'    },
+    { name: 'Customer concern',   color: 'indigo'  },
+    { name: 'Inspector note',     color: 'emerald' },
+]);
+
+export interface TagRow extends TagRecord {
+    tenantId: string;
+}
+
+function rowToRecord(row: typeof tags.$inferSelect): TagRow {
+    return {
+        id:        row.id as string,
+        tenantId:  row.tenantId as string,
+        name:      row.name as string,
+        color:     (row.color as string | null) ?? null,
+        isSeed:    Boolean(row.isSeed),
+        createdAt: Number(row.createdAt),
+    };
+}
+
+export class TagService {
+    constructor(private db: D1Database) {}
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private getDrizzle() { return drizzle(this.db as any); }
+
+    /** All tags visible to a tenant. Sorted: seeds first, then alpha. */
+    async list(tenantId: string): Promise<TagRow[]> {
+        const db = this.getDrizzle();
+        const rows = await db.select().from(tags)
+            .where(eq(tags.tenantId, tenantId))
+            .all();
+        const records = rows.map(rowToRecord);
+        records.sort((a, b) => {
+            if (a.isSeed !== b.isSeed) return a.isSeed ? -1 : 1;
+            return a.name.localeCompare(b.name);
+        });
+        return records;
+    }
+
+    async get(id: string, tenantId: string): Promise<TagRow | null> {
+        const db = this.getDrizzle();
+        const row = await db.select().from(tags)
+            .where(and(eq(tags.id, id), eq(tags.tenantId, tenantId)))
+            .get();
+        return row ? rowToRecord(row) : null;
+    }
+
+    async create(tenantId: string, input: CreateTagInput): Promise<TagRow> {
+        const db = this.getDrizzle();
+        const name = input.name.trim();
+        if (!name) throw Errors.BadRequest('Name is required');
+
+        const existing = await db.select({ id: tags.id }).from(tags)
+            .where(and(eq(tags.tenantId, tenantId), eq(tags.name, name)))
+            .get();
+        if (existing) throw Errors.Conflict(`A tag named '${name}' already exists`);
+
+        const id = crypto.randomUUID();
+        await db.insert(tags).values({
+            id,
+            tenantId,
+            name,
+            color:     input.color ?? null,
+            isSeed:    0,
+            createdAt: Date.now(),
+        });
+        const created = await this.get(id, tenantId);
+        if (!created) throw Errors.Internal('Failed to read back created tag');
+        return created;
+    }
+
+    async update(id: string, tenantId: string, input: UpdateTagInput): Promise<TagRow> {
+        const db = this.getDrizzle();
+        const existing = await this.get(id, tenantId);
+        if (!existing) throw Errors.NotFound('Tag not found');
+        if (existing.isSeed && input.name !== undefined && input.name !== existing.name) {
+            throw Errors.Forbidden('Seed tags cannot be renamed');
+        }
+
+        const updates: Record<string, unknown> = {};
+        if (input.name !== undefined) {
+            const name = input.name.trim();
+            if (!name) throw Errors.BadRequest('Name is required');
+            if (name !== existing.name) {
+                const conflict = await db.select({ id: tags.id }).from(tags)
+                    .where(and(eq(tags.tenantId, tenantId), eq(tags.name, name)))
+                    .get();
+                if (conflict) throw Errors.Conflict(`A tag named '${name}' already exists`);
+            }
+            updates.name = name;
+        }
+        if (input.color !== undefined) {
+            updates.color = input.color ?? null;
+        }
+        if (Object.keys(updates).length === 0) return existing;
+
+        await db.update(tags).set(updates)
+            .where(and(eq(tags.id, id), eq(tags.tenantId, tenantId)));
+        const refreshed = await this.get(id, tenantId);
+        if (!refreshed) throw Errors.Internal('Failed to read back updated tag');
+        return refreshed;
+    }
+
+    /** Deletes the tag + cascades to all item links. */
+    async delete(id: string, tenantId: string): Promise<{ deleted: true }> {
+        const db = this.getDrizzle();
+        const existing = await this.get(id, tenantId);
+        if (!existing) throw Errors.NotFound('Tag not found');
+
+        // Cascade delete item links first to keep the FK-less link table consistent.
+        await db.delete(inspectionItemTagLinks)
+            .where(and(eq(inspectionItemTagLinks.tagId, id), eq(inspectionItemTagLinks.tenantId, tenantId)));
+        await db.delete(tags)
+            .where(and(eq(tags.id, id), eq(tags.tenantId, tenantId)));
+        return { deleted: true as const };
+    }
+
+    /** Idempotent first-run seeder. Returns counts of inserted vs. skipped. */
+    async seedDefaults(tenantId: string): Promise<{ inserted: number; skipped: number }> {
+        const db = this.getDrizzle();
+        const existingRows = await db.select({ name: tags.name }).from(tags)
+            .where(eq(tags.tenantId, tenantId)).all();
+        const existingNames = new Set(existingRows.map(r => r.name as string));
+
+        let inserted = 0;
+        let skipped = 0;
+        const now = Date.now();
+        for (const seed of SEED_TAGS) {
+            if (existingNames.has(seed.name)) { skipped++; continue; }
+            await db.insert(tags).values({
+                id:        crypto.randomUUID(),
+                tenantId,
+                name:      seed.name,
+                color:     seed.color,
+                isSeed:    1,
+                createdAt: now,
+            });
+            inserted++;
+        }
+        if (inserted > 0) logger.info('tags.seeded', { tenantId, inserted, skipped });
+        return { inserted, skipped };
+    }
+
+    /**
+     * Link a tag to an item position on an inspection. Idempotent — the
+     * composite PK (inspection_id, item_id, tag_id) catches re-links.
+     */
+    async linkToItem(tenantId: string, inspectionId: string, itemId: string, tagId: string): Promise<void> {
+        const tag = await this.get(tagId, tenantId);
+        if (!tag) throw Errors.NotFound('Tag not found');
+        const db = this.getDrizzle();
+        try {
+            await db.insert(inspectionItemTagLinks).values({
+                inspectionId,
+                itemId,
+                tagId,
+                tenantId,
+                createdAt: Date.now(),
+            });
+        } catch (e) {
+            // PK conflict on re-link is expected — swallow.
+            const msg = e instanceof Error ? e.message.toLowerCase() : '';
+            if (!msg.includes('unique') && !msg.includes('constraint')) throw e;
+        }
+    }
+
+    async unlinkFromItem(tenantId: string, inspectionId: string, itemId: string, tagId: string): Promise<void> {
+        const db = this.getDrizzle();
+        await db.delete(inspectionItemTagLinks)
+            .where(and(
+                eq(inspectionItemTagLinks.tenantId, tenantId),
+                eq(inspectionItemTagLinks.inspectionId, inspectionId),
+                eq(inspectionItemTagLinks.itemId, itemId),
+                eq(inspectionItemTagLinks.tagId, tagId),
+            ));
+    }
+
+    /** Tags currently linked to a single inspection-item position. */
+    async getItemTags(tenantId: string, inspectionId: string, itemId: string): Promise<TagRow[]> {
+        const db = this.getDrizzle();
+        const links = await db.select({ tagId: inspectionItemTagLinks.tagId }).from(inspectionItemTagLinks)
+            .where(and(
+                eq(inspectionItemTagLinks.tenantId, tenantId),
+                eq(inspectionItemTagLinks.inspectionId, inspectionId),
+                eq(inspectionItemTagLinks.itemId, itemId),
+            ))
+            .all();
+        if (links.length === 0) return [];
+        const tagIds = links.map(l => l.tagId as string);
+        const rows = await db.select().from(tags)
+            .where(and(eq(tags.tenantId, tenantId), inArray(tags.id, tagIds)))
+            .all();
+        return rows.map(rowToRecord).sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    /**
+     * Bulk fetch — returns a map of itemId → TagRow[] for an entire
+     * inspection. Used by inspection-edit on initial render to hydrate
+     * tag chips for every item in one round-trip.
+     */
+    async getInspectionTagMap(tenantId: string, inspectionId: string): Promise<Record<string, TagRow[]>> {
+        const db = this.getDrizzle();
+        const links = await db.select().from(inspectionItemTagLinks)
+            .where(and(
+                eq(inspectionItemTagLinks.tenantId, tenantId),
+                eq(inspectionItemTagLinks.inspectionId, inspectionId),
+            ))
+            .all();
+        if (links.length === 0) return {};
+
+        const tagIds = Array.from(new Set(links.map(l => l.tagId as string)));
+        const tagRows = await db.select().from(tags)
+            .where(and(eq(tags.tenantId, tenantId), inArray(tags.id, tagIds)))
+            .all();
+        const tagById = new Map<string, TagRow>(tagRows.map(r => [r.id as string, rowToRecord(r)]));
+
+        const map: Record<string, TagRow[]> = {};
+        for (const link of links) {
+            const itemId = link.itemId as string;
+            const tag = tagById.get(link.tagId as string);
+            if (!tag) continue;
+            if (!map[itemId]) map[itemId] = [];
+            map[itemId].push(tag);
+        }
+        for (const k of Object.keys(map)) {
+            map[k]!.sort((a, b) => a.name.localeCompare(b.name));
+        }
+        return map;
+    }
+
+    /** Count of items tagged with each tag inside one inspection. */
+    async countByTag(tenantId: string, inspectionId: string): Promise<Record<string, number>> {
+        const db = this.getDrizzle();
+        const rows = await db.select({
+            tagId: inspectionItemTagLinks.tagId,
+            count: sql<number>`count(*)`,
+        }).from(inspectionItemTagLinks)
+            .where(and(
+                eq(inspectionItemTagLinks.tenantId, tenantId),
+                eq(inspectionItemTagLinks.inspectionId, inspectionId),
+            ))
+            .groupBy(inspectionItemTagLinks.tagId)
+            .all();
+        const out: Record<string, number> = {};
+        for (const r of rows) out[r.tagId as string] = Number(r.count);
+        return out;
+    }
+
+    /** All inspection ids in the tenant that have at least one item tagged with `tagId`. */
+    async listInspectionsByTag(tenantId: string, tagId: string): Promise<string[]> {
+        const db = this.getDrizzle();
+        const rows = await db.selectDistinct({ inspectionId: inspectionItemTagLinks.inspectionId })
+            .from(inspectionItemTagLinks)
+            .where(and(eq(inspectionItemTagLinks.tenantId, tenantId), eq(inspectionItemTagLinks.tagId, tagId)))
+            .all();
+        return rows.map(r => r.inspectionId as string);
+    }
+}

--- a/src/templates/components/burst-camera.tsx
+++ b/src/templates/components/burst-camera.tsx
@@ -1,0 +1,156 @@
+/**
+ * S3-6 — AI burst photo capture modal.
+ *
+ * Full-screen, dark camera surface mounted once at the bottom of the
+ * inspection-edit page. Visibility, lifecycle, and shutter logic live in
+ * `public/js/burst-camera.js` (Alpine factory `burstCamera`).
+ *
+ * UX:
+ *   - Live preview from `getUserMedia({ video: { facingMode: ... } })`.
+ *   - Single tap on the shutter = single photo.
+ *   - Long-press (≥ 200 ms) = burst capture, capped at 30 frames @ 10 fps.
+ *   - Bottom strip shows captured thumbnails. "Done" uploads them all,
+ *     "Discard" cancels. Per-thumbnail discard via the small `×` button.
+ *   - If `getUserMedia` is unavailable or rejected, the modal closes
+ *     and falls back to the existing native file picker
+ *     (`#hotkey-photo-input`).
+ *
+ * Design tokens (Sprint 1): rose-500 burst counter, slate-900 chrome
+ * background, indigo accent for the Done button. The page gets
+ * `overflow-hidden` while open so the live feed is the only surface.
+ */
+export const BurstCamera = (): JSX.Element => (
+    <div
+        x-data="burstCamera"
+        x-show="open"
+        {...{
+            'x-cloak': '',
+            'x-on:keydown.escape.window': 'if (open) close()',
+        }}
+        class="fixed inset-0 z-50 bg-black flex flex-col"
+        role="dialog"
+        aria-label="Burst camera"
+        aria-modal="true"
+        style="display: none"
+    >
+        {/* Live preview. `playsinline` keeps iOS Safari from going full screen. */}
+        <video
+            x-ref="video"
+            autoplay
+            muted
+            playsinline
+            class="absolute inset-0 w-full h-full object-cover"
+        ></video>
+        <canvas x-ref="canvas" class="hidden"></canvas>
+
+        {/* Top chrome — close + facing toggle. */}
+        <div class="relative z-10 flex items-center justify-between px-4 pt-4">
+            <button
+                type="button"
+                x-on:click="close()"
+                class="w-10 h-10 rounded-full bg-black/40 text-white flex items-center justify-center hover:bg-black/60 transition"
+                aria-label="Close camera"
+                title="Close (Esc)"
+            >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+            <div class="text-white text-xs font-mono px-3 py-1 rounded-full bg-black/40" x-show="captures.length > 0">
+                <span x-text="captures.length"></span> captured
+            </div>
+            <button
+                type="button"
+                x-on:click="switchFacing()"
+                class="w-10 h-10 rounded-full bg-black/40 text-white flex items-center justify-center hover:bg-black/60 transition"
+                aria-label="Switch camera"
+                title="Switch camera"
+            >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h5M20 20v-5h-5M4 9a8 8 0 0114-3M20 15a8 8 0 01-14 3" />
+                </svg>
+            </button>
+        </div>
+
+        {/* Spacer pushes shutter row to the bottom. */}
+        <div class="flex-1"></div>
+
+        {/* Captured thumbnail strip. Horizontally scrollable when > 8 frames. */}
+        <div
+            x-show="captures.length > 0"
+            class="relative z-10 mb-3 px-4"
+            style="display: none"
+        >
+            <div class="flex gap-2 overflow-x-auto pb-1" data-testid="burst-thumbnails">
+                <template x-for="(c, ci) in captures" x-bind:key="c.id">
+                    <div class="relative flex-shrink-0">
+                        <img
+                            x-bind:src="c.url"
+                            class="w-16 h-16 object-cover rounded-md border-2 border-white/30"
+                            alt="Captured frame"
+                        />
+                        <button
+                            type="button"
+                            x-on:click="discardOne(c.id)"
+                            class="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-rose-500 text-white text-xs font-bold flex items-center justify-center hover:bg-rose-600"
+                            aria-label="Discard this frame"
+                        >×</button>
+                    </div>
+                </template>
+            </div>
+        </div>
+
+        {/* Bottom action row — discard / shutter / done. */}
+        <div class="relative z-10 pb-8 px-4 flex items-center justify-between gap-4">
+            <button
+                type="button"
+                x-on:click="discardAll()"
+                x-show="captures.length > 0"
+                style="display: none"
+                class="text-rose-300 text-xs font-semibold hover:text-rose-200 transition"
+                aria-label="Discard all captures"
+            >
+                Discard all
+            </button>
+            <div x-show="captures.length === 0" class="w-20" aria-hidden="true"></div>
+
+            {/* Shutter — tap = single shot, hold = burst. */}
+            <button
+                type="button"
+                x-on:mousedown="onShutterDown($event)"
+                x-on:mouseup="onShutterUp($event)"
+                x-on:mouseleave="onShutterCancel()"
+                {...{
+                    'x-on:touchstart.prevent': 'onShutterDown($event)',
+                    'x-on:touchend.prevent': 'onShutterUp($event)',
+                    'x-on:touchcancel.prevent': 'onShutterCancel()',
+                }}
+                class="w-20 h-20 rounded-full bg-white border-4 transition flex items-center justify-center"
+                x-bind:class="burstActive ? 'border-rose-500 scale-110' : 'border-white/40 hover:scale-105'"
+                aria-label="Capture (tap for single, hold for burst)"
+                data-testid="burst-shutter"
+            >
+                <span x-show="!burstActive" class="text-slate-700 text-[10px] font-bold tracking-widest uppercase">Shoot</span>
+                <span
+                    x-show="burstActive"
+                    style="display: none"
+                    class="text-rose-600 text-xs font-bold animate-pulse"
+                    x-text="burstCount + ' / 30'"
+                ></span>
+            </button>
+
+            <button
+                type="button"
+                x-on:click="commit()"
+                x-show="captures.length > 0"
+                style="display: none"
+                class="px-5 py-2.5 rounded-full bg-indigo-500 text-white text-sm font-bold shadow-lg hover:bg-indigo-600 transition"
+                aria-label="Upload captures"
+                data-testid="burst-done"
+            >
+                <span x-text="uploading ? 'Uploading…' : 'Done'"></span>
+            </button>
+            <div x-show="captures.length === 0" class="w-20" aria-hidden="true"></div>
+        </div>
+    </div>
+);

--- a/src/templates/components/property-facts-card.tsx
+++ b/src/templates/components/property-facts-card.tsx
@@ -32,11 +32,44 @@ export const PropertyFactsCard = (): JSX.Element => (
         class="space-y-4"
         data-testid="property-facts-card"
     >
-        <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Property facts</legend>
-        <p class="text-[12px] text-slate-500">
-            Surfaced as a banner on the published report. Leave blank for fields you didn't capture —
-            the report renders only the facts you fill in.
-        </p>
+        <div class="flex items-start justify-between gap-3 flex-wrap">
+            <div>
+                <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Property facts</legend>
+                <p class="text-[12px] text-slate-500">
+                    Surfaced as a banner on the published report. Leave blank for fields you didn't capture —
+                    the report renders only the facts you fill in.
+                </p>
+            </div>
+            {/* Sprint 3 S3-1 — Auto-fill button. Hits /property-facts/autofill
+                with the property address; server proxies Estated.io and
+                returns mapped facts. Manual entries are never overwritten. */}
+            <button
+                type="button"
+                data-testid="property-facts-autofill"
+                x-on:click="autofillFromAddress()"
+                {...{ 'x-bind:disabled': "autofillState === 'pending'" }}
+                class="h-8 px-3 rounded-md bg-indigo-50 text-indigo-700 text-[12px] font-bold ring-1 ring-inset ring-indigo-200 hover:bg-indigo-100 disabled:opacity-50 disabled:cursor-wait inline-flex items-center gap-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                title="Auto-fill from public records (Estated.io)"
+            >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" /></svg>
+                <span x-show="autofillState !== 'pending'">Auto-fill from address</span>
+                <span x-show="autofillState === 'pending'" style="display:none">Fetching…</span>
+            </button>
+        </div>
+
+        <p
+            x-show="autofillMessage"
+            style="display:none"
+            x-text="autofillMessage"
+            x-bind:class="
+                autofillState === 'success' ? 'text-emerald-700 bg-emerald-50 ring-emerald-200' :
+                autofillState === 'no_key'  ? 'text-slate-700 bg-slate-50 ring-slate-200' :
+                autofillState === 'not_found' ? 'text-amber-700 bg-amber-50 ring-amber-200' :
+                'text-rose-700 bg-rose-50 ring-rose-200'
+            "
+            class="text-[12px] px-3 py-2 rounded-md ring-1 ring-inset"
+            data-testid="property-facts-autofill-message"
+        ></p>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {/* Year Built */}

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -199,6 +199,7 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                     <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
                                     <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
                                     <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
+                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Tags</a>
                                 </div>
                             </details>
                             <a href="/contacts" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
@@ -308,6 +309,7 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                     <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
                                     <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
                                     <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
+                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Tags</a>
                                 </div>
                             </details>
                             <a href="/contacts" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">

--- a/src/templates/pages/calendar.tsx
+++ b/src/templates/pages/calendar.tsx
@@ -21,6 +21,81 @@ export const CalendarPage = ({ branding }: { branding?: BrandingConfig | undefin
                 </div>
             </div>
 
+            {/*
+                Sprint 3 · S3-9 — Calendar drag-drop reschedule conflict modal.
+                Driven by Alpine `calendarConflict` data on the body, populated by
+                the FullCalendar eventDrop handler in /js/calendar.js when the
+                drop target is already occupied. Three resolutions:
+                  - Replace: bump the existing inspection back to the dragged
+                    inspection's old slot.
+                  - Swap: exchange the two slots.
+                  - Cancel: revert (no API call).
+            */}
+            <div
+                x-data="calendarConflict"
+                x-show="open"
+                style="display:none"
+                class="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+                {...{ 'x-on:click.self': 'cancel()' }}
+                {...{ 'x-on:keydown.escape.window': 'cancel()' }}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="calendar-conflict-title"
+            >
+                <div class="bg-white rounded-md shadow-xl w-full max-w-md p-6 max-h-[90vh] overflow-y-auto" {...{ 'x-on:click.stop': '' }}>
+                    <header class="flex items-start justify-between gap-3 mb-4">
+                        <div class="min-w-0 flex-1">
+                            <h2 id="calendar-conflict-title" class="text-lg font-bold text-slate-900">Time slot taken</h2>
+                            <p class="text-sm text-slate-500 mt-0.5">
+                                <span x-text="conflictTitle"></span>
+                                <span class="text-slate-400"> already occupies </span>
+                                <span x-text="targetLabel" class="font-semibold text-slate-700"></span>
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            aria-label="Close dialog"
+                            class="w-8 h-8 rounded-xl bg-slate-100 hover:bg-slate-200 flex items-center justify-center text-slate-500 flex-shrink-0"
+                            x-on:click="cancel()"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </header>
+                    <p class="text-sm text-slate-600 mb-4">Choose how to resolve the overlap:</p>
+                    <div class="space-y-2">
+                        <button
+                            type="button"
+                            x-on:click="resolve('replace')"
+                            x-bind:disabled="busy"
+                            class="w-full text-left px-4 py-3 rounded-md border border-slate-200 hover:bg-slate-50 disabled:opacity-50 transition-colors"
+                        >
+                            <div class="text-sm font-bold text-slate-900">Replace</div>
+                            <div class="text-xs text-slate-500 mt-0.5">Move the existing inspection back to the dragged inspection&rsquo;s old slot.</div>
+                        </button>
+                        <button
+                            type="button"
+                            x-on:click="resolve('swap')"
+                            x-bind:disabled="busy"
+                            class="w-full text-left px-4 py-3 rounded-md border border-slate-200 hover:bg-slate-50 disabled:opacity-50 transition-colors"
+                        >
+                            <div class="text-sm font-bold text-slate-900">Swap</div>
+                            <div class="text-xs text-slate-500 mt-0.5">Exchange the two inspections&rsquo; slots.</div>
+                        </button>
+                        <button
+                            type="button"
+                            x-on:click="cancel()"
+                            x-bind:disabled="busy"
+                            class="w-full text-left px-4 py-3 rounded-md border border-slate-200 hover:bg-slate-50 disabled:opacity-50 transition-colors"
+                        >
+                            <div class="text-sm font-bold text-slate-900">Pick another slot</div>
+                            <div class="text-xs text-slate-500 mt-0.5">Revert this drag and choose a different time.</div>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             {/* FullCalendar vendor scripts (CSS bundled in JS for global build) */}
             <script src="/vendor/fullcalendar/core.global.min.js"></script>
             <script src="/vendor/fullcalendar/daygrid.global.min.js"></script>

--- a/src/templates/pages/customer-repair-request.tsx
+++ b/src/templates/pages/customer-repair-request.tsx
@@ -1,0 +1,312 @@
+/**
+ * Sprint 3 Track B (S3-2) — Customer-driven Repair Request export.
+ *
+ * Public, token-gated companion to the inspector-facing repair list (Track
+ * E1). The customer who received the report opens this page from a link on
+ * the published report (`/report/:id`), reviews the per-defect cards, can
+ * jot per-item comments to share with their contractor, and either:
+ *
+ *   1. Print / save to PDF via `window.print()` (uses the same
+ *      `@media print` rules as the inspector repair list); or
+ *   2. Email the list to themselves via the
+ *      `POST /api/public/repair-request/email` endpoint.
+ *
+ * Distinct from the inspector view: this page is the homeowner / buyer's
+ * tool, no inspector chrome (no shell sub-nav, no "Edit in report tab"
+ * link). Every interaction is fully public — no JWT — but the same
+ * payment + agreement gates that protect the report itself protect this
+ * export (the route mirrors `/report/:id` gating server-side).
+ */
+
+import { BareLayout } from '../layouts/main-layout';
+import type { BrandingConfig } from '../../types/auth';
+
+export interface CustomerRepairRequestEntry {
+    sectionId:           string;
+    sectionTitle:        string;
+    itemId:              string;
+    itemLabel:           string;
+    comment:             string;
+    location:            string | null;
+    category:            'safety' | 'recommendation' | 'maintenance';
+    recommendationLabel: string | null;
+    estimateLow:         number | null;
+    estimateHigh:        number | null;
+    photos:              Array<{ key: string; url: string }>;
+}
+
+export interface CustomerRepairRequestPageProps {
+    inspectionId:    string;
+    propertyAddress: string;
+    inspectionDate:  string | null;
+    inspectorName:   string | null;
+    clientEmail:     string | null;
+    defects:         CustomerRepairRequestEntry[];
+    showEstimates:   boolean;
+    branding?:       BrandingConfig | undefined;
+}
+
+const CATEGORY_TONE: Record<CustomerRepairRequestEntry['category'], { bg: string; text: string; ring: string; label: string }> = {
+    safety:         { bg: 'bg-rose-50',  text: 'text-rose-700',  ring: 'ring-rose-200',  label: 'Safety' },
+    recommendation: { bg: 'bg-amber-50', text: 'text-amber-700', ring: 'ring-amber-200', label: 'Recommend' },
+    maintenance:    { bg: 'bg-slate-50', text: 'text-slate-700', ring: 'ring-slate-200', label: 'Maintain' },
+};
+
+function formatMoney(cents: number | null): string {
+    if (cents == null || cents <= 0) return '';
+    return `$${Math.round(cents / 100).toLocaleString()}`;
+}
+
+function groupBySection(entries: CustomerRepairRequestEntry[]): Array<{ sectionId: string; sectionTitle: string; items: CustomerRepairRequestEntry[] }> {
+    const order: string[] = [];
+    const map = new Map<string, { sectionId: string; sectionTitle: string; items: CustomerRepairRequestEntry[] }>();
+    for (const e of entries) {
+        if (!map.has(e.sectionId)) {
+            map.set(e.sectionId, { sectionId: e.sectionId, sectionTitle: e.sectionTitle, items: [] });
+            order.push(e.sectionId);
+        }
+        map.get(e.sectionId)!.items.push(e);
+    }
+    return order.map(id => map.get(id)!);
+}
+
+const CUSTOMER_REPAIR_CSS = `
+@media print {
+    .no-print { display: none !important; }
+    body { background: white !important; }
+    .crr-card { page-break-inside: avoid; break-inside: avoid; }
+    .crr-section { page-break-inside: avoid; }
+    textarea.crr-comments {
+        border: 1px dashed #cbd5e1;
+        background: white !important;
+    }
+}
+textarea.crr-comments {
+    background: #f8fafc;
+}
+`;
+
+export const CustomerRepairRequestPage = ({
+    inspectionId,
+    propertyAddress,
+    inspectionDate,
+    inspectorName,
+    clientEmail,
+    defects,
+    showEstimates,
+    branding,
+}: CustomerRepairRequestPageProps): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
+    const grouped = groupBySection(defects);
+    // Encode props for the Alpine x-data initializer. The runtime collects
+    // the per-item textarea inputs into a single payload before posting to
+    // the email endpoint.
+    const itemRefs = defects.map(d => ({ itemId: d.itemId, sectionTitle: d.sectionTitle, itemLabel: d.itemLabel }));
+    const initialState = JSON.stringify({
+        inspectionId,
+        recipientEmail: clientEmail || '',
+        items: itemRefs,
+    }).replace(/'/g, '&#39;');
+
+    return (
+        <BareLayout
+            title={`${siteName} | Repair request`}
+            {...(branding ? { branding } : {})}
+            extraHead={<style dangerouslySetInnerHTML={{ __html: CUSTOMER_REPAIR_CSS }} />}
+        >
+            <div
+                class="max-w-3xl mx-auto px-4 sm:px-6 py-8"
+                x-data={`customerRepairRequest(${initialState})`}
+                data-testid="customer-repair-request-root"
+            >
+                {/* Header */}
+                <header class="mb-6">
+                    <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mb-1">
+                        Repair Request
+                    </p>
+                    <h1 class="text-[24px] sm:text-[28px] font-semibold tracking-tight text-slate-900 leading-tight">
+                        {propertyAddress}
+                    </h1>
+                    <p class="text-[13px] text-slate-500 mt-2">
+                        Generated from your inspection report. Review the items below, add any
+                        comments for your contractor, then print this list or email a copy to yourself.
+                    </p>
+                    {inspectionDate || inspectorName ? (
+                        <p class="text-[12px] text-slate-500 mt-1">
+                            {inspectionDate ? <span>Inspected <strong class="text-slate-700">{inspectionDate}</strong></span> : null}
+                            {inspectorName ? <span> &middot; By <strong class="text-slate-700">{inspectorName}</strong></span> : null}
+                        </p>
+                    ) : null}
+                </header>
+
+                {/* Toolbar (hidden in print) */}
+                <div class="no-print mb-6 flex flex-wrap items-center gap-2">
+                    <button
+                        type="button"
+                        onclick="window.print()"
+                        data-testid="crr-print"
+                        class="inline-flex items-center gap-1.5 px-3 h-9 rounded-md bg-slate-900 text-white text-[12px] font-bold hover:bg-slate-700 transition-colors"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+                        </svg>
+                        Download PDF
+                    </button>
+                    <div class="flex items-center gap-2 flex-1 min-w-[260px]">
+                        <input
+                            type="email"
+                            x-model="recipientEmail"
+                            placeholder="you@example.com"
+                            data-testid="crr-email-input"
+                            class="flex-1 h-9 px-3 rounded-md border border-slate-200 text-[13px] text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
+                        />
+                        <button
+                            type="button"
+                            x-on:click="sendEmail()"
+                            x-bind:disabled="sending || !recipientEmail"
+                            data-testid="crr-email-submit"
+                            class="inline-flex items-center gap-1.5 px-3 h-9 rounded-md bg-blue-600 text-white text-[12px] font-bold hover:bg-blue-700 disabled:bg-slate-300 disabled:cursor-not-allowed transition-colors"
+                        >
+                            <span x-show="!sending">Email this list to me</span>
+                            <span x-show="sending" style="display:none">Sending&hellip;</span>
+                        </button>
+                    </div>
+                </div>
+
+                {/* Toast */}
+                <div
+                    x-show="toast"
+                    x-transition
+                    style="display:none"
+                    class="no-print mb-4 px-4 py-2 rounded-md text-[13px] font-semibold"
+                    x-bind:class="toastError ? 'bg-rose-50 text-rose-800 border border-rose-200' : 'bg-emerald-50 text-emerald-800 border border-emerald-200'"
+                    data-testid="crr-toast"
+                    x-text="toast"
+                ></div>
+
+                {/* Empty state */}
+                {defects.length === 0 ? (
+                    <div
+                        class="text-center py-12 px-6 rounded-md bg-emerald-50 border border-emerald-200"
+                        data-testid="crr-empty"
+                    >
+                        <p class="text-[14px] text-emerald-700 font-semibold">
+                            Good news! No defects were flagged on your inspection.
+                        </p>
+                        <p class="text-[12px] text-emerald-600 mt-1">
+                            There is nothing to request a repair for.
+                        </p>
+                    </div>
+                ) : null}
+
+                {/* Defects grouped by section */}
+                {grouped.map(group => (
+                    <section class="space-y-3 mb-8 crr-section">
+                        <header class="flex items-baseline justify-between border-b border-slate-200 pb-2">
+                            <h2 class="text-[14px] font-bold text-slate-900">{group.sectionTitle}</h2>
+                            <span class="text-[11px] text-slate-400 font-mono">
+                                {group.items.length} item{group.items.length === 1 ? '' : 's'}
+                            </span>
+                        </header>
+                        <ul class="space-y-3">
+                            {group.items.map((d, idx) => {
+                                const tone = CATEGORY_TONE[d.category];
+                                const lo = formatMoney(d.estimateLow);
+                                const hi = formatMoney(d.estimateHigh);
+                                const showEstimateBadge = showEstimates && (lo || hi);
+                                return (
+                                    <li
+                                        class="crr-card rounded-md border border-slate-200 bg-white px-5 py-4"
+                                        data-testid="crr-card"
+                                        data-category={d.category}
+                                    >
+                                        <div class="flex items-start justify-between gap-3 mb-2">
+                                            <div class="flex-1 min-w-0">
+                                                <div class="flex flex-wrap items-center gap-2 mb-1">
+                                                    <span class={`inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide ring-1 ring-inset ${tone.bg} ${tone.text} ${tone.ring}`}>
+                                                        {tone.label}
+                                                    </span>
+                                                    <span class="text-[11px] font-mono text-slate-400">
+                                                        {group.sectionTitle} &rsaquo; {d.itemLabel}
+                                                    </span>
+                                                </div>
+                                                <p class="text-[14px] font-semibold text-slate-900 leading-snug">
+                                                    {d.itemLabel}
+                                                </p>
+                                                {d.location ? (
+                                                    <p class="text-[12px] text-slate-500 mt-0.5">
+                                                        Location: {d.location}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            {d.recommendationLabel ? (
+                                                <span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200">
+                                                    {d.recommendationLabel}
+                                                </span>
+                                            ) : null}
+                                        </div>
+
+                                        {d.comment ? (
+                                            <p class="text-[13px] text-slate-700 leading-relaxed whitespace-pre-line">
+                                                {d.comment}
+                                            </p>
+                                        ) : null}
+
+                                        {showEstimateBadge ? (
+                                            <div
+                                                class="mt-3 inline-flex items-center px-2 py-1 rounded-md text-[12px] font-semibold bg-emerald-50 text-emerald-700 tabular-nums"
+                                                data-testid="crr-card-estimate"
+                                            >
+                                                Estimated cost: {lo || '$?'} – {hi || '$?'}
+                                            </div>
+                                        ) : null}
+
+                                        {d.photos.length > 0 ? (
+                                            <div class="mt-3 grid grid-cols-3 gap-2">
+                                                {d.photos.slice(0, 6).map((p, pi) => (
+                                                    <img
+                                                        src={p.url}
+                                                        alt={`${d.itemLabel} photo ${pi + 1}`}
+                                                        class="w-full h-24 object-cover rounded border border-slate-200"
+                                                        loading="lazy"
+                                                    />
+                                                ))}
+                                            </div>
+                                        ) : null}
+
+                                        {/* Customer comments — printed line for the contractor. */}
+                                        <div class="mt-3">
+                                            <label
+                                                class="block text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mb-1"
+                                                for={`crr-note-${d.itemId}-${idx}`}
+                                            >
+                                                Your notes for the contractor
+                                            </label>
+                                            <textarea
+                                                id={`crr-note-${d.itemId}-${idx}`}
+                                                rows={2}
+                                                class="crr-comments w-full px-3 py-2 rounded-md border border-slate-200 text-[13px] text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
+                                                placeholder="Optional comment (e.g. preferred quote scope, timing, access details)"
+                                                data-testid="crr-card-note"
+                                                x-on:input={`itemNotes['${d.itemId}'] = $event.target.value`}
+                                            ></textarea>
+                                        </div>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </section>
+                ))}
+
+                <footer class="no-print mt-12 pt-6 border-t border-slate-200 text-[11px] text-slate-400 text-center">
+                    Generated by <strong class="text-slate-600">{siteName}</strong>. This list reflects
+                    items flagged in your inspection report and does not constitute a legally binding
+                    contract or repair scope.
+                </footer>
+            </div>
+
+            <script src="/js/auth.js"></script>
+            <script src="/js/customer-repair-request.js"></script>
+        </BareLayout>
+    );
+};

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -173,11 +173,39 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                                 ></span>
                             </button>
                         </template>
+
+                        {/* Sprint 3 S3-3 — Tag filter. Combines with the time
+                            filter (intersection) so an inspector can scope to
+                            "today + Critical" in two clicks. The dropdown
+                            populates on load via /api/tags. Shows a count
+                            badge when active. */}
+                        <div class="ml-2 flex items-center gap-2" data-test="inspection-tag-filter">
+                            <select
+                                x-model="activeTagFilter"
+                                x-on:change="onTagFilterChange()"
+                                aria-label="Filter by tag"
+                                class="h-7 px-2 rounded-full border text-[11px] font-bold uppercase tracking-[0.08em] outline-none focus:ring-2 focus:ring-indigo-500/30 bg-white text-slate-600 border-slate-200"
+                                data-testid="dashboard-tag-filter"
+                            >
+                                <option value="">Any tag</option>
+                                <template x-for="t in availableTags" {...{ 'x-bind:key': 't.id' }}>
+                                    <option {...{ 'x-bind:value': 't.id' }} x-text="t.name"></option>
+                                </template>
+                            </select>
+                            <button
+                                type="button"
+                                x-show="activeTagFilter"
+                                style="display:none"
+                                x-on:click="activeTagFilter = ''; onTagFilterChange()"
+                                class="text-[10px] font-bold uppercase tracking-[0.08em] text-indigo-600 hover:text-indigo-700"
+                            >Clear</button>
+                        </div>
                     </div>
 
-                    {/* C1 — Flat filtered list, shown only when activeFilter !== 'all'. */}
+                    {/* C1 — Flat filtered list, shown when activeFilter !== 'all'
+                        OR a tag filter is active (Sprint 3 S3-3). */}
                     <section
-                        x-show="!loading && activeFilter !== 'all'"
+                        x-show="!loading && (activeFilter !== 'all' || !!tagFilterIds)"
                         {...{ 'x-cloak': true }}
                         class="bg-white border border-slate-200 rounded-md scroll-mt-20"
                         data-test="inspection-filter-list"
@@ -211,7 +239,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Needs Attention */}
-                    <section id="bucket-needsAttention" x-show="!loading && activeFilter === 'all' && buckets.needsAttention.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-needsAttention" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.needsAttention.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.needsAttention = !sections.needsAttention"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -229,7 +257,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Today */}
-                    <section id="bucket-today" x-show="!loading && activeFilter === 'all' && buckets.today.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-today" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.today.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.today = !sections.today"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -247,7 +275,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Today's events (Spec 4D.T10) */}
-                    <section x-show="!loading && activeFilter === 'all' && todayEvents.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
+                    <section x-show="!loading && activeFilter === 'all' && !tagFilterIds && todayEvents.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
                         <button type="button" x-on:click="sections.todayEvents = !sections.todayEvents"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -270,7 +298,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: This Week */}
-                    <section id="bucket-thisWeek" x-show="!loading && activeFilter === 'all' && buckets.thisWeek.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-thisWeek" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.thisWeek.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.thisWeek = !sections.thisWeek"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -288,7 +316,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Later */}
-                    <section x-show="!loading && activeFilter === 'all' && (buckets.later.length > 0 || buckets.laterTotal > 0)" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
+                    <section x-show="!loading && activeFilter === 'all' && !tagFilterIds && (buckets.later.length > 0 || buckets.laterTotal > 0)" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
                         <button type="button" x-on:click="sections.later = !sections.later"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -311,7 +339,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Recent Reports */}
-                    <section id="bucket-recentReports" x-show="!loading && activeFilter === 'all' && buckets.recentReports.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
+                    <section id="bucket-recentReports" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.recentReports.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.recentReports = !sections.recentReports"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">
@@ -329,7 +357,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
                     </section>
 
                     {/* Section: Cancelled */}
-                    <section x-show="!loading && activeFilter === 'all' && buckets.cancelled.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
+                    <section x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.cancelled.length > 0" {...{ 'x-cloak': true }} class="bg-white border border-slate-200 rounded-md">
                         <button type="button" x-on:click="sections.cancelled = !sections.cancelled"
                                 class="w-full flex items-center justify-between px-5 py-4 text-left">
                             <div class="flex items-center gap-3">

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -867,6 +867,22 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   class="text-[11px] font-mono text-slate-500"
                   x-text="searchMatchCount + ' match' + (searchMatchCount === 1 ? '' : 'es')"
                 ></span>
+                {/* Sprint 3 S3-4 — Tablet 1024-1279: ACTIVE ITEM lives in a
+                    drawer (the persistent right pane only renders at xl ≥1280).
+                    Visible only at lg-not-xl (compound `hidden lg:inline-flex
+                    xl:hidden`) so mobile + desktop are unaffected. */}
+                <button
+                  type="button"
+                  x-show="activeItem"
+                  x-on:click="tabletInspectorOpen = !tabletInspectorOpen"
+                  data-testid="tablet-active-item-toggle"
+                  aria-label="Toggle active item inspector"
+                  class="hidden lg:inline-flex xl:hidden items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-xl border border-slate-200 hover:bg-slate-50 transition-colors"
+                  style="color: #475569"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
+                  Inspector
+                </button>
                 <button x-on:click="previewReport()" class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl" style="color: #64748b">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
                   Preview
@@ -1434,10 +1450,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
           </main>
 
           {/* Spec 5G M1 — Right pane: active item photos + quick comments.
-              Hidden in focus mode (⌘2), on screens narrower than xl, and
-              while the Comment Library drawer is open (Sprint 1 A-1: avoids
-              the slash-trigger popover overlapping ACTIVE ITEM at 1024-1280px). */}
-          <aside x-show="viewMode !== 'focus' && activeItem && !showCommentLibrary && !slashPickerOpen" class="hidden lg:flex w-[280px] sticky top-0 h-screen flex-shrink-0 flex-col border-l overflow-hidden" style="background: rgba(255,255,255,0.6); backdrop-filter: blur(12px); border-color: rgba(226,232,240,0.6);">
+              Hidden in focus mode (⌘2), on screens narrower than xl
+              (Sprint 3 S3-4: 1024-1279 tablet zone gets a slide-in drawer
+              instead — see tablet-active-item-drawer below), and while the
+              Comment Library drawer is open (Sprint 1 A-1: avoids the
+              slash-trigger popover overlapping ACTIVE ITEM). */}
+          <aside x-show="viewMode !== 'focus' && activeItem && !showCommentLibrary && !slashPickerOpen" class="hidden xl:flex w-[280px] sticky top-0 h-screen flex-shrink-0 flex-col border-l overflow-hidden" style="background: rgba(255,255,255,0.6); backdrop-filter: blur(12px); border-color: rgba(226,232,240,0.6);">
             <header class="px-4 py-3 border-b" style="border-color: rgba(226,232,240,0.5);">
               <h3 class="text-[10px] font-semibold text-slate-400 uppercase tracking-widest">Active Item</h3>
               <p class="text-sm font-bold text-slate-900 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
@@ -1503,6 +1521,106 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               </div>
             </footer>
           </aside>
+
+          {/* Sprint 3 S3-4 — Tablet 1024-1279 ACTIVE ITEM drawer.
+              Slides in from the right when the inspector taps the
+              "Inspector" button in the toolbar. Visible ONLY at
+              lg-not-xl (compound `hidden lg:flex xl:hidden` + x-show);
+              the persistent right pane handles ≥1280, mobile gets the
+              dedicated mobile layout.
+              The drawer mirrors the structure of the persistent pane:
+              Active Item header + Photos thumbnail grid + Quick Comments. */}
+          <aside
+            x-show="tabletInspectorOpen && activeItem"
+            data-testid="tablet-active-item-drawer"
+            x-transition:enter="transition ease-out duration-200"
+            x-transition:enter-start="translate-x-full opacity-0"
+            x-transition:enter-end="translate-x-0 opacity-100"
+            x-transition:leave="transition ease-in duration-150"
+            x-transition:leave-start="translate-x-0 opacity-100"
+            x-transition:leave-end="translate-x-full opacity-0"
+            class="hidden lg:flex xl:hidden fixed inset-y-0 right-0 z-30 w-[320px] flex-col border-l shadow-xl overflow-y-auto"
+            style="background: rgba(255,255,255,0.96); backdrop-filter: blur(12px); border-color: rgba(226,232,240,0.6); display: none;"
+          >
+            <header class="px-4 py-3 border-b flex items-center justify-between" style="border-color: rgba(226,232,240,0.5);">
+              <div class="flex-1 min-w-0">
+                <h3 class="text-[10px] font-semibold text-slate-400 uppercase tracking-widest">Active Item</h3>
+                <p class="text-sm font-bold text-slate-900 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
+                <p class="text-[10px] font-mono text-slate-400 mt-0.5" x-text="activeItem?.number || ''"></p>
+              </div>
+              <button
+                type="button"
+                x-on:click="tabletInspectorOpen = false"
+                aria-label="Close inspector drawer"
+                class="ml-2 w-8 h-8 rounded-md flex items-center justify-center text-slate-500 hover:bg-slate-100"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </header>
+
+            {/* Photos */}
+            <section class="px-4 py-3 border-b" style="border-color: rgba(226,232,240,0.5);">
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-[10px] font-semibold text-slate-500 uppercase tracking-widest">
+                  Photos &middot; <span x-text="(results[activeItemId]?.photos || []).length"></span>
+                </span>
+                <label class="text-[10px] text-indigo-500 hover:underline cursor-pointer">
+                  + Add
+                  <input type="file" accept="image/*" capture="environment" class="hidden" x-on:change="if (activeItemId) { uploadPhoto(activeItemId, $event); $event.target.value = ''; }" />
+                </label>
+              </div>
+              <div class="grid grid-cols-2 gap-1.5" x-show="(results[activeItemId]?.photos || []).length > 0">
+                <template x-for="(photo, pi) in (results[activeItemId]?.photos || []).slice(0, 8)" x-bind:key="pi">
+                  <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100">
+                    <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)" class="w-full h-full object-cover" alt="Photo" />
+                  </div>
+                </template>
+              </div>
+              <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 py-2">
+                No photos. Press <kbd class="px-1 bg-slate-100 border rounded font-mono">P</kbd> to add.
+              </p>
+            </section>
+
+            {/* Quick comments */}
+            <section class="px-4 py-3 flex-1">
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-[10px] font-semibold text-slate-500 uppercase tracking-widest">Quick Comments</span>
+                <button x-on:click="openCommentLibrary()" class="text-[10px] text-indigo-500 hover:underline">Browse all</button>
+              </div>
+              <div class="space-y-1">
+                <template x-for="(c, i) in quickCommentsForActive" x-bind:key="i">
+                  <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 leading-snug border border-slate-200 hover:border-indigo-400 hover:bg-indigo-50 transition-all">
+                    <div class="flex items-start gap-1.5">
+                      <span class="px-1 py-0.5 text-[8px] font-bold uppercase rounded text-white shrink-0 mt-0.5"
+                        x-bind:style="c.rating === 'satisfactory' ? 'background:#10b981' : (c.rating === 'monitor' ? 'background:#f59e0b' : (c.rating === 'defect' ? 'background:#ef4444' : 'background:#64748b'))"
+                        x-text="c.rating === 'all' ? 'GEN' : c.rating.slice(0, 3)"></span>
+                      <span x-text="c.text"></span>
+                    </div>
+                  </button>
+                </template>
+              </div>
+              <p class="text-[10px] text-slate-400 italic mt-3">
+                Press <kbd class="px-1 bg-slate-100 border rounded font-mono">/</kbd> for full library
+              </p>
+            </section>
+          </aside>
+
+          {/* Backdrop for the tablet drawer — clicking outside closes it. */}
+          <div
+            x-show="tabletInspectorOpen"
+            x-on:click="tabletInspectorOpen = false"
+            x-transition:enter="transition ease-out duration-200"
+            x-transition:enter-start="opacity-0"
+            x-transition:enter-end="opacity-100"
+            x-transition:leave="transition ease-in duration-150"
+            x-transition:leave-start="opacity-100"
+            x-transition:leave-end="opacity-0"
+            class="hidden lg:block xl:hidden fixed inset-0 z-20 bg-slate-900/30"
+            style="display: none;"
+            aria-hidden="true"
+          ></div>
         </div>
 
         {/* Round-2 F1 — Multi-recipient Publish modal (Spectora §G.3).

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -2,6 +2,7 @@
 import { BareLayout } from '../layouts/main-layout';
 import { Modal, ModalFooter } from '../components/modal';
 import { PublishModal } from '../components/publish-modal';
+import { BurstCamera } from '../components/burst-camera';
 import type { BrandingConfig } from '../../types/auth';
 import { RECOMMENDATION_CATEGORIES } from '../../lib/recommendation-categories';
 
@@ -331,11 +332,18 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     </button>
                   </div>
                   <div class="mt-2 flex gap-2 flex-wrap">
-                    <label class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">
+                    {/* S3-6 — Camera button now opens the burst-camera modal
+                        (long-press for burst, tap for single shot). On
+                        unsupported browsers the modal silently falls back to
+                        the native <input capture> picker. */}
+                    <button type="button"
+                      x-on:click="openBurstCamera(item.id)"
+                      class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer"
+                      style="background: #eef2ff; color: var(--ih-primary, #6366f1)"
+                      aria-label="Open burst camera">
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
                       Camera
-                      <input type="file" accept="image/*" capture="environment" class="hidden" x-on:change="uploadPhoto(item.id, $event)" />
-                    </label>
+                    </button>
                     <button type="button" onclick="openCommentPicker(this)" class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors" style="background: #f0fdf4; color: #16a34a">
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3-3-3z"></path></svg>
                       Library
@@ -1148,11 +1156,18 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                       </button>
                     </div>
                     <div class="mt-2 flex gap-2 flex-wrap">
-                      <label class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">
+                      {/* S3-6 — desktop Camera button mirrors the mobile flow:
+                          opens the burst-camera modal (single tap = one shot,
+                          long-press = burst). Modal degrades to file picker if
+                          the browser blocks getUserMedia. */}
+                      <button type="button"
+                        x-on:click="openBurstCamera(item.id)"
+                        class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer"
+                        style="background: #eef2ff; color: var(--ih-primary, #6366f1)"
+                        aria-label="Open burst camera">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
                         Camera
-                        <input type="file" accept="image/*" class="hidden" x-on:change="uploadPhoto(item.id, $event)" />
-                      </label>
+                      </button>
                       <button type="button" onclick="openCommentPicker(this)" class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors" style="background: #f0fdf4; color: #16a34a">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3-3-3z"></path></svg>
                         Library
@@ -1513,6 +1528,11 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
              Send All disabled when nothing is checked. Empty-state shown
              when the inspection has no contacts. */}
         <PublishModal />
+        {/* S3-6 — burst-camera modal lives at the page level so it stays
+            mounted across item navigation. inspection-edit.js dispatches a
+            `burst-camera:open` window event when the user taps a Camera
+            button; the modal's `init()` listens and opens for that item. */}
+        <BurstCamera />
         <Modal
             name="showLegacyPublishOptions"
             title="Publish options"
@@ -1885,6 +1905,10 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         }}
       ></script>
       <script src="/js/inspection-edit.js"></script>
+      {/* S3-6 — burst-camera Alpine factory. Loads after inspection-edit.js
+          so the editor's _uploadBlobAsPhoto helper is reachable at commit
+          time. */}
+      <script src="/js/burst-camera.js"></script>
       <script src="/js/inspection-events.js"></script>
       {/* Sprint 2 S2-2 — request switcher Alpine factory. */}
       <script src="/js/request-switcher.js"></script>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -289,6 +289,36 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   </template>
                 </div>
 
+                {/* Sprint 3 S3-3 — Tag chips. Internal labels only (never on
+                    customer report). Click a chip to remove the link. */}
+                <div
+                  x-show="getItemTags(item.id).length > 0"
+                  style="display:none"
+                  class="flex items-center gap-1.5 flex-wrap mb-3"
+                  data-testid="item-tag-chips"
+                >
+                  <template x-for="t in getItemTags(item.id)" x-bind:key="t.id">
+                    <button
+                      type="button"
+                      {...{ 'x-on:click.stop': 'removeItemTag(item.id, t.id)' }}
+                      x-bind:title="'Remove tag: ' + t.name"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-bold ring-1 ring-inset hover:opacity-80 transition"
+                      x-bind:class="
+                        t.color === 'amber'   ? 'bg-amber-100 text-amber-700 ring-amber-200'   :
+                        t.color === 'rose'    ? 'bg-rose-100 text-rose-700 ring-rose-200'      :
+                        t.color === 'indigo'  ? 'bg-indigo-100 text-indigo-700 ring-indigo-200':
+                        t.color === 'emerald' ? 'bg-emerald-100 text-emerald-700 ring-emerald-200':
+                        t.color === 'sky'     ? 'bg-sky-100 text-sky-700 ring-sky-200'         :
+                        t.color === 'fuchsia' ? 'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200':
+                        t.color === 'lime'    ? 'bg-lime-100 text-lime-700 ring-lime-200'      :
+                                                'bg-slate-100 text-slate-700 ring-slate-200'"
+                    >
+                      <span x-text="t.name"></span>
+                      <svg class="w-2.5 h-2.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
+                  </template>
+                </div>
+
                 {/* Expand Toggle */}
                 <div class="flex items-center gap-3 text-xs" style="color: #94a3b8">
                   <button x-on:click="toggleExpand(item.id)" class="flex items-center gap-1 hover:text-gray-700">
@@ -1791,6 +1821,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">G + 0–9</span><span>Jump to section by index</span></li>
                 <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">/</span><span>Open Comment Library · <span class="font-mono">;</span> = My Snippets</span></li>
                 <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">P</span><span>Add photo to active item</span></li>
+                <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">T</span><span>Open tag picker for active item</span></li>
                 <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">⌘1 / ⌘2 / ⌘3</span><span>Split / Focus / Preview view mode</span></li>
                 <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">⌘K</span><span>Command palette (coming soon)</span></li>
                 <li class="flex items-start gap-3"><span class="mt-0.5 inline-block px-2 py-0.5 rounded-md font-mono text-[11px] font-semibold" style="background: #eef2ff; color: var(--ih-primary, #6366f1)">?</span><span>Toggle this cheatsheet · <span class="font-mono">Esc</span> = close</span></li>
@@ -1864,6 +1895,86 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             <kbd class="inline-flex items-center px-1 rounded bg-slate-100 text-slate-600 text-[10px]">↑↓</kbd> navigate
             <kbd class="inline-flex items-center px-1 rounded bg-slate-100 text-slate-600 text-[10px]">↵</kbd> jump
             <kbd class="inline-flex items-center px-1 rounded bg-slate-100 text-slate-600 text-[10px]">Esc</kbd> close
+          </div>
+        </div>
+      </div>
+
+      {/* Sprint 3 S3-3 — Tag picker popover. Triggered by T hotkey. Shares
+          the inspection-edit Alpine scope so toggles update tagsByItem
+          and chip rendering without an extra round-trip. */}
+      <div
+        x-show="tagPickerOpen"
+        style="display:none"
+        {...{
+          'x-cloak': '',
+          'x-on:keydown.escape.window': 'if (tagPickerOpen) closeTagPicker()',
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Tag picker"
+        aria-keyshortcuts="t"
+        class="fixed inset-0 z-[55] flex items-start justify-center pt-[12vh] px-4"
+      >
+        <div
+          class="absolute inset-0 bg-slate-900/30"
+          style="backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px);"
+          x-on:click="closeTagPicker()"
+          x-transition:enter="ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
+          x-transition:leave="ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
+        ></div>
+        <div
+          class="relative w-80 rounded-lg bg-white border border-slate-200"
+          style="box-shadow: 0 12px 32px rgba(15,23,42,0.12);"
+          x-transition:enter="ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2 scale-[0.97]" x-transition:enter-end="opacity-100 translate-y-0 scale-100"
+          x-transition:leave="ease-in duration-150" x-transition:leave-start="opacity-100 translate-y-0 scale-100" x-transition:leave-end="opacity-0 translate-y-1 scale-[0.98]"
+        >
+          <div class="px-4 py-3 border-b border-slate-100">
+            <input
+              id="tag-picker-input"
+              type="text"
+              x-model="tagPickerQuery"
+              x-on:keydown="onTagPickerKeydown($event)"
+              placeholder="Filter tags…"
+              class="w-full h-8 px-3 rounded-md border border-slate-200 outline-none text-[13px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 transition-colors"
+              aria-label="Tag search"
+              data-testid="tag-picker-input"
+            />
+          </div>
+          <div class="max-h-72 overflow-y-auto py-1" role="listbox" data-testid="tag-picker-list">
+            <template x-for="t in filteredTagsForPicker" x-bind:key="t.id">
+              <button
+                type="button"
+                x-on:click="toggleTag(t)"
+                x-bind:disabled="tagSavingId === t.id"
+                x-bind:class="isTagLinked(t) ? 'bg-indigo-50 text-indigo-700' : 'text-slate-700 hover:bg-slate-50'"
+                class="block w-full text-left px-3 py-2 text-[13px] font-medium transition-colors focus:outline-none flex items-center gap-2 disabled:opacity-50"
+                role="option"
+                data-testid="tag-picker-option"
+              >
+                <span
+                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-bold ring-1 ring-inset"
+                  x-bind:class="
+                    t.color === 'amber'   ? 'bg-amber-100 text-amber-700 ring-amber-200'   :
+                    t.color === 'rose'    ? 'bg-rose-100 text-rose-700 ring-rose-200'      :
+                    t.color === 'indigo'  ? 'bg-indigo-100 text-indigo-700 ring-indigo-200':
+                    t.color === 'emerald' ? 'bg-emerald-100 text-emerald-700 ring-emerald-200':
+                    t.color === 'sky'     ? 'bg-sky-100 text-sky-700 ring-sky-200'         :
+                    t.color === 'fuchsia' ? 'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200':
+                    t.color === 'lime'    ? 'bg-lime-100 text-lime-700 ring-lime-200'      :
+                                            'bg-slate-100 text-slate-700 ring-slate-200'"
+                  x-text="t.name"
+                ></span>
+                <span x-show="isTagLinked(t)" class="ml-auto text-indigo-600 font-bold">✓</span>
+              </button>
+            </template>
+            <p x-show="filteredTagsForPicker.length === 0" class="px-3 py-3 text-[12px] italic text-slate-400">
+              No tags match. Manage tags in <a href="/library/tags" class="text-indigo-600 hover:underline">Library → Tags</a>.
+            </p>
+          </div>
+          <div class="px-4 py-2 border-t border-slate-100 bg-slate-50/50 rounded-b-lg text-[11px] text-slate-400 font-medium flex items-center gap-2">
+            <kbd class="inline-flex items-center px-1 rounded bg-slate-100 text-slate-600 text-[10px]">T</kbd> open
+            <kbd class="inline-flex items-center px-1 rounded bg-slate-100 text-slate-600 text-[10px]">Esc</kbd> close
+            <a href="/library/tags" class="ml-auto text-indigo-600 hover:underline">Manage</a>
           </div>
         </div>
       </div>

--- a/src/templates/pages/report-card-stack.tsx
+++ b/src/templates/pages/report-card-stack.tsx
@@ -62,6 +62,11 @@ interface ReportPageProps {
   // Track E1 (ITB §11) — when true, surface a "View repair list" link in
   // the report header so realtors can jump to the contractor punch-list.
   enableRepairList?: boolean;
+  // Sprint 3 S3-2 — when true, surface a "Generate repair request" link
+  // (top-right of the report) that takes the customer to the public
+  // print-friendly export page. Independent of enableRepairList — the
+  // inspector list and the customer export are gated separately.
+  enableCustomerRepairExport?: boolean;
   // Round-2 backlog G1 (Spectora §E.2) — Property Facts banner payload.
   // Renders nothing when every field is null/empty.
   propertyFacts?: PropertyFactsBannerProps['facts'] | undefined;
@@ -88,6 +93,7 @@ export function ReportCardStackPage(props: ReportPageProps) {
   // the editor from the published view.
   const showEditAffordance = canEditSection(props.viewerRole ?? null);
   const enableRepairList = props.enableRepairList ?? false;
+  const enableCustomerRepairExport = props.enableCustomerRepairExport ?? false;
   // Server-side defect filter for ?summary=1 (PDF Summary mode).
   // Keeps only sections with at least one defect, and within each kept
   // section, only items whose severityBucket maps to defect.
@@ -217,6 +223,17 @@ export function ReportCardStackPage(props: ReportPageProps) {
                 >
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" /></svg>
                   View Repair List
+                </a>
+              )}
+              {/* Sprint 3 S3-2 — Customer-facing repair-request export. */}
+              {enableCustomerRepairExport && (
+                <a
+                  href={`/r/${inspectionId}/repair-request`}
+                  data-testid="report-customer-repair-export-link"
+                  class="no-print px-4 py-2 text-sm font-medium rounded-lg theme-border border theme-text-secondary flex items-center gap-2 hover:bg-slate-50 transition-colors"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+                  Generate repair request
                 </a>
               )}
               <button x-on:click="showRepairPanel = !showRepairPanel" class="px-4 py-2 text-sm font-semibold rounded-lg text-white flex items-center gap-2 theme-accent">

--- a/src/templates/pages/settings-workspace.tsx
+++ b/src/templates/pages/settings-workspace.tsx
@@ -7,10 +7,11 @@ interface Props { branding?: BrandingConfig | undefined; }
 // Sprint 2 S2-4 + Track E1 + Round-2 #10 — extra props only used by the
 // new Reports sub-page so the toggles reflect persisted state on first paint.
 interface ReportsProps extends Props {
-    showEstimates?:          boolean;
-    enableRepairList?:       boolean;
-    blockUnpaid?:            boolean;
-    blockUnsignedAgreement?: boolean;
+    showEstimates?:               boolean;
+    enableRepairList?:            boolean;
+    enableCustomerRepairExport?:  boolean;
+    blockUnpaid?:                 boolean;
+    blockUnsignedAgreement?:      boolean;
 }
 
 // Round-2 backlog G3 — extra prop only used by the new Referral sub-page
@@ -190,9 +191,10 @@ export const SettingsWorkspaceTelemetryPage = ({ branding }: Props): JSX.Element
  * (block when invoice unpaid / block when agreement unsigned). Both groups
  * share the same Alpine `save()` shared method that PATCHes /api/branding.
  */
-export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRepairList, blockUnpaid, blockUnsignedAgreement }: ReportsProps): JSX.Element => {
+export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRepairList, enableCustomerRepairExport, blockUnpaid, blockUnsignedAgreement }: ReportsProps): JSX.Element => {
     const initialEstimates              = showEstimates ? 'true' : 'false';
     const initialRepairList             = enableRepairList ? 'true' : 'false';
+    const initialCustomerRepairExport   = enableCustomerRepairExport ? 'true' : 'false';
     const initialBlockUnpaid            = blockUnpaid ? 'true' : 'false';
     const initialBlockUnsignedAgreement = blockUnsignedAgreement ? 'true' : 'false';
     return (
@@ -209,6 +211,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                 x-data={`{
                     showEstimates: ${initialEstimates},
                     enableRepairList: ${initialRepairList},
+                    enableCustomerRepairExport: ${initialCustomerRepairExport},
                     blockUnpaid: ${initialBlockUnpaid},
                     blockUnsignedAgreement: ${initialBlockUnsignedAgreement},
                     saving: false,
@@ -278,6 +281,29 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(enableRepairList ? { checked: true } : {})}
+                    />
+                </label>
+
+                {/* Sprint 3 S3-2 — Customer-driven repair-request export. */}
+                <div class="border-t border-surface-200" />
+                <label class="flex items-start justify-between gap-6 cursor-pointer">
+                    <div class="flex-1">
+                        <div class="text-sm font-bold text-ink-900">Enable customer repair-request export</div>
+                        <div class="text-xs text-ink-500 mt-1 leading-relaxed">
+                            Surfaces a "Generate repair request" link on the published report
+                            so the customer (homeowner / buyer) can produce a printable list
+                            to hand off to a contractor. They can also email a copy to themselves.
+                            The export honors the same payment + agreement gates as the report.
+                        </div>
+                    </div>
+                    <input
+                        type="checkbox"
+                        data-testid="settings-enable-customer-repair-export-toggle"
+                        x-model="enableCustomerRepairExport"
+                        x-on:change="save({ enableCustomerRepairExport: enableCustomerRepairExport })"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        style="background-position: left center; background-repeat: no-repeat;"
+                        {...(enableCustomerRepairExport ? { checked: true } : {})}
                     />
                 </label>
 
@@ -436,17 +462,18 @@ Referral partner"
  * `subPage` URL segment. Keeps `index.ts` route registrations short.
  */
 export const SettingsWorkspacePage = (
-    { branding, subPage, showEstimates, enableRepairList, blockUnpaid, blockUnsignedAgreement, customReferralSources }:
+    { branding, subPage, showEstimates, enableRepairList, enableCustomerRepairExport, blockUnpaid, blockUnsignedAgreement, customReferralSources }:
     ReportsProps & ReferralProps & { subPage: WorkspaceSubPage }
 ): JSX.Element => {
     if (subPage === 'theme') return SettingsWorkspaceThemePage({ branding });
     if (subPage === 'telemetry') return SettingsWorkspaceTelemetryPage({ branding });
     if (subPage === 'reports') {
         const props: ReportsProps = { branding };
-        if (typeof showEstimates          === 'boolean') props.showEstimates          = showEstimates;
-        if (typeof enableRepairList       === 'boolean') props.enableRepairList       = enableRepairList;
-        if (typeof blockUnpaid            === 'boolean') props.blockUnpaid            = blockUnpaid;
-        if (typeof blockUnsignedAgreement === 'boolean') props.blockUnsignedAgreement = blockUnsignedAgreement;
+        if (typeof showEstimates              === 'boolean') props.showEstimates              = showEstimates;
+        if (typeof enableRepairList           === 'boolean') props.enableRepairList           = enableRepairList;
+        if (typeof enableCustomerRepairExport === 'boolean') props.enableCustomerRepairExport = enableCustomerRepairExport;
+        if (typeof blockUnpaid                === 'boolean') props.blockUnpaid                = blockUnpaid;
+        if (typeof blockUnsignedAgreement     === 'boolean') props.blockUnsignedAgreement     = blockUnsignedAgreement;
         return SettingsWorkspaceReportsPage(props);
     }
     if (subPage === 'referral') {

--- a/src/templates/pages/tags.tsx
+++ b/src/templates/pages/tags.tsx
@@ -1,0 +1,150 @@
+/**
+ * Sprint 3 S3-3 — Library → Tags page.
+ *
+ * Tenant-scoped CRUD over the tags library. Five seeded tags appear on
+ * first visit (lazy seed via the GET /api/tags handler). Tags rendered
+ * as colored pills via the Sprint 1 design tokens (slate / amber / rose
+ * / indigo / emerald / sky / fuchsia / lime).
+ *
+ * Edit + delete are restricted to admin/owner roles by RBAC on the API
+ * — this page just disables the buttons for non-privileged users.
+ */
+import { MainLayout } from '../layouts/main-layout';
+import { Modal } from '../components/modal';
+import { PageHeader } from '../components/page-header';
+import type { BrandingConfig } from '../../types/auth';
+
+interface Props { branding?: BrandingConfig | undefined }
+
+const TAG_COLORS: ReadonlyArray<{ value: string; label: string; tw: string }> = [
+    { value: 'slate',    label: 'Slate',    tw: 'bg-slate-100 text-slate-700 ring-slate-200' },
+    { value: 'amber',    label: 'Amber',    tw: 'bg-amber-100 text-amber-700 ring-amber-200' },
+    { value: 'rose',     label: 'Rose',     tw: 'bg-rose-100 text-rose-700 ring-rose-200' },
+    { value: 'indigo',   label: 'Indigo',   tw: 'bg-indigo-100 text-indigo-700 ring-indigo-200' },
+    { value: 'emerald',  label: 'Emerald',  tw: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
+    { value: 'sky',      label: 'Sky',      tw: 'bg-sky-100 text-sky-700 ring-sky-200' },
+    { value: 'fuchsia',  label: 'Fuchsia',  tw: 'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200' },
+    { value: 'lime',     label: 'Lime',     tw: 'bg-lime-100 text-lime-700 ring-lime-200' },
+];
+
+export const TagsPage = ({ branding }: Props): JSX.Element => {
+    const siteName = branding?.siteName || 'OpenInspection';
+    return (
+        <MainLayout title={`${siteName} | Tags`} branding={branding}>
+            <div x-data="tagsLibrary" x-init="init()" class="space-y-6 animate-fade-in">
+                <PageHeader
+                    eyebrow="LIBRARY · TAGS"
+                    eyebrowColor="slate"
+                    title="Tags"
+                    breadcrumb={[{ label: 'Library', href: '/templates' }, { label: 'Tags' }]}
+                    meta={
+                        <span x-text="`${tags.length} tag${tags.length === 1 ? '' : 's'} · internal-only labels never shown on customer report`"></span>
+                    }
+                    actions={
+                        <button
+                            type="button"
+                            data-testid="tag-create-button"
+                            x-on:click="openCreate()"
+                            class="h-8 px-4 rounded-md bg-indigo-600 text-white font-bold text-[13px] hover:bg-indigo-700 active:scale-95 transition-all inline-flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
+                            New tag
+                        </button>
+                    }
+                />
+
+                {/* Loading + error */}
+                <div x-show="loading" class="text-center py-12 bg-slate-50 rounded-md text-[13px] text-slate-500 font-semibold">Loading tags…</div>
+                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-[13px] text-rose-700" x-text="error"></div>
+
+                {/* Empty */}
+                <div x-show="!loading && tags.length === 0" style="display:none" class="text-center py-12 bg-slate-50 rounded-md">
+                    <p class="text-slate-500 font-semibold">No tags yet.</p>
+                    <p class="text-slate-400 text-sm mt-2">Reload to plant the five seed tags, or add your own.</p>
+                </div>
+
+                {/* List */}
+                <div x-show="!loading && tags.length > 0" style="display:none" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="tag-list">
+                    <template x-for="tag in tags" {...{ 'x-bind:key': 'tag.id' }}>
+                        <div class="p-4 bg-white border border-slate-200 rounded-md shadow-sm hover:shadow transition" x-bind:data-tag-id="tag.id" x-bind:data-tag-name="tag.name">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="flex-1 min-w-0">
+                                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-bold ring-1 ring-inset" x-bind:class="colorClass(tag.color)" x-text="tag.name"></span>
+                                    <p x-show="tag.isSeed" class="mt-2 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Seed</p>
+                                </div>
+                                <div class="flex flex-col items-end gap-1 flex-shrink-0">
+                                    <button
+                                        type="button"
+                                        x-show="!tag.isSeed"
+                                        x-on:click="openEdit(tag)"
+                                        class="text-xs text-slate-700 hover:underline focus:outline-none"
+                                        data-testid="tag-edit-button"
+                                    >Edit</button>
+                                    <button
+                                        type="button"
+                                        x-on:click="confirmDelete(tag)"
+                                        class="text-xs text-rose-600 hover:underline focus:outline-none disabled:text-slate-300 disabled:no-underline"
+                                        x-bind:disabled="tag.isSeed"
+                                        x-bind:title="tag.isSeed ? 'Seed tags cannot be deleted' : 'Delete this tag'"
+                                        data-testid="tag-delete-button"
+                                    >Delete</button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+
+                {/* Edit / create modal */}
+                <Modal name="showEditModal" titleExpr="editing?.id ? 'Edit tag' : 'New tag'">
+                    <form {...{ 'x-on:submit.prevent': 'save()' }} class="space-y-4">
+                        <label class="block">
+                            <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Name</span>
+                            <input
+                                type="text"
+                                maxLength={40}
+                                required
+                                x-model="form.name"
+                                data-testid="tag-name-input"
+                                class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                            />
+                        </label>
+                        <label class="block">
+                            <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Color</span>
+                            <div class="mt-1 flex flex-wrap gap-2">
+                                {TAG_COLORS.map(c => (
+                                    <button
+                                        type="button"
+                                        x-on:click={`form.color = '${c.value}'`}
+                                        class={`px-3 py-1.5 rounded-full text-[12px] font-bold ring-1 ring-inset transition ${c.tw}`}
+                                        x-bind:class={`form.color === '${c.value}' ? 'ring-2 ring-offset-2 ring-indigo-500' : ''`}
+                                        data-testid={`tag-color-${c.value}`}
+                                    >
+                                        {c.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </label>
+
+                        <p x-show="formError" style="display:none" class="text-[12px] text-rose-600" x-text="formError"></p>
+
+                        <div class="flex items-center justify-end gap-2 pt-2 border-t border-slate-100">
+                            <button type="button" x-on:click="showEditModal = false" class="h-8 px-4 rounded-md text-slate-600 text-[13px] font-bold hover:bg-slate-50">Cancel</button>
+                            <button
+                                type="submit"
+                                x-bind:disabled="saving"
+                                class="h-8 px-4 rounded-md bg-indigo-600 text-white text-[13px] font-bold hover:bg-indigo-700 disabled:bg-slate-300"
+                                data-testid="tag-save-button"
+                            >
+                                <span x-show="!saving">Save</span>
+                                <span x-show="saving">Saving…</span>
+                            </button>
+                        </div>
+                    </form>
+                </Modal>
+            </div>
+
+            <script src="/js/auth.js"></script>
+            <script src="/js/tags.js"></script>
+        </MainLayout>
+    );
+};

--- a/src/types/hono.ts
+++ b/src/types/hono.ts
@@ -68,6 +68,14 @@ export interface AppEnv {
     // never leaks to the client. Optional: when absent, dashboard.tsx falls
     // back to a free-text address input (no autocomplete dropdown).
     GOOGLE_PLACES_API_KEY?: string;
+
+    // Sprint 3 S3-1 — Estated.io public-records API. Server-side proxy holds
+    // the key so it never leaks to the client. Optional: when absent the
+    // /api/inspections/:id/property-facts/autofill endpoint returns
+    // `{ data: null, reason: 'NO_API_KEY' }` and the UI falls back to manual
+    // entry. Matches the existing GOOGLE_PLACES_API_KEY graceful-degrade
+    // pattern.
+    ESTATED_API_KEY?: string;
 }
 
 import { AdminService } from '../services/admin.service';
@@ -100,6 +108,8 @@ import { ImportHistoryService } from '../services/import-history.service';
 import { InspectionRequestService } from '../services/inspection-request.service';
 import { RatingSystemService } from '../services/rating-system.service';
 import { DashboardPrefsService } from '../services/dashboard-prefs.service';
+import { TagService } from '../services/tag.service';
+import { PropertyLookupService } from '../services/property-lookup.service';
 import { AuthVariables } from './auth';
 
 /**
@@ -138,6 +148,8 @@ export interface AppServices {
     inspectionRequest: InspectionRequestService;
     ratingSystem: RatingSystemService;
     dashboardPrefs: DashboardPrefsService;
+    tag: TagService;
+    propertyLookup: PropertyLookupService;
 }
 
 /**

--- a/tests/public-pages-responsive.spec.ts
+++ b/tests/public-pages-responsive.spec.ts
@@ -22,6 +22,12 @@ const VIEWPORTS = [
     { name: 'iphone-pro',   w: 414,  h: 896  },
     { name: 'tablet',       w: 768,  h: 1024 },
     { name: 'small-laptop', w: 1024, h: 768  },
+    // Sprint 3 S3-4 — tablet-mid is the 1024-1279 zone (iPad Pro 11"
+    // landscape sits at 1180px). The inspection-edit page now drops its
+    // right pane in this zone in favor of a slide-in drawer; this viewport
+    // pins the regression so a future layout change can't silently break
+    // the iPad inspector experience.
+    { name: 'tablet-mid',   w: 1100, h: 768  },
     { name: 'desktop',      w: 1440, h: 900  },
 ];
 

--- a/tests/unit/burst-camera-timing.spec.ts
+++ b/tests/unit/burst-camera-timing.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * S3-6 — burst-camera timing helpers.
+ *
+ * The DOM-bound modal is exercised manually (Playwright can't reliably
+ * fake `getUserMedia`), but the pure timing logic that decides
+ * single-shot vs burst, computes frame counts, and caps the maximum is
+ * unit-testable in isolation.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    LONG_PRESS_MS,
+    BURST_FPS,
+    MAX_BURST_FRAMES,
+    BURST_INTERVAL_MS,
+    burstFrameCount,
+} from '../../public/js/burst-camera.js';
+
+describe('S3-6 — burst-camera timing constants', () => {
+    it('uses sensible defaults', () => {
+        expect(LONG_PRESS_MS).toBe(200);
+        expect(BURST_FPS).toBe(10);
+        expect(MAX_BURST_FRAMES).toBe(30);
+        expect(BURST_INTERVAL_MS).toBe(100);
+    });
+});
+
+describe('S3-6 — burstFrameCount(heldMs)', () => {
+    it('returns 0 for negative or non-numeric input', () => {
+        expect(burstFrameCount(-1)).toBe(0);
+        // @ts-expect-error testing invalid input
+        expect(burstFrameCount(null)).toBe(0);
+        // @ts-expect-error testing invalid input
+        expect(burstFrameCount('abc')).toBe(0);
+    });
+
+    it('treats a quick tap as a single shot', () => {
+        // Below LONG_PRESS_MS = single-shot intent.
+        expect(burstFrameCount(0)).toBe(1);
+        expect(burstFrameCount(50)).toBe(1);
+        expect(burstFrameCount(LONG_PRESS_MS - 1)).toBe(1);
+    });
+
+    it('produces the first burst frame at exactly LONG_PRESS_MS', () => {
+        // First burst frame fires at the threshold, then one every 100 ms.
+        expect(burstFrameCount(LONG_PRESS_MS)).toBe(1 + Math.floor(LONG_PRESS_MS / BURST_INTERVAL_MS));
+    });
+
+    it('grows linearly with held time', () => {
+        // 200 ms = 1 + 2 = 3 frames; 300 ms = 4; 1000 ms = 11.
+        expect(burstFrameCount(200)).toBe(3);
+        expect(burstFrameCount(300)).toBe(4);
+        expect(burstFrameCount(1000)).toBe(11);
+        expect(burstFrameCount(2000)).toBe(21);
+    });
+
+    it('caps at MAX_BURST_FRAMES regardless of how long the press lasts', () => {
+        // 30 frames = 1 + 30 = at 3000 ms; longer holds must not overflow.
+        expect(burstFrameCount(3000)).toBe(MAX_BURST_FRAMES);
+        expect(burstFrameCount(10_000)).toBe(MAX_BURST_FRAMES);
+        expect(burstFrameCount(60_000)).toBe(MAX_BURST_FRAMES);
+    });
+
+    it('never exceeds the documented 10 fps cap', () => {
+        // For any held duration, frames-per-second derived from the helper
+        // must stay <= BURST_FPS — otherwise we'd risk overrunning the
+        // canvas + toBlob pipeline on low-end mobile.
+        for (const ms of [200, 500, 1000, 2500, 4000]) {
+            const frames = burstFrameCount(ms);
+            const fps = (frames - 1) / (ms / 1000);
+            expect(fps).toBeLessThanOrEqual(BURST_FPS + 0.01);
+        }
+    });
+});

--- a/tests/unit/calendar-conflict.spec.ts
+++ b/tests/unit/calendar-conflict.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Sprint 3 · S3-9 — Calendar drag-drop reschedule.
+ *
+ * Pure helper that decides whether dropping an inspection on a new date/hour
+ * collides with another inspection on the same tenant's calendar.
+ *
+ * The function lives in `src/lib/calendar-conflict.ts` so it can be reused
+ * from both the FullCalendar drag handler (eventDrop / eventAllow) and from
+ * any future swap modal logic without pulling in the DOM.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    detectSlotConflict,
+    sameDayHour,
+    type CalendarItem,
+} from '../../src/lib/calendar-conflict';
+
+const inspections: CalendarItem[] = [
+    { id: 'a', date: '2026-06-15T09:00:00.000Z' },
+    { id: 'b', date: '2026-06-15T13:00:00.000Z' },
+    { id: 'c', date: '2026-06-16T09:00:00.000Z' },
+    // Day-only entries (no time) — calendar-events API returns these for
+    // FullCalendar dayGridMonth view because `inspections.date` may be stored
+    // as plain `YYYY-MM-DD`.
+    { id: 'd', date: '2026-06-17' },
+];
+
+describe('sameDayHour', () => {
+    it('matches same UTC day + same hour', () => {
+        expect(sameDayHour('2026-06-15T09:00:00.000Z', '2026-06-15T09:30:00.000Z')).toBe(true);
+        expect(sameDayHour('2026-06-15T09:00:00.000Z', '2026-06-15T09:00:00.000Z')).toBe(true);
+    });
+
+    it('rejects different hour', () => {
+        expect(sameDayHour('2026-06-15T09:00:00.000Z', '2026-06-15T10:00:00.000Z')).toBe(false);
+    });
+
+    it('rejects different day', () => {
+        expect(sameDayHour('2026-06-15T09:00:00.000Z', '2026-06-16T09:00:00.000Z')).toBe(false);
+    });
+
+    it('treats YYYY-MM-DD inputs as same calendar day (any time)', () => {
+        // Day-precision entries collide on any drop within the same day.
+        expect(sameDayHour('2026-06-17', '2026-06-17T14:00:00.000Z')).toBe(true);
+        expect(sameDayHour('2026-06-17', '2026-06-18T14:00:00.000Z')).toBe(false);
+    });
+
+    it('returns false for invalid input rather than throwing', () => {
+        expect(sameDayHour('not-a-date', '2026-06-15T09:00:00.000Z')).toBe(false);
+        expect(sameDayHour('', '')).toBe(false);
+    });
+});
+
+describe('detectSlotConflict', () => {
+    it('returns null when slot is free', () => {
+        const result = detectSlotConflict(inspections, '2026-06-15T11:00:00.000Z', 'a');
+        expect(result).toBeNull();
+    });
+
+    it('returns the conflicting inspection when a same-hour slot is taken', () => {
+        // Drop inspection `c` on 2026-06-15 09:00 — collides with `a`.
+        const result = detectSlotConflict(inspections, '2026-06-15T09:00:00.000Z', 'c');
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe('a');
+    });
+
+    it('ignores the inspection being dragged itself (ignoreId)', () => {
+        // Dropping `a` on its own current slot must not flag a conflict.
+        const result = detectSlotConflict(inspections, '2026-06-15T09:00:00.000Z', 'a');
+        expect(result).toBeNull();
+    });
+
+    it('treats day-only entries as full-day occupants', () => {
+        // Inspection `d` is YYYY-MM-DD on 2026-06-17. Any 17th drop conflicts.
+        const result = detectSlotConflict(inspections, '2026-06-17T14:00:00.000Z', 'a');
+        expect(result?.id).toBe('d');
+    });
+
+    it('returns null for empty list', () => {
+        expect(detectSlotConflict([], '2026-06-15T09:00:00.000Z', 'x')).toBeNull();
+    });
+
+    it('returns null when the only candidate is the dragged inspection', () => {
+        const list: CalendarItem[] = [{ id: 'solo', date: '2026-06-15T09:00:00.000Z' }];
+        expect(detectSlotConflict(list, '2026-06-15T09:00:00.000Z', 'solo')).toBeNull();
+    });
+});

--- a/tests/unit/customer-repair-request.spec.ts
+++ b/tests/unit/customer-repair-request.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Sprint 3 Track B (S3-2) — Customer Repair Request export page render.
+ *
+ * Snapshots the SSR'd HTML output for the public token-gated repair-request
+ * page across the three meaningful coverage states:
+ *
+ *   1. Zero defects — emerald empty state, no card list.
+ *   2. Multiple defects across multiple sections — every defect rendered as
+ *      a card grouped by section.
+ *   3. Estimates surface only when `showEstimates = true` — gated by the
+ *      tenant flag.
+ *
+ * The page also seeds an Alpine x-data initializer with the inspection id +
+ * client email; we assert the JSON envelope is sanitised against the page's
+ * own quote-escaping (' is HTML-escaped) so the runtime parser can read it.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    CustomerRepairRequestPage,
+    type CustomerRepairRequestEntry,
+} from '../../src/templates/pages/customer-repair-request';
+
+function render(node: unknown): string {
+    return String(node);
+}
+
+const BASE_PROPS = {
+    inspectionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    propertyAddress: '1 Main St, Anywhere',
+    inspectionDate: 'June 1, 2026',
+    inspectorName: 'Jane Inspector',
+    clientEmail: 'buyer@example.com',
+};
+
+const DEFECT_A: CustomerRepairRequestEntry = {
+    sectionId: 'roof',
+    sectionTitle: 'Roof',
+    itemId: 'roof-shingles',
+    itemLabel: 'Shingles',
+    comment: 'Worn surface granules.',
+    location: 'Front slope',
+    category: 'maintenance',
+    recommendationLabel: null,
+    estimateLow: 25000,
+    estimateHigh: 75000,
+    photos: [],
+};
+
+const DEFECT_B: CustomerRepairRequestEntry = {
+    sectionId: 'electrical',
+    sectionTitle: 'Electrical',
+    itemId: 'elec-panel',
+    itemLabel: 'Main Panel',
+    comment: 'Double-tap on breaker 4.',
+    location: null,
+    category: 'safety',
+    recommendationLabel: 'Licensed Electrician',
+    estimateLow: null,
+    estimateHigh: null,
+    photos: [{ key: 'p1', url: '/photo/p1.jpg' }],
+};
+
+describe('CustomerRepairRequestPage', () => {
+    it('renders the empty-state card when no defects supplied', () => {
+        const html = render(CustomerRepairRequestPage({
+            ...BASE_PROPS,
+            defects: [],
+            showEstimates: false,
+        }));
+        expect(html).toContain('data-testid="crr-empty"');
+        expect(html).toContain('No defects were flagged');
+        // No defect cards should render.
+        expect(html).not.toContain('data-testid="crr-card"');
+    });
+
+    it('renders one card per defect, grouped by section title', () => {
+        const html = render(CustomerRepairRequestPage({
+            ...BASE_PROPS,
+            defects: [DEFECT_A, DEFECT_B],
+            showEstimates: false,
+        }));
+        const cardMatches = (html.match(/data-testid="crr-card"/g) || []).length;
+        expect(cardMatches).toBe(2);
+        // Section headings render once each.
+        expect(html.indexOf('>Roof<')).toBeGreaterThan(-1);
+        expect(html.indexOf('>Electrical<')).toBeGreaterThan(-1);
+        // Per-card item label + comment render.
+        expect(html).toContain('Worn surface granules.');
+        expect(html).toContain('Double-tap on breaker 4.');
+        // Recommendation label badge surfaces for the safety defect.
+        expect(html).toContain('Licensed Electrician');
+        // Per-item textarea ALWAYS renders — that's the whole UX of this page.
+        const noteAreas = (html.match(/data-testid="crr-card-note"/g) || []).length;
+        expect(noteAreas).toBe(2);
+        // Empty state is hidden when defects present.
+        expect(html).not.toContain('data-testid="crr-empty"');
+    });
+
+    it('shows estimate badges only when showEstimates is true', () => {
+        const off = render(CustomerRepairRequestPage({
+            ...BASE_PROPS,
+            defects: [DEFECT_A],
+            showEstimates: false,
+        }));
+        expect(off).not.toContain('data-testid="crr-card-estimate"');
+
+        const on = render(CustomerRepairRequestPage({
+            ...BASE_PROPS,
+            defects: [DEFECT_A],
+            showEstimates: true,
+        }));
+        expect(on).toContain('data-testid="crr-card-estimate"');
+        // Money formatting (cents → dollars) — 25000c = $250, 75000c = $750.
+        expect(on).toContain('$250');
+        expect(on).toContain('$750');
+    });
+
+    it('seeds Alpine x-data with the inspection id + recipient email', () => {
+        const html = render(CustomerRepairRequestPage({
+            ...BASE_PROPS,
+            defects: [DEFECT_A],
+            showEstimates: false,
+        }));
+        // Alpine initializer references the factory + payload.
+        expect(html).toContain('customerRepairRequest(');
+        expect(html).toContain(BASE_PROPS.inspectionId);
+        // Email appears in the seeded JSON (HTML-encoded form).
+        expect(html).toContain(BASE_PROPS.clientEmail);
+        // Print + email submit testids both render.
+        expect(html).toContain('data-testid="crr-print"');
+        expect(html).toContain('data-testid="crr-email-submit"');
+        expect(html).toContain('data-testid="crr-email-input"');
+    });
+
+    it('escapes single quotes inside the JSON initializer so x-data parses safely', () => {
+        // Construct a defect whose item label contains an apostrophe — this
+        // becomes part of the items[] payload embedded inside x-data.
+        const defectWithApostrophe: CustomerRepairRequestEntry = {
+            ...DEFECT_A,
+            itemLabel: "Buyer's Slope",
+        };
+        const html = render(CustomerRepairRequestPage({
+            ...BASE_PROPS,
+            defects: [defectWithApostrophe],
+            showEstimates: false,
+        }));
+        // The x-data attribute must NOT contain a raw single quote inside its
+        // JSON envelope (would close the attribute prematurely). Allow the
+        // HTML-encoded form only.
+        const xDataMatch = html.match(/x-data="customerRepairRequest\([^"]*\)"/);
+        expect(xDataMatch).not.toBeNull();
+        const inner = xDataMatch ? xDataMatch[0] : '';
+        expect(inner).not.toMatch(/[^&#3]'/);  // no unescaped apostrophes
+    });
+});

--- a/tests/unit/inspection-edit-tablet-layout.spec.ts
+++ b/tests/unit/inspection-edit-tablet-layout.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Sprint 3 Track B (S3-4) — Tablet 1024-1279 layout breakpoints.
+ *
+ * The three-pane editor at 1024-1279 (iPad Pro 11" landscape) currently
+ * shows left + middle + cramped right pane. After S3-4, the right pane
+ * collapses to an on-demand drawer between 1024 and 1279, restoring its
+ * sticky position only at xl (≥1280).
+ *
+ * These tests rely on the rendered Tailwind class set; they don't probe
+ * actual viewport rendering (that's the Playwright snapshot test).
+ */
+import { describe, it, expect } from 'vitest';
+import { InspectionEditPage } from '../../src/templates/pages/inspection-edit';
+
+function render(node: unknown): string {
+    return String(node);
+}
+
+describe('Sprint 3 S3-4 — inspection-edit tablet breakpoints', () => {
+    it('renders the right pane with xl:flex (≥1280) instead of lg:flex (≥1024)', () => {
+        const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+        // The persistent (sticky) right pane is gated to xl+. At 1024-1279
+        // it stays hidden; the drawer-trigger button + drawer take over.
+        // Look for the active-item right aside specifically.
+        // The aside has Active Item header + Photos + Quick Comments.
+        const rightPaneIdx = html.indexOf('Active Item');
+        expect(rightPaneIdx).toBeGreaterThan(-1);
+
+        // Check the surrounding aside class — should have hidden xl:flex
+        // (not the prior hidden lg:flex). Search 200 chars before the
+        // header for the aside open tag.
+        const before = html.slice(Math.max(0, rightPaneIdx - 600), rightPaneIdx);
+        expect(before).toMatch(/hidden xl:flex/);
+        expect(before).not.toMatch(/hidden lg:flex/);
+    });
+
+    it('exposes a tablet-mid drawer trigger (visible only at lg-not-xl)', () => {
+        const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+        // The button is a tablet-only affordance. It uses Tailwind's
+        // hidden lg:inline-flex xl:hidden compound: hides at mobile +
+        // hides at xl+, shows only at the 1024-1279 zone.
+        expect(html).toContain('data-testid="tablet-active-item-toggle"');
+        const btnIdx = html.indexOf('data-testid="tablet-active-item-toggle"');
+        const around = html.slice(Math.max(0, btnIdx - 300), btnIdx + 300);
+        expect(around).toMatch(/hidden lg:inline-flex xl:hidden/);
+    });
+
+    it('renders the tablet drawer aside with hidden + lg:flex + xl:hidden combo', () => {
+        const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+        // The drawer is a separate aside that overlays from the right edge.
+        expect(html).toContain('data-testid="tablet-active-item-drawer"');
+        const drawerIdx = html.indexOf('data-testid="tablet-active-item-drawer"');
+        // The class= attribute lives ahead of the testid (testids appear
+        // mid-attribute order); look at the next ~600 chars to find class.
+        const around = html.slice(drawerIdx, drawerIdx + 800);
+        // Drawer hidden at mobile (<lg) and at xl+ (≥1280) — only in 1024-1279.
+        expect(around).toMatch(/lg:flex/);
+        expect(around).toMatch(/xl:hidden/);
+    });
+});

--- a/tests/unit/inspection-edit-tablet-layout.spec.ts
+++ b/tests/unit/inspection-edit-tablet-layout.spec.ts
@@ -57,4 +57,34 @@ describe('Sprint 3 S3-4 — inspection-edit tablet breakpoints', () => {
         expect(around).toMatch(/lg:flex/);
         expect(around).toMatch(/xl:hidden/);
     });
+
+    /**
+     * Snapshot-style structural shape — pin the three breakpoint surfaces
+     * so a future layout refactor that accidentally drops one of them
+     * trips a clear assertion instead of a Playwright pixel-diff hours
+     * later. This is the unit-level analog of a viewport screenshot at
+     * mobile / tablet-mid / desktop:
+     *
+     *   - mobile     surface: x-show="!isDesktop" branch (mobile chip nav)
+     *   - tablet-mid surface: tablet-active-item-toggle + drawer (1024-1279)
+     *   - desktop    surface: persistent right pane (xl ≥1280)
+     */
+    it('snapshot — every breakpoint surface present in a single render', () => {
+        const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+
+        // Mobile surface — has the lg:hidden mobile container.
+        expect(html).toMatch(/x-show="!isDesktop" class="lg:hidden"/);
+
+        // Tablet-mid surface — toggle button + drawer + backdrop, all
+        // gated to the lg-not-xl zone.
+        expect(html).toContain('data-testid="tablet-active-item-toggle"');
+        expect(html).toContain('data-testid="tablet-active-item-drawer"');
+        // The backdrop uses lg:block xl:hidden so the click-outside layer
+        // only mounts in the tablet zone.
+        expect(html).toMatch(/hidden lg:block xl:hidden/);
+
+        // Desktop surface — the persistent right ACTIVE ITEM pane uses
+        // hidden xl:flex (post-S3-4); pre-S3-4 was hidden lg:flex.
+        expect(html).toMatch(/hidden xl:flex w-\[280px\]/);
+    });
 });

--- a/tests/unit/internachi-13-seed.spec.ts
+++ b/tests/unit/internachi-13-seed.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { TemplateSchemaV2Schema, CreateTemplateSchema } from '../../src/lib/validations/template.schema';
+
+/**
+ * S3-5 — InterNACHI 13-Section Standard template seed.
+ *
+ * 1. Structural snapshot: 13 sections, every section has a disclaimer, all
+ *    items are rich (not free-text) with all three tab buckets present.
+ * 2. Round-trip via `CreateTemplateSchema` to mirror what
+ *    `templateService.createFromMarketplace` does on import — guards
+ *    against the schema tightening (max-length section/item) ever
+ *    silently dropping the new template.
+ * 3. Schema length tightening: section.title max 50, item.label max 100
+ *    are enforced.
+ */
+describe('S3-5 — InterNACHI 13-Section seed', () => {
+    const seedPath = path.resolve(
+        __dirname,
+        '../../src/data/seed-templates/internachi-13.json'
+    );
+    const doc = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+
+    it('has exactly 13 sections covering the InterNACHI standard systems', () => {
+        const titles = doc.schema.sections.map((s: { title: string }) => s.title);
+        expect(titles).toHaveLength(13);
+        // Order matches the InterNACHI 13-section ordering called out in the
+        // Spec 4F plan. Asserted explicitly so a future PR can't reorder
+        // sections without a deliberate test update.
+        expect(titles).toEqual([
+            'Inspection Details',
+            'Exterior',
+            'Roof',
+            'Basement, Foundation, Crawlspace & Structure',
+            'Heating',
+            'Cooling',
+            'Plumbing',
+            'Electrical',
+            'Fireplace',
+            'Attic, Insulation & Ventilation',
+            'Doors, Windows & Interior',
+            'Built-in Appliances',
+            'Garage',
+        ]);
+    });
+
+    it('every section ships with a per-section disclaimer (Sprint 2 polish E2)', () => {
+        for (const s of doc.schema.sections) {
+            expect(s.disclaimerText, `section ${s.title} missing disclaimerText`).toBeDefined();
+            expect(typeof s.disclaimerText).toBe('string');
+            expect((s.disclaimerText as string).length).toBeGreaterThan(20);
+        }
+    });
+
+    it('every item declares all three canned-comment tabs', () => {
+        for (const s of doc.schema.sections) {
+            for (const item of s.items) {
+                expect(item.type, `${s.title} > ${item.label} should be rich`).toBe('rich');
+                expect(item.tabs).toBeDefined();
+                expect(Array.isArray(item.tabs.information)).toBe(true);
+                expect(Array.isArray(item.tabs.limitations)).toBe(true);
+                expect(Array.isArray(item.tabs.defects)).toBe(true);
+            }
+        }
+    });
+
+    it('passes the v2 template schema validator', () => {
+        const result = TemplateSchemaV2Schema.safeParse(doc.schema);
+        if (!result.success) {
+            const first = result.error.issues[0];
+            throw new Error(
+                `internachi-13 failed v2 validation at ${first?.path?.join('.')}: ${first?.message}`
+            );
+        }
+        expect(result.success).toBe(true);
+    });
+
+    it('round-trips through CreateTemplateSchema (marketplace import path)', () => {
+        // Mirrors what the marketplace import handler does: take the seeded
+        // schema as-is, wrap in a `name + schema` payload, and re-validate.
+        const result = CreateTemplateSchema.safeParse({
+            name: doc.name,
+            schema: doc.schema,
+        });
+        expect(result.success).toBe(true);
+    });
+});
+
+describe('S3-5 — schema length tightening', () => {
+    const baseRichItem = {
+        id: 'i1',
+        label: 'Item',
+        type: 'rich' as const,
+        ratingOptions: ['Inspected'],
+        tabs: { information: [], limitations: [], defects: [] },
+    };
+
+    function build(section: Record<string, unknown>) {
+        return {
+            name: 'T',
+            schema: {
+                schemaVersion: 2 as const,
+                sections: [{ id: 's1', title: 'OK', items: [baseRichItem], ...section }],
+            },
+        };
+    }
+
+    it('rejects section.title longer than 50 chars', () => {
+        const tooLong = 'x'.repeat(51);
+        const result = CreateTemplateSchema.safeParse(build({ title: tooLong }));
+        expect(result.success).toBe(false);
+    });
+
+    it('accepts section.title exactly 50 chars', () => {
+        const exact = 'y'.repeat(50);
+        const result = CreateTemplateSchema.safeParse(build({ title: exact }));
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects item.label longer than 100 chars', () => {
+        const longLabel = 'z'.repeat(101);
+        const payload = build({
+            items: [{ ...baseRichItem, label: longLabel }],
+        });
+        const result = CreateTemplateSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+    });
+
+    it('accepts item.label exactly 100 chars', () => {
+        const exact = 'a'.repeat(100);
+        const payload = build({
+            items: [{ ...baseRichItem, label: exact }],
+        });
+        const result = CreateTemplateSchema.safeParse(payload);
+        expect(result.success).toBe(true);
+    });
+});

--- a/tests/unit/property-lookup.service.spec.ts
+++ b/tests/unit/property-lookup.service.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Sprint 3 S3-1 — PropertyLookupService unit suite.
+ *
+ * Critical invariants:
+ *   - Without ESTATED_API_KEY: returns { data: null, reason: 'NO_API_KEY' }.
+ *     No fetch is issued.
+ *   - With key + Estated 200: returns mapped facts.
+ *   - With key + Estated 404: returns { data: null, reason: 'NOT_FOUND' }.
+ *   - With key + Estated 5xx: returns { data: null, reason: 'PROVIDER_ERROR' }.
+ *   - Address whitespace is trimmed.
+ *   - Empty / too-short address rejects with BadRequest.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { PropertyLookupService } from '../../src/services/property-lookup.service';
+
+describe('PropertyLookupService', () => {
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis as any).fetch = vi.fn();
+    });
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    it('returns NO_API_KEY when ESTATED_API_KEY is unset (graceful degrade)', async () => {
+        const svc = new PropertyLookupService({});
+        const out = await svc.lookup('123 Main St, Anytown, CA');
+        expect(out).toEqual({ data: null, reason: 'NO_API_KEY' });
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns NO_API_KEY when key is empty string', async () => {
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: '' });
+        const out = await svc.lookup('123 Main St');
+        expect(out).toEqual({ data: null, reason: 'NO_API_KEY' });
+    });
+
+    it('rejects too-short address', async () => {
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: 'k' });
+        await expect(svc.lookup('xx')).rejects.toThrow();
+    });
+
+    it('returns mapped facts when Estated returns a 200 with data', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis.fetch as any).mockResolvedValueOnce(new Response(JSON.stringify({
+            data: {
+                structure: {
+                    year_built:        1990,
+                    total_area_sq_ft:  1850,
+                    beds_count:        3,
+                    baths:             2.5,
+                    foundation_type:   'basement',
+                },
+                parcel: { area_sq_ft: 8400 },
+            },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: 'k' });
+        const out = await svc.lookup('123 Main St, Anytown, CA');
+
+        expect(out.reason).toBeUndefined();
+        expect(out.source).toBe('estated');
+        expect(out.data).toMatchObject({
+            yearBuilt:      1990,
+            sqft:           1850,
+            bedrooms:       3,
+            bathrooms:      2.5,
+            foundationType: 'basement',
+        });
+        // Lot size is rendered as a free-text string per Property Facts schema.
+        expect(out.data?.lotSize).toContain('8400');
+    });
+
+    it('returns NOT_FOUND on 404', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis.fetch as any).mockResolvedValueOnce(new Response('', { status: 404 }));
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: 'k' });
+        const out = await svc.lookup('Fake Address That Does Not Exist 99999');
+        expect(out).toEqual({ data: null, reason: 'NOT_FOUND' });
+    });
+
+    it('returns PROVIDER_ERROR on 5xx', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis.fetch as any).mockResolvedValueOnce(new Response('', { status: 503 }));
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: 'k' });
+        const out = await svc.lookup('123 Main St, Anytown');
+        expect(out).toEqual({ data: null, reason: 'PROVIDER_ERROR' });
+    });
+
+    it('coerces invalid Estated payload into NOT_FOUND', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis.fetch as any).mockResolvedValueOnce(new Response(JSON.stringify({}), {
+            status: 200, headers: { 'Content-Type': 'application/json' },
+        }));
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: 'k' });
+        const out = await svc.lookup('123 Main St, Anytown');
+        // No structure data == NOT_FOUND so the UI shows graceful empty.
+        expect(out.reason).toBe('NOT_FOUND');
+    });
+
+    it('drops fields the provider returned as null/missing', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis.fetch as any).mockResolvedValueOnce(new Response(JSON.stringify({
+            data: {
+                structure: {
+                    year_built: 2002,
+                    // sqft missing
+                    beds_count: 4,
+                    // baths null
+                    baths: null,
+                    foundation_type: null,
+                },
+            },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+        const svc = new PropertyLookupService({ ESTATED_API_KEY: 'k' });
+        const out = await svc.lookup('123 Main St, Anytown');
+        expect(out.source).toBe('estated');
+        expect(out.data).toMatchObject({ yearBuilt: 2002, bedrooms: 4 });
+        expect(out.data?.sqft).toBeUndefined();
+        expect(out.data?.bathrooms).toBeUndefined();
+        expect(out.data?.foundationType).toBeUndefined();
+    });
+});

--- a/tests/unit/tag.service.spec.ts
+++ b/tests/unit/tag.service.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Sprint 3 S3-3 — TagService unit suite.
+ *
+ * Critical invariants:
+ *   - seedDefaults inserts the five canonical tags + is idempotent
+ *   - tenants cannot read each other's tags
+ *   - cannot create duplicates within a tenant (UNIQUE constraint)
+ *   - link / unlink round-trip + idempotent
+ *   - getItemTags returns only the active item's links
+ *   - countByTag aggregates across an inspection
+ *   - delete cascades the item links
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TagService } from '../../src/services/tag.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT_A = '00000000-0000-0000-0000-000000000001';
+const TENANT_B = '00000000-0000-0000-0000-000000000002';
+const INSPECTION_X = '00000000-0000-0000-0000-0000000000aa';
+const INSPECTION_Y = '00000000-0000-0000-0000-0000000000bb';
+const ITEM_1 = 'item_1';
+const ITEM_2 = 'item_2';
+
+async function seedTenants(testDb: BetterSQLite3Database<typeof schema>) {
+    await testDb.insert(schema.tenants).values([
+        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+    ]);
+}
+
+describe('TagService', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let svc: TagService;
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        testDb = setup.db;
+        await setupSchema(setup.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        svc = new TagService({} as any);
+        await seedTenants(testDb);
+    });
+
+    it('seeds the five canonical tags + is idempotent', async () => {
+        const first = await svc.seedDefaults(TENANT_A);
+        expect(first.inserted).toBe(5);
+        expect(first.skipped).toBe(0);
+
+        const second = await svc.seedDefaults(TENANT_A);
+        expect(second.inserted).toBe(0);
+        expect(second.skipped).toBe(5);
+
+        const list = await svc.list(TENANT_A);
+        expect(list.length).toBe(5);
+        expect(list.every(t => t.isSeed)).toBe(true);
+        const names = list.map(t => t.name).sort();
+        expect(names).toEqual([
+            'Critical',
+            'Customer concern',
+            'Inspector note',
+            'Needs follow-up',
+            'Waiting for client',
+        ]);
+    });
+
+    it('isolates each tenant\'s tags', async () => {
+        await svc.seedDefaults(TENANT_A);
+        const aList = await svc.list(TENANT_A);
+        const bList = await svc.list(TENANT_B);
+        expect(aList.length).toBe(5);
+        expect(bList.length).toBe(0);
+    });
+
+    it('creates a custom tag', async () => {
+        const t = await svc.create(TENANT_A, { name: 'Reviewed', color: 'emerald' });
+        expect(t.id).toBeTruthy();
+        expect(t.name).toBe('Reviewed');
+        expect(t.color).toBe('emerald');
+        expect(t.isSeed).toBe(false);
+    });
+
+    it('rejects duplicate names within a tenant', async () => {
+        await svc.create(TENANT_A, { name: 'Reviewed' });
+        await expect(svc.create(TENANT_A, { name: 'Reviewed' })).rejects.toThrow();
+    });
+
+    it('allows the same name across tenants', async () => {
+        await svc.create(TENANT_A, { name: 'Reviewed' });
+        const b = await svc.create(TENANT_B, { name: 'Reviewed' });
+        expect(b.tenantId).toBe(TENANT_B);
+    });
+
+    it('updates a tag', async () => {
+        const t = await svc.create(TENANT_A, { name: 'Reviewed' });
+        const u = await svc.update(t.id, TENANT_A, { name: 'Reviewed-2', color: 'rose' });
+        expect(u.name).toBe('Reviewed-2');
+        expect(u.color).toBe('rose');
+    });
+
+    it('refuses cross-tenant update', async () => {
+        const t = await svc.create(TENANT_A, { name: 'Reviewed' });
+        await expect(svc.update(t.id, TENANT_B, { name: 'X' })).rejects.toThrow();
+    });
+
+    it('links and unlinks a tag to an inspection item', async () => {
+        const t = await svc.create(TENANT_A, { name: 'Reviewed' });
+
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_1, t.id);
+        const linked = await svc.getItemTags(TENANT_A, INSPECTION_X, ITEM_1);
+        expect(linked.map(x => x.id)).toEqual([t.id]);
+
+        // Re-link is idempotent
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_1, t.id);
+        const stillOne = await svc.getItemTags(TENANT_A, INSPECTION_X, ITEM_1);
+        expect(stillOne.length).toBe(1);
+
+        await svc.unlinkFromItem(TENANT_A, INSPECTION_X, ITEM_1, t.id);
+        const empty = await svc.getItemTags(TENANT_A, INSPECTION_X, ITEM_1);
+        expect(empty.length).toBe(0);
+    });
+
+    it('getItemTags isolates by tenant', async () => {
+        const tA = await svc.create(TENANT_A, { name: 'A1' });
+        const tB = await svc.create(TENANT_B, { name: 'B1' });
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_1, tA.id);
+        await svc.linkToItem(TENANT_B, INSPECTION_X, ITEM_1, tB.id);
+
+        const aList = await svc.getItemTags(TENANT_A, INSPECTION_X, ITEM_1);
+        expect(aList.map(x => x.name)).toEqual(['A1']);
+    });
+
+    it('countByTag aggregates link counts within an inspection', async () => {
+        const t1 = await svc.create(TENANT_A, { name: 'T1' });
+        const t2 = await svc.create(TENANT_A, { name: 'T2' });
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_1, t1.id);
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_2, t1.id);
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_2, t2.id);
+
+        // Different inspection — should not contribute.
+        await svc.linkToItem(TENANT_A, INSPECTION_Y, ITEM_1, t1.id);
+
+        const counts = await svc.countByTag(TENANT_A, INSPECTION_X);
+        expect(counts[t1.id]).toBe(2);
+        expect(counts[t2.id]).toBe(1);
+    });
+
+    it('delete removes the tag and its item links', async () => {
+        const t = await svc.create(TENANT_A, { name: 'Reviewed' });
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_1, t.id);
+        await svc.delete(t.id, TENANT_A);
+
+        const tags = await svc.list(TENANT_A);
+        expect(tags.find(x => x.id === t.id)).toBeUndefined();
+
+        const links = await svc.getItemTags(TENANT_A, INSPECTION_X, ITEM_1);
+        expect(links.length).toBe(0);
+    });
+
+    it('listInspectionsByTag returns only matching inspection ids', async () => {
+        const t = await svc.create(TENANT_A, { name: 'Critical' });
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_1, t.id);
+        await svc.linkToItem(TENANT_A, INSPECTION_X, ITEM_2, t.id);
+        await svc.linkToItem(TENANT_A, INSPECTION_Y, ITEM_1, t.id);
+
+        const ids = await svc.listInspectionsByTag(TENANT_A, t.id);
+        expect(ids.sort()).toEqual([INSPECTION_X, INSPECTION_Y].sort());
+    });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -46,6 +46,10 @@ TURNSTILE_SITE_KEY = "1x00000000000000000000AA"
 # TURNSTILE_SECRET_KEY    — Optional. Server-side Turnstile key (skipped if absent)
 # GOOGLE_CLIENT_ID        — Optional. Google Calendar OAuth client ID
 # GOOGLE_CLIENT_SECRET    — Optional. Google Calendar OAuth client secret
+# GOOGLE_PLACES_API_KEY   — Optional. Powers address autocomplete on /book + new-inspection wizard
+# ESTATED_API_KEY         — Optional. Sprint 3 S3-1 — public-records auto-fill for Property Facts.
+#                           Without it, /api/inspections/:id/property-facts/autofill returns
+#                           { data: null, reason: 'NO_API_KEY' } and the UI prompts manual entry.
 
 # ── Cloudflare resource bindings ─────────────────────────────────────────────
 # These IDs are populated automatically by `npm run setup:cloudflare`.


### PR DESCRIPTION
## Summary

Sprint 3 ships 8 features across 4 parallel worktree-isolated tracks. Two original Sprint 3 items (S3-7 portal indigo migration + S3-9 calendar DnD) are split: S3-9 in this PR; S3-7 ships separately at superproject level (portal is a regular subdir, not submodule).

### Track A — Schema + Integration
- **S3-1** Property auto-fill — Estated.io v4 wrapper with NO_API_KEY/NOT_FOUND/PROVIDER_ERROR graceful degrade. New "Auto-fill from address" button on Property Facts card; never overwrites filled fields.
- **S3-3** T-key Tag system — `tags` + `inspection_item_tag_links` tables (migration 0049), 5 seed tags, full CRUD, T hotkey replaces "coming soon" toast with fuzzy-search popover, dashboard tag filter, library Tags CRUD page.

### Track B — UI polish
- **S3-2** Customer-driven repair-request export — public `/r/:id/repair-request` page with email submit + print-to-PDF. Tenant toggle in Settings → Reports. Migration 0051 adds `enable_customer_repair_export`.
- **S3-4** 1024-1279 tablet two-pane editor — right inspector pane drops at `lg`, slides in as drawer toggled by tablet-only button. Snapshot tests at `tablet-mid` 1100×768.

### Track C — Heavy lift
- **S3-5** InterNACHI 13-section template — `internachi-13.json` seed (50 items across 13 sections), each with `disclaimerText` (Sprint 2 polish E2). Tightens `section.title` (max 50) and `item.label` (max 100).
- **S3-6** AI burst photo capture — full-screen `getUserMedia` modal with shutter (single tap = 1 shot, long-press ≥200ms = burst @ 10fps cap 30 frames), thumbnail strip, graceful degrade to native input on permission denial.

### Track D — Calendar
- **S3-9** Calendar drag-drop reschedule — FullCalendar `eventDrop` + `longPressDelay: 500` mobile + conflict modal (Replace/Swap/Cancel). UTC day-hour bucket conflict detection.

## Stats

- 8 features, 4 parallel worktree-isolated tracks
- **515 unit tests pass** + 7 skipped (was 456; +59 new)
- type-check 0 errors, lint 0 errors
- 3 new migrations: 0049 (tags), 0050 (reserved by Track C, untouched), 0051 (customer repair export)
- 1 merge conflict resolved (`src/index.ts` route imports — Track A tags + Track B repair-requests)

## Test plan

- [x] type-check 0
- [x] lint 0
- [x] 515 unit
- [x] Migration chain replays cleanly
- [x] No CF Browser Rendering dependency added (still no Workers Paid plan)

## Out of scope

- **S3-7 portal v1 indigo migration** — shipped separately as 4 commits on superproject master (not in this PR; portal is a regular subdir of inspectorhub, not a submodule)
- **S3-8 buffer** — reserved for post-merge bug fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)