### PR TITLE
fix(ui): dark mode overrides for ink-* text and bg palette

### DIFF
--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -618,6 +618,17 @@ html[data-color-scheme="dark"] .text-slate-600    { color: var(--ih-fg-2) !impor
 html[data-color-scheme="dark"] .text-slate-500    { color: var(--ih-fg-3) !important; }
 html[data-color-scheme="dark"] .text-slate-400    { color: var(--ih-fg-4) !important; }
 html[data-color-scheme="dark"] .text-indigo-600   { color: #818cf8 !important; }
+/* Custom ink palette (tailwind.config ink-*) — warm grays need brightening in dark mode */
+html[data-color-scheme="dark"] .text-ink-900      { color: var(--ih-fg-1) !important; }
+html[data-color-scheme="dark"] .text-ink-800      { color: var(--ih-fg-1) !important; }
+html[data-color-scheme="dark"] .text-ink-700      { color: var(--ih-fg-2) !important; }
+html[data-color-scheme="dark"] .text-ink-600      { color: var(--ih-fg-2) !important; }
+html[data-color-scheme="dark"] .text-ink-500      { color: var(--ih-fg-3) !important; }
+html[data-color-scheme="dark"] .text-ink-400      { color: var(--ih-fg-4) !important; }
+html[data-color-scheme="dark"] .text-ink-300      { color: var(--ih-fg-5) !important; }
+/* ink backgrounds used as subtle dividers/chips */
+html[data-color-scheme="dark"] .bg-ink-900        { background-color: var(--ih-bg-card) !important; }
+html[data-color-scheme="dark"] .bg-ink-300        { background-color: rgba(255,255,255,0.10) !important; }
 
 /* ── Borders ─────────────────────────────────────────────── */
 html[data-color-scheme="dark"] .border-slate-100  { border-color: rgba(255,255,255,0.06) !important; }


### PR DESCRIPTION
## Summary

- Custom `ink-*` warm gray palette (defined in tailwind.config) had no dark mode overrides
- `text-ink-600` (#6b6560) and similar colors are unreadable on dark backgrounds (#0b1120)
- Maps `text-ink-900/800` → `--ih-fg-1`, `text-ink-700/600` → `--ih-fg-2`, `text-ink-500` → `--ih-fg-3`, `text-ink-400` → `--ih-fg-4`, `text-ink-300` → `--ih-fg-5`
- Maps `bg-ink-900` → `--ih-bg-card`, `bg-ink-300` → translucent white overlay
- Affects 19 template files: booking, agent dashboard, settings pages, etc.

## Test plan

- [ ] `/book` fallback page in dark mode — subtitle text readable
- [ ] Agent dashboard in dark mode — ink-colored labels/text readable
- [ ] Settings pages in dark mode — section headers/descriptions readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)