### PR TITLE
Iter-2 test bugs — paywall + UX + soft pages (12 bugs across 3 parallel tracks)

### DIFF
--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -1,12 +1,27 @@
 // ─── Sub-spec B Task 3 — PageHeader meta ────────────────────────────────────
+//
+// Iter-2 bug #5 — query param names previously read `from`/`to` which the
+// /api/inspections schema silently dropped, leaving the count uninformative.
+// The schema accepts `dateFrom`/`dateTo` so we send those instead and split
+// the subtitle into "X confirmed · N drafts hidden" so an inspector who
+// only sees gray DRAFT chips on the grid still understands the count.
 function calendarMeta() {
     return {
-        weekCount: 0,
-        nextOpen:  '',
+        weekCount:  0,
+        draftCount: 0,
+        nextOpen:   '',
         get metaText() {
             const parts = [];
-            if (this.weekCount > 0) parts.push(this.weekCount + ' this week');
-            else parts.push('No inspections scheduled this week');
+            const confirmed = this.weekCount - this.draftCount;
+            if (this.weekCount === 0) {
+                parts.push('No inspections scheduled this week');
+            } else if (this.draftCount > 0 && confirmed === 0) {
+                parts.push(this.draftCount + ' draft' + (this.draftCount === 1 ? '' : 's') + ' this week');
+            } else if (this.draftCount > 0) {
+                parts.push(confirmed + ' confirmed · ' + this.draftCount + ' draft' + (this.draftCount === 1 ? '' : 's'));
+            } else {
+                parts.push(this.weekCount + ' this week');
+            }
             if (this.nextOpen) parts.push('next open ' + this.nextOpen);
             return parts.join(' · ');
         },
@@ -15,11 +30,12 @@ function calendarMeta() {
                 const now = new Date();
                 const start = now.toISOString().slice(0, 10);
                 const end = new Date(now.getTime() + 7 * 86400 * 1000).toISOString().slice(0, 10);
-                const r = await authFetch('/api/inspections?from=' + start + '&to=' + end + '&limit=200');
+                const r = await authFetch('/api/inspections?dateFrom=' + start + '&dateTo=' + end + '&limit=200');
                 if (!r.ok) return;
                 const j = await r.json();
-                const list = j.data?.inspections || [];
-                this.weekCount = list.length;
+                const list = j.data || [];
+                this.weekCount  = list.length;
+                this.draftCount = list.filter(function(i) { return i && i.status === 'draft'; }).length;
             } catch {}
         },
     };
@@ -311,6 +327,15 @@ document.addEventListener('DOMContentLoaded', function() {
             if (info.event.extendedProps && info.event.extendedProps.source === 'google') {
                 info.el.style.cursor = 'default';
                 info.el.style.opacity = '0.7';
+            }
+            // Iter-2 bug #5 — drafts render with a dashed-style border + slightly
+            // muted opacity so they read as "tentative" against the brand-color
+            // confirmed events. Pure CSS, no extra DOM nodes.
+            if (info.event.extendedProps && info.event.extendedProps.isDraft) {
+                info.el.classList.add('fc-event-draft');
+                info.el.style.borderStyle = 'dashed';
+                info.el.style.borderWidth = '1.5px';
+                info.el.style.opacity = '0.85';
             }
         },
     });

--- a/public/js/conflict-modal.js
+++ b/public/js/conflict-modal.js
@@ -1,5 +1,6 @@
 import { db, openDb } from './db.js';
 import { drainQueue } from './sync-engine.js';
+import { resetLocalStore } from './reset-local-store.js';
 
 // See network-pill.js for the rationale behind alpine:init registration.
 function conflictModalFactory() {
@@ -7,6 +8,10 @@ function conflictModalFactory() {
         open: false,
         conflicts: [],
         index: 0,
+        // Iter-2 bug #12 — disables the reset button while the action is
+        // in flight so a double-click can't fire two parallel
+        // deleteDatabase() calls.
+        resetting: false,
         get current() { return this.conflicts[this.index]; },
 
         async init() {
@@ -76,6 +81,34 @@ function conflictModalFactory() {
             // /api/admin/audit-logs feed. Fire-and-forget — never block UX.
             this._recordAuditLog(cf, resolution, chosen);
             await drainQueue();
+        },
+
+        /**
+         * Iter-2 bug #12 — escape hatch. Wipes the local Dexie store
+         * (`oi_offline`) plus inspection-related localStorage and reloads.
+         * The native confirm() dialog gates the destructive action because
+         * it cannot be undone — the user will lose any locally-cached
+         * unsynced edits the modal can no longer adjudicate.
+         */
+        async resetLocal() {
+            if (this.resetting) return;
+            const ok = (typeof window !== 'undefined' && typeof window.confirm === 'function')
+                ? window.confirm('Reset local copy and reload?\n\nAny offline edits not yet synced will be discarded. The page will reload from the server.')
+                : true;
+            if (!ok) return;
+            this.resetting = true;
+            try {
+                await resetLocalStore();
+            } catch (err) {
+                console.error('[conflict-modal] resetLocalStore failed', err);
+            }
+            // Reload regardless of clear result — a partial wipe + reload is
+            // strictly better than leaving the user in a stuck modal.
+            if (typeof window !== 'undefined' && typeof window.location?.reload === 'function') {
+                window.location.reload();
+            } else {
+                this.resetting = false;
+            }
         },
 
         _recordAuditLog(cf, resolution, mergedValue) {

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -7,7 +7,60 @@ let selectedServiceIds = [];
 let discountCode = '';
 let discountResult = null;
 
+// ─── iter-2 Bug #15 — friendly mapping for ?error= redirect codes ──────────
+// htmlAuthGuard redirects unauthorized role hits with ?error=unauthorized_role.
+// Map the code to a human message and surface it as a toast on first paint.
+// Unknown codes fall back to a generic message — never echo the raw code to
+// the user (UX + privacy).
+const DASHBOARD_ERROR_MESSAGES = {
+    unauthorized_role: 'Agent dashboard is for users with agent role only',
+};
+const GENERIC_DASHBOARD_ERROR = "Sorry, we couldn't open that page";
+
+function mapDashboardErrorMessage(code) {
+    if (!code) return null;
+    if (Object.prototype.hasOwnProperty.call(DASHBOARD_ERROR_MESSAGES, code)) {
+        return DASHBOARD_ERROR_MESSAGES[code];
+    }
+    return GENERIC_DASHBOARD_ERROR;
+}
+
+// Read ?error=, return the friendly message, and strip the param from the URL
+// (history.replaceState) so a refresh doesn't repeat the toast. Preserves any
+// other query params + the hash. Returns null when no error param is present.
+function consumeDashboardErrorParam(win) {
+    const w = win || window;
+    const search = w.location.search || '';
+    if (!search) return null;
+    const params = new URLSearchParams(search);
+    const code = params.get('error');
+    if (!code) return null;
+    params.delete('error');
+    const remaining = params.toString();
+    const cleanUrl = w.location.pathname + (remaining ? '?' + remaining : '') + (w.location.hash || '');
+    try { w.history.replaceState({}, '', cleanUrl); } catch (e) { /* old browser, ignore */ }
+    return mapDashboardErrorMessage(code);
+}
+
+// Expose for unit tests + future inline triggers.
+if (typeof window !== 'undefined') {
+    window.mapDashboardErrorMessage = mapDashboardErrorMessage;
+    window.consumeDashboardErrorParam = consumeDashboardErrorParam;
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
+    // iter-2 Bug #15 — surface the htmlAuthGuard redirect's ?error= code as a
+    // toast before anything else, then strip the param from the URL.
+    try {
+        const errMsg = consumeDashboardErrorParam(window);
+        if (errMsg && typeof showToast === 'function') {
+            showToast(errMsg, true);
+        }
+    } catch (e) {
+        // Toast surfacing must never block dashboard boot.
+        console.warn('[Dashboard] error-toast bootstrap failed', e);
+    }
+
     // Fetch current user for avatar. If unauthenticated, htmlAuthGuard already redirected.
     try {
         const meRes = await authFetch('/api/auth/me');

--- a/public/js/form-renderer.js
+++ b/public/js/form-renderer.js
@@ -127,12 +127,27 @@ document.addEventListener('alpine:init', () => {
     setItemStatus(itemId, status) {
       this.results[itemId].status = status;
       this.results[itemId].updatedAt = Date.now();
+      this._markDirty(itemId, 'status');
       this.saveLocally();
     },
 
     noteChanged(itemId) {
       if (this.results[itemId]) this.results[itemId].updatedAt = Date.now();
+      this._markDirty(itemId, 'notes');
       this.saveLocally();
+    },
+
+    /**
+     * Iter-2 bug #11 — track which (itemId, field) pairs the local user has
+     * edited since the last successful sync. The merge endpoint reads this
+     * to skip 3-way comparison on untouched fields, so a server-only write
+     * (admin paymentRequired toggle, automation, signature) cannot raise a
+     * conflict modal at the inspector for fields they never touched.
+     */
+    _markDirty(itemId, field) {
+      if (!this._dirtyFields) this._dirtyFields = {};
+      const set = (this._dirtyFields[itemId] ||= []);
+      if (!set.includes(field)) set.push(field);
     },
 
     async handleFileUpload(itemId, event) {
@@ -158,6 +173,7 @@ document.addEventListener('alpine:init', () => {
         await pendingPhotoDb.add({ id: localId, inspectionId: this.inspectionId, itemId, blob: uploadFile, type: 'upload' });
         this.results[itemId].photos.push({ key: localId, pending: true, dataUrl });
         this.results[itemId].updatedAt = Date.now();
+        this._markDirty(itemId, 'photos');
         this.saveLocally();
         event.target.value = '';
         return;
@@ -173,6 +189,7 @@ document.addEventListener('alpine:init', () => {
           const { key } = await res.json();
           this.results[itemId].photos.push({ key });
           this.results[itemId].updatedAt = Date.now();
+          this._markDirty(itemId, 'photos');
           this.saveLocally();
         } else {
           modalAlert('Failed to upload photo', 'Error');
@@ -188,6 +205,7 @@ document.addEventListener('alpine:init', () => {
     async removePhoto(itemId, index) {
       this.results[itemId].photos.splice(index, 1);
       this.results[itemId].updatedAt = Date.now();
+      this._markDirty(itemId, 'photos');
       // B4 trigger Task 2 — enqueue a photo.delete op so the sync engine hits
       // DELETE /api/inspections/:id/items/:itemId/photos/:photoIndex once online.
       try {
@@ -241,6 +259,7 @@ document.addEventListener('alpine:init', () => {
       }
       this.results[itemId].recommendations.push(snapshot);
       this.results[itemId].updatedAt = Date.now();
+      this._markDirty(itemId, 'recommendations');
       this.saveLocally();
     },
 
@@ -249,6 +268,7 @@ document.addEventListener('alpine:init', () => {
       if (!Array.isArray(arr)) return;
       arr.splice(ridx, 1);
       this.results[itemId].updatedAt = Date.now();
+      this._markDirty(itemId, 'recommendations');
       this.saveLocally();
     },
 
@@ -434,21 +454,52 @@ document.addEventListener('alpine:init', () => {
     async saveLocally() {
       await openOfflineDb();
       const now = Date.now();
+      // Iter-2 bug #11 — snapshot the dirty-field map and ship it with the
+      // queued merge. We deep-copy so subsequent edits during the queue
+      // drain race do not mutate the in-flight payload. The queue uses an
+      // upsert key (`merge:<id>`) so multiple edits between drains collapse
+      // into one merge; we therefore union dirty fields from any prior
+      // queued payload so dirty bits survive the collapse.
+      const baseRow = await offlineDb.bases.get(this.inspectionId);
+      const base = baseRow?.data || {};
+      const queuedKey = `merge:${this.inspectionId}`;
+      const prior = await offlineDb.syncQueue.get(queuedKey);
+      const priorDirty = (prior && prior.payload && prior.payload.dirtyFields) || {};
+      const dirtySnapshot = {};
+      const live = this._dirtyFields || {};
+      const ids = new Set([...Object.keys(priorDirty), ...Object.keys(live)]);
+      for (const id of ids) {
+        const seen = new Set();
+        const out = [];
+        for (const f of [...(priorDirty[id] || []), ...(live[id] || [])]) {
+          if (!seen.has(f)) { seen.add(f); out.push(f); }
+        }
+        dirtySnapshot[id] = out;
+      }
       await offlineDb.results.put({
         inspectionId: this.inspectionId,
         data: this.results,
         updatedAt: now,
         syncedAt: this._lastSyncedAt || 0,
       });
-      const baseRow = await offlineDb.bases.get(this.inspectionId);
-      const base = baseRow?.data || {};
       await offlineDb.syncQueue.put({
-        id: `merge:${this.inspectionId}`, // upsert key — multiple edits collapse to one queued merge
+        id: queuedKey,
         op: 'results.merge',
-        payload: { inspectionId: this.inspectionId, baseSyncedAt: this._lastSyncedAt || 0, base, ours: this.results },
+        payload: {
+          inspectionId: this.inspectionId,
+          baseSyncedAt: this._lastSyncedAt || 0,
+          base,
+          ours: this.results,
+          dirtyFields: dirtySnapshot,
+        },
         attempts: 0, createdAt: now,
       });
-      if (this.online) { drainQueue(); }
+      if (this.online) {
+        // Optimistically clear the dirty set — the sync engine reapplies it
+        // on retry by replaying the queued payload, so we don't lose anything.
+        this._dirtyFields = {};
+        drainQueue();
+      }
     },
 
     async getLocalData() {

--- a/public/js/reset-local-store.d.ts
+++ b/public/js/reset-local-store.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Iter-2 bug #12 — type stub for the reset-local-store browser helper.
+ */
+export const OFFLINE_DB_NAME: string;
+
+export interface ResetLocalStoreOptions {
+    indexedDB?:    IDBFactory | null;
+    localStorage?: Storage | null;
+    dbName?:       string;
+}
+
+export type ResetLocalStoreResult =
+    | { ok: true;  deletedDb: boolean; clearedKeys: number }
+    | { ok: false; error: string };
+
+export function resetLocalStore(opts?: ResetLocalStoreOptions): Promise<ResetLocalStoreResult>;
+export function resetLocalAndReload(): Promise<ResetLocalStoreResult>;

--- a/public/js/reset-local-store.js
+++ b/public/js/reset-local-store.js
@@ -1,0 +1,78 @@
+/**
+ * Iter-2 bug #12 — escape hatch for users trapped behind a stuck Sync
+ * Conflict modal. Wipes the offline IndexedDB (`oi_offline` — the Dexie
+ * store used by db.js / sync-engine.js / form-renderer.js) plus any
+ * inspection-scoped localStorage keys, then reloads the page.
+ *
+ * Pure function so it can be unit-tested by injecting a fake
+ * `indexedDB` and `localStorage`. The default export wires it to the
+ * real browser globals.
+ *
+ * IDB name kept in sync with public/js/db.js — change here if the Dexie
+ * database name changes.
+ */
+export const OFFLINE_DB_NAME = 'oi_offline';
+
+const INSPECTION_LOCAL_STORAGE_PREFIXES = [
+    'oi:inspection:',  // per-inspection scratchpad written by form-renderer
+    'oi:dirty:',       // dirty-field cache fallback (iter-2 bug #11)
+    'oi:lastSyncedAt:',// per-inspection sync watermark mirror
+];
+
+/**
+ * Pure helper. Returns a result object so the caller can decide how to
+ * surface success/failure (e.g. toast vs reload).
+ *
+ *   { ok: true, deletedDb: boolean, clearedKeys: number }
+ *   { ok: false, error: string }
+ */
+export async function resetLocalStore({
+    indexedDB: idb = (typeof indexedDB !== 'undefined' ? indexedDB : null),
+    localStorage: ls = (typeof localStorage !== 'undefined' ? localStorage : null),
+    dbName = OFFLINE_DB_NAME,
+} = {}) {
+    let deletedDb = false;
+    if (idb && typeof idb.deleteDatabase === 'function') {
+        try {
+            await new Promise((resolve, reject) => {
+                const req = idb.deleteDatabase(dbName);
+                req.onsuccess = () => { deletedDb = true; resolve(); };
+                req.onerror   = () => reject(req.error || new Error('deleteDatabase failed'));
+                // Some browsers fire `blocked` when other tabs hold the DB
+                // open. We treat it as a soft success — the caller will
+                // reload anyway, which closes those tabs' connections.
+                req.onblocked = () => { deletedDb = true; resolve(); };
+            });
+        } catch (err) {
+            return { ok: false, error: (err && err.message) || String(err) };
+        }
+    }
+
+    let clearedKeys = 0;
+    if (ls && typeof ls.length === 'number') {
+        // Walk in reverse so removeItem() doesn't shift indexes underneath us.
+        for (let i = ls.length - 1; i >= 0; i--) {
+            const key = ls.key(i);
+            if (!key) continue;
+            for (const prefix of INSPECTION_LOCAL_STORAGE_PREFIXES) {
+                if (key.startsWith(prefix)) {
+                    ls.removeItem(key);
+                    clearedKeys++;
+                    break;
+                }
+            }
+        }
+    }
+
+    return { ok: true, deletedDb, clearedKeys };
+}
+
+// Browser entry point: clear + reload. Caller is expected to pop a
+// `confirm()` first because the action is destructive.
+export async function resetLocalAndReload() {
+    const result = await resetLocalStore();
+    if (typeof window !== 'undefined' && typeof window.location?.reload === 'function') {
+        window.location.reload();
+    }
+    return result;
+}

--- a/public/js/sync-engine.js
+++ b/public/js/sync-engine.js
@@ -20,7 +20,10 @@ export const syncEngineState = (() => {
 })();
 
 const ENDPOINT = {
-    'results.merge':         (p) => ({ method: 'POST',   url: `/api/inspections/${p.inspectionId}/results/merge`, json: { baseSyncedAt: p.baseSyncedAt, base: p.base, ours: p.ours } }),
+    // Iter-2 bug #11 — forward the dirty-field map so the server can skip
+    // 3-way comparison on fields the local user has not edited. Keeping the
+    // field optional preserves backwards-compat with older clients.
+    'results.merge':         (p) => ({ method: 'POST',   url: `/api/inspections/${p.inspectionId}/results/merge`, json: { baseSyncedAt: p.baseSyncedAt, base: p.base, ours: p.ours, ...(p.dirtyFields ? { dirtyFields: p.dirtyFields } : {}) } }),
     'photo.upload':          (p) => ({ method: 'POST',   url: `/api/inspections/${p.inspectionId}/upload`, formData: makePhotoForm(p) }),
     'photo.delete':          (p) => ({ method: 'DELETE', url: `/api/inspections/${p.inspectionId}/items/${p.itemId}/photos/${p.photoIndex}` }),
     'signature.inspector':   (p) => ({ method: 'POST',   url: `/api/inspections/${p.inspectionId}/inspector-signature`, json: { signatureBase64: p.signatureBase64, signedAt: p.signedAt } }),

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -574,6 +574,18 @@ coreAuthRoutes.openapi(logoutRoute, async (c) => {
         sameSite: 'Strict',
     });
 
+    // iter-2 production bug #4 — clear the CSRF cookie alongside the auth
+    // cookie. Without this, `__Host-csrf_token` outlives the session and
+    // becomes a fixation vector: a subsequent login on the same browser
+    // inherits the same CSRF token, which an attacker who exfiltrated it
+    // pre-logout can replay against the new session. Same `__Host-` prefix
+    // rules apply (Secure + Path=/).
+    deleteCookie(c, '__Host-csrf_token', {
+        path: '/',
+        secure: true,
+        sameSite: 'Strict',
+    });
+
     return c.json({ success: true, data: { success: true } }, 200);
 });
 

--- a/src/api/calendar-events.ts
+++ b/src/api/calendar-events.ts
@@ -7,6 +7,7 @@ import { users } from '../lib/db/schema/tenant';
 import type { HonoConfig } from '../types/hono';
 import { requireRole } from '../lib/middleware/rbac';
 import { logger } from '../lib/logger';
+import { getCalendarEventStyle } from '../lib/calendar-event-style';
 
 const GOOGLE_CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
@@ -88,15 +89,25 @@ calendarEventsRoutes.openapi(eventsRoute, async (c) => {
             lt(inspections.date, endDate),
         ));
 
-    const events: unknown[] = rows.map((r) => ({
-        id: r.id,
-        title: r.propertyAddress,
-        start: r.date,
-        allDay: true,
-        url: `/inspections/${r.id}/edit`,
-        color: '#6366F1',
-        extendedProps: { source: 'local', status: r.status },
-    }));
+    const events: unknown[] = rows.map((r) => {
+        // Iter-2 bug #5 — drafts must render on the calendar with a visual
+        // pill so inspectors can see un-confirmed work without clicking
+        // through. See src/lib/calendar-event-style.ts.
+        const style = getCalendarEventStyle(r.status);
+        return {
+            id: r.id,
+            title: `${style.titlePrefix}${r.propertyAddress}`,
+            start: r.date,
+            allDay: true,
+            url: `/inspections/${r.id}/edit`,
+            color: style.color,
+            extendedProps: {
+                source: 'local',
+                status: r.status,
+                isDraft: style.isDraft,
+            },
+        };
+    });
 
     // Google Calendar events — best-effort; failures don't break local events
     if (jwtUser?.sub && c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET) {

--- a/src/api/inspection-sync.ts
+++ b/src/api/inspection-sync.ts
@@ -5,7 +5,7 @@ import type { HonoConfig } from '../types/hono';
 import { requireRole } from '../lib/middleware/rbac';
 import { Errors } from '../lib/errors';
 import { auditFromContext } from '../lib/audit';
-import { mergeResults, type ResultsBlob } from '../services/diff3.service';
+import { mergeResults, type ResultsBlob, type DirtyFieldsMap } from '../services/diff3.service';
 import {
     ResultsMergeRequestSchema,
     ResultsMergeResponseSchema,
@@ -55,7 +55,7 @@ syncRoutes.openapi(createRoute({
     },
 }), async (c) => {
     const { id } = c.req.valid('param');
-    const { base, ours } = c.req.valid('json');
+    const { base, ours, dirtyFields } = c.req.valid('json');
     const tenantId = c.get('tenantId') as string;
     const db = drizzle(c.env.DB);
 
@@ -71,7 +71,16 @@ syncRoutes.openapi(createRoute({
     // True 3-way merge: client supplies its last server-confirmed `base` snapshot
     // (server doesn't keep result history). diff3 uses base to distinguish the
     // client's edits from server-side third-party concurrent writes.
-    const { merged, conflicts } = mergeResults(base as ResultsBlob, ours as ResultsBlob, theirs);
+    //
+    // Iter-2 bug #11 — `dirtyFields` narrows the conflict surface so untouched
+    // local fields silently take theirs (no modal). When the client omits the
+    // field we fall through to the original "compare every field" behaviour.
+    const { merged, conflicts } = mergeResults(
+        base as ResultsBlob,
+        ours as ResultsBlob,
+        theirs,
+        dirtyFields as DirtyFieldsMap | undefined,
+    );
 
     if (conflicts.length > 0) {
         return c.json({

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ const STATIC_ASSET_EXT = /\.(css|js|mjs|map|png|jpe?g|gif|svg|ico|webp|woff2?|tt
 app.use('*', async (c, next) => {
     const path = c.req.path;
     const isAuthPublic = path === '/api/auth/login' || path === '/api/auth/register' || path === '/api/auth/setup' || path === '/api/auth/login/2fa';
-    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/ics/') || path.startsWith('/api/messages/public/') || path === '/book' || path === '/widget.js' || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/r/') || path.startsWith('/agreements/sign/') || path.startsWith('/messages/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || STATIC_ASSET_EXT.test(path);
+    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/ics/') || path.startsWith('/api/messages/public/') || path === '/book' || path === '/widget.js' || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/r/') || path.startsWith('/agreements/sign/') || path.startsWith('/sign/') || path.startsWith('/messages/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || STATIC_ASSET_EXT.test(path);
 
     if (isAuthPublic || isPublic || path === '/setup' || path === '/login' || path === '/join' || path.startsWith('/agreements/sign/')) return next();
 
@@ -545,6 +545,36 @@ app.get('/not-found', (c) => {
 // these handlers the request would fall through to the generic Hono 404.
 app.get('/agreement-sign', (c) => c.redirect('/not-found?from=agreement-sign', 302));
 app.get('/agreements/sign', (c) => c.redirect('/not-found?from=agreement-sign', 302));
+
+// iter-2 production bug #9 — `/sign/:id` redirect target for the
+// ReportGatePage "Sign agreement" CTA. Sprint 1 D-7 minted the URL
+// `${baseUrl}/sign/${id}` with id = inspection id, but no route was
+// registered, so the customer who hit the gate landed on a 404.
+//
+// Resolves the inspection's most recent non-terminal agreement request
+// and 302s to the canonical token-gated page `/agreements/sign/:token`.
+// When no live request exists (every row is signed / declined / expired
+// / never created), redirects to the friendly not-found page so the
+// customer at least sees branded copy instead of the bare 404.
+//
+// Public — no JWT required. tenantId resolves from the subdomain via
+// tenantRouter middleware (`resolvedTenantId`), the same way the public
+// `/report/:id` viewer is scoped.
+app.get('/sign/:id', async (c) => {
+    const id = c.req.param('id') as string;
+    const tenantId = c.get('tenantId') || c.get('resolvedTenantId');
+    if (!tenantId) return c.redirect('/not-found?from=agreement-sign', 302);
+
+    try {
+        const pending = await c.var.services.agreement.findPendingByInspectionId(tenantId as string, id);
+        if (pending) {
+            return c.redirect(`/agreements/sign/${pending.token}`, 302);
+        }
+    } catch (e) {
+        logger.warn('sign-redirect: lookup failed', { inspectionId: id.slice(0, 8), error: (e as Error).message });
+    }
+    return c.redirect('/not-found?from=agreement-sign', 302);
+});
 
 // Spec 5H P1 — Internal render route consumed by SignCompletionWorkflow.
 // Auth model: token IS the secret (256-bit hex from createSigningRequest).

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { InspectionSignaturesPage } from './templates/pages/inspection/signature
 import { InspectionSettingsPage } from './templates/pages/inspection/settings';
 import { RepairListPage } from './templates/pages/inspection/repair-list';
 import { CustomerRepairRequestPage } from './templates/pages/customer-repair-request';
+import { FeatureDisabledPage } from './templates/pages/feature-disabled';
 import { SettingsAutomationsPage } from './templates/pages/settings-automations';
 import { SettingsWidgetPage } from './templates/pages/settings-widget';
 import { SettingsServicesPage } from './templates/pages/settings-services';
@@ -1455,8 +1456,14 @@ app.get('/inspections/:id/repair-list', htmlAuthGuard(['owner', 'admin', 'inspec
     const shell = await loadInspectionShellData(c, id);
 
     // Gate on the tenant toggle so an admin can't deep-link past the opt-in.
+    // Iter-2 Bug #13 — replaced the generic 404 with a friendly disabled-feature
+    // page so admins/inspectors are told WHY (toggle is off) and HOW to enable
+    // it (deep-link CTA to Settings → Workspace → Reports).
     if (!shell?.enableRepairList) {
-        return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+        return c.html(
+            FeatureDisabledPage({ from: 'repair-list', branding: c.get('branding') }),
+            403,
+        );
     }
     try {
         const data = await c.var.services.inspection.getRepairList(id, tenantId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,8 +1016,15 @@ app.get('/r/:id/repair-request', async (c) => {
             enableCustomerRepairExport = !!cfgRow?.enableCustomerRepairExport;
             enableRepairList = !!cfgRow?.enableRepairList;
         } catch { /* default off */ }
+        // Iter-2 Bug #14 — when the tenant has not enabled the customer
+        // repair-request export, render a friendly disabled-feature page that
+        // tells the customer to contact their inspector. Previously returned a
+        // generic 404 which made the link look broken from the customer's POV.
         if (!enableCustomerRepairExport) {
-            return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+            return c.html(
+                FeatureDisabledPage({ from: 'customer-repair-request', branding: c.get('branding') }),
+                403,
+            );
         }
         // Suppress unused-var lint — enableRepairList is read for symmetry
         // with /report/:id but the customer view never surfaces the link.

--- a/src/index.ts
+++ b/src/index.ts
@@ -914,7 +914,7 @@ app.get('/report/:id', async (c) => {
                     reason:          'payment',
                     companyName,
                     primaryColor,
-                    actionUrl:       `${baseUrl}/invoices?inspection=${id}`,
+                    actionUrl:       `${baseUrl}/r/${id}/invoice`,
                     actionLabel:     'View invoice & pay',
                     propertyAddress: insp.propertyAddress ?? null,
                     inspectorName,
@@ -1000,6 +1000,84 @@ app.get('/report/:id', async (c) => {
         }));
     } catch {
         return c.text('Report not found', 404);
+    }
+});
+
+// iter-2 production bug #10 — public invoice payment page.
+//
+// Replaces `/invoices?inspection=<id>` as the report-gate "Pay invoice"
+// CTA target. The legacy `/invoices` route is JWT-protected (admin-only),
+// so an unauthenticated customer who clicked the gate CTA was redirected
+// to /login — a dead end for a buyer with no account.
+//
+// This route is public, scoped by inspection id; the inspection id itself
+// IS the secret (same pattern as `/r/:id/repair-request` and `/report/:id`).
+// We surface the invoice's line items, total, and either a hosted Stripe
+// Checkout link (when the workspace has Stripe Connect configured) or a
+// "Contact your inspector" fallback. No account required, no /login
+// detour.
+app.get('/r/:id/invoice', async (c) => {
+    const id = c.req.param('id') as string;
+    const tenantId = c.get('tenantId') || c.get('resolvedTenantId');
+    if (!tenantId) return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+
+    try {
+        const db = drizzle(c.env.DB);
+        const insp = await db.select({
+            id:              schema.inspections.id,
+            propertyAddress: schema.inspections.propertyAddress,
+            date:            schema.inspections.date,
+            inspectorId:     schema.inspections.inspectorId,
+        }).from(schema.inspections)
+            .where(and(eq(schema.inspections.id, id), eq(schema.inspections.tenantId, tenantId as string)))
+            .get();
+        if (!insp) return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
+
+        const branding = c.get('branding');
+        const companyName = branding?.siteName || c.env.APP_NAME || 'OpenInspection';
+        const primaryColor = branding?.primaryColor || c.env.PRIMARY_COLOR || '#6366f1';
+
+        let inspectorName: string | null = null;
+        let inspectorEmail: string | null = null;
+        if (insp.inspectorId) {
+            const inspectorRow = await db.select({ name: users.name, email: users.email })
+                .from(users)
+                .where(and(eq(users.id, insp.inspectorId), eq(users.tenantId, tenantId as string)))
+                .get();
+            inspectorName = inspectorRow?.name ?? null;
+            inspectorEmail = inspectorRow?.email ?? null;
+        }
+
+        const invoice = await c.var.services.invoice.findByInspectionId(tenantId as string, id);
+
+        // No Stripe Connect integration in core today — payUrl stays null
+        // and the page renders the "Contact your inspector" fallback. When
+        // STRIPE_SECRET_KEY is wired up, mint a Checkout session here and
+        // pass its URL through. Tested by InvoicePublicPage's `payUrl=null`
+        // path which is the live behavior on every standalone deploy.
+        const payUrl: string | null = null;
+
+        const { InvoicePublicPage } = await import('./templates/pages/invoice-public');
+        return c.html(InvoicePublicPage({
+            companyName,
+            primaryColor,
+            propertyAddress: insp.propertyAddress ?? null,
+            inspectorName,
+            inspectorEmail,
+            scheduledDate: insp.date ?? null,
+            invoice: invoice ? {
+                id:          invoice.id,
+                amountCents: invoice.amountCents,
+                status:      invoice.status,
+                dueDate:     invoice.dueDate ?? null,
+                notes:       invoice.notes ?? null,
+                lineItems:   invoice.lineItems ?? [],
+            } : null,
+            payUrl,
+        }) as string);
+    } catch (e) {
+        logger.warn('public invoice page failed', { inspectionId: id.slice(0, 8), error: (e as Error).message });
+        return c.html(NotFoundPage({ branding: c.get('branding') }), 404);
     }
 });
 
@@ -1093,7 +1171,7 @@ app.get('/r/:id/repair-request', async (c) => {
                     reason:          'payment',
                     companyName,
                     primaryColor,
-                    actionUrl:       `${baseUrl}/invoices?inspection=${id}`,
+                    actionUrl:       `${baseUrl}/r/${id}/invoice`,
                     actionLabel:     'View invoice & pay',
                     propertyAddress: insp.propertyAddress ?? null,
                     inspectorName,

--- a/src/lib/calendar-event-style.ts
+++ b/src/lib/calendar-event-style.ts
@@ -1,0 +1,59 @@
+/**
+ * Iter-2 UX bug #5 — Calendar visual differentiation for inspection events.
+ *
+ * Pure helper that maps an inspection's lifecycle status to FullCalendar
+ * style hints. Drafts get a lighter color and an explicit "DRAFT" prefix in
+ * the title so inspectors can spot un-confirmed work straight from the grid
+ * without clicking through.
+ *
+ * Cancelled events get a strikethrough-style gray pill so they stay visible
+ * but read as "not happening". Everything else stays on the default indigo
+ * brand color — same as before this change so existing UX is preserved.
+ *
+ * Pure function: easy to unit-test with a status matrix and reuse anywhere
+ * we render an inspection on a calendar surface.
+ */
+
+export interface CalendarEventStyle {
+    /** Hex fill color FullCalendar applies to the event chip. */
+    color: string;
+    /** Optional title prefix (e.g. "DRAFT · ") — empty string when not needed. */
+    titlePrefix: string;
+    /**
+     * If true the event chip should render with an "outline" treatment —
+     * lighter background, dashed-style border in the front-end CSS. Used
+     * for drafts so they read as scheduled-but-tentative.
+     */
+    isDraft: boolean;
+}
+
+/**
+ * Computes the visual style for an inspection on the calendar.
+ *
+ * Defensive: an unknown / missing status falls through to the default
+ * "scheduled" treatment so partial rows never break the calendar render.
+ */
+export function getCalendarEventStyle(status: string | null | undefined): CalendarEventStyle {
+    const s = (status ?? '').toLowerCase();
+    if (s === 'draft') {
+        return {
+            // Sprint 1 design tokens — slate-400 reads as "tentative" against
+            // the indigo "confirmed" chips without introducing a new hue.
+            color: '#94A3B8',
+            titlePrefix: 'DRAFT · ',
+            isDraft: true,
+        };
+    }
+    if (s === 'cancelled') {
+        return {
+            color: '#9CA3AF',
+            titlePrefix: 'CANCELLED · ',
+            isDraft: false,
+        };
+    }
+    return {
+        color: '#6366F1', // brand indigo — unchanged from pre-bug #5
+        titlePrefix: '',
+        isDraft: false,
+    };
+}

--- a/src/lib/validations/sync.schema.ts
+++ b/src/lib/validations/sync.schema.ts
@@ -22,10 +22,27 @@ const ItemResultSchema = z.object({
 
 export const ResultsBlobSchema = z.record(z.string(), ItemResultSchema).openapi('ResultsBlob');
 
+/**
+ * Iter-2 bug #11 — dirty-field map narrows the conflict surface.
+ *
+ * Shape: `{ [itemId]: ['notes','status','photos','recommendations'] }`.
+ * Only listed (itemId, field) pairs contribute to a conflict — every
+ * other field silently takes theirs so server-only writes (e.g. an admin
+ * toggling `paymentRequired` from another tab, or a third-party adding
+ * an agreement signature) cannot pop a conflict modal at the inspector.
+ *
+ * Optional for backwards-compat: callers that omit the field fall back
+ * to the pre-bug-#11 "compare every field" behaviour so older clients
+ * that haven't shipped the new sync engine still merge correctly.
+ */
+const ItemDirtyFieldsSchema = z.array(z.enum(['status', 'notes', 'photos', 'recommendations']));
+export const DirtyFieldsMapSchema = z.record(z.string(), ItemDirtyFieldsSchema).openapi('DirtyFieldsMap');
+
 export const ResultsMergeRequestSchema = z.object({
     baseSyncedAt: z.number().int().nonnegative(),
     base:         ResultsBlobSchema, // client's last server-confirmed snapshot — needed because server doesn't keep history
     ours:         ResultsBlobSchema,
+    dirtyFields:  DirtyFieldsMapSchema.optional(),
 }).openapi('ResultsMergeRequest');
 
 export const MergeConflictSchema = z.object({

--- a/src/services/agreement.service.ts
+++ b/src/services/agreement.service.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/d1';
-import { eq, and, inArray, sql } from 'drizzle-orm';
+import { eq, and, inArray, sql, desc } from 'drizzle-orm';
 import { agreements, agreementRequests, inspections } from '../lib/db/schema';
 import { Errors } from '../lib/errors';
 import { logger } from '../lib/logger';
@@ -180,6 +180,39 @@ export class AgreementService {
      */
     async getRequestByToken(token: string) {
         return this.getDrizzle().select().from(agreementRequests).where(eq(agreementRequests.token, token)).get();
+    }
+
+    /**
+     * iter-2 production bug #9 — given an inspection id, return the most recent
+     * non-terminal (pending/sent/viewed) signing request for that inspection
+     * within the given tenant. Used by the public `/sign/:id` redirect route
+     * so a customer who hits the report-gate "Sign agreement" CTA lands on
+     * the live agreement page instead of a 404.
+     *
+     * Returns `null` when the inspection has no agreement request at all,
+     * or when all existing requests are in a terminal state (signed /
+     * declined / expired). Tenant-scoped — never crosses workspaces.
+     *
+     * NOTE: this is a read-only counterpart to `findOrCreate()`. Callers
+     * that want to mint a token when none exists should use the latter;
+     * the public `/sign/:id` redirect deliberately stays read-only so an
+     * unauthenticated customer cannot trigger row inserts.
+     */
+    async findPendingByInspectionId(tenantId: string, inspectionId: string): Promise<{ token: string; status: string } | null> {
+        const row = await this.getDrizzle().select({
+            token:  agreementRequests.token,
+            status: agreementRequests.status,
+        })
+            .from(agreementRequests)
+            .where(and(
+                eq(agreementRequests.tenantId, tenantId),
+                eq(agreementRequests.inspectionId, inspectionId),
+                inArray(agreementRequests.status, ['pending', 'sent', 'viewed']),
+            ))
+            .orderBy(desc(agreementRequests.createdAt))
+            .limit(1)
+            .get();
+        return row ?? null;
     }
 
     /**

--- a/src/services/diff3.service.ts
+++ b/src/services/diff3.service.ts
@@ -31,13 +31,46 @@ export interface MergeOutcome {
 }
 
 /**
+ * Per-item dirty-field map. Keys are item IDs; values are the subset of
+ * fields the local user has edited since the last successful sync.
+ *
+ * Iter-2 bug #11 — narrows the conflict surface so server-only updates
+ * (admin toggles, signature events, automation writes) cannot pop a
+ * conflict at the inspector for fields they never touched.
+ *
+ * When the map is `undefined` the merge falls back to the pre-bug-#11
+ * "treat every field as dirty" behaviour so older clients keep working.
+ */
+export type DirtyField = 'status' | 'notes' | 'photos' | 'recommendations';
+export type DirtyFieldsMap = Record<string, DirtyField[]>;
+
+const ALL_FIELDS: readonly DirtyField[] = ['status', 'notes', 'photos', 'recommendations'] as const;
+
+function isDirty(dirty: DirtyField[] | undefined, field: DirtyField): boolean {
+    // Backwards-compat: a missing dirty list means "everything is dirty" so
+    // older clients that don't ship the dirty-field tracker keep merging the
+    // way they always have.
+    if (!dirty) return true;
+    return dirty.includes(field);
+}
+
+/**
  * Three-way merge of inspection-results blobs.
  * - status: LWW by per-item updatedAt
  * - notes:  diff3 line-level merge; collisions surface as MergeConflict
  * - photos: array union by `key`
  * Items present on only one side are added (no merge needed).
+ *
+ * If `dirtyFields` is supplied, only the fields listed for an item are
+ * eligible to flip "ours" — every other field on that item silently
+ * takes theirs (or base when theirs is missing). See DirtyFieldsMap.
  */
-export function mergeResults(base: ResultsBlob, ours: ResultsBlob, theirs: ResultsBlob): MergeOutcome {
+export function mergeResults(
+    base: ResultsBlob,
+    ours: ResultsBlob,
+    theirs: ResultsBlob,
+    dirtyFields?: DirtyFieldsMap,
+): MergeOutcome {
     const allItems = new Set([...Object.keys(base), ...Object.keys(ours), ...Object.keys(theirs)]);
     const merged:    ResultsBlob = {};
     const conflicts: MergeConflict[] = [];
@@ -46,6 +79,7 @@ export function mergeResults(base: ResultsBlob, ours: ResultsBlob, theirs: Resul
         const b = base[itemId];
         const o = ours[itemId];
         const t = theirs[itemId];
+        const dirty = dirtyFields?.[itemId];
 
         // Item only in ours (new addition by ours)
         if (!b && o && !t) { merged[itemId] = o; continue; }
@@ -54,7 +88,7 @@ export function mergeResults(base: ResultsBlob, ours: ResultsBlob, theirs: Resul
         // Item in neither base but in both sides — treat as empty base, merge both additions
         if (!b && o && t) {
             const empty: ItemResult = { status: null, notes: '', photos: [], updatedAt: 0 };
-            const sub = mergeOne(empty, o, t);
+            const sub = mergeOne(empty, o, t, dirty);
             merged[itemId] = sub.item;
             if (sub.conflict) conflicts.push({ ...sub.conflict, itemId });
             continue;
@@ -66,8 +100,34 @@ export function mergeResults(base: ResultsBlob, ours: ResultsBlob, theirs: Resul
         // Item in base + ours only — ours wins
         if (b && o && !t)  { merged[itemId] = o; continue; }
 
-        // All three present — full three-way merge
-        const sub = mergeOne(b, o, t);
+        // All three present.
+        // Iter-2 bug #11 — short-circuit when the local user has not edited
+        // any field on this item. The server's value (`theirs`) wins
+        // wholesale: no diff3, no conflict, no modal noise. Photos and
+        // recommendations remain a union since photo-upload pipes already
+        // wrote to ours and we don't want to drop them on a no-edit save.
+        if (dirty !== undefined && dirty.length === 0) {
+            const seen = new Set<string>();
+            const photos: ItemResult['photos'] = [];
+            for (const p of [...(t.photos || []), ...(o.photos || [])]) {
+                if (!seen.has(p.key)) { seen.add(p.key); photos.push(p); }
+            }
+            const seenRec = new Set<string>();
+            const recommendations: ItemResult['recommendations'] = [];
+            for (const r of [...(t.recommendations || []), ...(o.recommendations || [])]) {
+                if (!seenRec.has(r.recommendationId)) { seenRec.add(r.recommendationId); recommendations.push(r); }
+            }
+            merged[itemId] = {
+                status: t.status,
+                notes:  t.notes,
+                photos,
+                updatedAt: Math.max(o.updatedAt, t.updatedAt),
+                ...(recommendations.length > 0 ? { recommendations } : {}),
+            };
+            continue;
+        }
+
+        const sub = mergeOne(b, o, t, dirty);
         merged[itemId] = sub.item;
         if (sub.conflict) conflicts.push({ ...sub.conflict, itemId });
     }
@@ -79,30 +139,47 @@ function mergeOne(
     base: ItemResult,
     ours: ItemResult,
     theirs: ItemResult,
+    dirty?: DirtyField[],
 ): { item: ItemResult; conflict?: Omit<MergeConflict, 'itemId'> } {
-    // LWW for status field
-    const status = (ours.updatedAt >= theirs.updatedAt) ? ours.status : theirs.status;
+    // Iter-2 bug #11 — when the dirty-fields contract is opted into, only
+    // fields the local user actually touched are eligible to flip "ours".
+    // For non-dirty fields, theirs wins (or base when theirs absent) without
+    // a 3-way merge — that's the entire point of the dirty-field map.
+    const statusDirty = isDirty(dirty, 'status');
+    const notesDirty  = isDirty(dirty, 'notes');
+    const photosDirty = isDirty(dirty, 'photos');
+    const recsDirty   = isDirty(dirty, 'recommendations');
+
+    // LWW for status field — only when ours is dirty; otherwise theirs.
+    const status = !statusDirty
+        ? theirs.status
+        : ((ours.updatedAt >= theirs.updatedAt) ? ours.status : theirs.status);
 
     // Photo union by key (preserve first occurrence order: ours first, then theirs additions)
     const seen = new Set<string>();
     const photos: ItemResult['photos'] = [];
-    for (const p of [...(ours.photos || []), ...(theirs.photos || [])]) {
+    const photoLeft  = photosDirty ? (ours.photos || [])    : (theirs.photos || []);
+    const photoRight = photosDirty ? (theirs.photos || [])  : (ours.photos || []);
+    for (const p of [...photoLeft, ...photoRight]) {
         if (!seen.has(p.key)) { seen.add(p.key); photos.push(p); }
     }
 
-    // Recommendations union by recommendationId (snapshots are immutable per attach;
-    // any duplicate ID is treated as the same attachment regardless of snapshot text)
+    // Recommendations union by recommendationId
     const seenRec = new Set<string>();
     const recommendations: ItemResult['recommendations'] = [];
-    for (const r of [...(ours.recommendations || []), ...(theirs.recommendations || [])]) {
+    const recLeft  = recsDirty ? (ours.recommendations || [])    : (theirs.recommendations || []);
+    const recRight = recsDirty ? (theirs.recommendations || [])  : (ours.recommendations || []);
+    for (const r of [...recLeft, ...recRight]) {
         if (!seenRec.has(r.recommendationId)) {
             seenRec.add(r.recommendationId);
             recommendations.push(r);
         }
     }
 
-    // diff3 merge for notes
-    const notesResult = mergeNotes(base.notes || '', ours.notes || '', theirs.notes || '');
+    // diff3 merge for notes — only when ours is dirty; otherwise theirs.
+    const notesResult = notesDirty
+        ? mergeNotes(base.notes || '', ours.notes || '', theirs.notes || '')
+        : { text: theirs.notes || '', conflict: false };
     const item: ItemResult = {
         status,
         notes: notesResult.text,
@@ -119,6 +196,9 @@ function mergeOne(
     }
     return { item };
 }
+
+// `ALL_FIELDS` is exported for tests to enumerate the field surface.
+export const _ALL_FIELDS: readonly DirtyField[] = ALL_FIELDS;
 
 function mergeNotes(base: string, ours: string, theirs: string): { text: string; conflict: boolean } {
     // Fast-path: identical — no merge needed

--- a/src/services/invoice.service.ts
+++ b/src/services/invoice.service.ts
@@ -30,6 +30,33 @@ export class InvoiceService {
         }));
     }
 
+    /**
+     * iter-2 production bug #10 — given an inspection id, return its most
+     * recent invoice (if any) within the given tenant. Used by the public
+     * `/r/:id/invoice` payment page that the report-gate "Pay invoice" CTA
+     * now points at, so an unauthenticated customer can see what they owe
+     * and how to pay without being redirected to /login.
+     *
+     * Returns `null` when no invoice exists. Tenant-scoped — never crosses
+     * workspaces.
+     */
+    async findByInspectionId(tenantId: string, inspectionId: string) {
+        const db = this.getDrizzle();
+        const row = await db.select().from(invoices)
+            .where(and(eq(invoices.tenantId, tenantId), eq(invoices.inspectionId, inspectionId)))
+            .orderBy(desc(invoices.createdAt))
+            .limit(1)
+            .get();
+        if (!row) return null;
+        return {
+            ...row,
+            status: getStatus(row),
+            createdAt: safeISODate(row.createdAt),
+            sentAt: row.sentAt ? safeISODate(row.sentAt) : null,
+            paidAt: row.paidAt ? safeISODate(row.paidAt) : null,
+        };
+    }
+
     async createInvoice(tenantId: string, data: {
         inspectionId?: string | null | undefined;
         clientName: string;

--- a/src/templates/components/conflict-modal.tsx
+++ b/src/templates/components/conflict-modal.tsx
@@ -1,6 +1,13 @@
 /**
  * B4 — Three-column conflict resolution modal (base / yours / theirs).
  * Triggered when db.conflicts is non-empty.
+ *
+ * Iter-2 bug #12 — adds a "Reset local copy & reload" escape hatch as a
+ * fourth action separated from the primary three. Calling it deletes the
+ * Dexie offline DB (`oi_offline`) plus inspection-related localStorage,
+ * then reloads. The UX is intentionally one click + native confirm so a
+ * user trapped behind a stuck conflict no longer needs DevTools to dig
+ * out of an IDB corruption.
  */
 export const ConflictModal = () => (
     <div
@@ -27,6 +34,23 @@ export const ConflictModal = () => (
                 <button x-on:click="resolve('ours')"   class="px-5 py-2 rounded-lg bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-indigo-700">Keep Mine</button>
                 <button x-on:click="resolve('theirs')" class="px-5 py-2 rounded-lg bg-rose-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-rose-700">Accept Theirs</button>
                 <button x-on:click="resolve('edit')"   class="px-5 py-2 rounded-lg ring-2 ring-slate-300 text-slate-700 text-xs font-bold uppercase tracking-widest hover:bg-slate-50">Edit Merged</button>
+                {/* Iter-2 bug #12 — visual separator + escape hatch. The
+                    `aria-hidden` divider keeps screen readers focused on the
+                    actionable buttons. The reset button itself is destructive
+                    so we surface it last and tag it with text-rose-600 ring
+                    treatment instead of the primary fill — readers should
+                    pause before pressing it. */}
+                <span aria-hidden="true" class="mx-2 h-6 w-px bg-slate-200"></span>
+                <button
+                    type="button"
+                    data-testid="conflict-reset-local"
+                    x-on:click="resetLocal()"
+                    x-bind:disabled="resetting"
+                    class="px-5 py-2 rounded-lg ring-2 ring-rose-200 text-rose-600 text-xs font-bold uppercase tracking-widest hover:bg-rose-50 disabled:opacity-50"
+                >
+                    <span x-show="!resetting">Reset Local Copy &amp; Reload</span>
+                    <span x-show="resetting" style="display:none">Resetting…</span>
+                </button>
             </footer>
         </div>
     </div>

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -192,14 +192,21 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                     <span class="flex-1">Library</span>
                                     <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
                                 </summary>
+                                {/* Iter-2 bug #8 — canonical Library order: Inspection
+                                    Templates / Marketplace / Comments / Repair Items /
+                                    Tags / Agreements / Rating Systems. All seven entries
+                                    are required; the previous order shipped Marketplace
+                                    after Agreements which made customers think it was
+                                    missing when the menu was reading-cut on small
+                                    viewports. */}
                                 <div class="mt-1 ml-7 pl-3 border-l border-slate-100 space-y-0.5">
                                     <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Inspection Templates</a>
+                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
                                     <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Comments</a>
                                     <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Repair Items</a>
-                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
-                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
                                     <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Tags</a>
+                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
+                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
                                 </div>
                             </details>
                             <a href="/contacts" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
@@ -302,14 +309,16 @@ export const MainLayout = (props: { title: string, children: unknown, branding?:
                                     <span class="flex-1">Library</span>
                                     <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
                                 </summary>
+                                {/* Iter-2 bug #8 — canonical Library order, kept in
+                                    sync with the mobile drawer above. */}
                                 <div class="mt-1 ml-7 pl-3 border-l border-slate-100 space-y-0.5">
                                     <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Inspection Templates</a>
+                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
                                     <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Comments</a>
                                     <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Repair Items</a>
-                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
-                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
                                     <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Tags</a>
+                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
+                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
                                 </div>
                             </details>
                             <a href="/contacts" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">

--- a/src/templates/pages/booking.tsx
+++ b/src/templates/pages/booking.tsx
@@ -167,6 +167,7 @@ export const PublicBookingPage = ({ siteKey, branding, embed, style }: PublicBoo
                                     <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Inspection date</span>
                                     <input
                                         type="date"
+                                        lang="en"
                                         name="inspectionDate"
                                         x-model="inspectionDate"
                                         {...{

--- a/src/templates/pages/feature-disabled.tsx
+++ b/src/templates/pages/feature-disabled.tsx
@@ -1,0 +1,102 @@
+import { BareLayout } from '../layouts/main-layout';
+import { BrandingConfig } from '../../types/auth';
+
+/**
+ * Iter-2 soft-error pages — Friendly disabled-feature page.
+ *
+ * Replaces the generic `NotFoundPage` 404 that Track E1 (repair-list) and
+ * Sprint 3 S3-2 (customer repair-request) used to return when the per-tenant
+ * toggle was off. The customer/admin should be told WHY the page is
+ * unavailable, not handed a "Page not found" dead end.
+ *
+ * Layout matches `not-found.tsx` for visual consistency:
+ *  - slate canvas (calm, "not your fault" vibe)
+ *  - 22px section heading + 14px slate-500 body
+ *  - optional indigo CTA button
+ *  - no atmospheric blob, no glass-panel
+ *
+ * `from` keys:
+ *   `repair-list`               — admin/inspector deep-linked when tenant
+ *                                 `enable_repair_list = false`. CTA points
+ *                                 to the settings anchor that holds the
+ *                                 toggle.
+ *   `customer-repair-request`   — customer deep-linked when tenant
+ *                                 `enable_customer_repair_export = false`.
+ *                                 No CTA — customer can't enable it
+ *                                 themselves; copy invites them to contact
+ *                                 the inspector.
+ *   (anything else)             — generic friendly fallback.
+ */
+type DisabledKey = 'repair-list' | 'customer-repair-request';
+
+interface DisabledContext {
+    title: string;
+    body:  string;
+    cta?:  { label: string; href: string };
+}
+
+interface FeatureDisabledPageProps {
+    branding?: BrandingConfig | undefined;
+    /** Variant key — drives copy + CTA. Unknown values fall back to generic. */
+    from?:     string | undefined;
+}
+
+const CONTEXT_MESSAGES: Record<DisabledKey, DisabledContext> = {
+    'repair-list': {
+        title: 'Repair List is disabled',
+        body:  'Tenant administrators can enable Repair List in Settings → Workspace → Reports.',
+        cta:   { label: 'Go to settings', href: '/settings/workspace/reports#repair-list' },
+    },
+    'customer-repair-request': {
+        title: 'Repair request unavailable',
+        body:  "Your inspector hasn't enabled the customer repair-request export. Please contact them to request a printable defect list.",
+    },
+};
+
+const DEFAULT_CONTEXT: DisabledContext = {
+    title: 'Feature unavailable',
+    body:  'This feature is not currently enabled for your workspace.',
+};
+
+function resolveContext(from?: string): DisabledContext {
+    if (from && from in CONTEXT_MESSAGES) {
+        return CONTEXT_MESSAGES[from as DisabledKey];
+    }
+    return DEFAULT_CONTEXT;
+}
+
+export const FeatureDisabledPage = (props: FeatureDisabledPageProps = {}): JSX.Element => {
+    const { branding, from } = props;
+    const siteName = branding?.siteName || 'OpenInspection';
+    const ctx = resolveContext(from);
+
+    return (
+        <BareLayout title={`${siteName} | ${ctx.title}`} branding={branding}>
+            <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4 py-12">
+                <div class="max-w-md w-full text-center space-y-6">
+                    {branding?.logoUrl && (
+                        <img src={branding.logoUrl} alt={siteName} class="h-10 mx-auto opacity-80" />
+                    )}
+                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 text-slate-400 mx-auto">
+                        {/* Lock icon — communicates "gated by config", not "broken". */}
+                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                        </svg>
+                    </div>
+                    <div class="space-y-2">
+                        <h1 class="text-[22px] font-bold tracking-tight text-slate-900">{ctx.title}</h1>
+                        <p class="text-[14px] text-slate-500 leading-relaxed">{ctx.body}</p>
+                    </div>
+                    {ctx.cta && (
+                        <a
+                            href={ctx.cta.href}
+                            class="inline-flex items-center justify-center h-10 px-5 rounded-md bg-indigo-600 text-white text-[13px] font-bold hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 transition-colors"
+                        >
+                            {ctx.cta.label}
+                        </a>
+                    )}
+                </div>
+            </div>
+        </BareLayout>
+    );
+};

--- a/src/templates/pages/inspection/settings.tsx
+++ b/src/templates/pages/inspection/settings.tsx
@@ -71,8 +71,13 @@ export const InspectionSettingsPage = ({
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <label class="block">
                                     <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Date</span>
+                                    {/* Iter-2 bug #6 — explicit `lang="en"` stops Chrome on
+                                        zh-CN OS locales from rendering the native date
+                                        placeholder as 「年/月/日」. */}
                                     <input
                                         type="date"
+                                        lang="en"
+                                        placeholder="YYYY-MM-DD"
                                         x-model="form.date"
                                         class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
                                     />
@@ -96,8 +101,13 @@ export const InspectionSettingsPage = ({
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <label class="block">
                                     <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Closing Date</span>
+                                    {/* Iter-2 bug #6 — same as the schedule date input above:
+                                        explicit `lang="en"` overrides the OS locale so users
+                                        on zh-CN do not see 「年/月/日」 as the placeholder. */}
                                     <input
                                         type="date"
+                                        lang="en"
+                                        placeholder="YYYY-MM-DD"
                                         data-testid="inspection-closing-date"
                                         x-model="form.closingDate"
                                         class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"

--- a/src/templates/pages/invoice-public.tsx
+++ b/src/templates/pages/invoice-public.tsx
@@ -1,0 +1,277 @@
+import type { FC } from 'hono/jsx';
+
+interface InvoicePublicProps {
+    companyName:        string;
+    primaryColor:       string;
+    propertyAddress?:   string | null;
+    inspectorName?:     string | null;
+    inspectorEmail?:    string | null;
+    scheduledDate?:     string | null;
+    invoice: {
+        id:           string;
+        amountCents:  number;
+        status:       'draft' | 'sent' | 'paid';
+        dueDate?:     string | null;
+        notes?:       string | null;
+        lineItems:    Array<{ description: string; amountCents: number }>;
+    } | null;
+    /**
+     * When the inspector workspace has Stripe Connect configured, we surface
+     * a "Pay now" CTA that hands off to a hosted Checkout session. When
+     * absent, we fall back to a "Contact your inspector" message — never a
+     * dead-end for the customer.
+     */
+    payUrl?: string | null;
+}
+
+/**
+ * iter-2 production bug #10 — public invoice payment page.
+ *
+ * Token-gated companion to `/r/:id/repair-request` (Sprint 3 S3-2). The
+ * customer landing here came from the report-gate "Pay invoice" CTA and
+ * has no account, so this page MUST work without authentication.
+ *
+ * Design mirrors `report-gate.tsx`: calm amber pill, single CTA, branded
+ * footer. Self-contained inline styles so the page renders even when
+ * /styles.css is unavailable.
+ */
+export const InvoicePublicPage: FC<InvoicePublicProps> = ({
+    companyName, primaryColor,
+    propertyAddress, inspectorName, inspectorEmail, scheduledDate,
+    invoice, payUrl,
+}) => {
+    const formattedDate = scheduledDate ? (() => {
+        try {
+            return new Date(scheduledDate).toLocaleDateString('en-US', {
+                weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+            });
+        } catch {
+            return scheduledDate;
+        }
+    })() : null;
+
+    const formatMoney = (cents: number) => {
+        const dollars = (cents / 100).toFixed(2);
+        return `$${dollars}`;
+    };
+
+    const isPaid = invoice?.status === 'paid';
+    const hasInvoice = !!invoice;
+    const canPayOnline = hasInvoice && !isPaid && !!payUrl;
+
+    const title = isPaid ? 'Invoice paid' : (hasInvoice ? 'Invoice due' : 'Payment information');
+    const headline = isPaid
+        ? 'Your invoice has been paid.'
+        : (hasInvoice
+            ? 'Complete your payment to view the report.'
+            : 'Contact your inspector for payment instructions.');
+
+    const message = isPaid
+        ? 'Thank you. Your inspection report should be available now — if you still see the gate, please refresh the page.'
+        : (hasInvoice
+            ? (canPayOnline
+                ? 'Review the line items below and pay securely with your card. Once payment is confirmed, your inspection report will unlock automatically.'
+                : 'Your inspector will reach out with payment instructions, or you can contact them using the details below.')
+            : 'No invoice has been issued for this inspection yet. Please contact your inspector to arrange payment.');
+
+    return (
+        <html lang="en">
+            <head>
+                <meta charset="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>{title} — {companyName}</title>
+                <style dangerouslySetInnerHTML={{ __html: `
+                    :root { --brand: ${primaryColor}; }
+                    * { box-sizing: border-box; }
+                    body {
+                        margin: 0;
+                        background: #f8fafc;
+                        color: #0f172a;
+                        font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Helvetica Neue', Arial, sans-serif;
+                        font-size: 14px;
+                        line-height: 1.5;
+                        min-height: 100vh;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        padding: 24px 16px;
+                    }
+                    .card {
+                        background: #ffffff;
+                        border: 1px solid #e2e8f0;
+                        border-radius: 12px;
+                        padding: 32px;
+                        max-width: 520px;
+                        width: 100%;
+                    }
+                    .pill {
+                        display: inline-flex;
+                        align-items: center;
+                        gap: 6px;
+                        height: 24px;
+                        padding: 0 8px;
+                        border-radius: 4px;
+                        font-size: 11px;
+                        font-weight: 600;
+                        letter-spacing: 0.02em;
+                        margin-bottom: 16px;
+                    }
+                    .pill.amber { background: #fef3c7; color: #92400e; }
+                    .pill.green { background: #d1fae5; color: #065f46; }
+                    .pill::before {
+                        content: '';
+                        display: inline-block;
+                        width: 6px; height: 6px;
+                        border-radius: 50%;
+                    }
+                    .pill.amber::before { background: #f59e0b; }
+                    .pill.green::before { background: #10b981; }
+                    h1 {
+                        margin: 0 0 8px 0;
+                        font-size: 22px;
+                        font-weight: 700;
+                        letter-spacing: -0.015em;
+                        color: #0f172a;
+                    }
+                    p.lead {
+                        margin: 0 0 24px 0;
+                        color: #64748b;
+                        line-height: 1.6;
+                    }
+                    .meta {
+                        background: #f8fafc;
+                        border: 1px solid #e2e8f0;
+                        border-radius: 6px;
+                        padding: 12px 16px;
+                        margin: 0 0 24px 0;
+                        font-size: 13px;
+                        color: #475569;
+                    }
+                    .meta strong { color: #0f172a; font-weight: 600; }
+                    .meta div + div { margin-top: 4px; }
+                    .invoice-box {
+                        border: 1px solid #e2e8f0;
+                        border-radius: 8px;
+                        padding: 16px;
+                        margin: 0 0 24px 0;
+                    }
+                    .invoice-box .row {
+                        display: flex;
+                        justify-content: space-between;
+                        align-items: baseline;
+                        padding: 6px 0;
+                        font-size: 13px;
+                        color: #475569;
+                    }
+                    .invoice-box .row + .row { border-top: 1px solid #f1f5f9; }
+                    .invoice-box .row.total {
+                        border-top: 1px solid #cbd5e1;
+                        margin-top: 4px;
+                        padding-top: 12px;
+                        color: #0f172a;
+                        font-weight: 700;
+                        font-size: 15px;
+                    }
+                    .invoice-box .row.total .amount { color: var(--brand); }
+                    .invoice-box .desc { color: #475569; }
+                    .invoice-box .amount { color: #0f172a; font-variant-numeric: tabular-nums; font-weight: 600; }
+                    .due-line {
+                        font-size: 12px;
+                        color: #64748b;
+                        margin-top: 8px;
+                    }
+                    a.cta {
+                        display: inline-flex;
+                        align-items: center;
+                        justify-content: center;
+                        height: 40px;
+                        padding: 0 20px;
+                        border-radius: 6px;
+                        background: var(--brand);
+                        color: #ffffff;
+                        font-weight: 700;
+                        font-size: 13px;
+                        text-decoration: none;
+                        transition: opacity 120ms ease;
+                    }
+                    a.cta:hover { opacity: 0.92; }
+                    a.cta:focus-visible {
+                        outline: none;
+                        box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.32);
+                    }
+                    .contact-line {
+                        font-size: 13px;
+                        color: #475569;
+                        margin-top: 4px;
+                    }
+                    .contact-line a { color: var(--brand); text-decoration: none; }
+                    .contact-line a:hover { text-decoration: underline; }
+                    .brand {
+                        margin-top: 24px;
+                        font-size: 11px;
+                        color: #94a3b8;
+                        text-align: center;
+                    }
+                    @media (prefers-reduced-motion: reduce) {
+                        a.cta { transition: none; }
+                    }
+                `}} />
+            </head>
+            <body>
+                <div class="card">
+                    <span class={isPaid ? 'pill green' : 'pill amber'}>{title}</span>
+                    <h1>{headline}</h1>
+                    <p class="lead">{message}</p>
+
+                    {(propertyAddress || inspectorName || formattedDate) && (
+                        <div class="meta">
+                            {propertyAddress && <div><strong>{propertyAddress}</strong></div>}
+                            {inspectorName && <div>Inspector: {inspectorName}</div>}
+                            {formattedDate && <div>Scheduled: {formattedDate}</div>}
+                        </div>
+                    )}
+
+                    {invoice && (
+                        <div class="invoice-box">
+                            {invoice.lineItems.length > 0 ? (
+                                invoice.lineItems.map((line) => (
+                                    <div class="row">
+                                        <span class="desc">{line.description}</span>
+                                        <span class="amount">{formatMoney(line.amountCents)}</span>
+                                    </div>
+                                ))
+                            ) : (
+                                <div class="row">
+                                    <span class="desc">Inspection services</span>
+                                    <span class="amount">{formatMoney(invoice.amountCents)}</span>
+                                </div>
+                            )}
+                            <div class="row total">
+                                <span>Total {isPaid ? 'paid' : 'due'}</span>
+                                <span class="amount">{formatMoney(invoice.amountCents)}</span>
+                            </div>
+                            {invoice.dueDate && !isPaid && (
+                                <div class="due-line">Due by {invoice.dueDate}</div>
+                            )}
+                        </div>
+                    )}
+
+                    {canPayOnline && payUrl && (
+                        <a class="cta" href={payUrl}>Pay {formatMoney(invoice!.amountCents)} now</a>
+                    )}
+                    {!canPayOnline && !isPaid && (inspectorName || inspectorEmail) && (
+                        <div class="contact-line">
+                            Contact{' '}
+                            {inspectorEmail
+                                ? <a href={`mailto:${inspectorEmail}`}>{inspectorName || inspectorEmail}</a>
+                                : <strong>{inspectorName}</strong>}
+                            {' '}to arrange payment.
+                        </div>
+                    )}
+
+                    <div class="brand">Powered by {companyName}</div>
+                </div>
+            </body>
+        </html>
+    );
+};

--- a/src/templates/pages/invoices.tsx
+++ b/src/templates/pages/invoices.tsx
@@ -94,7 +94,9 @@ export const InvoicesPage = ({ branding }: { branding?: BrandingConfig | undefin
                             </div>
                             <div>
                                 <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Due Date</label>
-                                <input type="date" id="invDueDate" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                                {/* Iter-2 bug #6 — `lang="en"` prevents OS-locale leak
+                                    (e.g. zh-CN browsers showing「年/月/日」placeholder). */}
+                                <input type="date" lang="en" placeholder="YYYY-MM-DD" id="invDueDate" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                             </div>
                         </div>
                         <div>

--- a/tests/repair-list.spec.ts
+++ b/tests/repair-list.spec.ts
@@ -21,9 +21,11 @@ test.describe('Track E1 — repair-list route', () => {
             maxRedirects: 0,
             failOnStatusCode: false,
         });
-        // Either a 302 to /login (unauth) or a 200/404 (auth + opt-in/out).
-        // A 500 or anything else means the route blew up.
-        expect([200, 301, 302, 303, 307, 308, 404]).toContain(res.status());
+        // Either a 302 to /login (unauth), a 200 (auth + opt-in), a 403
+        // (auth + opt-out, iter-2 Bug #13 friendly disabled-feature page) or
+        // a 404 (legacy / catch-all). A 500 or anything else means the route
+        // blew up.
+        expect([200, 301, 302, 303, 307, 308, 403, 404]).toContain(res.status());
         if ([301, 302, 303, 307, 308].includes(res.status())) {
             const location = res.headers()['location'] || '';
             expect(location).toMatch(/\/login/);

--- a/tests/unit/booking-date-input.spec.ts
+++ b/tests/unit/booking-date-input.spec.ts
@@ -23,7 +23,10 @@ describe('R7-06 — /book inspection date input', () => {
         // The previous code used type="text" + a JS mask. The fix flips the
         // input to a native <input type="date"> which triggers the native
         // iOS spinner picker on mobile Safari.
-        expect(tsx).toMatch(/type="date"\s+name="inspectionDate"/);
+        // Iter-2 bug #6 added a `lang="en"` attribute between type and name
+        // to avoid OS-locale placeholder leaks on zh-CN; the regex permits
+        // any attributes between type="date" and name="inspectionDate".
+        expect(tsx).toMatch(/type="date"[\s\S]*?name="inspectionDate"/);
         // And no leftover "type=text" + "name=dateMasked" remnant.
         expect(tsx).not.toMatch(/type="text"\s+name="dateMasked"/);
     });

--- a/tests/unit/calendar-event-style.spec.ts
+++ b/tests/unit/calendar-event-style.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getCalendarEventStyle } from '../../src/lib/calendar-event-style';
+
+describe('getCalendarEventStyle (iter-2 bug #5)', () => {
+    it('renders draft inspections with a DRAFT prefix and lighter color', () => {
+        const style = getCalendarEventStyle('draft');
+        expect(style.titlePrefix).toBe('DRAFT · ');
+        expect(style.isDraft).toBe(true);
+        expect(style.color).not.toBe('#6366F1');
+    });
+
+    it('renders cancelled inspections with a CANCELLED prefix', () => {
+        const style = getCalendarEventStyle('cancelled');
+        expect(style.titlePrefix).toBe('CANCELLED · ');
+        expect(style.isDraft).toBe(false);
+    });
+
+    it('falls back to brand indigo for confirmed/scheduled/in_progress', () => {
+        for (const s of ['scheduled', 'confirmed', 'in_progress', 'completed', 'delivered']) {
+            const style = getCalendarEventStyle(s);
+            expect(style.color).toBe('#6366F1');
+            expect(style.titlePrefix).toBe('');
+            expect(style.isDraft).toBe(false);
+        }
+    });
+
+    it('handles null/undefined/empty status defensively', () => {
+        for (const s of [null, undefined, '']) {
+            const style = getCalendarEventStyle(s);
+            expect(style.color).toBe('#6366F1');
+            expect(style.titlePrefix).toBe('');
+            expect(style.isDraft).toBe(false);
+        }
+    });
+
+    it('is case-insensitive on status', () => {
+        expect(getCalendarEventStyle('DRAFT').isDraft).toBe(true);
+        expect(getCalendarEventStyle('Draft').isDraft).toBe(true);
+    });
+});

--- a/tests/unit/dashboard-error-toast.spec.ts
+++ b/tests/unit/dashboard-error-toast.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Iter-2 soft-error pages — Bug #15 — unauthorized_role error toast.
+ *
+ * `htmlAuthGuard` redirects to `/dashboard?error=unauthorized_role` when a
+ * user without an allowed role tries to deep-link an admin/inspector page.
+ * The dashboard previously left the URL param dangling without surfacing
+ * any UI feedback, leaving the user confused about what just happened.
+ *
+ * This spec exercises the new helpers added to `public/js/dashboard.js`:
+ *
+ *   - `mapDashboardErrorMessage(code)` — code → friendly toast string
+ *   - `consumeDashboardErrorParam(win)` — read the param, strip from URL,
+ *     return the resolved message
+ *
+ * The helpers are exposed on `window` so the DOMContentLoaded handler can
+ * call them and so this test can drive them in isolation.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface DashWindow {
+    mapDashboardErrorMessage: (code: string | null | undefined) => string | null;
+    consumeDashboardErrorParam: (win: { location: { search: string; pathname: string; hash: string }; history: { replaceState: (s: unknown, t: string, url: string) => void } }) => string | null;
+}
+
+describe('dashboard error-param helpers (public/js/dashboard.js)', () => {
+    let dash: DashWindow;
+
+    beforeAll(() => {
+        const code = readFileSync(
+            join(process.cwd(), 'public', 'js', 'dashboard.js'),
+            'utf8',
+        );
+        const fakeWindow: Record<string, unknown> = {};
+        const fakeDocument = {
+            addEventListener: () => {},
+            getElementById: () => null,
+            querySelector: () => null,
+            createElement: () => ({ textContent: '', innerHTML: '', className: '', style: {} }),
+            body: { appendChild: () => {} },
+        };
+        // Wrap the script so it executes against our fake window/document.
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+        const fn = new Function('window', 'document', 'authFetch', 'logout', 'showToast', code);
+        fn(
+            fakeWindow,
+            fakeDocument,
+            () => Promise.resolve(new Response()),
+            () => {},
+            () => {},
+        );
+        dash = {
+            mapDashboardErrorMessage: fakeWindow.mapDashboardErrorMessage as DashWindow['mapDashboardErrorMessage'],
+            consumeDashboardErrorParam: fakeWindow.consumeDashboardErrorParam as DashWindow['consumeDashboardErrorParam'],
+        };
+        if (typeof dash.mapDashboardErrorMessage !== 'function') {
+            throw new Error('mapDashboardErrorMessage was not exported on window');
+        }
+        if (typeof dash.consumeDashboardErrorParam !== 'function') {
+            throw new Error('consumeDashboardErrorParam was not exported on window');
+        }
+    });
+
+    describe('mapDashboardErrorMessage', () => {
+        it('returns the agent-only message for unauthorized_role', () => {
+            const msg = dash.mapDashboardErrorMessage('unauthorized_role');
+            expect(msg).toBe('Agent dashboard is for users with agent role only');
+        });
+
+        it('returns null for empty / nullish codes', () => {
+            expect(dash.mapDashboardErrorMessage('')).toBeNull();
+            expect(dash.mapDashboardErrorMessage(null)).toBeNull();
+            expect(dash.mapDashboardErrorMessage(undefined)).toBeNull();
+        });
+
+        it('falls back to a generic friendly message for unknown codes', () => {
+            const msg = dash.mapDashboardErrorMessage('some_future_code');
+            expect(msg).toBeTruthy();
+            // Generic message MUST NOT echo the raw code (privacy / UX).
+            expect(msg).not.toContain('some_future_code');
+            // But it should communicate that something went wrong.
+            expect(String(msg).toLowerCase()).toMatch(/sorry|unable|cannot|error|something/);
+        });
+    });
+
+    describe('consumeDashboardErrorParam', () => {
+        let calls: Array<[unknown, string, string]>;
+        function makeWin(search: string) {
+            calls = [];
+            return {
+                location: { search, pathname: '/dashboard', hash: '' },
+                history: {
+                    replaceState: (s: unknown, t: string, url: string) => {
+                        calls.push([s, t, url]);
+                    },
+                },
+            };
+        }
+
+        beforeEach(() => { calls = []; });
+
+        it('returns null when no error param is present', () => {
+            const win = makeWin('');
+            expect(dash.consumeDashboardErrorParam(win)).toBeNull();
+            // No URL rewrite when nothing to strip.
+            expect(calls.length).toBe(0);
+        });
+
+        it('returns the friendly message AND strips the param from the URL', () => {
+            const win = makeWin('?error=unauthorized_role');
+            const msg = dash.consumeDashboardErrorParam(win);
+            expect(msg).toBe('Agent dashboard is for users with agent role only');
+            // history.replaceState invoked with the param removed.
+            expect(calls.length).toBe(1);
+            const [, , url] = calls[0]!;
+            expect(url).toBe('/dashboard');
+        });
+
+        it('preserves OTHER query params while stripping ?error', () => {
+            const win = makeWin('?bucket=today&error=unauthorized_role&q=foo');
+            dash.consumeDashboardErrorParam(win);
+            expect(calls.length).toBe(1);
+            const [, , url] = calls[0]!;
+            expect(url).toContain('bucket=today');
+            expect(url).toContain('q=foo');
+            expect(url).not.toContain('error=unauthorized_role');
+        });
+
+        it('preserves URL hash when stripping the error param', () => {
+            const win = {
+                location: { search: '?error=unauthorized_role', pathname: '/dashboard', hash: '#today' },
+                history: {
+                    replaceState: (s: unknown, t: string, url: string) => {
+                        calls.push([s, t, url]);
+                    },
+                },
+            };
+            dash.consumeDashboardErrorParam(win);
+            expect(calls.length).toBe(1);
+            const [, , url] = calls[0]!;
+            expect(url).toContain('#today');
+        });
+
+        it('returns null + still strips the param when code is unknown', () => {
+            // Even if mapDashboardErrorMessage falls back to generic, the
+            // helper should still strip the URL — unknown codes should still
+            // surface the generic toast (returning the message) so we keep
+            // returning truthy here. But the URL should be cleaned either way.
+            const win = makeWin('?error=mystery');
+            const msg = dash.consumeDashboardErrorParam(win);
+            // Generic fallback message returned, not null.
+            expect(msg).toBeTruthy();
+            expect(calls.length).toBe(1);
+        });
+    });
+});

--- a/tests/unit/date-input-locale.spec.ts
+++ b/tests/unit/date-input-locale.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Iter-2 bug #6 — every <input type="date"> in the codebase must carry an
+ * explicit `lang="en"` so Chromium-based browsers running with a non-English
+ * OS locale don't render the native placeholder as 「年/月/日」 (zh-CN) or
+ * its other locale-specific equivalents.
+ *
+ * Static check on each template that has a date input. Cheap to run and
+ * cheap to keep green — also acts as a regression fence so a future PR
+ * cannot reintroduce a date input without the attribute.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const TEMPLATES = [
+    'src/templates/pages/booking.tsx',
+    'src/templates/pages/invoices.tsx',
+    'src/templates/pages/inspection/settings.tsx',
+];
+
+describe('iter-2 bug #6 — <input type="date"> lang="en"', () => {
+    for (const rel of TEMPLATES) {
+        it(`${rel} — every type="date" carries lang="en"`, () => {
+            const raw = readFileSync(resolve(__dirname, '../../', rel), 'utf8');
+            // Strip JS/JSX block + line comments + JSX `{/* … */}` comment
+            // blocks — date-input strings appearing in prose docs (e.g. the
+            // file-level comment about the locale leak) are not real markup.
+            const src = raw
+                .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '')
+                .replace(/\/\*[\s\S]*?\*\//g, '')
+                .replace(/\/\/.*$/gm, '');
+            // Find every occurrence of type="date".
+            const matches = [...src.matchAll(/type="date"/g)];
+            expect(matches.length, `expected at least one <input type="date"> in ${rel}`).toBeGreaterThan(0);
+
+            // For each occurrence, walk forward from the type="date" attribute
+            // to the closing `/>` of the same tag and assert lang="en" appears
+            // somewhere inside that span. Walking forward avoids being fooled
+            // by sibling <input ...> tags above the date input.
+            for (const m of matches) {
+                const idx = m.index ?? 0;
+                // Look for the tag's lang attribute either before or after the
+                // type="date" attribute, but only within the same tag.
+                const tagEnd = src.indexOf('/>', idx);
+                expect(tagEnd, 'closing /> not found').toBeGreaterThan(idx);
+                // Walk back from idx to the most recent '<input' we have not
+                // yet closed. We do this by counting `/>` and `<input` tokens.
+                let cursor = idx;
+                let depth = 0;
+                while (cursor > 0) {
+                    cursor--;
+                    if (src.startsWith('/>', cursor)) depth++;
+                    if (src.startsWith('<input', cursor)) {
+                        if (depth === 0) break;
+                        depth--;
+                    }
+                }
+                const tag = src.slice(cursor, tagEnd + 2);
+                expect(tag, `<input type="date"> at offset ${idx} must declare lang="en"`).toMatch(/lang="en"/);
+            }
+        });
+    }
+});

--- a/tests/unit/diff3.service.spec.ts
+++ b/tests/unit/diff3.service.spec.ts
@@ -87,3 +87,83 @@ describe('mergeResults', () => {
         expect((out.merged.item1.recommendations || []).map(r => r.recommendationId)).toEqual(['r_A']);
     });
 });
+
+// ─── Iter-2 bug #11 — dirty-field map narrows the conflict surface ─────────
+describe('mergeResults dirtyFields (iter-2 bug #11)', () => {
+    it('takes theirs silently for fields the user did not edit, even when ours differs', () => {
+        // The local `ours.notes` happens to differ from base — say a stale
+        // snapshot — but the user did not edit `notes` on this item. Server
+        // has a real edit. Without dirty-tracking diff3 would surface a
+        // conflict; with it, theirs wins quietly.
+        const b: ResultsBlob = { item1: { status: 'satisfactory', notes: 'Original.', photos: [], updatedAt: 0 } };
+        const o: ResultsBlob = { item1: { status: 'satisfactory', notes: 'Stale local.', photos: [], updatedAt: 1 } };
+        const t: ResultsBlob = { item1: { status: 'satisfactory', notes: 'Server edit.', photos: [], updatedAt: 5 } };
+        const out = mergeResults(b, o, t, { item1: [] });
+        expect(out.conflicts).toHaveLength(0);
+        expect(out.merged.item1.notes).toBe('Server edit.');
+    });
+
+    it('still surfaces a conflict when the user did edit notes on this item', () => {
+        const b: ResultsBlob = { item1: { status: 'satisfactory', notes: 'Original.', photos: [], updatedAt: 0 } };
+        const o: ResultsBlob = { item1: { status: 'satisfactory', notes: 'Inspector.', photos: [], updatedAt: 1 } };
+        const t: ResultsBlob = { item1: { status: 'satisfactory', notes: 'Office.',    photos: [], updatedAt: 1 } };
+        const out = mergeResults(b, o, t, { item1: ['notes'] });
+        expect(out.conflicts).toHaveLength(1);
+        expect(out.conflicts[0]).toMatchObject({ itemId: 'item1', field: 'notes' });
+    });
+
+    it('non-dirty status takes theirs even when ours has higher updatedAt', () => {
+        // User did not change status. Server flipped it. Local updatedAt is
+        // newer (e.g. they edited notes elsewhere). Dirty map says only notes
+        // is dirty, so status must take theirs even though LWW would say ours.
+        const b: ResultsBlob = { item1: { status: 'satisfactory', notes: '', photos: [], updatedAt: 0 } };
+        const o: ResultsBlob = { item1: { status: 'satisfactory', notes: 'note', photos: [], updatedAt: 10 } };
+        const t: ResultsBlob = { item1: { status: 'defect',       notes: '',     photos: [], updatedAt: 5 } };
+        const out = mergeResults(b, o, t, { item1: ['notes'] });
+        expect(out.merged.item1.status).toBe('defect');
+    });
+
+    it('empty dirty list short-circuits to theirs but still unions photos', () => {
+        // Server-side write only — admin toggled something; the inspector
+        // didn't touch this item. But background photo uploads still
+        // happened (queued before the admin write). Photos must survive.
+        const b: ResultsBlob = { item1: { status: 'satisfactory', notes: 'orig', photos: [{ key: 'p1' }], updatedAt: 0 } };
+        const o: ResultsBlob = { item1: { status: 'satisfactory', notes: 'orig', photos: [{ key: 'p1' }, { key: 'p_new' }], updatedAt: 1 } };
+        const t: ResultsBlob = { item1: { status: 'defect',       notes: 'admin edit', photos: [{ key: 'p1' }], updatedAt: 5 } };
+        const out = mergeResults(b, o, t, { item1: [] });
+        expect(out.conflicts).toHaveLength(0);
+        expect(out.merged.item1.status).toBe('defect');
+        expect(out.merged.item1.notes).toBe('admin edit');
+        const keys = (out.merged.item1.photos || []).map(p => p.key).sort();
+        expect(keys).toEqual(['p1', 'p_new']);
+    });
+
+    it('per-item dirty mask: dirty on item1 does not affect item2', () => {
+        const b: ResultsBlob = {
+            item1: { status: 'satisfactory', notes: 'orig1', photos: [], updatedAt: 0 },
+            item2: { status: 'satisfactory', notes: 'orig2', photos: [], updatedAt: 0 },
+        };
+        const o: ResultsBlob = {
+            item1: { status: 'satisfactory', notes: 'mine',  photos: [], updatedAt: 1 },
+            item2: { status: 'satisfactory', notes: 'stale', photos: [], updatedAt: 1 },
+        };
+        const t: ResultsBlob = {
+            item1: { status: 'satisfactory', notes: 'theirs', photos: [], updatedAt: 1 },
+            item2: { status: 'satisfactory', notes: 'admin',  photos: [], updatedAt: 1 },
+        };
+        // Only item1.notes is dirty. item2 should silently take theirs.
+        const out = mergeResults(b, o, t, { item1: ['notes'], item2: [] });
+        expect(out.merged.item2.notes).toBe('admin');
+        // item1 has both sides editing notes — that's a real conflict.
+        expect(out.conflicts).toHaveLength(1);
+        expect(out.conflicts[0]?.itemId).toBe('item1');
+    });
+
+    it('omitting dirtyFields preserves pre-bug-#11 behaviour (back-compat)', () => {
+        const b: ResultsBlob = { item1: { status: 'satisfactory', notes: 'O', photos: [], updatedAt: 0 } };
+        const o: ResultsBlob = { item1: { status: 'satisfactory', notes: 'A', photos: [], updatedAt: 1 } };
+        const t: ResultsBlob = { item1: { status: 'satisfactory', notes: 'B', photos: [], updatedAt: 1 } };
+        const out = mergeResults(b, o, t);
+        expect(out.conflicts).toHaveLength(1);
+    });
+});

--- a/tests/unit/feature-disabled-page.spec.ts
+++ b/tests/unit/feature-disabled-page.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Iter-2 soft-error pages — FeatureDisabledPage render tests.
+ *
+ * Snapshots the disabled-feature page across the two friendly variants
+ * surfaced by Bug #13 (admin/inspector hits Repair List sub-route while
+ * the tenant toggle is off) and Bug #14 (customer hits the public
+ * repair-request URL while the customer-export toggle is off).
+ */
+import { describe, it, expect } from 'vitest';
+import { FeatureDisabledPage } from '../../src/templates/pages/feature-disabled';
+
+function render(node: unknown): string {
+    return String(node);
+}
+
+describe('FeatureDisabledPage', () => {
+    it('renders the inspector-facing repair-list disabled copy + settings CTA', () => {
+        const html = render(FeatureDisabledPage({
+            from: 'repair-list',
+        }));
+        expect(html).toContain('Repair List is disabled');
+        expect(html).toContain('Settings');
+        expect(html).toContain('Workspace');
+        expect(html).toContain('Reports');
+        // CTA links to the deep-link anchor on settings.
+        expect(html).toContain('href="/settings/workspace/reports#repair-list"');
+        expect(html).toContain('Go to settings');
+    });
+
+    it('renders the customer-facing repair-request disabled copy without an inspector CTA', () => {
+        const html = render(FeatureDisabledPage({
+            from: 'customer-repair-request',
+        }));
+        expect(html).toContain('Repair request unavailable');
+        // Customer copy must invite contact, never settings deep-link.
+        // hono/jsx HTML-encodes apostrophes — check both forms.
+        expect(html.includes("inspector hasn't enabled") || html.includes('inspector hasn&#39;t enabled')).toBe(true);
+        expect(html).not.toContain('href="/settings/');
+    });
+
+    it('falls back to a generic friendly disabled-feature message for unknown keys', () => {
+        const html = render(FeatureDisabledPage({
+            from: 'mystery-key',
+        }));
+        // Generic title + body still render.
+        expect(html).toContain('Feature unavailable');
+        expect(html).toContain('not currently enabled');
+    });
+
+    it('respects branding siteName in the document title', () => {
+        const html = render(FeatureDisabledPage({
+            from: 'repair-list',
+            branding: {
+                siteName: 'Acme Inspections',
+                primaryColor: '#6366f1',
+            } as never,
+        }));
+        expect(html).toContain('Acme Inspections | Repair List is disabled');
+    });
+});

--- a/tests/unit/iter2-bug10-public-invoice.spec.ts
+++ b/tests/unit/iter2-bug10-public-invoice.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { InvoiceService } from '../../src/services/invoice.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT_A = '00000000-0000-0000-0000-000000000001';
+const TENANT_B = '00000000-0000-0000-0000-000000000002';
+const INSP_ID  = '00000000-0000-0000-0000-000000000010';
+const INSP_B   = '00000000-0000-0000-0000-000000000011';
+
+async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
+    await testDb.insert(schema.tenants).values([
+        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+    ]);
+    await testDb.insert(schema.inspections).values([
+        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+        { id: INSP_B, tenantId: TENANT_B, propertyAddress: '2 Other St', clientName: 'Bob', clientEmail: 'bob@test.com', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 30000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+    ]);
+}
+
+/**
+ * iter-2 production bug #10 — ReportGatePage's "Pay invoice" CTA pointed
+ * at `/invoices?inspection=<id>`, a JWT-protected admin route. An
+ * unauthenticated customer who clicked the gate CTA was 302'd to /login,
+ * a dead end with no signup path.
+ *
+ * The fix introduces a public `/r/:id/invoice` payment page (token-gated
+ * like Sprint 3 S3-2's `/r/:id/repair-request`) that renders the invoice
+ * details + payment instructions without requiring auth. This spec pins
+ * the service-level `findByInspectionId` lookup that powers the page:
+ * tenant-scoped, returns null on miss, surfaces status from sentAt/paidAt.
+ */
+describe('iter-2 #10 — InvoiceService.findByInspectionId', () => {
+    let svc: InvoiceService;
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let sqlite: { close: () => void };
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        sqlite = fixture.sqlite;
+        await setupSchema(fixture.sqlite);
+        await seedBase(testDb);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InvoiceService({} as D1Database);
+    });
+
+    afterEach(() => {
+        sqlite.close();
+        vi.clearAllMocks();
+    });
+
+    it('returns null when no invoice exists for the inspection', async () => {
+        const result = await svc.findByInspectionId(TENANT_A, INSP_ID);
+        expect(result).toBeNull();
+    });
+
+    it('returns invoice details + status="draft" when not sent or paid', async () => {
+        const invId = '00000000-0000-0000-0000-000000000200';
+        await testDb.insert(schema.invoices).values({
+            id: invId,
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            clientName: 'Jane',
+            clientEmail: 'jane@test.com',
+            amountCents: 50000,
+            lineItems: [{ description: 'Standard inspection', amountCents: 50000 }],
+            createdAt: new Date(),
+        });
+        const result = await svc.findByInspectionId(TENANT_A, INSP_ID);
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe(invId);
+        expect(result?.amountCents).toBe(50000);
+        expect(result?.status).toBe('draft');
+    });
+
+    it('returns status="sent" when sentAt is set but not paid', async () => {
+        await testDb.insert(schema.invoices).values({
+            id: '00000000-0000-0000-0000-000000000201',
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            clientName: 'Jane',
+            amountCents: 50000,
+            lineItems: [],
+            sentAt: new Date(),
+            createdAt: new Date(),
+        });
+        const result = await svc.findByInspectionId(TENANT_A, INSP_ID);
+        expect(result?.status).toBe('sent');
+    });
+
+    it('returns status="paid" when paidAt is set', async () => {
+        await testDb.insert(schema.invoices).values({
+            id: '00000000-0000-0000-0000-000000000202',
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            clientName: 'Jane',
+            amountCents: 50000,
+            lineItems: [],
+            sentAt: new Date(),
+            paidAt: new Date(),
+            createdAt: new Date(),
+        });
+        const result = await svc.findByInspectionId(TENANT_A, INSP_ID);
+        expect(result?.status).toBe('paid');
+    });
+
+    it('does NOT leak invoices across tenants', async () => {
+        // Tenant B has an invoice for INSP_B
+        await testDb.insert(schema.invoices).values({
+            id: '00000000-0000-0000-0000-000000000203',
+            tenantId: TENANT_B,
+            inspectionId: INSP_B,
+            clientName: 'Bob',
+            amountCents: 30000,
+            lineItems: [],
+            createdAt: new Date(),
+        });
+        // Tenant A queries for tenant B's invoice — must NOT find it
+        const result = await svc.findByInspectionId(TENANT_A, INSP_B);
+        expect(result).toBeNull();
+    });
+});

--- a/tests/unit/iter2-bug4-logout-cookie.spec.ts
+++ b/tests/unit/iter2-bug4-logout-cookie.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * iter-2 production bug #4 — `/api/auth/logout` did not fully terminate
+ * the customer's session. The handler cleared `__Host-inspector_token`
+ * but left `__Host-csrf_token` in place, so the CSRF cookie outlived the
+ * session — a fixation vector if the token was exfiltrated pre-logout.
+ *
+ * The fix adds a second `deleteCookie` call alongside the auth-token
+ * clear. Both cookies use the `__Host-` prefix, which the browser
+ * silently rejects unless the deletion Set-Cookie carries `Secure` and
+ * `Path=/` — these tests pin both the wire format and the production
+ * route's behavior.
+ */
+
+describe('iter-2 #4 — logout cookie deletion contract', () => {
+    it('a deletion cookie for __Host- prefix MUST carry Secure and Path=/', async () => {
+        // Reproduce what hono/cookie's deleteCookie writes for the auth cookie.
+        // The serializer is `cookie` (npm) under the hood; we don't need to
+        // mock it — we just emit the same shape the helper produces and
+        // assert on the wire format.
+        const { deleteCookie } = await import('hono/cookie');
+        const { Hono } = await import('hono');
+        const app = new Hono();
+        app.post('/logout', (c) => {
+            deleteCookie(c, '__Host-inspector_token', { path: '/', secure: true, sameSite: 'Strict' });
+            deleteCookie(c, '__Host-csrf_token', { path: '/', secure: true, sameSite: 'Strict' });
+            return c.json({ success: true });
+        });
+        const res = await app.request('/logout', { method: 'POST' });
+        const setCookieHeaders = res.headers.getSetCookie?.() ?? [];
+        // Browsers / fetch return an array of Set-Cookie headers — both must be present.
+        expect(setCookieHeaders.length).toBeGreaterThanOrEqual(2);
+
+        const inspectorCookie = setCookieHeaders.find(h => h.startsWith('__Host-inspector_token='));
+        const csrfCookie = setCookieHeaders.find(h => h.startsWith('__Host-csrf_token='));
+        expect(inspectorCookie).toBeDefined();
+        expect(csrfCookie).toBeDefined();
+
+        // Both deletion cookies must carry Secure + Path=/ — `__Host-` cookies
+        // are silently ignored by the browser otherwise, leaving the live
+        // cookie in place and BUG #4 reappearing.
+        for (const cookie of [inspectorCookie!, csrfCookie!]) {
+            expect(cookie).toMatch(/Path=\//i);
+            expect(cookie).toMatch(/Secure/i);
+            // Max-Age=0 OR an Expires date in the past — either is a valid deletion.
+            expect(cookie).toMatch(/(Max-Age=0|Expires=)/i);
+        }
+    });
+
+    it('production logout helper deletes BOTH __Host-inspector_token AND __Host-csrf_token', async () => {
+        // Pin the production behavior by importing the actual helper used by
+        // the logout handler. If somebody removes the second deleteCookie
+        // call, this test breaks immediately.
+        const auth = await import('../../src/api/auth');
+        // The module exports `default` (coreAuthRoutes). We verify that the
+        // logout handler is wired by sending a synthetic request through the
+        // Hono router and reading the resulting Set-Cookie headers.
+        //
+        // The handler invokes `c.var.services.auth.invalidateUserSessions(user.sub)`
+        // when a user is in context — we omit the user binding so that side
+        // effect is skipped, leaving only the cookie clears under test.
+        const res = await auth.default.request('/logout', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+        });
+        const setCookieHeaders = res.headers.getSetCookie?.() ?? [];
+        const inspectorCookie = setCookieHeaders.find(h => h.startsWith('__Host-inspector_token='));
+        const csrfCookie = setCookieHeaders.find(h => h.startsWith('__Host-csrf_token='));
+        expect(inspectorCookie, 'logout did not clear __Host-inspector_token').toBeDefined();
+        expect(csrfCookie, 'logout did not clear __Host-csrf_token').toBeDefined();
+    });
+});

--- a/tests/unit/iter2-bug9-sign-redirect.spec.ts
+++ b/tests/unit/iter2-bug9-sign-redirect.spec.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { AgreementService } from '../../src/services/agreement.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../src/lib/db/schema';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT_A = '00000000-0000-0000-0000-000000000001';
+const TENANT_B = '00000000-0000-0000-0000-000000000002';
+const INSP_ID  = '00000000-0000-0000-0000-000000000010';
+const INSP_B   = '00000000-0000-0000-0000-000000000011';
+const AGR_ID   = '00000000-0000-0000-0000-000000000020';
+
+async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
+    await testDb.insert(schema.tenants).values([
+        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+    ]);
+    await testDb.insert(schema.inspections).values([
+        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+        { id: INSP_B, tenantId: TENANT_B, propertyAddress: '2 Other St', clientName: 'Bob', clientEmail: 'bob@test.com', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 30000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+    ]);
+    await testDb.insert(schema.agreements).values([
+        { id: AGR_ID, tenantId: TENANT_A, name: 'Standard', content: 'Agreement text...', version: 1, createdAt: new Date() },
+    ]);
+}
+
+/**
+ * iter-2 production bug #9 — Sprint 1 D-7 ReportGatePage minted CTA URLs
+ * `${baseUrl}/sign/${id}` (with id = inspection id), but no route was
+ * registered. The customer who hit the gate landed on a 404.
+ *
+ * The fix adds a public `/sign/:id` redirect route that resolves the
+ * inspection's pending agreement-signing request and 302s to the canonical
+ * `/agreements/sign/:token` page. This spec pins the service-level
+ * lookup that powers the redirect: tenant-scoped, terminal-state aware,
+ * most-recent-first.
+ */
+describe('iter-2 #9 — AgreementService.findPendingByInspectionId', () => {
+    let svc: AgreementService;
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let sqlite: { close: () => void };
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        sqlite = fixture.sqlite;
+        await setupSchema(fixture.sqlite);
+        await seedBase(testDb);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new AgreementService({} as D1Database);
+    });
+
+    afterEach(() => {
+        sqlite.close();
+        vi.clearAllMocks();
+    });
+
+    it('returns null when no agreement_request exists for the inspection', async () => {
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result).toBeNull();
+    });
+
+    it('returns the token for a pending request', async () => {
+        const reqId = '00000000-0000-0000-0000-000000000100';
+        const token = 'pending-token-1';
+        await testDb.insert(schema.agreementRequests).values({
+            id: reqId,
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            agreementId: AGR_ID,
+            clientEmail: 'jane@test.com',
+            clientName: 'Jane',
+            token,
+            status: 'pending',
+            createdAt: new Date(),
+        });
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result?.token).toBe(token);
+    });
+
+    it('returns the token for a sent request', async () => {
+        const token = 'sent-token-1';
+        await testDb.insert(schema.agreementRequests).values({
+            id: '00000000-0000-0000-0000-000000000101',
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            agreementId: AGR_ID,
+            clientEmail: 'jane@test.com',
+            clientName: 'Jane',
+            token,
+            status: 'sent',
+            sentAt: new Date(),
+            createdAt: new Date(),
+        });
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result?.token).toBe(token);
+    });
+
+    it('returns the token for a viewed request', async () => {
+        const token = 'viewed-token-1';
+        await testDb.insert(schema.agreementRequests).values({
+            id: '00000000-0000-0000-0000-000000000102',
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            agreementId: AGR_ID,
+            clientEmail: 'jane@test.com',
+            clientName: 'Jane',
+            token,
+            status: 'viewed',
+            viewedAt: new Date(),
+            createdAt: new Date(),
+        });
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result?.token).toBe(token);
+    });
+
+    it('returns null when the only request is signed (terminal)', async () => {
+        await testDb.insert(schema.agreementRequests).values({
+            id: '00000000-0000-0000-0000-000000000103',
+            tenantId: TENANT_A,
+            inspectionId: INSP_ID,
+            agreementId: AGR_ID,
+            clientEmail: 'jane@test.com',
+            token: 'signed-token',
+            status: 'signed',
+            signedAt: new Date(),
+            signatureBase64: 'data:image/png;base64,XX',
+            createdAt: new Date(),
+        });
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result).toBeNull();
+    });
+
+    it('returns null when the only request is declined or expired', async () => {
+        await testDb.insert(schema.agreementRequests).values([
+            {
+                id: '00000000-0000-0000-0000-000000000104',
+                tenantId: TENANT_A,
+                inspectionId: INSP_ID,
+                agreementId: AGR_ID,
+                clientEmail: 'jane@test.com',
+                token: 'declined-token',
+                status: 'declined',
+                createdAt: new Date(),
+            },
+            {
+                id: '00000000-0000-0000-0000-000000000105',
+                tenantId: TENANT_A,
+                inspectionId: INSP_ID,
+                agreementId: AGR_ID,
+                clientEmail: 'jane@test.com',
+                token: 'expired-token',
+                status: 'expired',
+                createdAt: new Date(),
+            },
+        ]);
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result).toBeNull();
+    });
+
+    it('does NOT leak across tenants', async () => {
+        // Pending request exists for tenant B's inspection
+        await testDb.insert(schema.agreementRequests).values({
+            id: '00000000-0000-0000-0000-000000000106',
+            tenantId: TENANT_B,
+            inspectionId: INSP_B,
+            agreementId: AGR_ID, // agreement template doesn't have FK enforcement on tenant
+            clientEmail: 'bob@test.com',
+            token: 'tenant-b-token',
+            status: 'pending',
+            createdAt: new Date(),
+        });
+        // Tenant A queries for tenant B's inspection — must NOT find it
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_B);
+        expect(result).toBeNull();
+    });
+
+    it('prefers the most recent non-terminal request when multiple exist', async () => {
+        const olderTime = new Date(Date.now() - 60_000);
+        const newerTime = new Date();
+        await testDb.insert(schema.agreementRequests).values([
+            {
+                id: '00000000-0000-0000-0000-000000000107',
+                tenantId: TENANT_A,
+                inspectionId: INSP_ID,
+                agreementId: AGR_ID,
+                clientEmail: 'jane@test.com',
+                token: 'older-token',
+                status: 'pending',
+                createdAt: olderTime,
+            },
+            {
+                id: '00000000-0000-0000-0000-000000000108',
+                tenantId: TENANT_A,
+                inspectionId: INSP_ID,
+                agreementId: AGR_ID,
+                clientEmail: 'jane@test.com',
+                token: 'newer-token',
+                status: 'pending',
+                createdAt: newerTime,
+            },
+        ]);
+        const result = await svc.findPendingByInspectionId(TENANT_A, INSP_ID);
+        expect(result?.token).toBe('newer-token');
+    });
+});

--- a/tests/unit/reset-local-store.spec.ts
+++ b/tests/unit/reset-local-store.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Iter-2 bug #12 — escape hatch helper for the Sync Conflict modal.
+ *
+ * The helper deletes the offline Dexie database (`oi_offline`) and any
+ * inspection-scoped localStorage entries so a user trapped behind a
+ * stuck conflict modal can recover without DevTools.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { resetLocalStore, OFFLINE_DB_NAME } from '../../public/js/reset-local-store.js';
+
+interface FakeIDBRequest {
+    onsuccess: (() => void) | null;
+    onerror:   (() => void) | null;
+    onblocked: (() => void) | null;
+    error: unknown;
+}
+
+function fakeIndexedDB(opts: { fail?: boolean; blocked?: boolean } = {}) {
+    const calls: string[] = [];
+    const idb = {
+        deleteDatabase(name: string) {
+            calls.push(name);
+            const req: FakeIDBRequest = { onsuccess: null, onerror: null, onblocked: null, error: null };
+            queueMicrotask(() => {
+                if (opts.fail) {
+                    req.error = new Error('synthetic');
+                    req.onerror?.();
+                } else if (opts.blocked) {
+                    req.onblocked?.();
+                } else {
+                    req.onsuccess?.();
+                }
+            });
+            return req;
+        },
+    };
+    return { idb, calls };
+}
+
+function fakeLocalStorage(seed: Record<string, string>) {
+    const store = new Map(Object.entries(seed));
+    return {
+        get length() { return store.size; },
+        key(i: number) { return [...store.keys()][i] ?? null; },
+        getItem(k: string) { return store.get(k) ?? null; },
+        setItem(k: string, v: string) { store.set(k, v); },
+        removeItem(k: string) { store.delete(k); },
+        clear() { store.clear(); },
+        _store: store,
+    };
+}
+
+describe('resetLocalStore (iter-2 bug #12)', () => {
+    it('deletes the offline Dexie database', async () => {
+        const { idb, calls } = fakeIndexedDB();
+        const ls = fakeLocalStorage({});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await resetLocalStore({ indexedDB: idb as any, localStorage: ls as any });
+        if (!result.ok) throw new Error('expected ok=true');
+        expect(result.deletedDb).toBe(true);
+        expect(calls).toEqual([OFFLINE_DB_NAME]);
+    });
+
+    it('clears only inspection-scoped localStorage keys', async () => {
+        const { idb } = fakeIndexedDB();
+        const ls = fakeLocalStorage({
+            'oi:inspection:abc': 'X',
+            'oi:dirty:abc':      'Y',
+            'oi:lastSyncedAt:abc': '123',
+            'oi:settings:theme': 'dark', // unrelated, must NOT be cleared
+            'unrelated':         'Z',
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await resetLocalStore({ indexedDB: idb as any, localStorage: ls as any });
+        if (!result.ok) throw new Error('expected ok=true');
+        expect(result.clearedKeys).toBe(3);
+        expect([...ls._store.keys()].sort()).toEqual(['oi:settings:theme', 'unrelated']);
+    });
+
+    it('treats deleteDatabase blocked event as a soft success', async () => {
+        const { idb } = fakeIndexedDB({ blocked: true });
+        const ls = fakeLocalStorage({});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await resetLocalStore({ indexedDB: idb as any, localStorage: ls as any });
+        if (!result.ok) throw new Error('expected ok=true');
+        expect(result.deletedDb).toBe(true);
+    });
+
+    it('returns ok=false on deleteDatabase error', async () => {
+        const { idb } = fakeIndexedDB({ fail: true });
+        const ls = fakeLocalStorage({ 'oi:inspection:keep': 'v' });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await resetLocalStore({ indexedDB: idb as any, localStorage: ls as any });
+        expect(result.ok).toBe(false);
+        // Localstorage was not touched because we bailed out early on the
+        // IDB failure — the user can retry without losing partial state.
+        expect(ls._store.has('oi:inspection:keep')).toBe(true);
+    });
+
+    it('survives missing localStorage (tests, ssr)', async () => {
+        const { idb } = fakeIndexedDB();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await resetLocalStore({ indexedDB: idb as any, localStorage: null as any });
+        if (!result.ok) throw new Error('expected ok=true');
+        expect(result.clearedKeys).toBe(0);
+    });
+
+    it('survives missing indexedDB (tests, ssr)', async () => {
+        const ls = fakeLocalStorage({ 'oi:inspection:a': '1' });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await resetLocalStore({ indexedDB: null as any, localStorage: ls as any });
+        if (!result.ok) throw new Error('expected ok=true');
+        expect(result.deletedDb).toBe(false);
+        expect(result.clearedKeys).toBe(1);
+    });
+
+    // Regression for a stale Dexie name change — keep the constant in sync
+    // with public/js/db.js so the helper actually wipes the DB.
+    it('uses the documented offline DB name', () => {
+        expect(OFFLINE_DB_NAME).toBe('oi_offline');
+    });
+
+    it('exposes the helper as an importable named export', () => {
+        expect(typeof resetLocalStore).toBe('function');
+        // Sanity: should not throw when called with undefined opts.
+        expect(() => vi.fn().getMockName()).not.toThrow();
+    });
+});

--- a/tests/unit/sidebar-library-entries.spec.ts
+++ b/tests/unit/sidebar-library-entries.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Iter-2 bug #8 — sidebar Library group must include all seven entries
+ * (both mobile drawer + desktop aside) in the canonical order:
+ *   Inspection Templates / Marketplace / Comments / Repair Items / Tags /
+ *   Agreements / Rating Systems
+ *
+ * Static check on main-layout.tsx so a future PR can't drop or reorder
+ * an entry without flipping this test.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const layoutSrc = readFileSync(
+    resolve(__dirname, '../../src/templates/layouts/main-layout.tsx'),
+    'utf8',
+);
+
+const EXPECTED_ORDER = [
+    { label: 'Inspection Templates',  href: '/templates' },
+    { label: 'Marketplace',           href: '/marketplace' },
+    { label: 'Comments',              href: '/comments' },
+    { label: 'Repair Items',          href: '/recommendations' },
+    { label: 'Tags',                  href: '/library/tags' },
+    { label: 'Agreements',            href: '/agreements' },
+    { label: 'Rating Systems',        href: '/library/rating-systems' },
+];
+
+describe('iter-2 bug #8 — sidebar Library entries', () => {
+    // Both copies of the menu (mobile drawer + desktop aside) live inside
+    // the same source file. Walk through every `data-sidebar-library`
+    // occurrence and keep only the ones that sit inside a real <details>
+    // tag (vs. the activate-sidebar querySelector string).
+    const blocks: string[] = [];
+    let cursor = 0;
+    while (true) {
+        const idx = layoutSrc.indexOf('data-sidebar-library', cursor);
+        if (idx < 0) break;
+        cursor = idx + 1;
+        // Skip the script-string occurrence (sits inside a JS string literal).
+        const before = layoutSrc.slice(Math.max(0, idx - 60), idx);
+        if (!before.includes('<details')) continue;
+        // Capture until the closing </details> for this block.
+        const end = layoutSrc.indexOf('</details>', idx);
+        if (end < 0) continue;
+        blocks.push(layoutSrc.slice(idx, end));
+    }
+
+    it('renders the Library group twice (mobile drawer + desktop aside)', () => {
+        expect(blocks.length).toBe(2);
+    });
+
+    for (let i = 0; i < blocks.length; i++) {
+        const which = i === 0 ? 'mobile drawer' : 'desktop aside';
+        it(`${which} — every entry present`, () => {
+            const scoped = blocks[i] ?? '';
+            for (const { label, href } of EXPECTED_ORDER) {
+                expect(scoped, `${which} missing href ${href}`).toContain(`href="${href}"`);
+                expect(scoped, `${which} missing label ${label}`).toContain(`>${label}<`);
+            }
+        });
+
+        it(`${which} — entries appear in canonical order`, () => {
+            const scoped = blocks[i] ?? '';
+            const positions = EXPECTED_ORDER.map((e) => scoped.indexOf(`href="${e.href}"`));
+            for (let j = 1; j < positions.length; j++) {
+                expect(
+                    positions[j],
+                    `${which} — ${EXPECTED_ORDER[j]?.label} should come after ${EXPECTED_ORDER[j - 1]?.label}`,
+                ).toBeGreaterThan(positions[j - 1] ?? -1);
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Summary

Iter-2 of Chrome MCP UC traversal surfaced 12 bugs. Fixed across 3 parallel worktree-isolated tracks.

### Track paywall (4 commits, 16 new tests)
- **#4** logout clears `__Host-csrf_token` companion (was leaving session fixation vector); both Set-Cookie wipes now have Secure+SameSite=Strict
- **#9** `/sign/:id` redirects to active agreement signing token (was 404 — dead link from ReportGatePage)
- **#10** public `/r/:id/invoice` page for unauthenticated customers (was 302→/login dead loop)

### Track ux (6 commits, 27 new tests)
- **#5** Calendar includes DRAFT inspections with badge
- **#6** Date inputs `lang="en"` avoids locale-leak placeholder (Chinese 「年/月/日」)
- **#8** Sidebar Library entry order + Marketplace/Rating Systems/Tags surfaced
- **#11** Sync conflict modal compares only locally-edited fields (server-only fields like `paymentRequired` no longer trigger noise)
- **#12** Conflict modal "Reset local copy & reload" action (one-click IDB+localStorage wipe)

### Track soft (4 commits, 13 new tests)
- **#13** Repair-list disabled-feature friendly page (was generic 404)
- **#14** Customer repair-request disabled-feature friendly page
- **#15** Unauthorized-role error toast on dashboard (was silent `?error=unauthorized_role` query param)

## Stats

- **591 unit tests pass** + 7 skipped (was 535; +56 new)
- type-check 0 errors, lint 0 errors
- 3 parallel tracks, 0 merge conflicts (clean isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)