### PR TITLE
fix(ui): dark mode overrides for bg-surface-50/100/200 palette

### DIFF
--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -605,6 +605,10 @@ html[data-color-scheme="dark"] .bg-slate-100      { background-color: #1a2540 !i
 html[data-color-scheme="dark"] .bg-slate-200      { background-color: #223050 !important; }
 html[data-color-scheme="dark"] .bg-slate-50\/50   { background-color: rgba(22,32,50,0.5) !important; }
 html[data-color-scheme="dark"] .bg-indigo-50      { background-color: rgba(129,140,248,0.12) !important; }
+/* Custom surface palette (tailwind.config surface-*) */
+html[data-color-scheme="dark"] .bg-surface-50    { background-color: var(--ih-bg-app)  !important; }
+html[data-color-scheme="dark"] .bg-surface-100   { background-color: var(--ih-bg-page) !important; }
+html[data-color-scheme="dark"] .bg-surface-200   { background-color: var(--ih-bg-card) !important; }
 
 /* ── Text ────────────────────────────────────────────────── */
 html[data-color-scheme="dark"] .text-slate-900    { color: var(--ih-fg-1) !important; }


### PR DESCRIPTION
## Summary

- The custom `surface-*` color palette defined in `tailwind.config.js` (`surface-50: #faf9f7`, `surface-100: #f3f1ed`, `surface-200: #e8e4dd`) had no dark mode overrides in `input.css`
- Pages using these classes (settings layout, agent dashboard, `/book` fallback, etc.) showed a warm off-white background instead of the dark background even when dark mode was active
- Maps `bg-surface-50` → `--ih-bg-app`, `bg-surface-100` → `--ih-bg-page`, `bg-surface-200` → `--ih-bg-card`

## Test plan

- [ ] Navigate to `/book` in dark mode — background should be dark (`#0b1120`)
- [ ] Open Settings pages — sidebar and content area should be dark
- [ ] Open Agent Dashboard — page background should be dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)