### PR TITLE
fix(conflict-modal): dark mode pre sections + continuous empty-conflict cleanup

### DIFF
--- a/public/js/agreements.js
+++ b/public/js/agreements.js
@@ -144,11 +144,11 @@ async function loadAgreements() {
                 <tr>
                     <td colspan="4" class="py-32 text-center">
                         <div class="flex flex-col items-center gap-6">
-                            <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center">
+                            <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
                                 <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                             </div>
                             <div>
-                                <p class="text-lg font-bold text-slate-900 tracking-tight">No agreements yet</p>
+                                <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">No agreements yet</p>
                                 <p class="text-sm text-slate-400 font-medium mt-1">Create a service agreement or liability waiver.</p>
                             </div>
                             <button onclick="showCreateModal()" class="px-6 py-3 rounded-xl bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-slate-900 transition-all active:scale-95">New Agreement</button>

--- a/public/js/conflict-modal.js
+++ b/public/js/conflict-modal.js
@@ -30,6 +30,12 @@ function conflictModalFactory() {
 
             const refresh = async () => {
                 const all = await db.conflicts.orderBy('createdAt').toArray();
+                // Continuously purge stale empty rows (mirrors the one-shot init
+                // cleanup) so new empties created after init don't accumulate.
+                const empties = all.filter(isEmpty);
+                if (empties.length > 0) {
+                    await Promise.all(empties.map((c) => db.conflicts.delete(c.id)));
+                }
                 this.conflicts = all.filter((c) => !isEmpty(c));
                 this.open = this.conflicts.length > 0;
                 if (this.index >= this.conflicts.length) this.index = 0;

--- a/public/js/tags.js
+++ b/public/js/tags.js
@@ -51,14 +51,14 @@
 
                 colorClass(color) {
                     const map = {
-                        slate:    'bg-slate-100 text-slate-700 ring-slate-200',
-                        amber:    'bg-amber-100 text-amber-700 ring-amber-200',
-                        rose:     'bg-rose-100 text-rose-700 ring-rose-200',
-                        indigo:   'bg-indigo-100 text-indigo-700 ring-indigo-200',
-                        emerald:  'bg-emerald-100 text-emerald-700 ring-emerald-200',
-                        sky:      'bg-sky-100 text-sky-700 ring-sky-200',
-                        fuchsia:  'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200',
-                        lime:     'bg-lime-100 text-lime-700 ring-lime-200',
+                        slate:   'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 ring-slate-200 dark:ring-slate-500',
+                        amber:   'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 ring-amber-200 dark:ring-amber-700',
+                        rose:    'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300 ring-rose-200 dark:ring-rose-700',
+                        indigo:  'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 ring-indigo-200 dark:ring-indigo-700',
+                        emerald: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 ring-emerald-200 dark:ring-emerald-700',
+                        sky:     'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 ring-sky-200 dark:ring-sky-700',
+                        fuchsia: 'bg-fuchsia-100 dark:bg-fuchsia-900/40 text-fuchsia-700 dark:text-fuchsia-300 ring-fuchsia-200 dark:ring-fuchsia-700',
+                        lime:    'bg-lime-100 dark:bg-lime-900/40 text-lime-700 dark:text-lime-300 ring-lime-200 dark:ring-lime-700',
                     };
                     return map[color] || map.slate;
                 },

--- a/public/js/team.js
+++ b/public/js/team.js
@@ -73,11 +73,11 @@ window.teamMeta = teamMeta;
                 <tr>
                     <td colspan="3" class="py-32 text-center">
                         <div class="flex flex-col items-center gap-6">
-                            <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center">
+                            <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
                                 <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
                             </div>
                             <div>
-                                <p class="text-lg font-bold text-slate-900 tracking-tight">Just you for now</p>
+                                <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">Just you for now</p>
                                 <p class="text-sm text-slate-400 font-medium mt-1">Invite team members to collaborate.</p>
                             </div>
                         </div>

--- a/public/js/templates.js
+++ b/public/js/templates.js
@@ -94,11 +94,11 @@ function renderTemplates() {
           <tr>
             <td colspan="4" class="py-32 text-center">
               <div class="flex flex-col items-center gap-6">
-                <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center">
+                <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
                   <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                 </div>
                 <div>
-                  <p class="text-lg font-bold text-slate-900 tracking-tight">No templates yet</p>
+                  <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">No templates yet</p>
                   <p class="text-sm text-slate-400 font-medium mt-1">Create a checklist template for your inspections.</p>
                 </div>
                 <button onclick="showCreateModal()" class="px-6 py-3 rounded-xl bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-slate-900 transition-all active:scale-95">New Template</button>

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -742,6 +742,33 @@ html[data-color-scheme="dark"] thead.bg-slate-50\/50 {
     background-color: rgba(255,255,255,0.03) !important;
 }
 
+/* ── JS-rendered table rows (contacts, invoices, agreements) ─ */
+html[data-color-scheme="dark"] #contactsBody tr:hover,
+html[data-color-scheme="dark"] #agentLinksBody tr:hover,
+html[data-color-scheme="dark"] #invoicesBody tr:hover,
+html[data-color-scheme="dark"] #membersList tr:hover,
+html[data-color-scheme="dark"] #invitesList tr:hover {
+    background-color: rgba(30,41,59,0.9) !important;
+}
+
+/* ── FullCalendar dark overrides ─────────────────────────── */
+html[data-color-scheme="dark"] #calendar th {
+    background-color: var(--ih-bg-card) !important;
+    border-color: rgba(255,255,255,0.08) !important;
+}
+html[data-color-scheme="dark"] #calendar td {
+    border-color: rgba(255,255,255,0.06) !important;
+}
+html[data-color-scheme="dark"] #calendar .fc-day-today {
+    background-color: rgba(99,102,241,0.12) !important;
+}
+html[data-color-scheme="dark"] #calendar .fc-event {
+    border-color: rgba(255,255,255,0.15) !important;
+}
+html[data-color-scheme="dark"] #calendar .fc-scrollgrid {
+    border-color: rgba(255,255,255,0.08) !important;
+}
+
 /* ── Borders on panels / sections ───────────────────────── */
 html[data-color-scheme="dark"] .border-slate-100,
 html[data-color-scheme="dark"] .border-slate-100\/50 {

--- a/src/templates/components/conflict-modal.tsx
+++ b/src/templates/components/conflict-modal.tsx
@@ -26,14 +26,14 @@ export const ConflictModal = () => (
                 <span x-text="`${index + 1} of ${conflicts.length}`" class="text-xs font-bold text-slate-400"></span>
             </header>
             <div class="flex-1 overflow-y-auto p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-                <section><h3 class="text-xs font-bold uppercase tracking-widest text-slate-400 mb-2">Base</h3><pre class="bg-slate-50 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.base"></pre></section>
-                <section><h3 class="text-xs font-bold uppercase tracking-widest text-indigo-600 mb-2">Yours</h3><pre class="bg-indigo-50 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.ours"></pre></section>
-                <section><h3 class="text-xs font-bold uppercase tracking-widest text-rose-600 mb-2">Theirs</h3><pre class="bg-rose-50 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.theirs"></pre></section>
+                <section><h3 class="text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-2">Base</h3><pre class="bg-slate-50 dark:bg-slate-800 dark:text-slate-200 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.base"></pre></section>
+                <section><h3 class="text-xs font-bold uppercase tracking-widest text-indigo-600 dark:text-indigo-400 mb-2">Yours</h3><pre class="bg-indigo-50 dark:bg-indigo-900/30 dark:text-indigo-200 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.ours"></pre></section>
+                <section><h3 class="text-xs font-bold uppercase tracking-widest text-rose-600 dark:text-rose-400 mb-2">Theirs</h3><pre class="bg-rose-50 dark:bg-rose-900/30 dark:text-rose-200 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.theirs"></pre></section>
             </div>
             <footer class="px-8 py-5 border-t border-slate-100 flex items-center gap-3 justify-end">
                 <button x-on:click="resolve('ours')"   class="px-5 py-2 rounded-lg bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-indigo-700">Keep Mine</button>
                 <button x-on:click="resolve('theirs')" class="px-5 py-2 rounded-lg bg-rose-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-rose-700">Accept Theirs</button>
-                <button x-on:click="resolve('edit')"   class="px-5 py-2 rounded-lg ring-2 ring-slate-300 text-slate-700 text-xs font-bold uppercase tracking-widest hover:bg-slate-50">Edit Merged</button>
+                <button x-on:click="resolve('edit')"   class="px-5 py-2 rounded-lg ring-2 ring-slate-300 dark:ring-slate-600 text-slate-700 dark:text-slate-300 text-xs font-bold uppercase tracking-widest hover:bg-slate-50 dark:hover:bg-slate-700">Edit Merged</button>
                 {/* Iter-2 bug #12 — visual separator + escape hatch. The
                     `aria-hidden` divider keeps screen readers focused on the
                     actionable buttons. The reset button itself is destructive

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -392,7 +392,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
 
                     {/* Empty state */}
                     <div x-show="!loading && allBucketsEmpty" {...{ 'x-cloak': true }} class="text-center py-10 text-slate-400">
-                        <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center mx-auto mb-4">
+                        <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center mx-auto mb-4">
                             <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path></svg>
                         </div>
                         <p class="text-sm">No inspections yet. Create one above to get started.</p>

--- a/src/templates/pages/login.tsx
+++ b/src/templates/pages/login.tsx
@@ -294,6 +294,40 @@ export const LoginPage = ({ branding }: { branding?: BrandingConfig | undefined 
                         .login-heading { font-size: 1.375rem; }
                         .brand-mark { margin-bottom: 2rem; }
                     }
+
+                    /* ---- Dark mode ---- */
+                    [data-color-scheme="dark"] body {
+                        background: #0f172a;
+                        color: #f1f5f9;
+                    }
+                    [data-color-scheme="dark"] .login-heading { color: #f1f5f9; }
+                    [data-color-scheme="dark"] .login-sub { color: #94a3b8; }
+                    [data-color-scheme="dark"] .form-label { color: #cbd5e1; }
+                    [data-color-scheme="dark"] .form-input {
+                        background: #1e293b;
+                        border-color: #334155;
+                        color: #f1f5f9;
+                    }
+                    [data-color-scheme="dark"] .form-input::placeholder { color: #64748b; }
+                    [data-color-scheme="dark"] .form-input:focus { border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,0.2); }
+                    [data-color-scheme="dark"] .form-input:-webkit-autofill,
+                    [data-color-scheme="dark"] .form-input:-webkit-autofill:hover,
+                    [data-color-scheme="dark"] .form-input:-webkit-autofill:focus {
+                        -webkit-box-shadow: 0 0 0 1000px #1e293b inset;
+                        -webkit-text-fill-color: #f1f5f9;
+                        caret-color: #f1f5f9;
+                    }
+                    [data-color-scheme="dark"] .form-hint { color: #94a3b8; }
+                    [data-color-scheme="dark"] .divider-text { color: #64748b; }
+                    [data-color-scheme="dark"] .divider-line { border-color: #334155; }
+                    [data-color-scheme="dark"] .link-subtle { color: #818cf8; }
+                    [data-color-scheme="dark"] .brand-name { color: #f1f5f9; }
+                    [data-color-scheme="dark"] .footer-text { color: #64748b; }
+                    [data-color-scheme="dark"] .error-box {
+                        background: #450a0a;
+                        border-color: #991b1b;
+                        color: #fca5a5;
+                    }
                 ` }} />
 
                 {gaMeasurementId && (

--- a/src/templates/pages/marketplace.tsx
+++ b/src/templates/pages/marketplace.tsx
@@ -19,7 +19,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                 {/* R7-25: Spell out the import / update relationship so
                     inspectors aren't unsure whether importing creates a
                     copy they own or links to a remote template. */}
-                <div class="inline-flex items-start gap-2 px-4 py-2 rounded-md bg-slate-50 border border-slate-200 text-[11px] text-slate-600 max-w-2xl">
+                <div class="inline-flex items-start gap-2 px-4 py-2 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-[11px] text-slate-600 dark:text-slate-300 max-w-2xl">
                     <svg class="w-4 h-4 mt-0.5 flex-shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                     <div>
                         <strong>Import = your own copy.</strong> When the publisher updates the template, you'll see "Update available" and can pull the new version (or keep your customizations).
@@ -30,9 +30,9 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                 <div class="flex flex-col sm:flex-row gap-3">
                     <input type="text" x-model="search" {...{ 'x-on:input.debounce.300ms': 'load()' }}
                         placeholder="Search templates..."
-                        class="flex-1 px-4 py-2.5 rounded-xl border border-slate-200 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500" />
+                        class="flex-1 px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500" />
                     <select x-model="category" x-on:change="load()"
-                        class="px-4 py-2.5 rounded-xl border border-slate-200 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
+                        class="px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
                         <option value="">All Categories</option>
                         <option value="residential">Residential</option>
                         <option value="commercial">Commercial</option>
@@ -42,7 +42,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                     </select>
                     {/* Polish 5 — client-side sort */}
                     <select x-model="sort" x-on:change="resort()"
-                        class="px-4 py-2.5 rounded-xl border border-slate-200 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
+                        class="px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
                         <option value="featured">Featured first</option>
                         <option value="recent">Recently added</option>
                         <option value="popular">Most imports</option>
@@ -60,11 +60,11 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                                 <div class="flex items-start justify-between">
                                     <div>
                                         <div class="flex items-center gap-2">
-                                            <h3 class="font-bold text-slate-900 text-lg" x-text="l.name"></h3>
-                                            <span x-show="l.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">★ Featured</span>
+                                            <h3 class="font-bold text-slate-900 dark:text-white text-lg" x-text="l.name"></h3>
+                                            <span x-show="l.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">★ Featured</span>
                                         </div>
                                         <div class="flex items-center gap-2 mt-1">
-                                            <span class="text-xs font-bold text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full capitalize" x-text="l.kind"></span>
+                                            <span class="text-xs font-bold text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-2 py-0.5 rounded-full capitalize" x-text="l.kind"></span>
                                             <span class="text-xs text-slate-400 font-mono" x-text="'v' + l.semver"></span>
                                             <span class="text-xs text-slate-500" x-text="l.itemCount + ' entries'"></span>
                                         </div>
@@ -81,7 +81,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                                         </button>
                                     </template>
                                     <template x-if="l.importedSemver && !l.hasUpdate">
-                                        <span class="px-4 py-1.5 text-sm rounded-md font-bold bg-slate-100 text-slate-400">Imported</span>
+                                        <span class="px-4 py-1.5 text-sm rounded-md font-bold bg-slate-100 dark:bg-slate-700 text-slate-400">Imported</span>
                                     </template>
                                     <template x-if="l.hasUpdate">
                                         <button x-on:click="openUpdateConfirm(l, 'library')"
@@ -104,17 +104,17 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <div class="flex items-start justify-between">
                                 <div>
                                     <div class="flex items-center gap-2">
-                                        <h3 class="font-bold text-slate-900 text-lg" x-text="t.name"></h3>
-                                        <span x-show="t.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">★ Featured</span>
+                                        <h3 class="font-bold text-slate-900 dark:text-white text-lg" x-text="t.name"></h3>
+                                        <span x-show="t.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">★ Featured</span>
                                     </div>
                                     <div class="flex items-center gap-2 mt-1">
-                                        <span class="text-xs font-bold text-violet-600 bg-violet-50 px-2 py-0.5 rounded-full capitalize" x-text="t.category.replace('_',' ')"></span>
+                                        <span class="text-xs font-bold text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-2 py-0.5 rounded-full capitalize" x-text="t.category.replace('_',' ')"></span>
                                         <span class="text-xs text-slate-400 font-mono" x-text="'v' + t.semver"></span>
                                     </div>
                                 </div>
                             </div>
                             <p class="text-sm text-slate-500" x-text="t.changelog || 'Standard inspection template.'"></p>
-                            <div class="flex items-center justify-between mt-auto pt-2 border-t border-slate-100 gap-2">
+                            <div class="flex items-center justify-between mt-auto pt-2 border-t border-slate-100 dark:border-slate-700 gap-2">
                                 <span class="text-xs text-slate-400" x-text="t.downloadCount + ' imports'"></span>
                                 <div class="flex items-center gap-2">
                                     {/* Polish 5 — Preview button */}
@@ -126,7 +126,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                                         </button>
                                     </template>
                                     <template x-if="t.importedSemver && !t.hasUpdate">
-                                        <span class="px-4 py-1.5 rounded-xl bg-slate-100 text-slate-400 text-xs font-bold">Imported</span>
+                                        <span class="px-4 py-1.5 rounded-xl bg-slate-100 dark:bg-slate-700 text-slate-400 text-xs font-bold">Imported</span>
                                     </template>
                                     {/* Round 37 — Update flow (Scheme 2). Opens a confirm
                                         modal explaining "creates a new copy" before POSTing. */}
@@ -150,10 +150,10 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                 {/* Pagination */}
                 <div class="flex items-center justify-center gap-3" x-show="totalPages > 1">
                     <button x-on:click="prevPage()" x-bind:disabled="page <= 1"
-                        class="px-4 py-2 rounded-xl border border-slate-200 text-sm font-bold disabled:opacity-40">Prev</button>
-                    <span class="text-sm text-slate-600 font-semibold" x-text="`Page ${page} of ${totalPages}`"></span>
+                        class="px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 dark:text-slate-300 text-sm font-bold disabled:opacity-40">Prev</button>
+                    <span class="text-sm text-slate-600 dark:text-slate-300 font-semibold" x-text="`Page ${page} of ${totalPages}`"></span>
                     <button x-on:click="nextPage()" x-bind:disabled="page >= totalPages"
-                        class="px-4 py-2 rounded-xl border border-slate-200 text-sm font-bold disabled:opacity-40">Next</button>
+                        class="px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 dark:text-slate-300 text-sm font-bold disabled:opacity-40">Next</button>
                 </div>
 
                 {/* Polish 5 — Preview modal. Footer has Close + Import (conditional),
@@ -168,7 +168,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <button
                                 type="button"
                                 x-on:click="previewOpen = false"
-                                class="h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                class="h-10 px-4 rounded-xl border bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                                 style="border-color: #e2e8f0"
                             >
                                 Close
@@ -193,20 +193,20 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <span class="text-rose-500" x-text="previewDefectTotal + ' defects'"></span>
                         </p>
                         <template x-for="sec in (previewSchema?.sections || [])" {...{ 'x-bind:key': 'sec.id' }}>
-                            <details class="bg-slate-50 rounded-xl p-3" open>
-                                <summary class="cursor-pointer font-bold text-sm text-slate-800 flex items-center justify-between">
+                            <details class="bg-slate-50 dark:bg-slate-800 rounded-xl p-3" open>
+                                <summary class="cursor-pointer font-bold text-sm text-slate-800 dark:text-slate-100 flex items-center justify-between">
                                     <span x-text="sec.title || sec.name || sec.id"></span>
                                     <span class="text-xs text-slate-400" x-text="(sec.items?.length || 0) + ' items'"></span>
                                 </summary>
-                                <ul class="mt-2 space-y-1 text-xs text-slate-600 pl-3">
+                                <ul class="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-400 pl-3">
                                     <template x-for="it in (sec.items || [])" {...{ 'x-bind:key': 'it.id' }}>
                                         <li class="flex items-center gap-2 flex-wrap py-1">
-                                            <span class="w-1 h-1 rounded-full bg-slate-300"></span>
-                                            <span class="font-semibold text-slate-700" x-text="it.label || it.name || it.id"></span>
-                                            <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 text-slate-600" x-text="it.type || 'rich'"></span>
-                                            <span x-show="it._info > 0" class="text-[10px] font-mono text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded" x-text="'info: ' + it._info"></span>
-                                            <span x-show="it._lim > 0" class="text-[10px] font-mono text-sky-700 bg-sky-50 px-1.5 py-0.5 rounded" x-text="'lim: ' + it._lim"></span>
-                                            <span x-show="it._def > 0" class="text-[10px] font-mono text-rose-700 bg-rose-50 px-1.5 py-0.5 rounded" x-text="'def: ' + it._def"></span>
+                                            <span class="w-1 h-1 rounded-full bg-slate-300 dark:bg-slate-600"></span>
+                                            <span class="font-semibold text-slate-700 dark:text-slate-200" x-text="it.label || it.name || it.id"></span>
+                                            <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300" x-text="it.type || 'rich'"></span>
+                                            <span x-show="it._info > 0" class="text-[10px] font-mono text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-1.5 py-0.5 rounded" x-text="'info: ' + it._info"></span>
+                                            <span x-show="it._lim > 0" class="text-[10px] font-mono text-sky-700 dark:text-sky-400 bg-sky-50 dark:bg-sky-900/30 px-1.5 py-0.5 rounded" x-text="'lim: ' + it._lim"></span>
+                                            <span x-show="it._def > 0" class="text-[10px] font-mono text-rose-700 dark:text-rose-400 bg-rose-50 dark:bg-rose-900/30 px-1.5 py-0.5 rounded" x-text="'def: ' + it._def"></span>
                                         </li>
                                     </template>
                                 </ul>
@@ -228,7 +228,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <button
                                 type="button"
                                 x-on:click="closeUpdateConfirm()"
-                                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                class="flex-1 h-10 px-4 rounded-xl border bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                                 style="border-color: #e2e8f0"
                             >
                                 Cancel
@@ -243,16 +243,16 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                         </>
                     }
                 >
-                    <div class="space-y-3 text-sm text-slate-700">
+                    <div class="space-y-3 text-sm text-slate-700 dark:text-slate-200">
                         <p>
                             <strong x-text="updateTarget?.name || ''"></strong>
-                            <span class="text-slate-500"> will move from </span>
-                            <span class="font-mono text-xs text-slate-700" x-text="'v' + (updateTarget?.importedSemver || '?')"></span>
-                            <span class="text-slate-500"> to </span>
-                            <span class="font-mono text-xs font-bold text-amber-700" x-text="'v' + (updateTarget?.semver || '?')"></span>.
+                            <span class="text-slate-500 dark:text-slate-400"> will move from </span>
+                            <span class="font-mono text-xs text-slate-700 dark:text-slate-300" x-text="'v' + (updateTarget?.importedSemver || '?')"></span>
+                            <span class="text-slate-500 dark:text-slate-400"> to </span>
+                            <span class="font-mono text-xs font-bold text-amber-700 dark:text-amber-400" x-text="'v' + (updateTarget?.semver || '?')"></span>.
                         </p>
                         <template x-if="updateKind === 'template'">
-                            <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
+                            <p class="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
                                 A new copy will be created with the suffix
                                 <span class="font-mono font-bold" x-text="'(v' + (updateTarget?.semver || '?') + ')'"></span>.
                                 Your current copy is <strong>preserved</strong> so existing
@@ -261,7 +261,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             </p>
                         </template>
                         <template x-if="updateKind === 'library'">
-                            <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
+                            <p class="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
                                 The new pack's entries will be <strong>added</strong> alongside
                                 your existing ones. Old entries are <strong>not deleted</strong>.
                                 If you want a clean state, delete the old entries from

--- a/src/templates/pages/not-found.tsx
+++ b/src/templates/pages/not-found.tsx
@@ -87,19 +87,19 @@ export const NotFoundPage = (props: NotFoundPageProps = {}): JSX.Element => {
 
     return (
         <BareLayout title={`${siteName} | ${ctx.title}`} branding={branding}>
-            <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4 py-12">
+            <div class="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-900 px-4 py-12">
                 <div class="max-w-md w-full text-center space-y-6">
                     {branding?.logoUrl && (
                         <img src={branding.logoUrl} alt={siteName} class="h-10 mx-auto opacity-80" />
                     )}
-                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 text-slate-400 mx-auto">
+                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 mx-auto">
                         <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
                         </svg>
                     </div>
                     <div class="space-y-2">
-                        <h1 class="text-[22px] font-bold tracking-tight text-slate-900">{ctx.title}</h1>
-                        <p class="text-[14px] text-slate-500 leading-relaxed">{ctx.body}</p>
+                        <h1 class="text-[22px] font-bold tracking-tight text-slate-900 dark:text-slate-100">{ctx.title}</h1>
+                        <p class="text-[14px] text-slate-500 dark:text-slate-400 leading-relaxed">{ctx.body}</p>
                     </div>
                     {cta && (
                         <a

--- a/src/templates/pages/rating-systems.tsx
+++ b/src/templates/pages/rating-systems.tsx
@@ -29,15 +29,15 @@ export const RatingSystemsPage = ({ branding }: Props): JSX.Element => {
                 />
 
                 {/* Loading state */}
-                <div x-show="loading" class="text-center py-12 bg-slate-50 rounded-md">
+                <div x-show="loading" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
                     <p class="text-slate-500 font-semibold">Loading rating systems…</p>
                 </div>
 
                 {/* Error banner */}
-                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-[13px] text-rose-700" x-text="error"></div>
+                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-[13px] text-rose-700 dark:text-rose-400" x-text="error"></div>
 
                 {/* Empty state — only shown when load completed and the list is genuinely empty */}
-                <div x-show="!loading && systems.length === 0" style="display:none" class="text-center py-12 bg-slate-50 rounded-md">
+                <div x-show="!loading && systems.length === 0" style="display:none" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
                     <p class="text-slate-500 font-semibold">No rating systems found.</p>
                     <p class="text-slate-400 text-sm mt-2">Reload the page to seed the four canonical systems.</p>
                 </div>
@@ -45,13 +45,13 @@ export const RatingSystemsPage = ({ branding }: Props): JSX.Element => {
                 {/* List */}
                 <div x-show="!loading && systems.length > 0" style="display:none" class="grid grid-cols-1 md:grid-cols-2 gap-3" data-testid="rating-system-list">
                     <template x-for="sys in systems" {...{ 'x-bind:key': 'sys.id' }}>
-                        <div class="p-4 bg-white border border-slate-200 rounded-lg shadow-sm hover:shadow-md transition" x-bind:data-rating-system-id="sys.id" x-bind:data-rating-system-slug="sys.slug">
+                        <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-sm hover:shadow-md transition" x-bind:data-rating-system-id="sys.id" x-bind:data-rating-system-slug="sys.slug">
                             <div class="flex items-start justify-between gap-3">
                                 <div class="flex-1 min-w-0">
                                     <div class="flex items-center gap-2 mb-1 flex-wrap">
-                                        <p class="font-bold text-slate-900" x-text="sys.name"></p>
-                                        <span x-show="sys.isDefault" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200">Default</span>
-                                        <span x-show="sys.isSeed" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 ring-1 ring-slate-200">Seed</span>
+                                        <p class="font-bold text-slate-900 dark:text-slate-100" x-text="sys.name"></p>
+                                        <span x-show="sys.isDefault" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-indigo-50 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 ring-1 ring-indigo-200 dark:ring-indigo-700">Default</span>
+                                        <span x-show="sys.isSeed" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400 ring-1 ring-slate-200 dark:ring-slate-600">Seed</span>
                                     </div>
                                     <p class="text-xs text-slate-500" x-text="sys.description || '(no description)'"></p>
                                     <div class="flex flex-wrap gap-1.5 mt-3">

--- a/src/templates/pages/recommendations.tsx
+++ b/src/templates/pages/recommendations.tsx
@@ -62,14 +62,14 @@ export const RecommendationsPage = ({ branding }: Props): JSX.Element => (
                 </select>
             </div>
 
-            <div x-show="items.length === 0 && !loading" class="text-center py-12 bg-slate-50 rounded-md">
-                <p class="text-slate-500 font-semibold">No recommendations yet.</p>
-                <p class="text-slate-400 text-sm mt-2">Click "Seed defaults" above to load 80 starter entries, or add your own.</p>
+            <div x-show="items.length === 0 && !loading" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+                <p class="text-slate-500 dark:text-slate-400 font-semibold">No recommendations yet.</p>
+                <p class="text-slate-400 dark:text-slate-500 text-sm mt-2">Click "Seed defaults" above to load 80 starter entries, or add your own.</p>
             </div>
 
             <div x-show="items.length > 0" class="grid grid-cols-1 md:grid-cols-2 gap-3 print:hidden">
                 <template x-for="rec in items" {...{ 'x-bind:key': 'rec.id' }}>
-                    <div class="p-4 bg-white border border-slate-200 rounded-lg shadow-sm hover:shadow-md transition">
+                    <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-sm hover:shadow-md transition">
                         <div class="flex items-start justify-between gap-3">
                             <div class="flex-1 min-w-0">
                                 <div class="flex items-center gap-2 mb-1">

--- a/src/templates/pages/tags.tsx
+++ b/src/templates/pages/tags.tsx
@@ -54,19 +54,19 @@ export const TagsPage = ({ branding }: Props): JSX.Element => {
                 />
 
                 {/* Loading + error */}
-                <div x-show="loading" class="text-center py-12 bg-slate-50 rounded-md text-[13px] text-slate-500 font-semibold">Loading tags…</div>
-                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-[13px] text-rose-700" x-text="error"></div>
+                <div x-show="loading" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md text-[13px] text-slate-500 dark:text-slate-400 font-semibold">Loading tags…</div>
+                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-[13px] text-rose-700 dark:text-rose-400" x-text="error"></div>
 
                 {/* Empty */}
-                <div x-show="!loading && tags.length === 0" style="display:none" class="text-center py-12 bg-slate-50 rounded-md">
-                    <p class="text-slate-500 font-semibold">No tags yet.</p>
-                    <p class="text-slate-400 text-sm mt-2">Reload to plant the five seed tags, or add your own.</p>
+                <div x-show="!loading && tags.length === 0" style="display:none" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+                    <p class="text-slate-500 dark:text-slate-400 font-semibold">No tags yet.</p>
+                    <p class="text-slate-400 dark:text-slate-500 text-sm mt-2">Reload to plant the five seed tags, or add your own.</p>
                 </div>
 
                 {/* List */}
                 <div x-show="!loading && tags.length > 0" style="display:none" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="tag-list">
                     <template x-for="tag in tags" {...{ 'x-bind:key': 'tag.id' }}>
-                        <div class="p-4 bg-white border border-slate-200 rounded-md shadow-sm hover:shadow transition" x-bind:data-tag-id="tag.id" x-bind:data-tag-name="tag.name">
+                        <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md shadow-sm hover:shadow transition" x-bind:data-tag-id="tag.id" x-bind:data-tag-name="tag.name">
                             <div class="flex items-start justify-between gap-3">
                                 <div class="flex-1 min-w-0">
                                     <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-bold ring-1 ring-inset" x-bind:class="colorClass(tag.color)" x-text="tag.name"></span>

--- a/src/templates/pages/tags.tsx
+++ b/src/templates/pages/tags.tsx
@@ -17,14 +17,14 @@ import type { BrandingConfig } from '../../types/auth';
 interface Props { branding?: BrandingConfig | undefined }
 
 const TAG_COLORS: ReadonlyArray<{ value: string; label: string; tw: string }> = [
-    { value: 'slate',    label: 'Slate',    tw: 'bg-slate-100 text-slate-700 ring-slate-200' },
-    { value: 'amber',    label: 'Amber',    tw: 'bg-amber-100 text-amber-700 ring-amber-200' },
-    { value: 'rose',     label: 'Rose',     tw: 'bg-rose-100 text-rose-700 ring-rose-200' },
-    { value: 'indigo',   label: 'Indigo',   tw: 'bg-indigo-100 text-indigo-700 ring-indigo-200' },
-    { value: 'emerald',  label: 'Emerald',  tw: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
-    { value: 'sky',      label: 'Sky',      tw: 'bg-sky-100 text-sky-700 ring-sky-200' },
-    { value: 'fuchsia',  label: 'Fuchsia',  tw: 'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200' },
-    { value: 'lime',     label: 'Lime',     tw: 'bg-lime-100 text-lime-700 ring-lime-200' },
+    { value: 'slate',   label: 'Slate',   tw: 'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 ring-slate-200 dark:ring-slate-500' },
+    { value: 'amber',   label: 'Amber',   tw: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 ring-amber-200 dark:ring-amber-700' },
+    { value: 'rose',    label: 'Rose',    tw: 'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300 ring-rose-200 dark:ring-rose-700' },
+    { value: 'indigo',  label: 'Indigo',  tw: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 ring-indigo-200 dark:ring-indigo-700' },
+    { value: 'emerald', label: 'Emerald', tw: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 ring-emerald-200 dark:ring-emerald-700' },
+    { value: 'sky',     label: 'Sky',     tw: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 ring-sky-200 dark:ring-sky-700' },
+    { value: 'fuchsia', label: 'Fuchsia', tw: 'bg-fuchsia-100 dark:bg-fuchsia-900/40 text-fuchsia-700 dark:text-fuchsia-300 ring-fuchsia-200 dark:ring-fuchsia-700' },
+    { value: 'lime',    label: 'Lime',    tw: 'bg-lime-100 dark:bg-lime-900/40 text-lime-700 dark:text-lime-300 ring-lime-200 dark:ring-lime-700' },
 ];
 
 export const TagsPage = ({ branding }: Props): JSX.Element => {


### PR DESCRIPTION
## Summary
- Added `dark:` variants to BASE/YOURS/THEIRS `<pre>` boxes — in dark mode the light `bg-slate-50`/`bg-indigo-50`/`bg-rose-50` backgrounds made content invisible (light-on-light)
- Added dark ring/text/hover variants to "Edit Merged" button
- `refresh()` now continuously purges empty conflict rows from IndexedDB on every 1-second poll, not only at `init()` time — prevents stale empty rows created after page load from re-opening the modal

## Root cause analysis
The "Sync Conflict" dialog appeared with empty BASE/YOURS/THEIRS fields. Investigation revealed:
1. Content **was present** in the `<pre>` elements but invisible due to missing dark mode variants
2. Empty conflict rows could accumulate in IndexedDB if the sync engine wrote them after `init()` ran its one-shot cleanup

## Test plan
- [ ] Trigger a sync conflict (edit inspection offline, then sync with server change)
- [ ] Verify BASE/YOURS/THEIRS content is readable in dark mode
- [ ] Verify empty conflict rows do not cause the modal to re-open after being dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)