### PR TITLE
Iter-1 test bugs — clientEmail Zod + error UX + gating coercion

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -16,6 +16,46 @@ async function logout() {
 window.authFetch = authFetch;
 window.logout = logout;
 
+// iter-1 production bug #2 — extract a human-readable error message from the
+// inconsistent error shapes returned by core. Three shapes are observed:
+//   1. AppError envelope:        { success:false, error:{ message, code, details? } }
+//   2. Zod validation envelope:  { success:false, error:{ issues: [...] } } (raw
+//      `@hono/zod-openapi` default — no defaultHook configured)
+//   3. Zod validation array:     { success:false, error: [...] }            (some
+//      legacy callsites that c.json the issues array directly)
+// In every Zod case we want the joined human message, never the raw object,
+// so the toast doesn't expose regex patterns to the inspector.
+function extractErrorMessage(payload, fallback) {
+    const FALLBACK = fallback || 'Something went wrong';
+    if (payload == null) return FALLBACK;
+
+    // Plain string envelope (e.g. text/plain 500 page)
+    if (typeof payload === 'string') return payload || FALLBACK;
+
+    const err = payload.error;
+    if (err == null) {
+        return (typeof payload.message === 'string' && payload.message) || FALLBACK;
+    }
+
+    // AppError envelope first — preserve the human message produced by the
+    // global error handler (Errors.NotFound, Errors.RateLimited, etc.).
+    if (typeof err === 'object' && typeof err.message === 'string' && err.message) {
+        return err.message;
+    }
+
+    // Zod issues — either as `error.issues` or `error` directly being the array.
+    const issues = Array.isArray(err) ? err : (Array.isArray(err.issues) ? err.issues : null);
+    if (issues && issues.length > 0) {
+        const messages = issues
+            .map((i) => (i && typeof i.message === 'string' ? i.message : null))
+            .filter(Boolean);
+        if (messages.length > 0) return messages.join(' · ');
+    }
+
+    return FALLBACK;
+}
+window.extractErrorMessage = extractErrorMessage;
+
 function _escapeHtml(str) {
     const d = document.createElement('div');
     d.textContent = str;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -487,7 +487,7 @@ async function cloneInspection(id) {
             window.dispatchEvent(new CustomEvent('inspection-updated'));
         } else {
             const err = await cloneRes.json().catch(function() { return {}; });
-            modalAlert('Failed to clone: ' + (err.error?.message || 'Unknown error'), 'Error');
+            modalAlert('Failed to clone: ' + window.extractErrorMessage(err, 'Unknown error'), 'Error');
         }
     } catch (e) {
         modalAlert('Network error: ' + e.message, 'Error');
@@ -503,7 +503,7 @@ async function deleteInspection(id) {
             window.dispatchEvent(new CustomEvent('inspection-updated'));
         } else {
             var err = await res.json().catch(function() { return {}; });
-            modalAlert('Failed to delete: ' + (err.error?.message || 'Unknown error'), 'Error');
+            modalAlert('Failed to delete: ' + window.extractErrorMessage(err, 'Unknown error'), 'Error');
         }
     } catch (e) {
         modalAlert('Network error: ' + e.message, 'Error');
@@ -583,8 +583,12 @@ async function submitInspection() {
            }
            window.dispatchEvent(new CustomEvent('inspection-updated'));
        } else {
-           const err = await res.json();
-           await modalAlert('Error: ' + (err.error?.message || err.error || 'Failed to create inspection'), 'Error');
+           // iter-1 bug #2 — use the shared helper so Zod validation issues
+           // surface the human `message` instead of the raw issue array
+           // (which previously leaked the email regex pattern to the toast).
+           const err = await res.json().catch(() => ({}));
+           const friendly = window.extractErrorMessage(err, 'Failed to create inspection');
+           await modalAlert('Error: ' + friendly, 'Error');
        }
    } catch (e) {
        console.error(e);

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -468,7 +468,18 @@ function inspectionEditor(inspectionId) {
         if (inspRes.status === 401) { window.location.href = '/login'; return; }
 
         var inspJson = await inspRes.json();
-        this.inspection = inspJson.data?.inspection || {};
+        var rawInsp = inspJson.data?.inspection || {};
+        // iter-1 production bug #3 — D1 booleans can transit as 0/1 ints
+        // depending on the codepath (raw queries vs Drizzle mode:'boolean'
+        // conversion). The Report Access toggles in the sidebar do
+        // `inspection.paymentRequired ? on : off`, so a truthy `1` from a
+        // raw query would show ON even when the gate (which uses
+        // `=== true`) treats the same value as falsy and skips paywalling.
+        // Force every gate-related flag to a strict boolean here so the
+        // Alpine toggles and the server-side gate agree on the same shape.
+        rawInsp.paymentRequired   = rawInsp.paymentRequired   === true || rawInsp.paymentRequired   === 1;
+        rawInsp.agreementRequired = rawInsp.agreementRequired === true || rawInsp.agreementRequired === 1;
+        this.inspection = rawInsp;
 
         // Try to load report-data (sections + rating levels)
         var dataRes = await authFetch('/api/inspections/' + this.inspectionId + '/report-data');

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -1168,7 +1168,8 @@ inspectionsRoutes.get('/:id/report', async (c) => {
         inspectorName = inspectorRow?.name ?? null;
     }
 
-    if (inspection.paymentRequired === true && inspection.paymentStatus !== 'paid') {
+    // iter-1 bug #3 — truthy coercion (see /report/:id gate in index.ts).
+    if (inspection.paymentRequired && inspection.paymentStatus !== 'paid') {
         return c.html(ReportGatePage({
             reason: 'payment',
             companyName, primaryColor,
@@ -1180,7 +1181,7 @@ inspectionsRoutes.get('/:id/report', async (c) => {
         }) as string);
     }
 
-    if (inspection.agreementRequired === true) {
+    if (inspection.agreementRequired) {
         const db2 = drizzle(c.env.DB);
         const signed = await db2.select({ id: agreementRequests.id })
             .from(agreementRequests)

--- a/src/index.ts
+++ b/src/index.ts
@@ -869,7 +869,16 @@ app.get('/report/:id', async (c) => {
                 inspectorName = inspectorRow?.name ?? null;
             }
 
-            if (insp.paymentRequired === true && insp.paymentStatus !== 'paid') {
+            // iter-1 production bug #3 — the gate previously used
+            // `=== true` strict equality, but D1 sometimes surfaces the
+            // boolean column as the raw integer `1` depending on the
+            // codepath (mode:'boolean' is a Drizzle-side conversion that
+            // can be skipped when the row originated from a raw insert).
+            // The inspection-edit sidebar toggle uses truthy coercion, so
+            // the toggle could show ON while the gate skipped paywalling
+            // — exactly what the live deploy traversal exposed. Treat any
+            // truthy value as "gate enabled" so both surfaces agree.
+            if (insp.paymentRequired && insp.paymentStatus !== 'paid') {
                 const { ReportGatePage } = await import('./templates/pages/report-gate');
                 return c.html(ReportGatePage({
                     reason:          'payment',
@@ -883,7 +892,7 @@ app.get('/report/:id', async (c) => {
                 }) as string);
             }
 
-            if (insp.agreementRequired === true) {
+            if (insp.agreementRequired) {
                 const signed = await db.select({ id: schema.agreementRequests.id })
                     .from(schema.agreementRequests)
                     .where(and(
@@ -1045,7 +1054,10 @@ app.get('/r/:id/repair-request', async (c) => {
                 inspectorName = inspectorRow?.name ?? null;
             }
 
-            if (insp.paymentRequired === true && insp.paymentStatus !== 'paid') {
+            // iter-1 bug #3 — same truthy coercion as the /report/:id gate
+            // (see comment at the first gate site). Keeps the repair-list
+            // page paywall in lockstep with the canonical report page.
+            if (insp.paymentRequired && insp.paymentStatus !== 'paid') {
                 const { ReportGatePage } = await import('./templates/pages/report-gate');
                 return c.html(ReportGatePage({
                     reason:          'payment',
@@ -1059,7 +1071,7 @@ app.get('/r/:id/repair-request', async (c) => {
                 }) as string);
             }
 
-            if (insp.agreementRequired === true) {
+            if (insp.agreementRequired) {
                 const signed = await drizzle(c.env.DB).select({ id: schema.agreementRequests.id })
                     .from(schema.agreementRequests)
                     .where(and(

--- a/src/lib/validations/inspection.schema.ts
+++ b/src/lib/validations/inspection.schema.ts
@@ -36,7 +36,15 @@ export const InspectionListQuerySchema = z.object({
 export const CreateInspectionSchema = z.object({
     propertyAddress: z.string().min(5, 'Property address is too short').openapi({ example: '123 Main St, Anytown' }),
     clientName: z.string().min(1, 'Client name is required').default('Private Client').openapi({ example: 'John Doe' }),
-    clientEmail: z.string().email('Invalid email address').optional().nullable().openapi({ example: 'john@example.com' }),
+    // iter-1 production bug #1 — the dashboard's New Inspection modal posts
+    // `clientEmail: ""` when the inspector skips the field. The previous
+    // chain `.email().optional().nullable()` rejected the empty string with
+    // a raw Zod regex pattern. Accept "" as a sentinel for "missing" and
+    // normalise it to null so the service layer sees one canonical shape.
+    clientEmail: z.union([z.string().email('Invalid email address'), z.literal(''), z.null()])
+        .optional()
+        .transform((v) => (v === '' || v === undefined ? null : v))
+        .openapi({ example: 'john@example.com' }),
     clientPhone: z.string().max(30).optional().nullable().openapi({ example: '(555) 123-4567' }),
     templateId: z.string().uuid('Invalid template ID').openapi({ example: '550e8400-e29b-41d4-a716-446655440002' }),
     inspectorId: z.string().uuid().optional().openapi({ example: '550e8400-e29b-41d4-a716-446655440001' }),

--- a/tests/unit/extract-error-message.spec.ts
+++ b/tests/unit/extract-error-message.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * iter-1 production bug #2 — the New Inspection error toast displayed the
+ * raw Zod issue array (regex patterns and all) instead of the human
+ * `message` string. The fix added an `extractErrorMessage(payload, fallback)`
+ * helper to public/js/auth.js. This spec loads the script in a sandbox
+ * window and exercises every error envelope the dashboard observes:
+ *
+ *   1. AppError    — { success:false, error:{ message, code, details? } }
+ *   2. Zod issues  — { success:false, error:{ issues: [...] } }
+ *   3. Zod array   — { success:false, error: [...] }
+ *   4. Plain text  — string body
+ *   5. Empty/null  — must fall back to caller-provided default
+ */
+describe('extractErrorMessage (public/js/auth.js)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let extractErrorMessage: (payload: unknown, fallback?: string) => string = (() => '') as any;
+
+    beforeAll(() => {
+        // Load auth.js in a controlled sandbox so we can hoist the helper
+        // without pulling in the rest of the page (no document, no fetch).
+        const code = readFileSync(
+            join(process.cwd(), 'public', 'js', 'auth.js'),
+            'utf8'
+        );
+        const sandbox: Record<string, unknown> = {};
+        const fakeWindow: Record<string, unknown> = {};
+        const fakeDocument = {
+            createElement: () => ({ textContent: '', innerHTML: '' }),
+        };
+        // Wrap the script in a function that exposes window/document refs.
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+        const fn = new Function('window', 'document', 'fetch', code);
+        fn(fakeWindow, fakeDocument, () => Promise.resolve(new Response()));
+        sandbox.extractErrorMessage = fakeWindow.extractErrorMessage;
+        extractErrorMessage = sandbox.extractErrorMessage as typeof extractErrorMessage;
+        if (typeof extractErrorMessage !== 'function') {
+            throw new Error('extractErrorMessage was not exported on window');
+        }
+    });
+
+    it('returns AppError envelope message verbatim', () => {
+        const payload = {
+            success: false,
+            error: { message: 'Inspection not found', code: 'NOT_FOUND' },
+        };
+        expect(extractErrorMessage(payload, 'fallback')).toBe('Inspection not found');
+    });
+
+    it('joins Zod issues into a friendly message (error.issues shape)', () => {
+        // This is the exact production bug: the previous toast displayed the
+        // entire issues array including the email regex `pattern`. The helper
+        // must surface ONLY the issue.message values.
+        const payload = {
+            success: false,
+            error: {
+                issues: [
+                    {
+                        origin: 'string',
+                        code: 'invalid_format',
+                        format: 'email',
+                        pattern: '/^(?!\\.).+/',
+                        path: ['clientEmail'],
+                        message: 'Invalid email address',
+                    },
+                ],
+            },
+        };
+        const msg = extractErrorMessage(payload, 'fallback');
+        expect(msg).toBe('Invalid email address');
+        expect(msg).not.toContain('pattern');
+        expect(msg).not.toContain('regex');
+    });
+
+    it('joins Zod issues into a friendly message (error: array shape)', () => {
+        const payload = {
+            success: false,
+            error: [
+                { code: 'too_small', message: 'Property address is too short', path: ['propertyAddress'] },
+                { code: 'invalid_format', message: 'Invalid email address', path: ['clientEmail'] },
+            ],
+        };
+        expect(extractErrorMessage(payload, 'fallback')).toBe(
+            'Property address is too short · Invalid email address',
+        );
+    });
+
+    it('falls back when payload is empty / null / undefined', () => {
+        expect(extractErrorMessage(null, 'fallback A')).toBe('fallback A');
+        expect(extractErrorMessage(undefined, 'fallback B')).toBe('fallback B');
+        expect(extractErrorMessage({}, 'fallback C')).toBe('fallback C');
+    });
+
+    it('uses the caller fallback when error has no usable shape', () => {
+        const payload = { success: false, error: 12345 };
+        expect(extractErrorMessage(payload, 'create failed')).toBe('create failed');
+    });
+
+    it('passes through plain string bodies', () => {
+        expect(extractErrorMessage('Service unavailable', 'fallback')).toBe('Service unavailable');
+    });
+
+    it('does NOT leak regex patterns from a malformed Zod issue (defensive)', () => {
+        const payload = {
+            success: false,
+            error: {
+                issues: [
+                    {
+                        origin: 'string',
+                        code: 'invalid_format',
+                        format: 'email',
+                        pattern: '/^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_\'+\\-\\.]*)[A-Za-z0-9_+-]@(...)+/',
+                        path: ['clientEmail'],
+                        message: 'Invalid email address',
+                    },
+                ],
+            },
+        };
+        const msg = extractErrorMessage(payload, 'fallback');
+        // The regex must never make it into the toast output.
+        expect(msg).not.toMatch(/\^\(\?!/);
+        expect(msg).not.toContain('A-Za-z0-9');
+        expect(msg).toBe('Invalid email address');
+    });
+});

--- a/tests/unit/inspection-schema.spec.ts
+++ b/tests/unit/inspection-schema.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { CreateInspectionSchema } from '../../src/lib/validations/inspection.schema';
+
+/**
+ * iter-1 production bug #1 — `clientEmail` Zod validation rejected an empty
+ * string from the New Inspection modal. The dashboard form posts
+ * `clientEmail: ""` when the inspector skips the field, and the previous
+ * `z.string().email().optional().nullable()` chain ran `.email()` on the
+ * empty string and returned `code: invalid_format` with the raw regex.
+ *
+ * After the fix, the schema accepts:
+ *   - a valid email
+ *   - an empty string (treated as "skip this field")
+ *   - null
+ *   - undefined (key omitted entirely)
+ *
+ * Empty string MUST be normalised to `null` so downstream service code that
+ * persists the row sees a single canonical "missing" representation.
+ */
+describe('CreateInspectionSchema.clientEmail', () => {
+    const baseValid = {
+        propertyAddress: '123 Main St, Anytown',
+        clientName: 'Jane Doe',
+        templateId: '550e8400-e29b-41d4-a716-446655440002',
+    };
+
+    it('accepts a valid email address', () => {
+        const result = CreateInspectionSchema.safeParse({
+            ...baseValid,
+            clientEmail: 'jane@example.com',
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.clientEmail).toBe('jane@example.com');
+        }
+    });
+
+    it('accepts an empty string and normalises it to null', () => {
+        const result = CreateInspectionSchema.safeParse({
+            ...baseValid,
+            clientEmail: '',
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.clientEmail).toBeNull();
+        }
+    });
+
+    it('accepts null', () => {
+        const result = CreateInspectionSchema.safeParse({
+            ...baseValid,
+            clientEmail: null,
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.clientEmail).toBeNull();
+        }
+    });
+
+    it('accepts undefined (clientEmail key omitted)', () => {
+        const result = CreateInspectionSchema.safeParse(baseValid);
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects a malformed email string', () => {
+        const result = CreateInspectionSchema.safeParse({
+            ...baseValid,
+            clientEmail: 'not-an-email',
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            // Ensure the human-friendly message is preserved (bug #2 fixture).
+            const messages = result.error.issues.map((i) => i.message);
+            expect(messages.some((m) => /invalid email/i.test(m))).toBe(true);
+        }
+    });
+});

--- a/tests/unit/report-gate-coercion.spec.ts
+++ b/tests/unit/report-gate-coercion.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * iter-1 production bug #3 — `/report/:id` paywall did not fire for an
+ * inspection whose `payment_required` column was set, because the gate
+ * compared with `=== true`. D1 booleans can transit as the integer `1`
+ * (Drizzle's `mode: 'boolean'` is a Drizzle-side conversion that some
+ * codepaths bypass), so the strict comparison missed the gate while the
+ * inspection-edit sidebar toggle — which uses truthy coercion — still
+ * showed the toggle as ON.
+ *
+ * This spec pins the coercion contract: any truthy value (`true` OR `1`
+ * OR `"1"`) MUST gate, and only false-y values (`false`, `0`, `null`,
+ * `undefined`, `""`) skip the gate. The same coercion is applied to
+ * BOTH the toggle (Alpine state, see public/js/inspection-edit.js) and
+ * the server gate (src/index.ts) so the two surfaces always agree.
+ */
+
+/**
+ * Mirror of the gate predicate after the iter-1 fix: `!!flag`.
+ * Codifies the rule we now rely on across every gate site.
+ */
+function shouldGatePayment(flag: unknown, paymentStatus: unknown): boolean {
+    return !!flag && paymentStatus !== 'paid';
+}
+
+function shouldGateAgreement(flag: unknown): boolean {
+    return !!flag;
+}
+
+describe('iter-1 #3 — report gate truthy coercion', () => {
+    describe('paymentRequired', () => {
+        it('gates when stored as boolean true', () => {
+            expect(shouldGatePayment(true, 'unpaid')).toBe(true);
+        });
+
+        it('gates when stored as integer 1 (D1 raw shape)', () => {
+            // Pre-fix, this case fell through `=== true` and the report
+            // rendered without paywall.
+            expect(shouldGatePayment(1, 'unpaid')).toBe(true);
+        });
+
+        it('skips gate when paymentStatus is "paid", regardless of flag', () => {
+            expect(shouldGatePayment(true, 'paid')).toBe(false);
+            expect(shouldGatePayment(1, 'paid')).toBe(false);
+        });
+
+        it('skips gate when flag is false / 0 / null / undefined', () => {
+            expect(shouldGatePayment(false, 'unpaid')).toBe(false);
+            expect(shouldGatePayment(0, 'unpaid')).toBe(false);
+            expect(shouldGatePayment(null, 'unpaid')).toBe(false);
+            expect(shouldGatePayment(undefined, 'unpaid')).toBe(false);
+        });
+    });
+
+    describe('agreementRequired', () => {
+        it('gates when stored as boolean true', () => {
+            expect(shouldGateAgreement(true)).toBe(true);
+        });
+
+        it('gates when stored as integer 1 (D1 raw shape)', () => {
+            expect(shouldGateAgreement(1)).toBe(true);
+        });
+
+        it('skips gate when flag is false / 0 / null / undefined', () => {
+            expect(shouldGateAgreement(false)).toBe(false);
+            expect(shouldGateAgreement(0)).toBe(false);
+            expect(shouldGateAgreement(null)).toBe(false);
+            expect(shouldGateAgreement(undefined)).toBe(false);
+        });
+    });
+
+    describe('toggle vs gate agreement', () => {
+        it('toggle ON ⇔ gate fires (no UI/server mismatch)', () => {
+            const flag = 1; // raw D1 shape that surfaced the bug
+            const toggleVisualOn = !!flag; // mirrors Alpine `flag ? on : off`
+            const gateFires = shouldGatePayment(flag, 'unpaid');
+            expect(toggleVisualOn).toBe(gateFires);
+        });
+    });
+});


### PR DESCRIPTION
Three production bugs found via Chrome MCP UC traversal of live deploy:

- BUG #1 — clientEmail Zod rejected empty string; now accepts email|empty|null with transform to null
- BUG #2 — error toast showed raw Zod issue array; now extracts .message via extractErrorMessage helper
- BUG #3 — /report/:id paywall didn't fire because === true comparison desynced from D1 integer 1 boolean transit; coerce to truthy

535 unit tests pass + 7 skipped (515 baseline + 20 new). Type-check 0. Lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)