### PR TITLE
feat(ui): theme dropdown menu + fix Inspections sidebar icon

### DIFF
--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,66 +1,85 @@
 /**
- * Color scheme toggle — auto / dark / light (3-way cycle).
+ * Color scheme — auto / dark / light.
  * Reads/writes localStorage key 'ih-color-scheme'.
- *   null      → auto  (follow OS prefers-color-scheme)
- *   'dark'    → dark
- *   'light'   → light
+ *   null / absent → auto  (follow OS prefers-color-scheme)
+ *   'dark'        → dark
+ *   'light'       → light
+ *
+ * Public API:
+ *   window.setColorScheme(mode)  — set 'auto'|'dark'|'light' explicitly
+ *   window.themeMenu()           — Alpine factory for the sidebar dropdown
+ *
  * The html[data-color-scheme] attribute is set by an inline <script> in
- * <head> before stylesheets load to prevent FOUC; this file handles the
- * runtime toggle and icon/label updates.
+ * <head> before stylesheets load to prevent FOUC.
  */
 (function () {
-    function isDarkActive() {
-        return document.documentElement.getAttribute('data-color-scheme') === 'dark';
+    function currentMode() {
+        var s = localStorage.getItem('ih-color-scheme');
+        return s === 'dark' || s === 'light' ? s : 'auto';
     }
 
-    function currentMode() {
-        var saved = localStorage.getItem('ih-color-scheme');
-        if (saved === 'dark' || saved === 'light') return saved;
-        return 'auto';
+    function isDark() {
+        return document.documentElement.getAttribute('data-color-scheme') === 'dark';
     }
 
     function applyMode(mode) {
         if (mode === 'auto') {
             localStorage.removeItem('ih-color-scheme');
-            var systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            document.documentElement.setAttribute('data-color-scheme', systemDark ? 'dark' : 'light');
+            var sysDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            document.documentElement.setAttribute('data-color-scheme', sysDark ? 'dark' : 'light');
         } else {
             localStorage.setItem('ih-color-scheme', mode);
             document.documentElement.setAttribute('data-color-scheme', mode);
         }
     }
 
-    function updateUI() {
+    function effectiveLabel() {
         var mode = currentMode();
-        var dark = isDarkActive();
-
-        // Desktop icons
-        var sun  = document.getElementById('themeSunIcon');
-        var moon = document.getElementById('themeMoonIcon');
-        var auto = document.getElementById('themeAutoIcon');
-        var lbl  = document.getElementById('themeToggleLabel');
-        if (sun)  sun.classList.toggle('hidden', mode !== 'dark');
-        if (moon) moon.classList.toggle('hidden', mode !== 'light');
-        if (auto) auto.classList.toggle('hidden', mode !== 'auto');
-        if (lbl)  lbl.textContent = mode === 'auto' ? 'Auto' : (dark ? 'Dark Mode' : 'Light Mode');
-
-        // Mobile icons + label
-        var msun  = document.getElementById('mobileThemeSunIcon');
-        var mmoon = document.getElementById('mobileThemeMoonIcon');
-        var mauto = document.getElementById('mobileThemeAutoIcon');
-        var mlbl  = document.getElementById('mobileThemeLabel');
-        if (msun)  msun.classList.toggle('hidden', mode !== 'dark');
-        if (mmoon) mmoon.classList.toggle('hidden', mode !== 'light');
-        if (mauto) mauto.classList.toggle('hidden', mode !== 'auto');
-        if (mlbl)  mlbl.textContent = mode === 'auto' ? 'Auto' : (dark ? 'Dark Mode' : 'Light Mode');
+        var dark = isDark();
+        if (mode === 'auto') return 'Auto · ' + (dark ? 'Dark' : 'Light');
+        return dark ? 'Dark' : 'Light';
     }
 
-    // Cycle: auto → dark → light → auto
-    window.toggleColorScheme = function () {
+    function updateUI() {
         var mode = currentMode();
-        var next = mode === 'auto' ? 'dark' : (mode === 'dark' ? 'light' : 'auto');
-        applyMode(next);
+        var label = effectiveLabel();
+
+        // Desktop icons
+        var moon = document.getElementById('themeMoonIcon');
+        var sun  = document.getElementById('themeSunIcon');
+        var auto = document.getElementById('themeAutoIcon');
+        var lbl  = document.getElementById('themeToggleLabel');
+        if (moon) moon.classList.toggle('hidden', mode !== 'dark');
+        if (sun)  sun.classList.toggle('hidden', mode !== 'light');
+        if (auto) auto.classList.toggle('hidden', mode !== 'auto');
+        if (lbl)  lbl.textContent = label;
+
+        // Mobile icons
+        var mmoon = document.getElementById('mobileThemeMoonIcon');
+        var msun  = document.getElementById('mobileThemeSunIcon');
+        var mauto = document.getElementById('mobileThemeAutoIcon');
+        var mlbl  = document.getElementById('mobileThemeLabel');
+        if (mmoon) mmoon.classList.toggle('hidden', mode !== 'dark');
+        if (msun)  msun.classList.toggle('hidden', mode !== 'light');
+        if (mauto) mauto.classList.toggle('hidden', mode !== 'auto');
+        if (mlbl)  mlbl.textContent = label;
+    }
+
+    window.setColorScheme = function (mode) {
+        applyMode(mode);
         updateUI();
+    };
+
+    // Alpine factory for the sidebar dropdown
+    window.themeMenu = function () {
+        return {
+            open: false,
+            get mode() { return currentMode(); },
+            set: function (m) {
+                this.open = false;
+                window.setColorScheme(m);
+            },
+        };
     };
 
     // Sync UI on first paint (icons may not be in DOM during <head> script)

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -210,7 +210,7 @@ export const MainLayout = (props: {
                         <nav class="flex-1 p-4 space-y-1 overflow-y-auto">
                             {/* Sprint 1 Sub-spec B Task 2 — mobile mirrors desktop IA. */}
                             <a href="/dashboard" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6z"></path></svg>
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
                                 <span>Inspections</span>
                                 <span id="msgUnreadBadge" class="hidden ml-auto px-1.5 min-w-[1.25rem] text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
                             </a>
@@ -282,12 +282,32 @@ export const MainLayout = (props: {
                         </nav>
                         {/* Bottom section */}
                         <div class="p-4 border-t border-slate-100 bg-slate-50/50 space-y-1">
-                            <button type="button" onclick="toggleColorScheme()" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-100 hover:text-indigo-600 transition-all font-semibold" aria-label="Toggle color scheme">
-                                <svg id="mobileThemeMoonIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
-                                <svg id="mobileThemeSunIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-                                <svg id="mobileThemeAutoIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-                                <span id="mobileThemeLabel">Auto</span>
-                            </button>
+                            <div x-data="themeMenu()" class="relative" {...{'x-on:click.outside': 'open = false'}}>
+                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-100 hover:text-indigo-600 transition-all font-semibold" aria-label="Color scheme">
+                                    <svg id="mobileThemeMoonIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                                    <svg id="mobileThemeSunIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                                    <svg id="mobileThemeAutoIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                                    <span id="mobileThemeLabel" class="flex-1 text-left text-sm">Auto</span>
+                                    <svg class="w-3.5 h-3.5 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                                </button>
+                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white border border-slate-200 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
+                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                                        <span class="flex-1 text-left">Auto</span>
+                                        <svg x-show="mode === 'auto'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    </button>
+                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                                        <span class="flex-1 text-left">Dark</span>
+                                        <svg x-show="mode === 'dark'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    </button>
+                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                                        <span class="flex-1 text-left">Light</span>
+                                        <svg x-show="mode === 'light'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    </button>
+                                </div>
+                            </div>
                             <button id="mobileLogoutBtn" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-red-600 hover:bg-red-50 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
                                 <span>Sign Out</span>
@@ -332,7 +352,7 @@ export const MainLayout = (props: {
                                 Reports merged into Inspections (Recent reports bucket on dashboard).
                                 Team relocated under Settings. */}
                             <a href="/dashboard" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group relative">
-                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6z"></path></svg>
+                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
                                 <span>Inspections</span>
                             </a>
                             <a href="/calendar" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">
@@ -379,12 +399,32 @@ export const MainLayout = (props: {
                                 <svg class="w-5 h-5 group-hover:rotate-45 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 002.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                 <span>Settings</span>
                             </a>
-                            <button type="button" onclick="toggleColorScheme()" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-white hover:text-indigo-600 hover:shadow-sm transition-all font-semibold group mt-2" aria-label="Toggle color scheme">
-                                <svg id="themeMoonIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
-                                <svg id="themeSunIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-                                <svg id="themeAutoIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-                                <span id="themeToggleLabel">Auto</span>
-                            </button>
+                            <div x-data="themeMenu()" class="relative mt-2" {...{'x-on:click.outside': 'open = false'}}>
+                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-white hover:text-indigo-600 hover:shadow-sm transition-all font-semibold group" aria-label="Color scheme">
+                                    <svg id="themeMoonIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                                    <svg id="themeSunIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                                    <svg id="themeAutoIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                                    <span id="themeToggleLabel" class="flex-1 text-left text-sm">Auto</span>
+                                    <svg class="w-3.5 h-3.5 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                                </button>
+                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white border border-slate-200 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
+                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                                        <span class="flex-1 text-left">Auto</span>
+                                        <svg x-show="mode === 'auto'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    </button>
+                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                                        <span class="flex-1 text-left">Dark</span>
+                                        <svg x-show="mode === 'dark'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    </button>
+                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                                        <span class="flex-1 text-left">Light</span>
+                                        <svg x-show="mode === 'light'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    </button>
+                                </div>
+                            </div>
                             <button id="logoutBtn" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-red-600 hover:bg-red-50 transition-all font-semibold group mt-2">
                                 <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
                                 <span>Sign Out</span>


### PR DESCRIPTION
## Summary

- Replace sidebar color-scheme cycle button (desktop + mobile) with a 3-option dropdown using the new `themeMenu()` Alpine factory
- Dropdown label shows effective state: **Auto · Dark**, **Auto · Light**, **Dark**, or **Light** — user always knows what the OS state is when in auto mode
- Active option shows a checkmark; dropdown opens upward (`bottom-full`) since it sits at the bottom of the sidebar
- Fix Inspections nav icon: SVG path previously had only one of four squares, rendering as a tiny invisible dot; now uses the complete `view-grid` path (all four 2×2 squares) on both desktop and mobile sidebars

## Test plan

- [ ] Sidebar theme button shows current mode label (Auto · Dark / Auto · Light / Dark / Light)
- [ ] Clicking button opens dropdown upward with Auto / Dark / Light options
- [ ] Active option has a checkmark
- [ ] Selecting an option changes the scheme immediately and closes dropdown
- [ ] Clicking outside the dropdown closes it
- [ ] Mobile sidebar has the same dropdown behavior
- [ ] Inspections link in sidebar shows the full 4-square grid icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)