### PR TITLE
feat(inspection-edit): M11 keyboard ergonomics — R repeat, J/K nav

### DIFF
--- a/public/js/agreements.js
+++ b/public/js/agreements.js
@@ -144,11 +144,11 @@ async function loadAgreements() {
                 <tr>
                     <td colspan="4" class="py-32 text-center">
                         <div class="flex flex-col items-center gap-6">
-                            <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center">
+                            <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
                                 <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                             </div>
                             <div>
-                                <p class="text-lg font-bold text-slate-900 tracking-tight">No agreements yet</p>
+                                <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">No agreements yet</p>
                                 <p class="text-sm text-slate-400 font-medium mt-1">Create a service agreement or liability waiver.</p>
                             </div>
                             <button onclick="showCreateModal()" class="px-6 py-3 rounded-xl bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-slate-900 transition-all active:scale-95">New Agreement</button>

--- a/public/js/agreements.js
+++ b/public/js/agreements.js
@@ -108,17 +108,17 @@ async function loadAgreements() {
                 <tr class="table-row-hover group">
                     <td class="py-6 pl-10 pr-3">
                         <div class="flex items-center gap-3">
-                            <div class="w-10 h-10 bg-indigo-50 rounded-xl flex items-center justify-center text-indigo-600 group-hover:bg-indigo-600 group-hover:text-white transition-all">
+                            <div class="w-10 h-10 bg-indigo-50 dark:bg-indigo-900/40 rounded-xl flex items-center justify-center text-indigo-600 dark:text-indigo-400 group-hover:bg-indigo-600 group-hover:text-white transition-all">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                             </div>
                             <div>
-                                <p class="text-sm font-bold text-slate-900">${a.name}</p>
+                                <p class="text-sm font-bold text-slate-900 dark:text-slate-100">${a.name}</p>
                                 <p class="text-[10px] text-slate-400 font-mono tracking-tighter uppercase">ID: ${a.id.split('-')[0]}</p>
                             </div>
                         </div>
                     </td>
                     <td class="px-6 py-6">
-                        <span class="inline-flex items-center rounded-lg border border-indigo-100 px-3 py-1 text-[10px] font-bold uppercase tracking-widest bg-indigo-50/50 text-indigo-600">v${a.version}.0</span>
+                        <span class="inline-flex items-center rounded-lg border border-indigo-100 dark:border-indigo-800 px-3 py-1 text-[10px] font-bold uppercase tracking-widest bg-indigo-50/50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">v${a.version}.0</span>
                     </td>
                     <td class="px-6 py-6 text-sm text-slate-500 font-bold">${new Date(a.createdAt).toLocaleDateString()}</td>
                     <td class="py-6 pl-3 pr-10 text-right">

--- a/public/js/conflict-modal.js
+++ b/public/js/conflict-modal.js
@@ -30,6 +30,12 @@ function conflictModalFactory() {
 
             const refresh = async () => {
                 const all = await db.conflicts.orderBy('createdAt').toArray();
+                // Continuously purge stale empty rows (mirrors the one-shot init
+                // cleanup) so new empties created after init don't accumulate.
+                const empties = all.filter(isEmpty);
+                if (empties.length > 0) {
+                    await Promise.all(empties.map((c) => db.conflicts.delete(c.id)));
+                }
                 this.conflicts = all.filter((c) => !isEmpty(c));
                 this.open = this.conflicts.length > 0;
                 if (this.index >= this.conflicts.length) this.index = 0;

--- a/public/js/contacts.js
+++ b/public/js/contacts.js
@@ -71,18 +71,18 @@ function renderContacts(list) {
     }
     tbody.innerHTML = list.map(function (c) {
         var typeBadge = c.type === 'agent'
-            ? '<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-indigo-100 text-indigo-700">Agent</span>'
-            : '<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-emerald-100 text-emerald-700">Client</span>';
-        return '<tr class="border-t border-slate-100 hover:bg-slate-50 transition">' +
-            '<td class="py-5 px-10 text-sm font-bold text-slate-900">' + c.name + '</td>' +
+            ? '<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">Agent</span>'
+            : '<span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">Client</span>';
+        return '<tr class="border-t border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition">' +
+            '<td class="py-5 px-10 text-sm font-bold text-slate-900 dark:text-slate-100">' + c.name + '</td>' +
             '<td class="py-5 px-8">' + typeBadge + '</td>' +
-            '<td class="py-5 px-8 text-sm text-slate-500">' + (c.email || '\u2014') + '</td>' +
-            '<td class="py-5 px-8 text-sm text-slate-500">' + (c.phone || '\u2014') + '</td>' +
-            '<td class="py-5 px-8 text-sm text-slate-500">' + (c.agency || '\u2014') + '</td>' +
-            '<td class="py-5 px-8 text-sm font-bold text-slate-700">' + (c.inspectionCount || 0) + '</td>' +
+            '<td class="py-5 px-8 text-sm text-slate-500 dark:text-slate-400">' + (c.email || '\u2014') + '</td>' +
+            '<td class="py-5 px-8 text-sm text-slate-500 dark:text-slate-400">' + (c.phone || '\u2014') + '</td>' +
+            '<td class="py-5 px-8 text-sm text-slate-500 dark:text-slate-400">' + (c.agency || '\u2014') + '</td>' +
+            '<td class="py-5 px-8 text-sm font-bold text-slate-700 dark:text-slate-300">' + (c.inspectionCount || 0) + '</td>' +
             '<td class="py-5 pr-10 text-right flex gap-2 justify-end">' +
-            '<button onclick="showEditModal(\'' + c.id + '\')" class="text-xs font-bold text-indigo-500 hover:text-indigo-700 px-3 py-1.5 rounded-lg hover:bg-indigo-50 transition">Edit</button>' +
-            '<button onclick="deleteContactById(\'' + c.id + '\')" class="text-xs font-bold text-red-400 hover:text-red-600 px-3 py-1.5 rounded-lg hover:bg-red-50 transition">Remove</button>' +
+            '<button onclick="showEditModal(\'' + c.id + '\')" class="text-xs font-bold text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-300 px-3 py-1.5 rounded-lg hover:bg-indigo-50 dark:hover:bg-indigo-900/40 transition">Edit</button>' +
+            '<button onclick="deleteContactById(\'' + c.id + '\')" class="text-xs font-bold text-red-400 hover:text-red-600 dark:hover:text-red-400 px-3 py-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/40 transition">Remove</button>' +
             '</td></tr>';
     }).join('');
 }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -111,13 +111,13 @@ function renderServicesSection() {
     if (!list) return;
     list.innerHTML = availableServices.map(svc => `
         <div onclick="toggleService('${svc.id}')" id="svc-card-${svc.id}"
-             class="flex items-center gap-3 p-3 rounded-xl border-2 cursor-pointer transition-all border-slate-200 bg-white">
-            <div id="svc-check-${svc.id}" class="w-5 h-5 rounded-md border-2 border-slate-300 flex items-center justify-center text-xs font-bold text-white flex-shrink-0"></div>
+             class="flex items-center gap-3 p-3 rounded-xl border-2 cursor-pointer transition-all border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700">
+            <div id="svc-check-${svc.id}" class="w-5 h-5 rounded-md border-2 border-slate-300 dark:border-slate-500 flex items-center justify-center text-xs font-bold text-white flex-shrink-0"></div>
             <div class="flex-1 min-w-0">
-                <div class="text-sm font-bold text-slate-900">${svc.name}</div>
-                ${svc.durationMinutes ? `<div class="text-xs text-slate-400">&#x23F1; ${svc.durationMinutes} min</div>` : ''}
+                <div class="text-sm font-bold text-slate-900 dark:text-slate-100">${svc.name}</div>
+                ${svc.durationMinutes ? `<div class="text-xs text-slate-400 dark:text-slate-400">&#x23F1; ${svc.durationMinutes} min</div>` : ''}
             </div>
-            <div class="text-sm font-bold text-slate-900">${formatCents(svc.price)}</div>
+            <div class="text-sm font-bold text-slate-900 dark:text-slate-100">${formatCents(svc.price)}</div>
         </div>
     `).join('');
     updateTotalBar();
@@ -132,7 +132,7 @@ function toggleService(id) {
     const check = document.getElementById('svc-check-' + id);
     const selected = selectedServiceIds.includes(id);
     if (card) {
-        card.className = `flex items-center gap-3 p-3 rounded-xl border-2 cursor-pointer transition-all ${selected ? 'border-indigo-500 bg-indigo-50' : 'border-slate-200 bg-white'}`;
+        card.className = `flex items-center gap-3 p-3 rounded-xl border-2 cursor-pointer transition-all ${selected ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30' : 'border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700'}`;
     }
     if (check) {
         check.className = `w-5 h-5 rounded-md border-2 flex items-center justify-center text-xs font-bold flex-shrink-0 ${selected ? 'bg-indigo-500 border-indigo-500 text-white' : 'border-slate-300'}`;
@@ -470,9 +470,9 @@ function renderPlacesDropdown(results) {
     }
     dropdown.innerHTML = results.slice(0, 6).map(r => `
         <button type="button" data-place-id="${r.placeId}" data-place-text="${(r.description || '').replace(/"/g, '&quot;')}"
-                class="w-full text-left px-5 py-3 hover:bg-emerald-50 border-b border-slate-100 last:border-b-0 transition">
-          <div class="font-bold text-sm text-slate-900">${r.mainText || r.description}</div>
-          ${r.secondaryText ? `<div class="text-xs text-slate-500 mt-0.5">${r.secondaryText}</div>` : ''}
+                class="w-full text-left px-5 py-3 hover:bg-emerald-50 dark:hover:bg-slate-600 border-b border-slate-100 dark:border-slate-600 last:border-b-0 transition">
+          <div class="font-bold text-sm text-slate-900 dark:text-slate-100">${r.mainText || r.description}</div>
+          ${r.secondaryText ? `<div class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">${r.secondaryText}</div>` : ''}
         </button>
     `).join('');
     dropdown.classList.remove('hidden');

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -361,15 +361,49 @@ function inspectionEditor(inspectionId) {
           return;
         }
         // Navigation: ArrowUp / ArrowDown move active item up/down,
+        // J / K Vim-style aliases (Design 0520 M11.2),
         // Enter advances to next, Shift+Enter goes to previous.
-        if (e.key === 'ArrowDown' || (e.key === 'Enter' && !e.shiftKey)) {
+        if (e.key === 'ArrowDown' || e.key === 'j' || e.key === 'J' || (e.key === 'Enter' && !e.shiftKey)) {
           e.preventDefault();
           this.navigateItem(1);
           return;
         }
-        if (e.key === 'ArrowUp' || (e.key === 'Enter' && e.shiftKey)) {
+        if (e.key === 'ArrowUp' || e.key === 'k' || (e.key === 'Enter' && e.shiftKey)) {
+          // Note: capital K is already used by an earlier handler (block toggle
+          // around line 261). Only lowercase k aliases ArrowUp to avoid a clash.
           e.preventDefault();
           this.navigateItem(-1);
+          return;
+        }
+        // R = repeat the previous item's rating + notes (Design 0520 M11.1).
+        // "Previous" = the nearest earlier item in the current section that
+        // already carries a rating, so an inspector can chain similar items
+        // without re-typing. Skips if no prior item has a rating yet.
+        if (e.key === 'r' || e.key === 'R') {
+          e.preventDefault();
+          if (!this.activeItem) {
+            if (typeof showToast === 'function') showToast('Select an item first to repeat the previous rating');
+            return;
+          }
+          var section = (this.template?.sections || []).find(s => (s.items || []).some(it => it.id === this.activeItem.id));
+          var sectionItems = section ? section.items : (this.template?.sections?.[0]?.items || []);
+          var activeIdx = sectionItems.findIndex(it => it.id === this.activeItem.id);
+          var prior = null;
+          for (var pi = activeIdx - 1; pi >= 0; pi--) {
+            var candidate = sectionItems[pi];
+            var res = this.results?.[candidate.id];
+            if (res && res.ratingLevelId) { prior = { id: candidate.id, res: res }; break; }
+          }
+          if (!prior) {
+            if (typeof showToast === 'function') showToast('No earlier rated item to repeat from');
+            return;
+          }
+          // Copy rating + canned/custom comment payload to the active item.
+          // Existing comments on the active item are replaced — `R` is the
+          // explicit "clone above" gesture, not an accumulator.
+          this.results[this.activeItem.id] = JSON.parse(JSON.stringify(prior.res));
+          this.debounceSave();
+          if (typeof showToast === 'function') showToast('Cloned rating + notes from previous item');
           return;
         }
         // P = add photo to active item (triggers global hidden file input)

--- a/public/js/reports.js
+++ b/public/js/reports.js
@@ -117,15 +117,15 @@ function render() {
         const dateStr = formatDate(r.date || r.createdAt);
         return `
         <tr class="table-row-hover group">
-            <td class="px-6 py-5"><a href="/inspections/${r.id}/edit" class="text-sm font-bold text-slate-900 hover:text-indigo-600 break-words">${_escapeHtml(r.propertyAddress || 'Untitled')}</a></td>
-            <td class="px-6 py-5 text-xs font-bold text-slate-700">${_escapeHtml(r.clientName || '—')}</td>
-            <td class="px-6 py-5 text-xs font-bold text-slate-500 font-mono">${_escapeHtml(dateStr)}</td>
+            <td class="px-6 py-5"><a href="/inspections/${r.id}/edit" class="text-sm font-bold text-slate-900 dark:text-slate-100 hover:text-indigo-600 dark:hover:text-indigo-400 break-words">${_escapeHtml(r.propertyAddress || 'Untitled')}</a></td>
+            <td class="px-6 py-5 text-xs font-bold text-slate-700 dark:text-slate-300">${_escapeHtml(r.clientName || '—')}</td>
+            <td class="px-6 py-5 text-xs font-bold text-slate-500 dark:text-slate-400 font-mono">${_escapeHtml(dateStr)}</td>
             <td class="px-6 py-5"><span class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${statusStyle(r.status)} shadow-sm ring-1 ring-inset"><span class="w-1 h-1 rounded-full bg-current"></span>${_escapeHtml((r.status || '').replace('_', ' '))}</span></td>
             <td class="px-6 py-5"><span class="text-xs font-bold ${r.paymentStatus === 'paid' ? 'text-emerald-600' : 'text-amber-600'}">$${(r.price || 0).toLocaleString()} · ${_escapeHtml(r.paymentStatus || 'unpaid')}</span></td>
             <td class="px-6 py-5 text-right">
                 <div class="flex items-center justify-end gap-2">
                     <a href="/api/inspections/${r.id}/report" target="_blank" class="px-3 py-1.5 rounded-lg bg-slate-900 text-white text-[10px] font-bold uppercase tracking-widest hover:bg-indigo-600 transition-all">View</a>
-                    <button onclick="copyReportLink('${r.id}')" class="px-3 py-1.5 rounded-lg bg-slate-100 text-slate-700 text-[10px] font-bold uppercase tracking-widest hover:bg-slate-200 transition-all">Copy Link</button>
+                    <button onclick="copyReportLink('${r.id}')" class="px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 text-[10px] font-bold uppercase tracking-widest hover:bg-slate-200 dark:hover:bg-slate-600 transition-all">Copy Link</button>
                 </div>
             </td>
         </tr>`;
@@ -137,13 +137,13 @@ function render() {
             return `
             <a href="/inspections/${r.id}/edit" class="block glass-panel rounded-md p-4 hover:shadow-lg transition active:scale-[0.98]">
                 <div class="flex items-start justify-between gap-3 mb-2">
-                    <p class="text-sm font-bold text-slate-900 break-words flex-1">${_escapeHtml(r.propertyAddress || 'Untitled')}</p>
+                    <p class="text-sm font-bold text-slate-900 dark:text-slate-100 break-words flex-1">${_escapeHtml(r.propertyAddress || 'Untitled')}</p>
                     <span class="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-[10px] font-bold uppercase tracking-wider whitespace-nowrap ${statusStyle(r.status)} shadow-sm ring-1 ring-inset">
                         <span class="w-1 h-1 rounded-full bg-current"></span>${_escapeHtml((r.status || '').replace('_', ' '))}
                     </span>
                 </div>
                 <div class="text-xs text-slate-500 space-y-0.5">
-                    <p><span class="font-semibold text-slate-700">${_escapeHtml(r.clientName || '—')}</span></p>
+                    <p><span class="font-semibold text-slate-700 dark:text-slate-300">${_escapeHtml(r.clientName || '—')}</span></p>
                     <p class="font-mono text-[10px] text-slate-400">${_escapeHtml(dateStr || '')} · $${(r.price || 0).toLocaleString()}</p>
                 </div>
             </a>`;
@@ -153,11 +153,11 @@ function render() {
 
 function statusStyle(s) {
     const map = {
-        'completed': 'bg-amber-50 text-amber-600 ring-amber-100',
-        'delivered': 'bg-emerald-50 text-emerald-600 ring-emerald-100',
-        'signed': 'bg-violet-50 text-violet-600 ring-violet-100',
+        'completed': 'bg-amber-50 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 ring-amber-100 dark:ring-amber-800',
+        'delivered': 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 ring-emerald-100 dark:ring-emerald-800',
+        'signed': 'bg-violet-50 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400 ring-violet-100 dark:ring-violet-800',
     };
-    return map[s] || 'bg-slate-100 text-slate-600 ring-slate-200';
+    return map[s] || 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400 ring-slate-200 dark:ring-slate-600';
 }
 
 function formatDate(d) {

--- a/public/js/slash-trigger.js
+++ b/public/js/slash-trigger.js
@@ -76,20 +76,20 @@
             // Caller is expected to provide a `position: relative` parent
             // (form-renderer's `<div class="relative group mb-8">` qualifies).
             const p = document.createElement('div');
-            p.className = 'oi-slash-picker absolute z-50 bg-white rounded-xl shadow-2xl border border-slate-200 overflow-hidden hidden';
+            p.className = 'oi-slash-picker absolute z-50 bg-white dark:bg-slate-800 rounded-xl shadow-2xl border border-slate-200 dark:border-slate-700 overflow-hidden hidden';
             p.style.minWidth = '320px';
             p.style.maxWidth = '480px';
             p.setAttribute('role', 'listbox');
             const header = document.createElement('div');
-            header.className = 'px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 bg-slate-50 border-b border-slate-100';
+            header.className = 'px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 bg-slate-50 dark:bg-slate-700/50 border-b border-slate-100 dark:border-slate-700';
             header.textContent = 'Comment library · / to search';
             p.appendChild(header);
             const ul = document.createElement('ul');
             ul.className = 'max-h-72 overflow-y-auto';
             p.appendChild(ul);
             const footer = document.createElement('div');
-            footer.className = 'px-4 py-2 text-[10px] text-slate-400 bg-slate-50 border-t border-slate-100 flex justify-between';
-            footer.innerHTML = '<span><kbd class="px-1 py-0.5 bg-white border rounded text-[10px] font-mono">↑↓</kbd> nav · <kbd class="px-1 py-0.5 bg-white border rounded text-[10px] font-mono">⏎</kbd> insert · <kbd class="px-1 py-0.5 bg-white border rounded text-[10px] font-mono">Esc</kbd> close</span>';
+            footer.className = 'px-4 py-2 text-[10px] text-slate-400 bg-slate-50 dark:bg-slate-700/50 border-t border-slate-100 dark:border-slate-700 flex justify-between';
+            footer.innerHTML = '<span><kbd class="px-1 py-0.5 bg-white dark:bg-slate-600 border border-slate-200 dark:border-slate-500 rounded text-[10px] font-mono dark:text-slate-300">↑↓</kbd> nav · <kbd class="px-1 py-0.5 bg-white dark:bg-slate-600 border border-slate-200 dark:border-slate-500 rounded text-[10px] font-mono dark:text-slate-300">⏎</kbd> insert · <kbd class="px-1 py-0.5 bg-white dark:bg-slate-600 border border-slate-200 dark:border-slate-500 rounded text-[10px] font-mono dark:text-slate-300">Esc</kbd> close</span>';
             p.appendChild(footer);
             parent.appendChild(p);
             state.picker = p;
@@ -113,7 +113,7 @@
             ul.innerHTML = '';
             state.visibleItems.forEach((item, idx) => {
                 const li = document.createElement('li');
-                li.className = 'px-4 py-2 cursor-pointer text-sm transition-colors ' + (idx === state.highlighted ? 'bg-indigo-50 text-indigo-700' : 'text-slate-700 hover:bg-slate-50');
+                li.className = 'px-4 py-2 cursor-pointer text-sm transition-colors ' + (idx === state.highlighted ? 'bg-indigo-50 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50');
                 li.setAttribute('role', 'option');
                 li.setAttribute('data-idx', String(idx));
                 // Truncate long snippets visually

--- a/public/js/tags.js
+++ b/public/js/tags.js
@@ -51,14 +51,14 @@
 
                 colorClass(color) {
                     const map = {
-                        slate:    'bg-slate-100 text-slate-700 ring-slate-200',
-                        amber:    'bg-amber-100 text-amber-700 ring-amber-200',
-                        rose:     'bg-rose-100 text-rose-700 ring-rose-200',
-                        indigo:   'bg-indigo-100 text-indigo-700 ring-indigo-200',
-                        emerald:  'bg-emerald-100 text-emerald-700 ring-emerald-200',
-                        sky:      'bg-sky-100 text-sky-700 ring-sky-200',
-                        fuchsia:  'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200',
-                        lime:     'bg-lime-100 text-lime-700 ring-lime-200',
+                        slate:   'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 ring-slate-200 dark:ring-slate-500',
+                        amber:   'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 ring-amber-200 dark:ring-amber-700',
+                        rose:    'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300 ring-rose-200 dark:ring-rose-700',
+                        indigo:  'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 ring-indigo-200 dark:ring-indigo-700',
+                        emerald: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 ring-emerald-200 dark:ring-emerald-700',
+                        sky:     'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 ring-sky-200 dark:ring-sky-700',
+                        fuchsia: 'bg-fuchsia-100 dark:bg-fuchsia-900/40 text-fuchsia-700 dark:text-fuchsia-300 ring-fuchsia-200 dark:ring-fuchsia-700',
+                        lime:    'bg-lime-100 dark:bg-lime-900/40 text-lime-700 dark:text-lime-300 ring-lime-200 dark:ring-lime-700',
                     };
                     return map[color] || map.slate;
                 },

--- a/public/js/team.js
+++ b/public/js/team.js
@@ -73,11 +73,11 @@ window.teamMeta = teamMeta;
                 <tr>
                     <td colspan="3" class="py-32 text-center">
                         <div class="flex flex-col items-center gap-6">
-                            <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center">
+                            <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
                                 <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
                             </div>
                             <div>
-                                <p class="text-lg font-bold text-slate-900 tracking-tight">Just you for now</p>
+                                <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">Just you for now</p>
                                 <p class="text-sm text-slate-400 font-medium mt-1">Invite team members to collaborate.</p>
                             </div>
                         </div>

--- a/public/js/team.js
+++ b/public/js/team.js
@@ -86,12 +86,12 @@ window.teamMeta = teamMeta;
             return;
         }
         membersList.innerHTML = members.map(m => `
-            <tr class="hover:bg-slate-50/80 transition-colors">
-                <td class="px-6 py-4 text-sm font-medium text-slate-900">${m.email}</td>
-                <td class="px-4 py-4 text-sm text-slate-500">
-                    <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-indigo-50 text-indigo-700">${roleNames[m.role] || m.role}</span>
+            <tr class="hover:bg-slate-50/80 dark:hover:bg-slate-700/50 transition-colors">
+                <td class="px-6 py-4 text-sm font-medium text-slate-900 dark:text-slate-100">${m.email}</td>
+                <td class="px-4 py-4 text-sm text-slate-500 dark:text-slate-400">
+                    <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-indigo-50 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">${roleNames[m.role] || m.role}</span>
                 </td>
-                <td class="px-4 py-4 text-sm text-slate-400">${m.createdAt ? new Date(m.createdAt).toLocaleDateString() : '—'}</td>
+                <td class="px-4 py-4 text-sm text-slate-400 dark:text-slate-500">${m.createdAt ? new Date(m.createdAt).toLocaleDateString() : '—'}</td>
             </tr>
         `).join('');
     }
@@ -102,11 +102,11 @@ window.teamMeta = teamMeta;
             return;
         }
         invitesList.innerHTML = invites.map(i => `
-            <tr class="hover:bg-slate-50/80 transition-colors">
-                <td class="px-6 py-4 text-sm font-medium text-slate-900">${i.email}</td>
-                <td class="px-4 py-4 text-sm text-slate-500 font-bold">${roleNames[i.role] || i.role}</td>
+            <tr class="hover:bg-slate-50/80 dark:hover:bg-slate-700/50 transition-colors">
+                <td class="px-6 py-4 text-sm font-medium text-slate-900 dark:text-slate-100">${i.email}</td>
+                <td class="px-4 py-4 text-sm text-slate-500 dark:text-slate-400 font-bold">${roleNames[i.role] || i.role}</td>
                 <td class="px-4 py-4 text-sm">
-                    <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-amber-50 text-amber-700 uppercase">${i.status}</span>
+                    <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold bg-amber-50 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 uppercase">${i.status}</span>
                 </td>
             </tr>
         `).join('');

--- a/public/js/templates.js
+++ b/public/js/templates.js
@@ -113,12 +113,12 @@ function renderTemplates() {
           <tr class="table-row-hover group">
             <td class="py-6 pl-10 pr-3">
               <div class="flex items-center gap-3">
-                <div class="w-10 h-10 bg-indigo-50 rounded-xl flex items-center justify-center text-indigo-600 group-hover:bg-indigo-600 group-hover:text-white transition-all">
+                <div class="w-10 h-10 bg-indigo-50 dark:bg-indigo-900/40 rounded-xl flex items-center justify-center text-indigo-600 dark:text-indigo-400 group-hover:bg-indigo-600 group-hover:text-white transition-all">
                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path></svg>
                 </div>
                 <div>
                   <div class="flex items-center gap-2">
-                    <a href="/templates/${t.id}/edit" class="text-sm font-bold text-slate-900 hover:text-indigo-600 transition-colors">${t.name}</a>
+                    <a href="/templates/${t.id}/edit" class="text-sm font-bold text-slate-900 dark:text-slate-100 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">${t.name}</a>
                     ${t.source === 'marketplace' ? '<span class="text-[9px] font-bold uppercase tracking-widest text-violet-700 bg-violet-100 px-1.5 py-0.5 rounded">Marketplace</span>' : ''}
                   </div>
                   <p class="text-[10px] text-slate-400 font-medium" title="${t.id}">${itemCount} items · v${t.version}.0${t.source === 'marketplace' ? ' · Imported from Marketplace' : ''}</p>
@@ -126,7 +126,7 @@ function renderTemplates() {
               </div>
             </td>
             <td class="px-6 py-6">
-              <span class="inline-flex items-center rounded-lg border border-indigo-100 px-3 py-1 text-[10px] font-bold uppercase tracking-widest bg-indigo-50/50 text-indigo-600">v${t.version}.0</span>
+              <span class="inline-flex items-center rounded-lg border border-indigo-100 dark:border-indigo-800 px-3 py-1 text-[10px] font-bold uppercase tracking-widest bg-indigo-50/50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">v${t.version}.0</span>
             </td>
             <td class="px-6 py-6 text-sm text-slate-500 font-bold">${itemCount} items</td>
             <td class="py-6 pl-3 pr-10 text-right">

--- a/public/js/templates.js
+++ b/public/js/templates.js
@@ -94,11 +94,11 @@ function renderTemplates() {
           <tr>
             <td colspan="4" class="py-32 text-center">
               <div class="flex flex-col items-center gap-6">
-                <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center">
+                <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
                   <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                 </div>
                 <div>
-                  <p class="text-lg font-bold text-slate-900 tracking-tight">No templates yet</p>
+                  <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">No templates yet</p>
                   <p class="text-sm text-slate-400 font-medium mt-1">Create a checklist template for your inspections.</p>
                 </div>
                 <button onclick="showCreateModal()" class="px-6 py-3 rounded-xl bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-slate-900 transition-all active:scale-95">New Template</button>

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -795,6 +795,7 @@ html[data-color-scheme="dark"] .text-ink-300 { color: var(--ih-fg-5) !important;
 html[data-color-scheme="dark"] .border-surface-200 { border-color: rgba(255,255,255,0.08) !important; }
 html[data-color-scheme="dark"] .bg-surface-50 { background-color: var(--ih-bg-app) !important; }
 html[data-color-scheme="dark"] .bg-surface-100 { background-color: var(--ih-bg-muted) !important; }
+html[data-color-scheme="dark"] .bg-blueprint-50  { background-color: rgba(99,102,241,0.12) !important; }
 html[data-color-scheme="dark"] .bg-blueprint-100 { background-color: rgba(99,102,241,0.15) !important; }
 html[data-color-scheme="dark"] .text-blueprint-700 { color: #818cf8 !important; }
 html[data-color-scheme="dark"] .hover\:bg-blueprint-500:hover { background-color: #6366f1 !important; }

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -742,6 +742,33 @@ html[data-color-scheme="dark"] thead.bg-slate-50\/50 {
     background-color: rgba(255,255,255,0.03) !important;
 }
 
+/* ── JS-rendered table rows (contacts, invoices, agreements) ─ */
+html[data-color-scheme="dark"] #contactsBody tr:hover,
+html[data-color-scheme="dark"] #agentLinksBody tr:hover,
+html[data-color-scheme="dark"] #invoicesBody tr:hover,
+html[data-color-scheme="dark"] #membersList tr:hover,
+html[data-color-scheme="dark"] #invitesList tr:hover {
+    background-color: rgba(30,41,59,0.9) !important;
+}
+
+/* ── FullCalendar dark overrides ─────────────────────────── */
+html[data-color-scheme="dark"] #calendar th {
+    background-color: var(--ih-bg-card) !important;
+    border-color: rgba(255,255,255,0.08) !important;
+}
+html[data-color-scheme="dark"] #calendar td {
+    border-color: rgba(255,255,255,0.06) !important;
+}
+html[data-color-scheme="dark"] #calendar .fc-day-today {
+    background-color: rgba(99,102,241,0.12) !important;
+}
+html[data-color-scheme="dark"] #calendar .fc-event {
+    border-color: rgba(255,255,255,0.15) !important;
+}
+html[data-color-scheme="dark"] #calendar .fc-scrollgrid {
+    border-color: rgba(255,255,255,0.08) !important;
+}
+
 /* ── Borders on panels / sections ───────────────────────── */
 html[data-color-scheme="dark"] .border-slate-100,
 html[data-color-scheme="dark"] .border-slate-100\/50 {

--- a/src/templates/components/conflict-modal.tsx
+++ b/src/templates/components/conflict-modal.tsx
@@ -14,6 +14,7 @@ export const ConflictModal = () => (
         x-data="conflictModal"
         x-show="open"
         x-cloak
+        style="display:none"
         class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
         {...{ 'x-on:click.self': 'open = false' }}
     >

--- a/src/templates/components/conflict-modal.tsx
+++ b/src/templates/components/conflict-modal.tsx
@@ -26,14 +26,14 @@ export const ConflictModal = () => (
                 <span x-text="`${index + 1} of ${conflicts.length}`" class="text-xs font-bold text-slate-400"></span>
             </header>
             <div class="flex-1 overflow-y-auto p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-                <section><h3 class="text-xs font-bold uppercase tracking-widest text-slate-400 mb-2">Base</h3><pre class="bg-slate-50 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.base"></pre></section>
-                <section><h3 class="text-xs font-bold uppercase tracking-widest text-indigo-600 mb-2">Yours</h3><pre class="bg-indigo-50 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.ours"></pre></section>
-                <section><h3 class="text-xs font-bold uppercase tracking-widest text-rose-600 mb-2">Theirs</h3><pre class="bg-rose-50 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.theirs"></pre></section>
+                <section><h3 class="text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-2">Base</h3><pre class="bg-slate-50 dark:bg-slate-800 dark:text-slate-200 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.base"></pre></section>
+                <section><h3 class="text-xs font-bold uppercase tracking-widest text-indigo-600 dark:text-indigo-400 mb-2">Yours</h3><pre class="bg-indigo-50 dark:bg-indigo-900/30 dark:text-indigo-200 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.ours"></pre></section>
+                <section><h3 class="text-xs font-bold uppercase tracking-widest text-rose-600 dark:text-rose-400 mb-2">Theirs</h3><pre class="bg-rose-50 dark:bg-rose-900/30 dark:text-rose-200 p-3 rounded-lg text-xs whitespace-pre-wrap" x-text="current?.theirs"></pre></section>
             </div>
             <footer class="px-8 py-5 border-t border-slate-100 flex items-center gap-3 justify-end">
                 <button x-on:click="resolve('ours')"   class="px-5 py-2 rounded-lg bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-indigo-700">Keep Mine</button>
                 <button x-on:click="resolve('theirs')" class="px-5 py-2 rounded-lg bg-rose-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-rose-700">Accept Theirs</button>
-                <button x-on:click="resolve('edit')"   class="px-5 py-2 rounded-lg ring-2 ring-slate-300 text-slate-700 text-xs font-bold uppercase tracking-widest hover:bg-slate-50">Edit Merged</button>
+                <button x-on:click="resolve('edit')"   class="px-5 py-2 rounded-lg ring-2 ring-slate-300 dark:ring-slate-600 text-slate-700 dark:text-slate-300 text-xs font-bold uppercase tracking-widest hover:bg-slate-50 dark:hover:bg-slate-700">Edit Merged</button>
                 {/* Iter-2 bug #12 — visual separator + escape hatch. The
                     `aria-hidden` divider keeps screen readers focused on the
                     actionable buttons. The reset button itself is destructive

--- a/src/templates/components/customize-columns-modal.tsx
+++ b/src/templates/components/customize-columns-modal.tsx
@@ -30,8 +30,7 @@ export const CustomizeColumnsModal = (): JSX.Element => (
                     <button
                         type="button"
                         x-on:click="resetColumns()"
-                        class="h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
-                        style="border-color: #e2e8f0"
+                        class="h-10 px-4 rounded-xl border bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 border-slate-200 dark:border-slate-600 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                     >
                         Reset to defaults
                     </button>
@@ -39,8 +38,7 @@ export const CustomizeColumnsModal = (): JSX.Element => (
                     <button
                         type="button"
                         onclick="document.getElementById('customizeColumnsModal')?.classList.add('hidden')"
-                        class="h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
-                        style="border-color: #e2e8f0"
+                        class="h-10 px-4 rounded-xl border bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 border-slate-200 dark:border-slate-600 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                     >
                         Cancel
                     </button>
@@ -59,7 +57,7 @@ export const CustomizeColumnsModal = (): JSX.Element => (
                 {DASHBOARD_COLUMNS.map((col) => (
                     <label
                         key={col.id}
-                        class={`flex items-start gap-3 p-3 rounded-md border transition-all ${col.alwaysOn ? 'bg-slate-50 border-slate-200 cursor-not-allowed' : 'bg-white border-slate-200 hover:border-indigo-300 cursor-pointer'}`}
+                        class={`flex items-start gap-3 p-3 rounded-md border transition-all ${col.alwaysOn ? 'bg-slate-50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 cursor-not-allowed' : 'bg-white dark:bg-slate-700 border-slate-200 dark:border-slate-600 hover:border-indigo-300 dark:hover:border-indigo-500 cursor-pointer'}`}
                         data-column-id={col.id}
                     >
                         <input
@@ -72,16 +70,16 @@ export const CustomizeColumnsModal = (): JSX.Element => (
                         />
                         <div class="flex-1 min-w-0">
                             <div class="flex items-center gap-2">
-                                <span class="text-sm font-bold text-slate-900">{col.label}</span>
+                                <span class="text-sm font-bold text-slate-900 dark:text-slate-100">{col.label}</span>
                                 {col.alwaysOn && (
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-slate-400 bg-slate-100 px-1.5 py-0.5 rounded">Required</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-slate-400 dark:text-slate-300 bg-slate-100 dark:bg-slate-600 px-1.5 py-0.5 rounded">Required</span>
                                 )}
                                 {col.mobileVisible === false && (
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-slate-400 bg-slate-100 px-1.5 py-0.5 rounded" title="Hidden on mobile to keep cards readable">Desktop only</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-slate-400 dark:text-slate-300 bg-slate-100 dark:bg-slate-600 px-1.5 py-0.5 rounded" title="Hidden on mobile to keep cards readable">Desktop only</span>
                                 )}
                             </div>
                             {col.description && (
-                                <p class="text-xs text-slate-500 mt-0.5">{col.description}</p>
+                                <p class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{col.description}</p>
                             )}
                         </div>
                     </label>

--- a/src/templates/components/inspection-shell.tsx
+++ b/src/templates/components/inspection-shell.tsx
@@ -92,9 +92,9 @@ export const InspectionShell = ({
             {hasMultipleSiblings && siblings && (
                 <nav
                     aria-label="Sibling inspections"
-                    class="flex flex-wrap items-center gap-2 px-3 py-2 bg-slate-50 rounded-md border border-slate-200"
+                    class="flex flex-wrap items-center gap-2 px-3 py-2 bg-slate-50 dark:bg-slate-800 rounded-md border border-slate-200 dark:border-slate-700"
                 >
-                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">
+                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
                         Same visit
                     </span>
                     {siblings.map((s) => {
@@ -103,8 +103,8 @@ export const InspectionShell = ({
                             <a
                                 href={`/inspections/${s.id}/${current}`}
                                 class={isCurrent
-                                    ? 'px-2.5 py-1 rounded-md bg-white border border-indigo-300 text-indigo-700 text-[11px] font-bold'
-                                    : 'px-2.5 py-1 rounded-md text-slate-600 text-[11px] font-medium hover:bg-white hover:text-slate-900 transition-colors'}
+                                    ? 'px-2.5 py-1 rounded-md bg-white dark:bg-slate-700 border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300 text-[11px] font-bold'
+                                    : 'px-2.5 py-1 rounded-md text-slate-600 dark:text-slate-400 text-[11px] font-medium hover:bg-white dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 transition-colors'}
                                 aria-current={isCurrent ? 'page' : undefined}
                             >
                                 {s.templateName}
@@ -118,7 +118,7 @@ export const InspectionShell = ({
             <nav
                 role="tablist"
                 aria-label="Inspection sections"
-                class="border-b border-slate-200 sticky top-0 z-20 bg-[#f8fafc]"
+                class="border-b border-slate-200 dark:border-slate-700 sticky top-0 z-20 bg-[#f8fafc] dark:bg-slate-900"
             >
                 <div class="flex items-center gap-1 overflow-x-auto hide-scrollbar">
                     {visibleTabs.map((t) => {
@@ -130,8 +130,8 @@ export const InspectionShell = ({
                                 aria-current={active ? 'page' : undefined}
                                 aria-selected={active ? 'true' : 'false'}
                                 class={active
-                                    ? 'px-4 py-3 text-[13px] font-bold border-b-2 border-indigo-500 text-slate-900 whitespace-nowrap'
-                                    : 'px-4 py-3 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors'}
+                                    ? 'px-4 py-3 text-[13px] font-bold border-b-2 border-indigo-500 text-slate-900 dark:text-slate-100 whitespace-nowrap'
+                                    : 'px-4 py-3 text-[13px] font-bold border-b-2 border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600 whitespace-nowrap transition-colors'}
                             >
                                 {t.label}
                             </a>

--- a/src/templates/components/modal.tsx
+++ b/src/templates/components/modal.tsx
@@ -117,28 +117,28 @@ export const Modal = ({
             {...alpineAttrs}
         >
             <div
-                class={`bg-white rounded-md shadow-xl w-full ${SIZE_CLASS[size]} p-6 max-h-[90vh] overflow-y-auto`}
+                class={`bg-white dark:bg-slate-800 rounded-md shadow-xl w-full ${SIZE_CLASS[size]} p-6 max-h-[90vh] overflow-y-auto`}
                 {...(name ? { 'x-on:click.stop': '' } : { onclick: 'event.stopPropagation()' })}
             >
                 {!hideHeader && (
                     <header class="flex items-start justify-between gap-3 mb-4">
                         <div class="min-w-0 flex-1">
                             {titleExpr ? (
-                                <h2 class="text-lg font-bold text-slate-900 truncate" x-text={titleExpr} />
+                                <h2 class="text-lg font-bold text-slate-900 dark:text-slate-100 truncate" x-text={titleExpr} />
                             ) : title ? (
-                                <h2 class="text-lg font-bold text-slate-900 truncate">{title}</h2>
+                                <h2 class="text-lg font-bold text-slate-900 dark:text-slate-100 truncate">{title}</h2>
                             ) : null}
                             {subtitleExpr ? (
-                                <p class="text-sm text-slate-500 mt-0.5" x-text={subtitleExpr} />
+                                <p class="text-sm text-slate-500 dark:text-slate-400 mt-0.5" x-text={subtitleExpr} />
                             ) : subtitle ? (
-                                <p class="text-sm text-slate-500 mt-0.5">{subtitle}</p>
+                                <p class="text-sm text-slate-500 dark:text-slate-400 mt-0.5">{subtitle}</p>
                             ) : null}
                         </div>
                         {!hideClose && (
                             <button
                                 type="button"
                                 aria-label="Close dialog"
-                                class="w-8 h-8 rounded-xl bg-slate-100 hover:bg-slate-200 flex items-center justify-center text-slate-500 flex-shrink-0"
+                                class="w-8 h-8 rounded-xl bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 flex items-center justify-center text-slate-500 dark:text-slate-400 flex-shrink-0"
                                 {...(name ? { 'x-on:click': close } : { onclick: close })}
                             >
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -214,8 +214,7 @@ export const ModalFooter = ({
         <>
             <button
                 type="button"
-                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
-                style="border-color: #e2e8f0"
+                class="flex-1 h-10 px-4 rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                 {...cancelAttrs}
             >
                 {cancelText}

--- a/src/templates/components/network-pill.tsx
+++ b/src/templates/components/network-pill.tsx
@@ -24,7 +24,7 @@ export const NetworkPill = ({ isPublic = false }: NetworkPillProps = {}): JSX.El
         <button
             type="button"
             x-on:click="popoverOpen = !popoverOpen"
-            class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-white shadow-md ring-1 ring-slate-200 text-xs font-bold text-slate-700 hover:bg-slate-50"
+            class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-white dark:bg-slate-800 shadow-md ring-1 ring-slate-200 dark:ring-slate-600 text-xs font-bold text-slate-700 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700"
         >
             <span class="w-2 h-2 rounded-full" x-bind:class="dotClass"></span>
             <span x-text="label"></span>
@@ -32,22 +32,22 @@ export const NetworkPill = ({ isPublic = false }: NetworkPillProps = {}): JSX.El
         <div
             x-show="popoverOpen"
             {...{ 'x-on:click.outside': 'popoverOpen = false' }}
-            class="absolute right-0 top-full mt-2 w-72 bg-white rounded-xl shadow-xl ring-1 ring-slate-200 p-4 text-sm"
+            class="absolute right-0 top-full mt-2 w-72 bg-white dark:bg-slate-800 rounded-xl shadow-xl ring-1 ring-slate-200 dark:ring-slate-700 p-4 text-sm"
         >
             {/* Round 38 — replace 'Tier E — Android / Other' technical jargon
                 with a plain-English status line. Tier-specific guidance only
                 surfaces when actionable (offline, low-storage iOS device,
                 cap-approaching). When online with no pending changes there is
                 nothing for the user to do — show a single calm status only. */}
-            <div class="font-semibold text-slate-900 mb-2"
+            <div class="font-semibold text-slate-900 dark:text-slate-100 mb-2"
                  x-text="!online ? 'Working offline' : (pendingItems.length > 0 ? `Syncing ${pendingItems.length} change${pendingItems.length === 1 ? '' : 's'}` : 'All synced')">
             </div>
 
-            <div x-show="online && pendingItems.length === 0" class="text-xs text-slate-500">
+            <div x-show="online && pendingItems.length === 0" class="text-xs text-slate-500 dark:text-slate-400">
                 Your work auto-saves to this device and uploads automatically.
             </div>
 
-            <div x-show="!online" class="text-xs text-slate-600 mb-2">
+            <div x-show="!online" class="text-xs text-slate-600 dark:text-slate-400 mb-2">
                 Your work is being saved on this device. It will upload as soon
                 as you're back online.
             </div>
@@ -65,7 +65,7 @@ export const NetworkPill = ({ isPublic = false }: NetworkPillProps = {}): JSX.El
                 Tip: install this app from your browser menu so the device keeps your data permanently.
             </div>
 
-            <ul x-show="pendingItems.length > 0" class="space-y-2 max-h-60 overflow-y-auto mt-2 border-t border-slate-100 pt-2">
+            <ul x-show="pendingItems.length > 0" class="space-y-2 max-h-60 overflow-y-auto mt-2 border-t border-slate-100 dark:border-slate-700 pt-2">
                 <template x-for="it in pendingItems" {...{ 'x-bind:key': 'it.id' }}>
                     <li class="flex items-start justify-between gap-2 text-xs">
                         <span x-text="`${it.op} · ${new Date(it.createdAt).toLocaleTimeString()}`"></span>

--- a/src/templates/components/publish-modal.tsx
+++ b/src/templates/components/publish-modal.tsx
@@ -44,8 +44,7 @@ export const PublishModal = (): JSX.Element => (
                 <button
                     type="button"
                     x-on:click="showPublishModal = false"
-                    class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border bg-white hover:bg-slate-50 transition-all"
-                    style="border-color: #e2e8f0; color: #475569"
+                    class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-500 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                 >
                     Cancel
                 </button>
@@ -93,18 +92,17 @@ export const PublishModal = (): JSX.Element => (
             {/* Body — only when recipients are loaded */}
             <div x-show="!loadingRecipients && recipients.length > 0" style="display:none" class="space-y-4">
                 {/* Report summary card (same as before) */}
-                <div class="p-3 rounded-xl" style="background: #f1f5f9">
-                    <div class="text-xs font-mono" style="color: #475569">Report Summary</div>
+                <div class="p-3 rounded-xl bg-slate-100 dark:bg-slate-700/50">
+                    <div class="text-xs font-mono text-slate-500 dark:text-slate-400">Report Summary</div>
                     <div
-                        class="text-sm mt-1 font-semibold"
-                        style="color: #0f172a"
+                        class="text-sm mt-1 font-semibold text-slate-900 dark:text-slate-100"
                         x-text="reportStats.total + ' items  |  ' + reportStats.defect + ' defects  |  ' + reportStats.monitor + ' monitors'"
                     ></div>
                 </div>
 
                 {/* Send a copy of … radio */}
                 <div class="space-y-2">
-                    <div class="text-[10px] font-bold uppercase tracking-[0.2em]" style="color: #475569">
+                    <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
                         Send a copy of
                     </div>
                     <div class="flex gap-2" data-test="publish-payload-radio">
@@ -115,7 +113,7 @@ export const PublishModal = (): JSX.Element => (
                                 x-model="publishOptions.payload"
                                 class="peer sr-only"
                             />
-                            <div class="px-3 py-2 rounded-xl border text-sm font-semibold text-slate-600 peer-checked:bg-indigo-50 peer-checked:text-indigo-700 peer-checked:border-indigo-300 transition-all" style="border-color: #e2e8f0">
+                            <div class="px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-600 text-sm font-semibold text-slate-600 dark:text-slate-300 peer-checked:bg-indigo-50 dark:peer-checked:bg-indigo-900/30 peer-checked:text-indigo-700 dark:peer-checked:text-indigo-300 peer-checked:border-indigo-300 dark:peer-checked:border-indigo-600 transition-all">
                                 The report
                             </div>
                         </label>
@@ -126,7 +124,7 @@ export const PublishModal = (): JSX.Element => (
                                 x-model="publishOptions.payload"
                                 class="peer sr-only"
                             />
-                            <div class="px-3 py-2 rounded-xl border text-sm font-semibold text-slate-600 peer-checked:bg-indigo-50 peer-checked:text-indigo-700 peer-checked:border-indigo-300 transition-all" style="border-color: #e2e8f0">
+                            <div class="px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-600 text-sm font-semibold text-slate-600 dark:text-slate-300 peer-checked:bg-indigo-50 dark:peer-checked:bg-indigo-900/30 peer-checked:text-indigo-700 dark:peer-checked:text-indigo-300 peer-checked:border-indigo-300 dark:peer-checked:border-indigo-600 transition-all">
                                 The agreement
                             </div>
                         </label>
@@ -135,16 +133,16 @@ export const PublishModal = (): JSX.Element => (
 
                 {/* Recipients list */}
                 <div class="space-y-2" data-test="publish-recipient-list">
-                    <div class="grid grid-cols-[1fr_auto_auto] gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.2em]" style="color: #475569">
+                    <div class="grid grid-cols-[1fr_auto_auto] gap-3 px-1 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
                         <span>Recipient</span>
                         <span class="w-12 text-center">Email</span>
                         <span class="w-12 text-center">Text</span>
                     </div>
                     <template x-for="(r, idx) in recipients" {...{ 'x-bind:key': '(r.contactId || "client") + idx' }}>
-                        <div class="grid grid-cols-[1fr_auto_auto] gap-3 items-center px-3 py-2 rounded-xl border" style="border-color: #e2e8f0; background: #f8fafc">
+                        <div class="grid grid-cols-[1fr_auto_auto] gap-3 items-center px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700/40">
                             <div class="min-w-0">
                                 <div class="flex items-center gap-2">
-                                    <span class="text-sm font-semibold truncate" style="color: #0f172a" x-text="r.name"></span>
+                                    <span class="text-sm font-semibold truncate text-slate-900 dark:text-slate-100" x-text="r.name"></span>
                                     {Object.entries(ROLE_CHIP).map(([role, chip]) => (
                                         <span
                                             x-show={`r.role === '${role}'`}
@@ -155,7 +153,7 @@ export const PublishModal = (): JSX.Element => (
                                         </span>
                                     ))}
                                 </div>
-                                <div class="text-[11px] mt-0.5 truncate" style="color: #64748b">
+                                <div class="text-[11px] mt-0.5 truncate text-slate-500 dark:text-slate-400">
                                     <span x-show="r.email" x-text="r.email"></span>
                                     <span x-show="r.email && r.phone"> · </span>
                                     <span x-show="r.phone" x-text="r.phone"></span>

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -167,22 +167,22 @@ export const MainLayout = (props: {
                 gaMeasurementId={sanitizeGaId(branding)}
                 {...(extraHead ? { extraHead } : {})}
             />
-            <body class="bg-[#f8fafc] text-slate-900 antialiased min-h-screen" x-data="{ mobileMenu: false }">
+            <body class="bg-[#f8fafc] dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased min-h-screen" x-data="{ mobileMenu: false }">
                 {sandboxMode && <SandboxBanner />}
                 {/* Mobile Header Bar */}
-                <div class="lg:hidden sticky top-0 z-40 bg-white border-b border-slate-200 px-4 py-3 flex items-center justify-between">
+                <div class="lg:hidden sticky top-0 z-40 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700 px-4 py-3 flex items-center justify-between">
                     <div class="flex items-center gap-3">
                         <div class="w-8 h-8 flex-shrink-0">
                             <img src={logoUrl || '/logo.svg'} alt={siteName} class="w-full h-full object-contain" />
                         </div>
-                        <span class="text-lg font-extrabold text-slate-900 tracking-tight">{siteName}</span>
+                        <span class="text-lg font-extrabold text-slate-900 dark:text-slate-100 tracking-tight">{siteName}</span>
                     </div>
                     <div class="flex items-center gap-1">
-                        <a href="/notifications" class="relative flex items-center justify-center w-10 h-10 rounded-xl text-slate-500 hover:bg-slate-100 hover:text-indigo-600 transition-all" aria-label="Notifications">
+                        <a href="/notifications" class="relative flex items-center justify-center w-10 h-10 rounded-xl text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 transition-all" aria-label="Notifications">
                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg>
                             <span id="notifyUnreadBadgeMobile" class="hidden absolute -top-0.5 -right-0.5 px-1.5 min-w-[1.25rem] h-5 text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
                         </a>
-                        <button x-on:click="mobileMenu = true" class="p-2 rounded-xl text-slate-600 hover:bg-slate-100 hover:text-indigo-600 transition-colors" aria-label="Open menu">
+                        <button x-on:click="mobileMenu = true" class="p-2 rounded-xl text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 transition-colors" aria-label="Open menu">
                             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
                         </button>
                     </div>
@@ -193,34 +193,34 @@ export const MainLayout = (props: {
                     {/* Backdrop */}
                     <div x-show="mobileMenu" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" x-on:click="mobileMenu = false" class="absolute inset-0 bg-slate-900/50 backdrop-blur-sm"></div>
                     {/* Panel */}
-                    <div x-show="mobileMenu" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 -translate-x-full" x-transition:enter-end="opacity-100 translate-x-0" x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100 translate-x-0" x-transition:leave-end="opacity-0 -translate-x-full" class="relative w-80 max-w-[85vw] h-full bg-white shadow-2xl flex flex-col">
+                    <div x-show="mobileMenu" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 -translate-x-full" x-transition:enter-end="opacity-100 translate-x-0" x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100 translate-x-0" x-transition:leave-end="opacity-0 -translate-x-full" class="relative w-80 max-w-[85vw] h-full bg-white dark:bg-slate-900 shadow-2xl flex flex-col">
                         {/* Close header */}
-                        <div class="p-6 flex items-center justify-between border-b border-slate-100">
+                        <div class="p-6 flex items-center justify-between border-b border-slate-100 dark:border-slate-700">
                             <div class="flex items-center gap-3">
                                 <div class="w-9 h-9 flex-shrink-0">
                                     <img src={logoUrl || '/logo.svg'} alt={siteName} class="w-full h-full object-contain" />
                                 </div>
-                                <span class="text-xl font-extrabold text-slate-900 tracking-tight">{siteName}</span>
+                                <span class="text-xl font-extrabold text-slate-900 dark:text-slate-100 tracking-tight">{siteName}</span>
                             </div>
-                            <button x-on:click="mobileMenu = false" class="p-2 rounded-xl text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors" aria-label="Close menu">
+                            <button x-on:click="mobileMenu = false" class="p-2 rounded-xl text-slate-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300 transition-colors" aria-label="Close menu">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                             </button>
                         </div>
                         {/* Nav links */}
                         <nav class="flex-1 p-4 space-y-1 overflow-y-auto">
                             {/* Sprint 1 Sub-spec B Task 2 — mobile mirrors desktop IA. */}
-                            <a href="/dashboard" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                            <a href="/dashboard" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
                                 <span>Inspections</span>
                                 <span id="msgUnreadBadge" class="hidden ml-auto px-1.5 min-w-[1.25rem] text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
                             </a>
-                            <a href="/calendar" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                            <a href="/calendar" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
                                 <span>Calendar</span>
                             </a>
                             {/* Library group (mobile) — collapsible. */}
                             <details class="group [&>summary]:list-none" data-sidebar-library>
-                                <summary class="cursor-pointer flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                                <summary class="cursor-pointer flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
                                     <span class="flex-1">Library</span>
                                     <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
@@ -232,83 +232,83 @@ export const MainLayout = (props: {
                                     after Agreements which made customers think it was
                                     missing when the menu was reading-cut on small
                                     viewports. */}
-                                <div class="mt-1 ml-7 pl-3 border-l border-slate-100 space-y-0.5">
-                                    <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Inspection Templates</a>
-                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
-                                    <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Comments</a>
-                                    <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Repair Items</a>
-                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Tags</a>
-                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
+                                <div class="mt-1 ml-7 pl-3 border-l border-slate-100 dark:border-slate-700 space-y-0.5">
+                                    <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Inspection Templates</a>
+                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Marketplace</a>
+                                    <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Comments</a>
+                                    <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Repair Items</a>
+                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Tags</a>
+                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Agreements</a>
+                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Rating Systems</a>
                                 </div>
                             </details>
-                            <a href="/contacts" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                            <a href="/contacts" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                 <span>Contacts</span>
                             </a>
-                            <a href="/invoices" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                            <a href="/invoices" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
                                 <span>Invoices</span>
                             </a>
-                            <a href="/metrics" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                            <a href="/metrics" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
                                 <span>Metrics</span>
                             </a>
 
                             {/* handoff-decisions §5 — Settings group fully expanded as
                                 a flat sub-list. Section header has no chevron. */}
-                            <div class="pt-4 mt-4 border-t border-slate-100">
-                                <a href="/settings" class="block px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 hover:text-indigo-600">Settings</a>
+                            <div class="pt-4 mt-4 border-t border-slate-100 dark:border-slate-700">
+                                <a href="/settings" class="block px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500 hover:text-indigo-600">Settings</a>
                                 <div class="space-y-0">
-                                    <a href="/settings/profile" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Profile</a>
-                                    <a href="/settings/workspace/branding" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Branding</a>
-                                    <a href="/settings/workspace/theme" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Report Theme</a>
-                                    <a href="/settings/workspace/telemetry" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Telemetry</a>
-                                    <a href="/settings/catalog/services" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Services &amp; Pricing</a>
-                                    <a href="/settings/catalog/event-types" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Event Types</a>
-                                    <a href="/settings/catalog/widget" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Embed Widget</a>
-                                    <a href="/settings/communication/email" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Email</a>
-                                    <a href="/settings/communication/automations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Automations</a>
-                                    <a href="/settings/communication/calendar" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Apple Calendar</a>
-                                    <a href="/settings/communication/integrations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Integrations</a>
-                                    <a href="/settings/account/password" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Change Password</a>
-                                    <a href="/settings/account/security" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Two-factor (2FA)</a>
-                                    <a href="/settings/account/bot-protection" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Bot Protection</a>
-                                    <a href="/settings/advanced/payments" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Payments</a>
-                                    <a href="/settings/advanced/ai" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">AI</a>
-                                    <a href="/settings/advanced/data" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors font-medium">Data Import / Export</a>
+                                    <a href="/settings/profile" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Profile</a>
+                                    <a href="/settings/workspace/branding" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Branding</a>
+                                    <a href="/settings/workspace/theme" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Report Theme</a>
+                                    <a href="/settings/workspace/telemetry" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Telemetry</a>
+                                    <a href="/settings/catalog/services" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Services &amp; Pricing</a>
+                                    <a href="/settings/catalog/event-types" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Event Types</a>
+                                    <a href="/settings/catalog/widget" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Embed Widget</a>
+                                    <a href="/settings/communication/email" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Email</a>
+                                    <a href="/settings/communication/automations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Automations</a>
+                                    <a href="/settings/communication/calendar" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Apple Calendar</a>
+                                    <a href="/settings/communication/integrations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Integrations</a>
+                                    <a href="/settings/account/password" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Change Password</a>
+                                    <a href="/settings/account/security" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Two-factor (2FA)</a>
+                                    <a href="/settings/account/bot-protection" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Bot Protection</a>
+                                    <a href="/settings/advanced/payments" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Payments</a>
+                                    <a href="/settings/advanced/ai" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">AI</a>
+                                    <a href="/settings/advanced/data" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Data Import / Export</a>
                                 </div>
                             </div>
                         </nav>
                         {/* Bottom section */}
-                        <div class="p-4 border-t border-slate-100 bg-slate-50/50 space-y-1">
+                        <div class="p-4 border-t border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/20 space-y-1">
                             <div x-data="themeMenu()" class="relative" {...{'x-on:click.outside': 'open = false'}}>
-                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 hover:bg-slate-100 hover:text-indigo-600 transition-all font-semibold" aria-label="Color scheme">
+                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold" aria-label="Color scheme">
                                     <svg id="mobileThemeMoonIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                                     <svg id="mobileThemeSunIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
                                     <svg id="mobileThemeAutoIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                                     <span id="mobileThemeLabel" class="flex-1 text-left text-sm">Auto</span>
                                     <svg class="w-3.5 h-3.5 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                                 </button>
-                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white border border-slate-200 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
-                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
+                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                                         <span class="flex-1 text-left">Auto</span>
                                         <svg x-show="mode === 'auto'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
-                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                                         <span class="flex-1 text-left">Dark</span>
                                         <svg x-show="mode === 'dark'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
-                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
                                         <span class="flex-1 text-left">Light</span>
                                         <svg x-show="mode === 'light'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
                                 </div>
                             </div>
-                            <button id="mobileLogoutBtn" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-red-600 hover:bg-red-50 transition-all font-semibold">
+                            <button id="mobileLogoutBtn" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all font-semibold">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
                                 <span>Sign Out</span>
                             </button>
@@ -318,13 +318,13 @@ export const MainLayout = (props: {
 
                 <div class="flex min-h-screen">
                     {/* Sidebar / Navigation */}
-                    <aside class="w-72 bg-white border-r border-slate-200 hidden lg:flex flex-col sticky top-0 h-screen">
-                        <div class="p-8 flex items-center gap-4 border-b border-slate-100">
+                    <aside class="w-72 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 hidden lg:flex flex-col sticky top-0 h-screen">
+                        <div class="p-8 flex items-center gap-4 border-b border-slate-100 dark:border-slate-700">
                             <div class="w-10 h-10 flex-shrink-0">
                                 <img src={logoUrl || '/logo.svg'} alt={siteName} class="w-full h-full object-contain" />
                             </div>
-                            <span class="text-xl font-extrabold text-slate-900 tracking-tight leading-tight">{siteName}</span>
-                            <a href="/notifications" class="ml-auto relative flex items-center justify-center w-10 h-10 rounded-xl text-slate-500 hover:bg-slate-100 hover:text-indigo-600 transition-all" aria-label="Notifications">
+                            <span class="text-xl font-extrabold text-slate-900 dark:text-slate-100 tracking-tight leading-tight">{siteName}</span>
+                            <a href="/notifications" class="ml-auto relative flex items-center justify-center w-10 h-10 rounded-xl text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 transition-all" aria-label="Notifications">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg>
                                 <span id="notifyUnreadBadge" class="hidden absolute -top-0.5 -right-0.5 px-1.5 min-w-[1.25rem] h-5 text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
                             </a>
@@ -339,23 +339,23 @@ export const MainLayout = (props: {
                                 id="oi-cmdk-trigger"
                                 x-data="{ isMac: navigator.platform?.startsWith('Mac') }"
                                 x-on:click="window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }))"
-                                class="w-full flex items-center gap-3 px-5 py-3 mb-2 rounded-2xl bg-slate-50 hover:bg-slate-100 text-slate-500 hover:text-slate-700 transition-all border border-slate-200/60 group"
+                                class="w-full flex items-center gap-3 px-5 py-3 mb-2 rounded-2xl bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-all border border-slate-200/60 dark:border-slate-700/60 group"
                                 aria-label="Open command palette"
                             >
                                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z"></path></svg>
                                 <span class="text-sm font-medium">Search…</span>
-                                <kbd class="ml-auto px-1.5 py-0.5 bg-white border border-slate-200 rounded text-[10px] font-mono text-slate-500 group-hover:border-slate-300" x-text="isMac ? '⌘K' : 'Ctrl /'">⌘K</kbd>
+                                <kbd class="ml-auto px-1.5 py-0.5 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded text-[10px] font-mono text-slate-500 dark:text-slate-400 group-hover:border-slate-300" x-text="isMac ? '⌘K' : 'Ctrl /'">⌘K</kbd>
                             </button>
                             {/* Sprint 1 Sub-spec B Task 2 — IA: 5 顶级 + Library + Settings.
                                 Order: Inspections / Calendar / Library / Contacts / Invoices / Metrics.
                                 Library group uses semantic <details> (auto-expand handled inline below).
                                 Reports merged into Inspections (Recent reports bucket on dashboard).
                                 Team relocated under Settings. */}
-                            <a href="/dashboard" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group relative">
+                            <a href="/dashboard" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group relative">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
                                 <span>Inspections</span>
                             </a>
-                            <a href="/calendar" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">
+                            <a href="/calendar" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
                                 <span>Calendar</span>
                             </a>
@@ -363,76 +363,76 @@ export const MainLayout = (props: {
                                 via the activate-sidebar script (sets `open` when current
                                 path starts with any Library route). */}
                             <details class="group [&>summary]:list-none" data-sidebar-library>
-                                <summary class="cursor-pointer flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold">
+                                <summary class="cursor-pointer flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
                                     <span class="flex-1">Library</span>
                                     <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
                                 </summary>
                                 {/* Iter-2 bug #8 — canonical Library order, kept in
                                     sync with the mobile drawer above. */}
-                                <div class="mt-1 ml-7 pl-3 border-l border-slate-100 space-y-0.5">
-                                    <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Inspection Templates</a>
-                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Marketplace</a>
-                                    <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Comments</a>
-                                    <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Repair Items</a>
-                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Tags</a>
-                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Agreements</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-colors">Rating Systems</a>
+                                <div class="mt-1 ml-7 pl-3 border-l border-slate-100 dark:border-slate-700 space-y-0.5">
+                                    <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Inspection Templates</a>
+                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Marketplace</a>
+                                    <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Comments</a>
+                                    <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Repair Items</a>
+                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Tags</a>
+                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Agreements</a>
+                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Rating Systems</a>
                                 </div>
                             </details>
-                            <a href="/contacts" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">
+                            <a href="/contacts" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                 <span>Contacts</span>
                             </a>
-                            <a href="/invoices" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">
+                            <a href="/invoices" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
                                 <span>Invoices</span>
                             </a>
-                            <a href="/metrics" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-slate-50 hover:text-indigo-600 transition-all font-semibold group">
+                            <a href="/metrics" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
                                 <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
                                 <span>Metrics</span>
                             </a>
                         </nav>
 
-                        <div class="p-6 border-t border-slate-100 bg-slate-50/50">
-                             <a href="/settings" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-white hover:text-indigo-600 hover:shadow-sm transition-all font-semibold group">
+                        <div class="p-6 border-t border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/20">
+                             <a href="/settings" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-white dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:shadow-sm transition-all font-semibold group">
                                 <svg class="w-5 h-5 group-hover:rotate-45 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 002.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                 <span>Settings</span>
                             </a>
                             <div x-data="themeMenu()" class="relative mt-2" {...{'x-on:click.outside': 'open = false'}}>
-                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 hover:bg-white hover:text-indigo-600 hover:shadow-sm transition-all font-semibold group" aria-label="Color scheme">
+                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-white dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:shadow-sm transition-all font-semibold group" aria-label="Color scheme">
                                     <svg id="themeMoonIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                                     <svg id="themeSunIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
                                     <svg id="themeAutoIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                                     <span id="themeToggleLabel" class="flex-1 text-left text-sm">Auto</span>
                                     <svg class="w-3.5 h-3.5 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                                 </button>
-                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white border border-slate-200 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
-                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
+                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                                         <span class="flex-1 text-left">Auto</span>
                                         <svg x-show="mode === 'auto'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
-                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                                         <span class="flex-1 text-left">Dark</span>
                                         <svg x-show="mode === 'dark'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
-                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-indigo-600 transition-colors">
+                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
                                         <span class="flex-1 text-left">Light</span>
                                         <svg x-show="mode === 'light'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
                                 </div>
                             </div>
-                            <button id="logoutBtn" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-red-600 hover:bg-red-50 transition-all font-semibold group mt-2">
+                            <button id="logoutBtn" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all font-semibold group mt-2">
                                 <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
                                 <span>Sign Out</span>
                             </button>
                         </div>
                     </aside>
 
-                    <main class="md:flex-1 w-full bg-[#f8fafc] overflow-y-auto">
+                    <main class="md:flex-1 w-full bg-[#f8fafc] dark:bg-slate-900 overflow-y-auto">
                         <div class="max-w-7xl mx-auto py-10 px-6 sm:px-8 lg:px-12">
                             {children}
                         </div>
@@ -442,27 +442,37 @@ export const MainLayout = (props: {
                     (function() {
                         var p = location.pathname;
                         var firstActive = null;
-                        document.querySelectorAll('aside a[href], nav a[href]').forEach(function(a) {
-                            if (a.getAttribute('href') === p || (a.getAttribute('href') === '/dashboard' && p === '/')) {
-                                a.classList.add('bg-indigo-50', 'text-indigo-600');
-                                a.classList.remove('text-slate-600');
-                                if (!firstActive) firstActive = a;
-                            }
-                        });
-                        // Sub-spec B Task 2 — auto-expand the Library <details>
-                        // when the current path lives in any Library sub-route.
+                        function applyHighlight() {
+                            var isDark = document.documentElement.getAttribute('data-color-scheme') === 'dark';
+                            document.querySelectorAll('aside a[href], nav a[href]').forEach(function(a) {
+                                if (a.closest('nav[role="tablist"]')) return;
+                                var isActive = a.getAttribute('href') === p || (a.getAttribute('href') === '/dashboard' && p === '/');
+                                a.classList.remove('bg-indigo-50', 'text-indigo-600', 'bg-slate-700', 'text-white');
+                                if (isActive) {
+                                    if (isDark) {
+                                        a.classList.add('bg-slate-700', 'text-white');
+                                    } else {
+                                        a.classList.add('bg-indigo-50', 'text-indigo-600');
+                                    }
+                                    a.classList.remove('text-slate-600');
+                                    if (!firstActive) firstActive = a;
+                                }
+                            });
+                        }
+                        applyHighlight();
+                        new MutationObserver(function() { applyHighlight(); }).observe(
+                            document.documentElement,
+                            { attributes: true, attributeFilter: ['data-color-scheme'] }
+                        );
                         var libraryRoutes = ['/templates', '/comments', '/recommendations', '/agreements', '/marketplace', '/library/'];
                         var inLibrary = libraryRoutes.some(function(r) { return p.indexOf(r) === 0; });
                         if (inLibrary) {
                             document.querySelectorAll('details[data-sidebar-library]').forEach(function(d) { d.open = true; });
                         }
-                        // handoff-decisions §6 — bring the active sub-item into view
-                        // inside the sidebar's overflow-y:auto scroll region.
                         if (firstActive && typeof firstActive.scrollIntoView === 'function') {
                             try {
                                 firstActive.scrollIntoView({ block: 'nearest', behavior: 'instant' });
                             } catch (e) {
-                                // 'instant' lands on older browsers; fall back to non-smooth.
                                 firstActive.scrollIntoView({ block: 'nearest' });
                             }
                         }

--- a/src/templates/pages/agreements.tsx
+++ b/src/templates/pages/agreements.tsx
@@ -30,10 +30,10 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
 
                 {/* Tabs: Templates / Signing Requests (Spec 5H P2) */}
                 <div x-data="{ tab: 'templates', requests: [], reqLoading: false, async loadRequests() { if (this.requests.length) return; this.reqLoading = true; try { const r = await authFetch('/api/admin/agreements/requests'); const j = await r.json(); this.requests = j.data?.requests || []; } finally { this.reqLoading = false; } } }" class="flex-1 flex flex-col">
-                    <div class="flex items-center gap-1 mb-4 border-b border-slate-200">
-                        <button x-on:click="tab = 'templates'" x-bind:class="tab === 'templates' ? 'border-indigo-600 text-indigo-600' : 'border-transparent text-slate-500 hover:text-slate-700'"
+                    <div class="flex items-center gap-1 mb-4 border-b border-slate-200 dark:border-slate-700">
+                        <button x-on:click="tab = 'templates'" x-bind:class="tab === 'templates' ? 'border-indigo-600 text-indigo-600' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'"
                             class="px-4 py-2 text-sm font-semibold border-b-2 transition-colors">Templates</button>
-                        <button x-on:click="tab = 'requests'; loadRequests()" x-bind:class="tab === 'requests' ? 'border-indigo-600 text-indigo-600' : 'border-transparent text-slate-500 hover:text-slate-700'"
+                        <button x-on:click="tab = 'requests'; loadRequests()" x-bind:class="tab === 'requests' ? 'border-indigo-600 text-indigo-600' : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'"
                             class="px-4 py-2 text-sm font-semibold border-b-2 transition-colors">Signing Requests</button>
                     </div>
 
@@ -42,14 +42,14 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                         <div class="overflow-x-auto flex-1">
                             <table class="min-w-full h-full">
                                 <thead>
-                                    <tr class="bg-slate-50/50">
-                                        <th scope="col" class="py-6 pl-10 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Agreement Name</th>
-                                        <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Version</th>
-                                        <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Effective Date</th>
+                                    <tr class="bg-slate-50/50 dark:bg-slate-700/50">
+                                        <th scope="col" class="py-6 pl-10 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Agreement Name</th>
+                                        <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Version</th>
+                                        <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Effective Date</th>
                                         <th scope="col" class="relative py-6 pl-3 pr-10"><span class="sr-only">Actions</span></th>
                                     </tr>
                                 </thead>
-                                <tbody id="agreementsList" class="divide-y divide-slate-100">
+                                <tbody id="agreementsList" class="divide-y divide-slate-100 dark:divide-slate-700">
                                     <tr id="loadingRow">
                                         <td colspan={4} class="py-32 text-center">
                                             <div class="flex flex-col items-center gap-4">
@@ -68,7 +68,7 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                         <div class="overflow-x-auto flex-1">
                             <table class="min-w-full">
                                 <thead>
-                                    <tr class="bg-slate-50/50">
+                                    <tr class="bg-slate-50/50 dark:bg-slate-700/50">
                                         <th class="py-4 pl-6 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Client</th>
                                         <th class="px-4 py-4 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Agreement</th>
                                         <th class="px-4 py-4 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Status</th>
@@ -77,16 +77,16 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                                         <th class="px-4 py-4 pr-6"><span class="sr-only">Actions</span></th>
                                     </tr>
                                 </thead>
-                                <tbody class="divide-y divide-slate-100">
+                                <tbody class="divide-y divide-slate-100 dark:divide-slate-700">
                                     <tr x-show="reqLoading"><td colspan={6} class="py-16 text-center text-sm text-slate-400 italic">Loading…</td></tr>
                                     <tr x-show="!reqLoading && requests.length === 0"><td colspan={6} class="py-16 text-center text-sm text-slate-400 italic">No signing requests yet. Use a template's "Send" action.</td></tr>
                                     <template x-for="r in requests" x-bind:key="r.id">
-                                        <tr class="hover:bg-slate-50/50">
+                                        <tr class="hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
                                             <td class="py-3 pl-6 pr-3 text-sm">
-                                                <div class="font-semibold text-slate-900" x-text="r.clientName || '—'"></div>
-                                                <div class="text-[11px] text-slate-500" x-text="r.clientEmail"></div>
+                                                <div class="font-semibold text-slate-900 dark:text-slate-100" x-text="r.clientName || '—'"></div>
+                                                <div class="text-[11px] text-slate-500 dark:text-slate-400" x-text="r.clientEmail"></div>
                                             </td>
-                                            <td class="px-4 py-3 text-sm text-slate-700" x-text="r.agreementName || '—'"></td>
+                                            <td class="px-4 py-3 text-sm text-slate-700 dark:text-slate-300" x-text="r.agreementName || '—'"></td>
                                             <td class="px-4 py-3">
                                                 <span class="ih-pill"
                                                     x-bind:style="r.status === 'signed' ? 'background:#dcfce7;color:#15803d' : (r.status === 'declined' ? 'background:#fee2e2;color:#b91c1c' : (r.status === 'viewed' ? 'background:#dbeafe;color:#1d4ed8' : 'background:#fef3c7;color:#b45309'))"
@@ -124,14 +124,14 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                 >
                     <header class="flex items-start justify-between gap-3 mb-4">
                         <div class="min-w-0 flex-1">
-                            <h2 id="modalAgreementTitle" class="text-lg font-bold text-slate-900">Create Professional Agreement</h2>
-                            <p class="text-sm text-slate-500 mt-0.5">Draft a new service agreement or liability waiver.</p>
+                            <h2 id="modalAgreementTitle" class="text-lg font-bold text-slate-900 dark:text-slate-100">Create Professional Agreement</h2>
+                            <p class="text-sm text-slate-500 dark:text-slate-400 mt-0.5">Draft a new service agreement or liability waiver.</p>
                         </div>
                         <button
                             type="button"
                             aria-label="Close dialog"
                             onclick="closeModal()"
-                            class="w-8 h-8 rounded-xl bg-slate-100 hover:bg-slate-200 flex items-center justify-center text-slate-500 flex-shrink-0"
+                            class="w-8 h-8 rounded-xl bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 flex items-center justify-center text-slate-500 dark:text-slate-300 flex-shrink-0"
                         >
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
                         </button>
@@ -141,12 +141,12 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                         <div class="space-y-2">
                             <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Agreement Name</label>
                             <input type="text" id="agreementName" placeholder="e.g., Standard Home Inspection Version 2.0"
-                                class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                                class="w-full px-3 py-2 rounded-md border border-slate-200 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                         </div>
                         <div class="space-y-2">
                             <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Legal Content (Rich Text)</label>
                             <link rel="stylesheet" href="/vendor/quill/quill.snow.css" />
-                            <div class="rounded-md border-2 border-slate-100 focus-within:border-indigo-600 focus-within:ring-4 focus-within:ring-indigo-50 transition-all overflow-hidden bg-white">
+                            <div class="rounded-md border-2 border-slate-100 dark:border-slate-600 focus-within:border-indigo-600 focus-within:ring-4 focus-within:ring-indigo-50 transition-all overflow-hidden bg-white dark:bg-slate-800">
                                 <div id="agreementEditor" style="min-height: 280px; font-size: 15px;"></div>
                             </div>
                             <input type="hidden" id="agreementContent" />
@@ -174,11 +174,11 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                     <div class="space-y-4">
                         <div>
                             <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Email *</label>
-                            <input type="email" id="sendClientEmail" placeholder="client@example.com" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                            <input type="email" id="sendClientEmail" placeholder="client@example.com" class="w-full px-3 py-2 rounded-md border border-slate-200 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                         </div>
                         <div>
                             <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Client Name</label>
-                            <input type="text" id="sendClientName" placeholder="John Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
+                            <input type="text" id="sendClientName" placeholder="John Smith" class="w-full px-3 py-2 rounded-md border border-slate-200 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all font-medium text-sm" />
                         </div>
                     </div>
                 </Modal>

--- a/src/templates/pages/comments.tsx
+++ b/src/templates/pages/comments.tsx
@@ -36,7 +36,7 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                 <template x-for="b in bucketTabs" {...{ 'x-bind:key': 'b.value' }}>
                     <button
                         x-on:click="setBucket(b.value)"
-                        x-bind:class="bucket === b.value ? 'bg-indigo-600 text-white shadow' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'"
+                        x-bind:class="bucket === b.value ? 'bg-indigo-600 text-white shadow' : 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600'"
                         class="px-3 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wide transition"
                         x-text="b.label"
                     ></button>
@@ -44,13 +44,13 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
             </div>
 
             <div class="flex gap-3 flex-wrap">
-                <select x-model="categoryFilter" x-on:change="reload()" class="px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                <select x-model="categoryFilter" x-on:change="reload()" class="px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-100 text-sm">
                     <option value="">All categories</option>
                     <template x-for="cat in distinctCategories" {...{ 'x-bind:key': 'cat' }}>
                         <option x-bind:value="cat" x-text="cat"></option>
                     </template>
                 </select>
-                <select x-model="sectionFilter" x-on:change="reload()" class="px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                <select x-model="sectionFilter" x-on:change="reload()" class="px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-100 text-sm">
                     <option value="">All sections</option>
                     <template x-for="s in distinctSections" {...{ 'x-bind:key': 's' }}>
                         <option x-bind:value="s" x-text="s"></option>
@@ -58,14 +58,14 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                 </select>
             </div>
 
-            <div x-show="items.length === 0 && !loading" class="text-center py-12 bg-slate-50 rounded-md">
-                <p class="text-slate-500 font-semibold">No comments yet.</p>
-                <p class="text-slate-400 text-sm mt-2">Click "+ Add comment" above to create your first comment snippet.</p>
+            <div x-show="items.length === 0 && !loading" class="text-center py-12 bg-slate-50 dark:bg-slate-700/30 rounded-md">
+                <p class="text-slate-500 dark:text-slate-400 font-semibold">No comments yet.</p>
+                <p class="text-slate-400 dark:text-slate-500 text-sm mt-2">Click "+ Add comment" above to create your first comment snippet.</p>
             </div>
 
             <div x-show="items.length > 0" class="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <template x-for="comment in items" {...{ 'x-bind:key': 'comment.id' }}>
-                    <div class="p-4 bg-white border border-slate-200 rounded-lg shadow-sm hover:shadow-md transition">
+                    <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-sm hover:shadow-md transition">
                         <div class="flex items-start justify-between gap-3">
                             <div class="flex-1 min-w-0">
                                 <div class="flex items-center gap-2 mb-1 flex-wrap">
@@ -79,10 +79,10 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                                         x-bind:class="comment.ratingBucket === 'satisfactory' ? 'ih-pill--sat' : comment.ratingBucket === 'monitor' ? 'ih-pill--monitor' : comment.ratingBucket === 'defect' ? 'ih-pill--defect' : 'ih-pill--gen'"
                                         x-text="comment.ratingBucket ? comment.ratingBucket : 'general'"
                                     ></span>
-                                    <span x-show="comment.section" class="text-[10px] font-bold uppercase tracking-wide text-slate-500" x-text="comment.section"></span>
-                                    <span x-show="comment.category" class="text-[10px] text-slate-400" x-text="'· ' + comment.category"></span>
+                                    <span x-show="comment.section" class="text-[10px] font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400" x-text="comment.section"></span>
+                                    <span x-show="comment.category" class="text-[10px] text-slate-400 dark:text-slate-500" x-text="'· ' + comment.category"></span>
                                 </div>
-                                <p class="text-sm text-slate-700 line-clamp-3" x-text="comment.text"></p>
+                                <p class="text-sm text-slate-700 dark:text-slate-300 line-clamp-3" x-text="comment.text"></p>
                             </div>
                             <div class="flex flex-col gap-1 flex-shrink-0">
                                 <button x-on:click="openEdit(comment)" class="text-xs text-indigo-600 hover:underline">Edit</button>
@@ -112,8 +112,8 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                 <div class="space-y-3">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                         <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Rating bucket</label>
-                            <select x-model="form.ratingBucket" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm bg-white">
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Rating bucket</label>
+                            <select x-model="form.ratingBucket" class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-700 dark:text-slate-100">
                                 <option value="">Unspecified</option>
                                 <option value="satisfactory">Satisfactory</option>
                                 <option value="monitor">Monitor</option>
@@ -122,14 +122,14 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                             <p class="text-[10px] text-slate-400 mt-1">Determines which tab it appears under in the Library drawer.</p>
                         </div>
                         <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Section</label>
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Section</label>
                             <input
                                 type="text"
                                 list="commentSectionOptions"
                                 x-model="form.section"
                                 placeholder="e.g., Roof"
                                 autocomplete="off"
-                                class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"
+                                class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 text-sm"
                             />
                             <datalist id="commentSectionOptions">
                                 <template x-for="s in distinctSections" {...{ 'x-bind:key': 's' }}>
@@ -140,14 +140,14 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                         </div>
                     </div>
                     <div>
-                        <label class="block text-xs font-bold text-slate-600 mb-1">Category</label>
+                        <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Category</label>
                         <input
                             type="text"
                             list="commentCategoryOptions"
                             x-model="form.category"
                             placeholder="e.g., Roof"
                             autocomplete="off"
-                            class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"
+                            class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 text-sm"
                         />
                         <datalist id="commentCategoryOptions">
                             <template x-for="cat in distinctCategories" {...{ 'x-bind:key': 'cat' }}>
@@ -157,8 +157,8 @@ export const CommentsPage = ({ branding }: Props): JSX.Element => (
                         <p class="text-[10px] text-slate-400 mt-1">Optional free-text label, kept for backward compat.</p>
                     </div>
                     <div>
-                        <label class="block text-xs font-bold text-slate-600 mb-1">Comment text</label>
-                        <textarea x-model="form.text" required rows={4} placeholder="e.g., Evidence of previous repair was observed." class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
+                        <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Comment text</label>
+                        <textarea x-model="form.text" required rows={4} placeholder="e.g., Evidence of previous repair was observed." class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 text-sm"></textarea>
                     </div>
                 </div>
             </Modal>

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -392,7 +392,7 @@ export const DashboardPage = ({ branding }: { branding?: BrandingConfig | undefi
 
                     {/* Empty state */}
                     <div x-show="!loading && allBucketsEmpty" {...{ 'x-cloak': true }} class="text-center py-10 text-slate-400">
-                        <div class="w-20 h-20 rounded-lg bg-indigo-50 flex items-center justify-center mx-auto mb-4">
+                        <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center mx-auto mb-4">
                             <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path></svg>
                         </div>
                         <p class="text-sm">No inspections yet. Create one above to get started.</p>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -57,7 +57,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             background-image: radial-gradient(circle, #cbd5e1 0.6px, transparent 0.6px);
             background-size: 20px 20px;
           }
-          .dark .editor-canvas {
+          [data-color-scheme="dark"] .editor-canvas {
             background: #0f172a;
             background-image: radial-gradient(circle, #334155 0.6px, transparent 0.6px);
             background-size: 20px 20px;
@@ -67,7 +67,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             backdrop-filter: blur(16px) saturate(1.5);
             border-bottom: 1px solid rgba(226,232,240,0.6);
           }
-          .dark .mobile-sticky-hdr {
+          [data-color-scheme="dark"] .mobile-sticky-hdr {
             background: rgba(15,23,42,0.92);
             border-bottom-color: rgba(51,65,85,0.6);
           }
@@ -78,7 +78,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             border-left: 3px solid transparent;
             touch-action: manipulation;
           }
-          .dark .item-card {
+          [data-color-scheme="dark"] .item-card {
             background: rgba(30,41,59,0.85);
             border-color: rgba(51,65,85,0.7);
           }
@@ -88,7 +88,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             border-top: 1px solid rgba(226,232,240,0.6);
             padding-bottom: max(12px, env(safe-area-inset-bottom));
           }
-          .dark .mobile-bottom-bar {
+          [data-color-scheme="dark"] .mobile-bottom-bar {
             background: rgba(15,23,42,0.92);
             border-top-color: rgba(51,65,85,0.6);
           }
@@ -97,7 +97,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             backdrop-filter: blur(12px);
             border-color: rgba(226,232,240,0.6);
           }
-          .dark .sidebar-glass {
+          [data-color-scheme="dark"] .sidebar-glass {
             background: rgba(15,23,42,0.80);
             border-color: rgba(51,65,85,0.6);
           }
@@ -106,7 +106,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             backdrop-filter: blur(16px) saturate(1.5);
             border-bottom: 1px solid rgba(226,232,240,0.6);
           }
-          .dark .toolbar-glass {
+          [data-color-scheme="dark"] .toolbar-glass {
             background: rgba(15,23,42,0.92);
             border-bottom-color: rgba(51,65,85,0.6);
           }
@@ -114,7 +114,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             background: #ffffff;
             box-shadow: 0 -8px 32px rgba(0,0,0,0.15);
           }
-          .dark .quick-rating-sheet {
+          [data-color-scheme="dark"] .quick-rating-sheet {
             background: #1e293b;
             box-shadow: 0 -8px 32px rgba(0,0,0,0.40);
           }
@@ -123,7 +123,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             border-color: #e2e8f0;
             color: #0f172a;
           }
-          .dark .item-notes-textarea {
+          [data-color-scheme="dark"] .item-notes-textarea {
             background: #1e293b;
             border-color: #475569;
             color: #e2e8f0;
@@ -132,20 +132,20 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             border-color: #e2e8f0;
             background: rgba(255,255,255,0.6);
           }
-          .dark .canned-comments-wrap {
+          [data-color-scheme="dark"] .canned-comments-wrap {
             border-color: #475569;
             background: rgba(30,41,59,0.6);
           }
           .canned-tab-border {
             border-color: #e2e8f0;
           }
-          .dark .canned-tab-border {
+          [data-color-scheme="dark"] .canned-tab-border {
             border-color: #475569;
           }
           .inline-input {
             border-color: #e2e8f0;
           }
-          .dark .inline-input {
+          [data-color-scheme="dark"] .inline-input {
             background: #1e293b;
             border-color: #475569;
             color: #e2e8f0;
@@ -154,7 +154,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             border-color: #e2e8f0;
             color: #475569;
           }
-          .dark .inline-select {
+          [data-color-scheme="dark"] .inline-select {
             background: #1e293b;
             border-color: #475569;
             color: #e2e8f0;
@@ -162,7 +162,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
           .status-bar {
             border-color: rgba(226,232,240,0.6);
           }
-          .dark .status-bar {
+          [data-color-scheme="dark"] .status-bar {
             background: #1e293b;
             border-color: rgba(51,65,85,0.6);
           }

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -50,6 +50,122 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
           .hide-scrollbar::-webkit-scrollbar { display: none; }
           .hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
           [x-cloak] { display: none !important; }
+
+          /* Dark mode — inline-style elements that Tailwind cannot reach */
+          .editor-canvas {
+            background: #f8fafc;
+            background-image: radial-gradient(circle, #cbd5e1 0.6px, transparent 0.6px);
+            background-size: 20px 20px;
+          }
+          .dark .editor-canvas {
+            background: #0f172a;
+            background-image: radial-gradient(circle, #334155 0.6px, transparent 0.6px);
+            background-size: 20px 20px;
+          }
+          .mobile-sticky-hdr {
+            background: rgba(255,255,255,0.85);
+            backdrop-filter: blur(16px) saturate(1.5);
+            border-bottom: 1px solid rgba(226,232,240,0.6);
+          }
+          .dark .mobile-sticky-hdr {
+            background: rgba(15,23,42,0.92);
+            border-bottom-color: rgba(51,65,85,0.6);
+          }
+          .item-card {
+            background: rgba(255,255,255,0.85);
+            backdrop-filter: blur(16px) saturate(1.5);
+            border: 1px solid rgba(255,255,255,0.7);
+            border-left: 3px solid transparent;
+            touch-action: manipulation;
+          }
+          .dark .item-card {
+            background: rgba(30,41,59,0.85);
+            border-color: rgba(51,65,85,0.7);
+          }
+          .mobile-bottom-bar {
+            background: rgba(255,255,255,0.90);
+            backdrop-filter: blur(16px);
+            border-top: 1px solid rgba(226,232,240,0.6);
+            padding-bottom: max(12px, env(safe-area-inset-bottom));
+          }
+          .dark .mobile-bottom-bar {
+            background: rgba(15,23,42,0.92);
+            border-top-color: rgba(51,65,85,0.6);
+          }
+          .sidebar-glass {
+            background: rgba(255,255,255,0.6);
+            backdrop-filter: blur(12px);
+            border-color: rgba(226,232,240,0.6);
+          }
+          .dark .sidebar-glass {
+            background: rgba(15,23,42,0.80);
+            border-color: rgba(51,65,85,0.6);
+          }
+          .toolbar-glass {
+            background: rgba(255,255,255,0.85);
+            backdrop-filter: blur(16px) saturate(1.5);
+            border-bottom: 1px solid rgba(226,232,240,0.6);
+          }
+          .dark .toolbar-glass {
+            background: rgba(15,23,42,0.92);
+            border-bottom-color: rgba(51,65,85,0.6);
+          }
+          .quick-rating-sheet {
+            background: #ffffff;
+            box-shadow: 0 -8px 32px rgba(0,0,0,0.15);
+          }
+          .dark .quick-rating-sheet {
+            background: #1e293b;
+            box-shadow: 0 -8px 32px rgba(0,0,0,0.40);
+          }
+          .item-notes-textarea {
+            background: #f1f5f9;
+            border-color: #e2e8f0;
+            color: #0f172a;
+          }
+          .dark .item-notes-textarea {
+            background: #1e293b;
+            border-color: #475569;
+            color: #e2e8f0;
+          }
+          .canned-comments-wrap {
+            border-color: #e2e8f0;
+            background: rgba(255,255,255,0.6);
+          }
+          .dark .canned-comments-wrap {
+            border-color: #475569;
+            background: rgba(30,41,59,0.6);
+          }
+          .canned-tab-border {
+            border-color: #e2e8f0;
+          }
+          .dark .canned-tab-border {
+            border-color: #475569;
+          }
+          .inline-input {
+            border-color: #e2e8f0;
+          }
+          .dark .inline-input {
+            background: #1e293b;
+            border-color: #475569;
+            color: #e2e8f0;
+          }
+          .inline-select {
+            border-color: #e2e8f0;
+            color: #475569;
+          }
+          .dark .inline-select {
+            background: #1e293b;
+            border-color: #475569;
+            color: #e2e8f0;
+          }
+          .status-bar {
+            border-color: rgba(226,232,240,0.6);
+          }
+          .dark .status-bar {
+            background: #1e293b;
+            border-color: rgba(51,65,85,0.6);
+          }
         ` }} />
       </>
     ),
@@ -63,7 +179,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
       <nav
         role="tablist"
         aria-label="Inspection sections"
-        class="sticky top-0 z-[60] bg-white border-b border-slate-200 print:hidden"
+        class="sticky top-0 z-[60] bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700 print:hidden"
       >
         <div class="max-w-full mx-auto px-4 flex items-center gap-1 overflow-x-auto hide-scrollbar">
           <a
@@ -71,19 +187,19 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             role="tab"
             aria-current="page"
             aria-selected="true"
-            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-indigo-500 text-slate-900 whitespace-nowrap"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-indigo-500 text-slate-900 dark:text-slate-100 whitespace-nowrap"
           >Report</a>
           <a
             href={`/inspections/${inspectionId}/photos`}
             role="tab"
             aria-selected="false"
-            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600 whitespace-nowrap transition-colors"
           >Photos</a>
           <a
             href={`/inspections/${inspectionId}/summary`}
             role="tab"
             aria-selected="false"
-            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600 whitespace-nowrap transition-colors"
           >Summary</a>
           {/* Track E1 (ITB §11) — opt-in 6th tab. */}
           {enableRepairList && (
@@ -92,20 +208,20 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               role="tab"
               aria-selected="false"
               data-testid="inspection-edit-repair-list-tab"
-              class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+              class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600 whitespace-nowrap transition-colors"
             >Repair List</a>
           )}
           <a
             href={`/inspections/${inspectionId}/signatures`}
             role="tab"
             aria-selected="false"
-            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600 whitespace-nowrap transition-colors"
           >Signatures</a>
           <a
             href={`/inspections/${inspectionId}/settings`}
             role="tab"
             aria-selected="false"
-            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 hover:text-slate-900 hover:border-slate-300 whitespace-nowrap transition-colors"
+            class="px-4 py-2.5 text-[13px] font-bold border-b-2 border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600 whitespace-nowrap transition-colors"
           >Settings</a>
           {/* PDF download dropdown — ml-auto pushes it to the right edge */}
           <div class="ml-auto flex-shrink-0 pl-2 py-1.5" x-data={`pdfDownloader('${inspectionId}')`} {...{'x-on:click.outside': 'open = false'}}>
@@ -115,7 +231,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 x-on:click="open = !open"
                 x-bind:disabled="loading"
                 aria-label="Download PDF"
-                class="flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-semibold rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-50 hover:text-indigo-600 hover:border-indigo-300 transition-all disabled:opacity-60"
+                class="flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-semibold rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:border-indigo-300 dark:hover:border-indigo-600 transition-all disabled:opacity-60"
               >
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -134,12 +250,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 x-transition:leave="transition ease-in duration-75"
                 x-transition:leave-start="opacity-100 scale-100"
                 x-transition:leave-end="opacity-0 scale-95"
-                class="absolute right-0 top-full mt-1 w-44 bg-white border border-slate-200 rounded-xl shadow-lg z-[80] py-1"
+                class="absolute right-0 top-full mt-1 w-44 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-[80] py-1"
               >
                 <button
                   type="button"
                   x-on:click="download('summary')"
-                  class="w-full text-left px-4 py-2 text-[12px] text-slate-700 hover:bg-slate-50 flex items-center gap-2 font-medium"
+                  class="w-full text-left px-4 py-2 text-[12px] text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2 font-medium"
                 >
                   <svg class="w-3.5 h-3.5 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -149,7 +265,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 <button
                   type="button"
                   x-on:click="download('full')"
-                  class="w-full text-left px-4 py-2 text-[12px] text-slate-700 hover:bg-slate-50 flex items-center gap-2 font-medium"
+                  class="w-full text-left px-4 py-2 text-[12px] text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2 font-medium"
                 >
                   <svg class="w-3.5 h-3.5 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v14a2 2 0 01-2 2z" />
@@ -164,8 +280,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
       </nav>
       <div
         x-data={`inspectionEditor('${inspectionId}')`}
-        class="min-h-screen"
-        style="background: #f8fafc; background-image: radial-gradient(circle, #cbd5e1 0.6px, transparent 0.6px); background-size: 20px 20px;"
+        class="min-h-screen editor-canvas"
       >
         {/* Spec 5G M1.1 — Global hotkey photo input. P key triggers .click()
             on this hidden input; uploadPhoto reads activeItemId. */}
@@ -189,8 +304,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 <button
                     type="button"
                     x-on:click="showAiPopover = false"
-                    class="h-10 px-6 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
-                    style="border-color: #e2e8f0"
+                    class="h-10 px-6 rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-700 transition-all"
                 >
                     Cancel
                 </button>
@@ -198,7 +312,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         >
             <div class="space-y-2">
                 <template x-for="(s, idx) in aiSuggestions" x-bind:key="idx">
-                    <button type="button" x-on:click="insertSuggestion(s)" class="w-full text-left p-3 rounded-xl border border-slate-200 hover:border-amber-400 hover:bg-amber-50 transition-all text-sm text-slate-700">
+                    <button type="button" x-on:click="insertSuggestion(s)" class="w-full text-left p-3 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-amber-400 dark:hover:border-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-all text-sm text-slate-700 dark:text-slate-200">
                         <span x-text="s"></span>
                     </button>
                 </template>
@@ -208,15 +322,15 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         {/* ===== Mobile View ===== */}
         <div x-show="!isDesktop" class="lg:hidden">
           {/* Sticky Header */}
-          <div class="sticky top-0 z-50" style="background: rgba(255,255,255,0.85); backdrop-filter: blur(16px) saturate(1.5); border-bottom: 1px solid rgba(226,232,240,0.6);">
+          <div class="sticky top-0 z-50 mobile-sticky-hdr">
             <div class="px-4 py-3 flex items-center justify-between">
               <div class="flex items-center gap-3">
-                <a href="/dashboard" class="w-8 h-8 rounded-xl bg-white/60 flex items-center justify-center">
+                <a href="/dashboard" class="w-8 h-8 rounded-xl bg-white/60 dark:bg-slate-800/60 flex items-center justify-center">
                   <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
                 </a>
                 <div>
-                  <h1 class="text-sm font-bold leading-tight" style="color: #0f172a" x-text="inspection.propertyAddress || 'Loading...'"></h1>
-                  <p class="text-[10px] font-mono" style="color: #cbd5e1" x-text="formattedDate"></p>
+                  <h1 class="text-sm font-bold leading-tight text-slate-900 dark:text-slate-100" x-text="inspection.propertyAddress || 'Loading...'"></h1>
+                  <p class="text-[10px] font-mono text-slate-300 dark:text-slate-500" x-text="formattedDate"></p>
                 </div>
               </div>
               <div class="flex items-center gap-2">
@@ -224,7 +338,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 <span x-show="saveState === 'saved'" x-cloak class="text-[10px] font-semibold text-emerald-500">Saved</span>
                 <span x-show="saveState === 'error'" x-cloak class="text-[10px] font-semibold text-red-500">Error</span>
                 <span class="text-xs font-mono font-semibold px-2 py-1 rounded-lg" style="background: #eef2ff; color: var(--ih-primary, #6366f1)" x-text="completionPercent + '%'"></span>
-                <button x-on:click="toggleCheatsheet()" class="w-8 h-8 rounded-xl bg-white/60 flex items-center justify-center" aria-label="Gesture help">
+                <button x-on:click="toggleCheatsheet()" class="w-8 h-8 rounded-xl bg-white/60 dark:bg-slate-800/60 flex items-center justify-center" aria-label="Gesture help">
                   <svg class="w-4 h-4" style="color: #64748b" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093M12 17h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                 </button>
               </div>
@@ -237,7 +351,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   x-on:click="selectSection(idx)"
                   x-show="sectionMatchesSearch(sec)"
                   class="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all whitespace-nowrap"
-                  x-bind:class="currentSectionIdx === idx ? 'text-white' : 'bg-white/60 text-gray-600'"
+                  x-bind:class="currentSectionIdx === idx ? 'text-white' : 'bg-white/60 dark:bg-slate-800/60 text-gray-600 dark:text-slate-300'"
                   x-bind:style="currentSectionIdx === idx ? 'background: var(--ih-primary, #6366f1)' : ''"
                 >
                   <span x-show="getSectionIconSvg(sec.icon)" x-html="getSectionIconSvg(sec.icon, 'w-3.5 h-3.5')"></span>
@@ -259,10 +373,10 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             style="display:none"
             class="mx-4 mt-3 flex flex-wrap items-center gap-1.5 px-3 py-2 bg-indigo-50 rounded-md border border-indigo-200"
           >
-            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-white ring-1 ring-inset ring-indigo-200 text-[10px] font-bold text-indigo-700">
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-white dark:bg-slate-800 ring-1 ring-inset ring-indigo-200 dark:ring-indigo-700 text-[10px] font-bold text-indigo-700 dark:text-indigo-300">
               Part <span x-text="partIndex"></span> of <span x-text="partTotal"></span>
             </span>
-            <span class="text-[10px] text-slate-500" x-text="'request ' + requestIdShort"></span>
+            <span class="text-[10px] text-slate-500 dark:text-slate-400" x-text="'request ' + requestIdShort"></span>
             <div class="flex flex-wrap gap-1 mt-1 w-full">
               <template x-for="s in siblings" {...{ 'x-bind:key': 's.id' }}>
                 <a
@@ -301,8 +415,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               <div
                 x-bind:data-item-id="item.id"
                 x-show="itemMatchesSearch(currentSection, item)"
-                class="rounded-md p-4 transition-all cursor-pointer"
-                style="background: rgba(255,255,255,0.85); backdrop-filter: blur(16px) saturate(1.5); border: 1px solid rgba(255,255,255,0.7); border-left: 3px solid transparent; touch-action: manipulation;"
+                class="rounded-md p-4 transition-all cursor-pointer item-card"
                 x-bind:style="(activeItemId === item.id ? 'border-color: #6366f1; ' : '') + 'border-left-color: ' + getRatingColor(getItemRating(item.id))"
                 x-bind:class="activeItemId === item.id ? 'ring-2 ring-indigo-100' : ''"
                 x-on:click="setActiveItem(item.id)"
@@ -312,8 +425,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               >
                 <div class="flex items-start justify-between mb-3">
                   <div>
-                    <h3 class="font-bold text-sm" style="color: #0f172a" x-html="highlightSearchMatch(item.label)"></h3>
-                    <span class="text-[10px] font-mono" style="color: #cbd5e1" x-text="item.number"></span>
+                    <h3 class="font-bold text-sm text-slate-900 dark:text-slate-100" x-html="highlightSearchMatch(item.label)"></h3>
+                    <span class="text-[10px] font-mono text-slate-300 dark:text-slate-500" x-text="item.number"></span>
                   </div>
                   <span class="w-3 h-3 rounded-full" x-bind:style="'background:' + getRatingColor(getItemRating(item.id))"></span>
                 </div>
@@ -374,7 +487,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 </div>
 
                 {/* Expand Toggle */}
-                <div class="flex items-center gap-3 text-xs" style="color: #94a3b8">
+                <div class="flex items-center gap-3 text-xs text-slate-400 dark:text-slate-500">
                   <button x-on:click="toggleExpand(item.id)" class="flex items-center gap-1 hover:text-gray-700">
                     <svg class="w-3 h-3 transition-transform" x-bind:class="expanded[item.id] ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
                     <span x-text="expanded[item.id] ? 'Collapse' : 'Expand'"></span>
@@ -384,9 +497,9 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 </div>
 
                 {/* Expanded Detail */}
-                <div x-show="expanded[item.id]" x-collapse="" class="mt-3 pt-3" style="border-top: 1px solid rgba(226,232,240,0.6)">
+                <div x-show="expanded[item.id]" x-collapse="" class="mt-3 pt-3 border-t border-slate-200/60 dark:border-slate-700/60">
                   {/* Sprint 1 A-10: simple-notes fallback hint when item has no tabs */}
-                  <div x-show="!item.tabs || (!item.tabs.information && !item.tabs.limitations && !item.tabs.defects)" class="mb-2 inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-slate-50 border border-slate-200 text-[11px] text-slate-500">
+                  <div x-show="!item.tabs || (!item.tabs.information && !item.tabs.limitations && !item.tabs.defects)" class="mb-2 inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-[11px] text-slate-500 dark:text-slate-400">
                     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                     <span>Simple notes mode.</span>
                     <a href="/templates" class="text-indigo-600 hover:underline">Upgrade to tabs →</a>
@@ -398,14 +511,13 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                       x-on:input="debounceSave()"
                       data-slash-trigger="true"
                       placeholder="Add notes — type / for snippets"
-                      class="w-full p-3 text-sm rounded-xl border resize-none"
-                      style="background: #f1f5f9; border-color: #e2e8f0; color: #0f172a"
+                      class="w-full p-3 text-sm rounded-xl border resize-none item-notes-textarea"
                       rows={3}
                     ></textarea>
                     <button type="button"
                       x-bind:data-mic-target="'notes-mob-' + item.id"
                       x-init="window.__rebindMicButtons && window.__rebindMicButtons()"
-                      class="absolute top-2 right-2 w-7 h-7 rounded-lg bg-white/90 border border-slate-200 flex items-center justify-center hover:bg-white"
+                      class="absolute top-2 right-2 w-7 h-7 rounded-lg bg-white/90 dark:bg-slate-700/90 border border-slate-200 dark:border-slate-600 flex items-center justify-center hover:bg-white dark:hover:bg-slate-700"
                       title="Dictate (Web Speech)"
                       aria-label="Dictate notes">
                       <svg class="w-3.5 h-3.5 text-slate-500" fill="currentColor" viewBox="0 0 24 24">
@@ -441,8 +553,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   </div>
 
                   {/* Spec 5B mobile — Canned Comment Tabs (compact). */}
-                  <div x-show="item.tabs && (item.tabs.information || item.tabs.limitations || item.tabs.defects)" class="mt-4 rounded-xl border" style="border-color: #e2e8f0; background: rgba(255,255,255,0.6);">
-                    <div class="flex items-center gap-1 px-2 py-1.5 border-b overflow-x-auto" style="border-color: #e2e8f0;">
+                  <div x-show="item.tabs && (item.tabs.information || item.tabs.limitations || item.tabs.defects)" class="mt-4 rounded-xl border canned-comments-wrap">
+                    <div class="flex items-center gap-1 px-2 py-1.5 border-b overflow-x-auto canned-tab-border">
                       <template x-for="tabName in ['information','limitations','defects']" x-bind:key="tabName">
                         <button type="button"
                           x-on:click="setActiveItemTab(tabName); activeItemId = item.id"
@@ -457,21 +569,20 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     <div class="p-2 space-y-2">
                       <template x-for="entry in getTabEntries(item.id, (activeItemId === item.id ? activeItemTab : 'information'))" x-bind:key="entry.cannedId">
                         <div class="rounded-lg border p-2"
-                          x-bind:class="entry.included ? 'bg-emerald-50 border-emerald-200' : 'bg-white border-slate-200'">
+                          x-bind:class="entry.included ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800' : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700'">
                           <label class="flex items-start gap-2 cursor-pointer">
                             <input type="checkbox"
                               x-bind:checked="entry.included"
                               x-on:change="toggleCannedComment(item.id, (activeItemId === item.id ? activeItemTab : 'information'), entry.cannedId)"
                               class="mt-1 rounded text-indigo-600" />
                             <div class="flex-1 min-w-0">
-                              <span class="text-xs font-bold text-slate-900" x-text="entry.title"></span>
-                              <p x-show="!entry.included" class="text-[11px] italic text-slate-500 line-clamp-2 mt-0.5" x-text="entry.comment"></p>
+                              <span class="text-xs font-bold text-slate-900 dark:text-slate-100" x-text="entry.title"></span>
+                              <p x-show="!entry.included" class="text-[11px] italic text-slate-500 dark:text-slate-400 line-clamp-2 mt-0.5" x-text="entry.comment"></p>
                               <textarea x-show="entry.included"
                                 x-bind:value="entry.effectiveComment"
                                 x-on:input="setCannedCommentText(item.id, (activeItemId === item.id ? activeItemTab : 'information'), entry.cannedId, $event.target.value)"
                                 rows={2}
-                                class="mt-1 w-full px-2 py-1.5 text-[12px] rounded border bg-white resize-y"
-                                style="border-color: #e2e8f0"></textarea>
+                                class="mt-1 w-full px-2 py-1.5 text-[12px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 resize-y inline-input"></textarea>
                               {/* Spec 5B P2B — AI Rewrite (mobile). */}
                               <div x-show="entry.included" class="mt-1 flex justify-end">
                                 <button type="button"
@@ -498,14 +609,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                 x-bind:value="custom.title"
                                 x-on:input="setCustomCommentTitle(item.id, (activeItemId === item.id ? activeItemTab : 'information'), custom.id, $event.target.value)"
                                 placeholder="Title"
-                                class="w-full px-1.5 py-0.5 text-[11px] font-bold rounded border bg-white"
-                                style="border-color: #e2e8f0" />
+                                class="w-full px-1.5 py-0.5 text-[11px] font-bold rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input" />
                               <textarea
                                 x-bind:value="custom.comment"
                                 x-on:input="setCustomCommentText(item.id, (activeItemId === item.id ? activeItemTab : 'information'), custom.id, $event.target.value)"
                                 rows={2}
-                                class="w-full px-1.5 py-1 text-[11px] rounded border bg-white resize-y"
-                                style="border-color: #e2e8f0"
+                                class="w-full px-1.5 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 resize-y inline-input"
                                 placeholder="Comment..."></textarea>
                               <template x-if="(activeItemId === item.id ? activeItemTab : 'information') === 'defects'">
                                 <div class="grid grid-cols-2 gap-1.5">
@@ -513,13 +622,11 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                     x-bind:value="custom.location || ''"
                                     x-on:input="setCustomCommentLocation(item.id, custom.id, $event.target.value)"
                                     placeholder="Location"
-                                    class="w-full px-1.5 py-0.5 text-[10px] rounded border bg-white"
-                                    style="border-color: #e2e8f0" />
+                                    class="w-full px-1.5 py-0.5 text-[10px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input" />
                                   <select
                                     x-bind:value="custom.category || 'maintenance'"
                                     x-on:change="setCustomCommentCategory(item.id, custom.id, $event.target.value)"
-                                    class="w-full px-1.5 py-0.5 text-[10px] rounded border bg-white"
-                                    style="border-color: #e2e8f0">
+                                    class="w-full px-1.5 py-0.5 text-[10px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input">
                                     <option value="maintenance">Maintenance</option>
                                     <option value="recommendation">Recommendation</option>
                                     <option value="safety">Safety</option>
@@ -545,8 +652,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                       </template>
                       <button type="button"
                         x-on:click="addCustomComment(item.id, (activeItemId === item.id ? activeItemTab : 'information'))"
-                        class="w-full mt-1 py-1 text-[10px] font-bold rounded-lg border-2 border-dashed text-slate-500 hover:bg-white/60"
-                        style="border-color: #e2e8f0">
+                        class="w-full mt-1 py-1 text-[10px] font-bold rounded-lg border-2 border-dashed border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:bg-white/60 dark:hover:bg-slate-700/60"
+                      >
                         + Add custom comment
                       </button>
                     </div>
@@ -555,7 +662,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   {/* Phase T (T15) — photo thumbnails with Annotate overlay */}
                   <div x-show="(results[item.id]?.photos || []).length > 0" class="mt-3 grid grid-cols-3 gap-2">
                     <template x-for="(photo, pi) in (results[item.id]?.photos || [])" x-bind:key="pi">
-                      <div class="relative group aspect-square overflow-hidden rounded-lg" style="background:#e2e8f0;">
+                      <div class="relative group aspect-square overflow-hidden rounded-lg bg-slate-200 dark:bg-slate-700">
                         <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)"
                           class="w-full h-full object-cover" alt="Photo" />
                         <button type="button"
@@ -575,28 +682,28 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               x-show="hasSearchQuery && searchMatchCount === 0"
               style="display:none"
               data-testid="editor-search-empty"
-              class="mt-4 rounded-md bg-white border border-dashed border-slate-200 p-6 text-center"
+              class="mt-4 rounded-md bg-white dark:bg-slate-800 border border-dashed border-slate-200 dark:border-slate-700 p-6 text-center"
             >
-              <p class="text-sm text-slate-500">No matches for &ldquo;<span class="font-semibold text-slate-700" x-text="searchQuery"></span>&rdquo;.</p>
+              <p class="text-sm text-slate-500 dark:text-slate-400">No matches for &ldquo;<span class="font-semibold text-slate-700 dark:text-slate-200" x-text="searchQuery"></span>&rdquo;.</p>
               <button x-on:click="clearSearch()" class="mt-2 text-xs font-semibold text-indigo-600 hover:underline">Clear search</button>
             </div>
           </div>
 
           {/* Spec 4D mobile — Inspection Events compact list */}
-          <section x-data={`inspectionEventsSection('${inspectionId}')`} x-init="load()" class="mx-4 mb-24 mt-3 rounded-md bg-white p-4 ring-1 ring-slate-200">
+          <section x-data={`inspectionEventsSection('${inspectionId}')`} x-init="load()" class="mx-4 mb-24 mt-3 rounded-md bg-white dark:bg-slate-800 p-4 ring-1 ring-slate-200 dark:ring-slate-700">
             <header class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-2">
-                <h2 class="text-sm font-bold text-slate-900">Events</h2>
-                <span class="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-slate-100 text-slate-500" x-show="events.length > 0" x-text="events.length"></span>
+                <h2 class="text-sm font-bold text-slate-900 dark:text-slate-100">Events</h2>
+                <span class="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400" x-show="events.length > 0" x-text="events.length"></span>
               </div>
               <button type="button" x-on:click="openCreate()" class="px-2.5 py-1 bg-indigo-600 text-white rounded-lg text-[11px] font-bold">+ Add</button>
             </header>
             <ul class="mt-2 space-y-1.5">
               <template x-for="ev in events" {...{ 'x-bind:key': 'ev.id' }}>
-                <li class="flex items-center gap-2 p-2 bg-slate-50 rounded-lg text-xs">
+                <li class="flex items-center gap-2 p-2 bg-slate-50 dark:bg-slate-700 rounded-lg text-xs">
                   <span class="w-2 h-2 rounded-full flex-shrink-0" {...{ 'x-bind:style': "'background:' + eventTypeColor(ev.eventTypeId)" }}></span>
-                  <span class="font-bold text-slate-900 truncate" x-text="eventTypeName(ev.eventTypeId)"></span>
-                  <span class="text-slate-500 text-[10px]" x-text="formatDate(ev.scheduledAt)"></span>
+                  <span class="font-bold text-slate-900 dark:text-slate-100 truncate" x-text="eventTypeName(ev.eventTypeId)"></span>
+                  <span class="text-slate-500 dark:text-slate-400 text-[10px]" x-text="formatDate(ev.scheduledAt)"></span>
                   <span class="ml-auto text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full" x-text="(ev.status || '').replace('_', ' ')" {...{ 'x-bind:class': 'statusBadgeClass(ev.status)' }}></span>
                   <button type="button" x-show="ev.status === 'scheduled'" x-on:click="markComplete(ev.id)" class="text-emerald-600 text-xs font-bold" title="Done">&#10003;</button>
                   <button type="button" x-on:click="del(ev.id)" class="text-rose-600 text-xs font-bold" title="Delete">&times;</button>
@@ -609,8 +716,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
           {/* Bottom Bar */}
           {/* Spec 5G mobile field-flow (Round 12) — pad-bottom honors iOS
               safe-area (home indicator) so Publish never sits under it. */}
-          <div class="fixed bottom-0 left-0 right-0 z-40 px-4 pt-3 flex gap-3" style="background: rgba(255,255,255,0.90); backdrop-filter: blur(16px); border-top: 1px solid rgba(226,232,240,0.6); padding-bottom: max(12px, env(safe-area-inset-bottom));">
-            <button x-on:click="previewReport()" class="flex-1 min-h-[44px] py-3 text-sm font-semibold rounded-xl border" style="border-color: #e2e8f0; color: #475569">Preview</button>
+          <div class="fixed bottom-0 left-0 right-0 z-40 px-4 pt-3 flex gap-3 mobile-bottom-bar">
+            <button x-on:click="previewReport()" class="flex-1 min-h-[44px] py-3 text-sm font-semibold rounded-xl border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300">Preview</button>
             <button
               x-on:click="showPublishModal = true"
               x-bind:disabled="completionPercent < 100"
@@ -629,10 +736,10 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             {...{ 'x-on:click.self': 'closeQuickRating()' }}
             style="background: rgba(0,0,0,0.4)"
           >
-            <div class="w-full rounded-t-3xl p-5 pb-8" style="background: #ffffff; box-shadow: 0 -8px 32px rgba(0,0,0,0.15)">
+            <div class="w-full rounded-t-3xl p-5 pb-8 quick-rating-sheet">
               <div class="flex items-center justify-between mb-4">
-                <h3 class="text-base font-bold" style="color: #0f172a">Quick Rate</h3>
-                <button x-on:click="closeQuickRating()" class="w-8 h-8 rounded-xl bg-gray-100 flex items-center justify-center" aria-label="Close">
+                <h3 class="text-base font-bold text-slate-900 dark:text-slate-100">Quick Rate</h3>
+                <button x-on:click="closeQuickRating()" class="w-8 h-8 rounded-xl bg-gray-100 dark:bg-slate-700 flex items-center justify-center" aria-label="Close">
                   <svg class="w-4 h-4" style="color: #64748b" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" /></svg>
                 </button>
               </div>
@@ -648,8 +755,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 </template>
                 <button
                   x-on:click="setQuickRating(null)"
-                  class="col-span-2 px-4 py-3 rounded-xl text-sm font-semibold text-gray-500 border"
-                  style="background: #f1f5f9; border-color: #e2e8f0"
+                  class="col-span-2 px-4 py-3 rounded-xl text-sm font-semibold text-gray-500 dark:text-slate-400 border border-slate-200 dark:border-slate-600 bg-slate-100 dark:bg-slate-800"
                 >
                   Clear rating
                 </button>
@@ -661,26 +767,26 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         {/* ===== Desktop View ===== */}
         <div x-show="isDesktop" class="hidden lg:flex min-h-screen">
           {/* Left Sidebar — hidden in focus mode (⌘2) */}
-          <aside x-show="viewMode !== 'focus'" class="w-[220px] sticky top-0 h-screen flex-shrink-0 flex flex-col border-r overflow-y-auto" style="background: rgba(255,255,255,0.6); backdrop-filter: blur(12px); border-color: rgba(226,232,240,0.6);">
+          <aside x-show="viewMode !== 'focus'" class="w-[220px] sticky top-0 h-screen flex-shrink-0 flex flex-col border-r overflow-y-auto sidebar-glass">
             <div class="px-5 pt-6 pb-4 border-b" style="border-color: rgba(226,232,240,0.5)">
-              <a href="/dashboard" class="flex items-center gap-2 text-xs mb-3 hover:text-indigo-600 transition-colors" style="color: #94a3b8">
+              <a href="/dashboard" class="flex items-center gap-2 text-xs mb-3 text-slate-400 dark:text-slate-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
                 Dashboard
               </a>
-              <h2 class="text-sm font-bold" style="color: #0f172a" x-text="inspection.propertyAddress || 'Loading...'"></h2>
-              <p class="text-[10px] font-mono mt-1" style="color: #cbd5e1" x-text="formattedDate"></p>
+              <h2 class="text-sm font-bold text-slate-900 dark:text-slate-100" x-text="inspection.propertyAddress || 'Loading...'"></h2>
+              <p class="text-[10px] font-mono mt-1 text-slate-300 dark:text-slate-500" x-text="formattedDate"></p>
             </div>
             {/* R7-20: surface what the progress bar measures so inspectors
                 stop wondering how it's computed. */}
             <div class="px-5 py-3" title="Percent of inspection items that have a rating set (Sat / Mon / Defect / NI / NP).">
-              <div class="flex justify-between text-[10px] font-mono mb-1" style="color: #94a3b8">
+              <div class="flex justify-between text-[10px] font-mono mb-1 text-slate-400 dark:text-slate-500">
                 <span>Progress · items rated</span>
                 <span x-text="completionPercent + '%'"></span>
               </div>
-              <div class="h-1.5 rounded-full" style="background: #e2e8f0">
+              <div class="h-1.5 rounded-full bg-slate-200 dark:bg-slate-700">
                 <div class="h-full rounded-full transition-all duration-500" x-bind:style="'width:' + completionPercent + '%; background: var(--ih-primary, #6366f1)'"></div>
               </div>
-              <div class="mt-2 text-[10px] font-mono" style="color: #94a3b8">
+              <div class="mt-2 text-[10px] font-mono text-slate-400 dark:text-slate-500">
                 <span x-show="saveState === 'saving'" x-cloak class="text-amber-500">Saving...</span>
                 <span x-show="saveState === 'saved'" x-cloak class="text-emerald-500">All changes saved</span>
                 <span x-show="saveState === 'error'" x-cloak class="text-red-500">Save failed</span>
@@ -688,9 +794,9 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             </div>
             {/* Report Access */}
             <div class="px-4 py-3 border-t space-y-2" style="border-color: rgba(226,232,240,0.5)">
-              <div class="text-[10px] font-mono font-semibold uppercase tracking-wide mb-2" style="color: #94a3b8">Report Access</div>
+              <div class="text-[10px] font-mono font-semibold uppercase tracking-wide mb-2 text-slate-400 dark:text-slate-500">Report Access</div>
               <label class="flex items-center justify-between cursor-pointer">
-                <span class="text-xs" style="color: #475569">Require Payment</span>
+                <span class="text-xs text-slate-600 dark:text-slate-300">Require Payment</span>
                 <button
                   x-on:click={`authFetch('/api/inspections/${inspectionId}', {method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify({paymentRequired:!inspection.paymentRequired})}).then(r=>r.json()).then(d=>{ if(d.success) inspection.paymentRequired=!inspection.paymentRequired; })`}
                   x-bind:class="inspection.paymentRequired ? 'bg-indigo-500' : 'bg-slate-200'"
@@ -700,7 +806,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 </button>
               </label>
               <label class="flex items-center justify-between cursor-pointer">
-                <span class="text-xs" style="color: #475569">Require Agreement</span>
+                <span class="text-xs text-slate-600 dark:text-slate-300">Require Agreement</span>
                 <button
                   x-on:click={`authFetch('/api/inspections/${inspectionId}', {method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify({agreementRequired:!inspection.agreementRequired})}).then(r=>r.json()).then(d=>{ if(d.success) inspection.agreementRequired=!inspection.agreementRequired; })`}
                   x-bind:class="inspection.agreementRequired ? 'bg-indigo-500' : 'bg-slate-200'"
@@ -751,8 +857,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   <select
                     x-bind:value="inspection.reportThemeOverride || ''"
                     x-on:change={`const v=$event.target.value||null;authFetch('/api/inspections/${inspectionId}', {method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify({reportThemeOverride:v})}).then(r=>r.json()).then(d=>{if(d.success)inspection.reportThemeOverride=v;});`}
-                    class="w-full px-2 py-1 text-xs border rounded bg-white"
-                    style="border-color: rgba(226,232,240,0.6); color: #475569"
+                    class="w-full px-2 py-1 text-xs border border-slate-200 dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300"
                   >
                     <option value="">Use tenant default</option>
                     <option value="modern">Modern</option>
@@ -772,11 +877,10 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   x-on:click={`copying=true; authFetch('/api/inspections/'+inspectionId+'/agent-token',{method:'POST'}).then(r=>r.json()).then(j=>{agentUrl=j.data?.url||'';copying=false;}).catch(()=>{agentErr='Failed to generate link';copying=false;});`}
                   x-bind:disabled="copying"
                   x-text="copying ? 'Generating...' : 'Share with Agent'"
-                  class="text-xs px-3 py-1.5 rounded-lg font-semibold w-full text-left"
-                  style="background: #f1f5f9; color: #475569"
+                  class="text-xs px-3 py-1.5 rounded-lg font-semibold w-full text-left bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300"
                 />
                 <div x-show="agentUrl" class="flex items-center gap-1 mt-1">
-                  <input x-bind:value="agentUrl" readonly class="flex-1 text-[10px] border rounded px-2 py-1 bg-white" style="border-color: rgba(226,232,240,0.6)" />
+                  <input x-bind:value="agentUrl" readonly class="flex-1 text-[10px] border border-slate-200 dark:border-slate-600 rounded px-2 py-1 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" />
                   <button x-on:click="navigator.clipboard.writeText(agentUrl)" class="text-[10px] px-2 py-1 rounded font-bold" style="background: #4f46e5; color: white">Copy</button>
                 </div>
                 <div x-show="agentErr" x-text="agentErr" class="text-[10px] mt-1" style="color: #dc2626" />
@@ -800,7 +904,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 style="border-color: rgba(226,232,240,0.5)"
             >
                 <div class="flex items-center justify-between">
-                    <div class="text-[10px] font-mono font-semibold uppercase tracking-wide" style="color: #94a3b8">Property Info</div>
+                    <div class="text-[10px] font-mono font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">Property Info</div>
                     <button x-show="!editing" x-on:click="editing=true" class="text-[10px] text-indigo-600 font-semibold">Edit</button>
                     <div x-show="editing" class="flex gap-1">
                         <button
@@ -821,16 +925,16 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     ].map(({ key, label, type }) => (
                         <div key={key}>
                             <div class="text-[9px] font-mono uppercase text-slate-400">{label}</div>
-                            <div x-show="!editing" class="font-semibold" style="color: #0f172a" x-text={`fields.${key} || '—'`} />
+                            <div x-show="!editing" class="font-semibold text-slate-900 dark:text-slate-100" x-text={`fields.${key} || '—'`} />
                             <input x-show="editing" x-model={`fields.${key}`} type={type}
-                                   class="w-full text-[11px] border border-slate-200 rounded px-1.5 py-0.5 bg-white" />
+                                   class="w-full text-[11px] border border-slate-200 dark:border-slate-600 rounded px-1.5 py-0.5 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" />
                         </div>
                     ))}
                     <div class="col-span-2">
                         <div class="text-[9px] font-mono uppercase text-slate-400">Foundation</div>
-                        <div x-show="!editing" class="font-semibold" style="color: #0f172a" x-text="fields.foundationType || '—'" />
+                        <div x-show="!editing" class="font-semibold text-slate-900 dark:text-slate-100" x-text="fields.foundationType || '—'" />
                         <select x-show="editing" x-model="fields.foundationType"
-                                class="w-full text-[11px] border border-slate-200 rounded px-1 py-0.5 bg-white">
+                                class="w-full text-[11px] border border-slate-200 dark:border-slate-600 rounded px-1 py-0.5 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100">
                             <option value="">—</option>
                             <option value="basement">Basement</option>
                             <option value="slab">Slab</option>
@@ -846,10 +950,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   x-on:click="selectSection(idx)"
                   x-show="sectionMatchesSearch(sec)"
                   class="w-full flex items-center gap-2 px-3 py-2.5 rounded-xl text-left text-sm transition-all"
-                  x-bind:style="currentSectionIdx === idx ? 'background: #eef2ff; color: var(--ih-primary, #6366f1)' : 'color: #64748b'"
+                  x-bind:class="currentSectionIdx === idx ? 'bg-indigo-50 dark:bg-indigo-900/30' : 'text-slate-500 dark:text-slate-400'"
+                  x-bind:style="currentSectionIdx === idx ? 'color: var(--ih-primary, #6366f1)' : ''"
                 >
                   <span class="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
-                    x-bind:style="currentSectionIdx === idx ? 'background: rgba(99,102,241,0.12)' : 'background: #f1f5f9'">
+                    x-bind:class="currentSectionIdx === idx ? 'bg-indigo-100/80 dark:bg-indigo-800/40' : 'bg-slate-100 dark:bg-slate-700/50'"
+                  >
                     <template x-if="getSectionIconSvg(sec.icon)">
                       <span x-html="getSectionIconSvg(sec.icon)"></span>
                     </template>
@@ -885,11 +991,11 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               role="region"
               aria-label="Inspection request siblings"
             >
-              <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-white ring-1 ring-inset ring-indigo-200 text-[11px] font-bold text-indigo-700">
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-white dark:bg-slate-800 ring-1 ring-inset ring-indigo-200 dark:ring-indigo-700 text-[11px] font-bold text-indigo-700 dark:text-indigo-300">
                 Part <span x-text="partIndex"></span> of <span x-text="partTotal"></span>
               </span>
-              <span class="text-[11px] text-slate-500">
-                in request <span class="font-mono font-semibold text-slate-700" x-text="requestIdShort"></span>
+              <span class="text-[11px] text-slate-500 dark:text-slate-400">
+                in request <span class="font-mono font-semibold text-slate-700 dark:text-slate-200" x-text="requestIdShort"></span>
               </span>
               <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 ml-2">Switch:</span>
               <template x-for="s in siblings" {...{ 'x-bind:key': 's.id' }}>
@@ -901,16 +1007,16 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               </template>
             </div>
             {/* Toolbar */}
-            <div class="sticky top-0 z-40 px-3 py-2 flex items-center justify-between" style="background: rgba(255,255,255,0.85); backdrop-filter: blur(16px) saturate(1.5); border-bottom: 1px solid rgba(226,232,240,0.6);">
+            <div class="sticky top-0 z-40 px-3 py-2 flex items-center justify-between toolbar-glass">
               <div class="flex items-center gap-3">
-                <h2 class="text-2xl font-bold" style="color: #0f172a" x-text="currentSection?.title || ''"></h2>
-                <span class="text-xs font-mono px-2 py-1 rounded-lg" style="background: #f1f5f9; color: #94a3b8" x-text="'SECTION ' + (currentSectionIdx + 1) + '/' + sections.length"></span>
+                <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100" x-text="currentSection?.title || ''"></h2>
+                <span class="text-xs font-mono px-2 py-1 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-400 dark:text-slate-400" x-text="'SECTION ' + (currentSectionIdx + 1) + '/' + sections.length"></span>
                 {/* Spec 5G M1 — keyboard hints inline next to section title (Mockup 01) */}
                 <span class="hidden lg:flex items-center gap-1.5 text-[10px] text-slate-400 ml-2" title="Keyboard shortcuts (press ? for full HUD)">
-                  <kbd class="px-1.5 py-0.5 bg-white/80 border border-slate-200 rounded font-mono">↑↓</kbd> nav
-                  <kbd class="px-1.5 py-0.5 bg-white/80 border border-slate-200 rounded font-mono">1-5</kbd> rate
-                  <kbd class="px-1.5 py-0.5 bg-white/80 border border-slate-200 rounded font-mono">/</kbd> lib
-                  <kbd class="px-1.5 py-0.5 bg-white/80 border border-slate-200 rounded font-mono">⏎</kbd> next
+                  <kbd class="px-1.5 py-0.5 bg-white/80 dark:bg-slate-700/80 border border-slate-200 dark:border-slate-600 rounded font-mono text-slate-600 dark:text-slate-300">↑↓</kbd> nav
+                  <kbd class="px-1.5 py-0.5 bg-white/80 dark:bg-slate-700/80 border border-slate-200 dark:border-slate-600 rounded font-mono text-slate-600 dark:text-slate-300">1-5</kbd> rate
+                  <kbd class="px-1.5 py-0.5 bg-white/80 dark:bg-slate-700/80 border border-slate-200 dark:border-slate-600 rounded font-mono text-slate-600 dark:text-slate-300">/</kbd> lib
+                  <kbd class="px-1.5 py-0.5 bg-white/80 dark:bg-slate-700/80 border border-slate-200 dark:border-slate-600 rounded font-mono text-slate-600 dark:text-slate-300">⏎</kbd> next
                 </span>
                 <button
                   x-on:click="batchMode = !batchMode"
@@ -934,8 +1040,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     placeholder="Search entire report…"
                     aria-label="Search the entire report"
                     data-testid="editor-search-input"
-                    class="w-56 pl-8 pr-7 py-1.5 text-xs rounded-lg border bg-white text-slate-700 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400 transition-all"
-                    style="border-color: #e2e8f0"
+                    class="w-56 pl-8 pr-7 py-1.5 text-xs rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:focus:ring-indigo-700 focus:border-indigo-400 transition-all"
                   />
                   <button
                     type="button"
@@ -968,13 +1073,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   x-on:click="tabletInspectorOpen = !tabletInspectorOpen"
                   data-testid="tablet-active-item-toggle"
                   aria-label="Toggle active item inspector"
-                  class="hidden lg:inline-flex xl:hidden items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-xl border border-slate-200 hover:bg-slate-50 transition-colors"
-                  style="color: #475569"
+                  class="hidden lg:inline-flex xl:hidden items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-xl border border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300 transition-colors"
                 >
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
                   Inspector
                 </button>
-                <button x-on:click="previewReport()" class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl" style="color: #64748b">
+                <button x-on:click="previewReport()" class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl text-slate-500 dark:text-slate-400">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
                   Preview
                 </button>
@@ -990,31 +1094,29 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             </div>
 
             {/* Batch Mode Toolbar */}
-            <div x-show="batchMode" class="px-6 py-2 flex items-center gap-3 text-sm" style="background: #eef2ff; border-bottom: 1px solid #c7d2fe">
+            <div x-show="batchMode" class="px-6 py-2 flex items-center gap-3 text-sm bg-indigo-50 dark:bg-indigo-900/30 border-b border-indigo-200 dark:border-indigo-800">
               <span class="font-semibold" style="color: var(--ih-primary, #6366f1)" x-text="'Selected ' + selectedBatchCount + '/' + currentSectionItems.length"></span>
-              <button x-on:click="batchSelectAll()" class="px-3 py-1 rounded-lg text-xs font-semibold" style="background: white; color: var(--ih-primary, #6366f1)">Select All</button>
+              <button x-on:click="batchSelectAll()" class="px-3 py-1 rounded-lg text-xs font-semibold bg-white dark:bg-slate-800" style="color: var(--ih-primary, #6366f1)">Select All</button>
               <template x-for="level in ratingLevels" x-bind:key="level.id">
                 <button
                     x-on:click="batchSetRating(level.id)"
                     x-bind:aria-label="'Set ' + level.label"
-                    class="px-3 py-1 rounded-lg text-xs font-semibold"
-                    style="background: white; color: #475569"
+                    class="px-3 py-1 rounded-lg text-xs font-semibold bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300"
                 >
                   <span class="hidden sm:inline" x-text="'Set ' + level.label"></span>
                   <span class="sm:hidden" x-text="'Set ' + level.abbreviation"></span>
                 </button>
               </template>
-              <button x-on:click="batchMode = false; batchSelected = {}" class="ml-auto px-3 py-1 rounded-lg text-xs font-semibold" style="color: #64748b">Exit</button>
+              <button x-on:click="batchMode = false; batchSelected = {}" class="ml-auto px-3 py-1 rounded-lg text-xs font-semibold text-slate-500 dark:text-slate-400">Exit</button>
             </div>
 
             {/* Status Machine Bar */}
             <div
                 x-data="{ showCancelModal: false, cancelReason: 'client_cancelled', cancelNotes: '' }"
-                class="mx-6 mt-3 bg-white border rounded-xl px-4 py-2.5 flex items-center justify-between gap-3"
-                style="border-color: rgba(226,232,240,0.6)"
+                class="mx-6 mt-3 bg-white dark:bg-slate-800 border rounded-xl px-4 py-2.5 flex items-center justify-between gap-3 status-bar"
             >
                 <div class="flex items-center gap-2">
-                    <span class="text-[10px] font-mono uppercase" style="color: #94a3b8">Status</span>
+                    <span class="text-[10px] font-mono uppercase text-slate-400 dark:text-slate-500">Status</span>
                     <span
                         x-text="(inspection.status||'').replace('_',' ').toUpperCase()"
                         x-bind:class={`{
@@ -1036,14 +1138,13 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     <button
                         x-show="inspection.status !== 'cancelled' && inspection.status !== 'completed'"
                         x-on:click="showCancelModal=true"
-                        class="text-[11px] border text-red-600 px-3 py-1 rounded-lg font-bold"
-                        style="border-color: #fecaca; background: #fef2f2"
+                        class="text-[11px] border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-3 py-1 rounded-lg font-bold"
                         title="Cancel this inspection — you'll be asked for a reason and refund handling"
                     >Cancel</button>
                     <button
                         x-show="inspection.status === 'cancelled'"
                         x-on:click={`authFetch('/api/inspections/${inspectionId}/uncancel',{method:'POST'}).then(r=>r.json()).then(d=>{if(d.success)inspection.status='scheduled'})`}
-                        class="text-[11px] bg-slate-100 text-slate-700 px-3 py-1 rounded-lg font-bold"
+                        class="text-[11px] bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 px-3 py-1 rounded-lg font-bold"
                         title="Restore this cancelled inspection back to scheduled state"
                     >Restore</button>
                 </div>
@@ -1062,34 +1163,34 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                         />
                     }
                 >
-                    <label class="block text-xs font-bold text-slate-600 mb-1">Reason</label>
-                    <select x-model="cancelReason" class="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm mb-3 bg-white">
+                    <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Reason</label>
+                    <select x-model="cancelReason" class="w-full border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-2 text-sm mb-3 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100">
                         <option value="client_cancelled">Client Cancelled</option>
                         <option value="scheduling_conflict">Scheduling Conflict</option>
                         <option value="weather">Weather</option>
                         <option value="other">Other</option>
                     </select>
-                    <label class="block text-xs font-bold text-slate-600 mb-1">Notes (optional)</label>
-                    <textarea x-model="cancelNotes" rows={3} class="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm" />
+                    <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Notes (optional)</label>
+                    <textarea x-model="cancelNotes" rows={3} class="w-full border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" />
                 </Modal>
             </div>
 
             {/* Inspection Events (Spec 4D.T9) */}
-            <section x-data={`inspectionEventsSection('${inspectionId}')`} x-init="load()" class="mx-6 mt-3 rounded-md bg-white p-5 ring-1 ring-slate-200">
+            <section x-data={`inspectionEventsSection('${inspectionId}')`} x-init="load()" class="mx-6 mt-3 rounded-md bg-white dark:bg-slate-800 p-5 ring-1 ring-slate-200 dark:ring-slate-700">
                 <header class="flex items-center justify-between gap-3">
                     <div class="flex items-center gap-2">
-                        <h2 class="text-base font-bold text-slate-900">Events</h2>
-                        <span class="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-slate-100 text-slate-500" x-show="events.length > 0" x-text="events.length + ' total'"></span>
+                        <h2 class="text-base font-bold text-slate-900 dark:text-slate-100">Events</h2>
+                        <span class="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400" x-show="events.length > 0" x-text="events.length + ' total'"></span>
                     </div>
                     <button type="button" x-on:click="openCreate()" class="px-3 py-1.5 bg-indigo-600 text-white rounded-lg text-xs font-bold hover:bg-indigo-700">+ Add event</button>
                 </header>
                 <ul class="mt-3 space-y-2">
                     <template x-for="ev in events" {...{ 'x-bind:key': 'ev.id' }}>
-                        <li class="flex items-center gap-3 p-3 bg-slate-50 rounded-lg text-sm">
+                        <li class="flex items-center gap-3 p-3 bg-slate-50 dark:bg-slate-700 rounded-lg text-sm">
                             <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" {...{ 'x-bind:style': "'background:' + eventTypeColor(ev.eventTypeId)" }}></span>
-                            <span class="font-bold text-slate-900" x-text="eventTypeName(ev.eventTypeId)"></span>
-                            <span class="text-slate-500 text-xs" x-text="formatDate(ev.scheduledAt)"></span>
-                            <span class="text-slate-400 text-xs" x-show="ev.durationMin" x-text="(ev.durationMin || 0) + ' min'"></span>
+                            <span class="font-bold text-slate-900 dark:text-slate-100" x-text="eventTypeName(ev.eventTypeId)"></span>
+                            <span class="text-slate-500 dark:text-slate-400 text-xs" x-text="formatDate(ev.scheduledAt)"></span>
+                            <span class="text-slate-400 dark:text-slate-500 text-xs" x-show="ev.durationMin" x-text="(ev.durationMin || 0) + ' min'"></span>
                             <span class="ml-auto text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full" x-text="(ev.status || '').replace('_', ' ')" {...{ 'x-bind:class': 'statusBadgeClass(ev.status)' }}></span>
                             <button type="button" x-show="ev.status === 'scheduled'" x-on:click="markComplete(ev.id)" class="text-emerald-600 text-xs font-bold hover:underline" title="Mark complete">&#10003;</button>
                             <button type="button" x-on:click="del(ev.id)" class="text-rose-600 text-xs font-bold hover:underline" title="Delete">&times;</button>
@@ -1114,8 +1215,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 >
                     <div class="space-y-3">
                         <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Type</label>
-                            <select x-model="form.eventTypeId" x-on:change="onTypeChange()" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Type</label>
+                            <select x-model="form.eventTypeId" x-on:change="onTypeChange()" class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100">
                                 <option value="">— Select —</option>
                                 <template x-for="t in types" {...{ 'x-bind:key': 't.id' }}>
                                     <option {...{ 'x-bind:value': 't.id' }} x-text="t.name"></option>
@@ -1124,22 +1225,22 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                             <p x-show="!types.length" class="text-[10px] text-amber-600 mt-1">No event types defined. <a href="/settings/event-types" class="underline">Create one</a> first.</p>
                         </div>
                         <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Date &amp; time</label>
-                            <input type="datetime-local" x-model="form.scheduledAt" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Date &amp; time</label>
+                            <input type="datetime-local" x-model="form.scheduledAt" class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" />
                         </div>
                         <div class="grid grid-cols-2 gap-3">
                             <div>
-                                <label class="block text-xs font-bold text-slate-600 mb-1">Duration (min)</label>
-                                <input type="number" {...{ 'x-model.number': 'form.durationMin' }} min="1" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
+                                <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Duration (min)</label>
+                                <input type="number" {...{ 'x-model.number': 'form.durationMin' }} min="1" class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" />
                             </div>
                             <div>
-                                <label class="block text-xs font-bold text-slate-600 mb-1">Price (cents)</label>
-                                <input type="number" {...{ 'x-model.number': 'form.priceCents' }} min="0" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm" />
+                                <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Price (cents)</label>
+                                <input type="number" {...{ 'x-model.number': 'form.priceCents' }} min="0" class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100" />
                             </div>
                         </div>
                         <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Inspector (optional)</label>
-                            <select x-model="form.inspectorId" class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm">
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Inspector (optional)</label>
+                            <select x-model="form.inspectorId" class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100">
                                 <option value="">Unassigned</option>
                                 <template x-for="i in inspectors" {...{ 'x-bind:key': 'i.id' }}>
                                     <option {...{ 'x-bind:value': 'i.id' }} x-text="i.name || i.email"></option>
@@ -1147,8 +1248,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                             </select>
                         </div>
                         <div>
-                            <label class="block text-xs font-bold text-slate-600 mb-1">Notes (optional)</label>
-                            <textarea x-model="form.notes" rows={2} class="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm"></textarea>
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Notes (optional)</label>
+                            <textarea x-model="form.notes" rows={2} class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100"></textarea>
                         </div>
                     </div>
                 </Modal>
@@ -1160,8 +1261,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 <div
                   x-bind:data-item-id="item.id"
                   x-show="itemMatchesSearch(currentSection, item)"
-                  class="rounded-md p-4 transition-all cursor-pointer group"
-                  style="background: rgba(255,255,255,0.85); backdrop-filter: blur(16px) saturate(1.5); border: 1px solid rgba(255,255,255,0.7);"
+                  class="rounded-md p-4 transition-all cursor-pointer group item-card"
                   x-bind:style="(activeItemId === item.id ? 'border-color: #6366f1; ' : '') + 'border-top: 4px solid ' + getRatingColor(getItemRating(item.id))"
                   x-bind:class="activeItemId === item.id ? 'ring-2 ring-indigo-100' : ''"
                   x-on:click="batchMode ? toggleBatchSelect(item.id) : (setActiveItem(item.id), toggleExpand(item.id))"
@@ -1171,8 +1271,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   </div>
                   <div class="flex items-start justify-between mb-3">
                     <div>
-                      <h3 class="font-bold text-sm group-hover:text-indigo-600 transition-colors" style="color: #0f172a" x-html="highlightSearchMatch(item.label)"></h3>
-                      <span class="text-[10px] font-mono" style="color: #cbd5e1" x-text="item.number"></span>
+                      <h3 class="font-bold text-sm text-slate-900 dark:text-slate-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors" x-html="highlightSearchMatch(item.label)"></h3>
+                      <span class="text-[10px] font-mono text-slate-300 dark:text-slate-500" x-text="item.number"></span>
                     </div>
                     <span
                       class="ih-pill"
@@ -1205,7 +1305,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                       <input> still opens the picker via native click); the
                       rest of the row falls through to the parent's expand
                       handler, and a chevron hints the card is expandable. */}
-                  <div class="flex items-center gap-3 text-[10px] font-mono" style="color: #cbd5e1">
+                  <div class="flex items-center gap-3 text-[10px] font-mono text-slate-300 dark:text-slate-500">
                     <label
                       x-on:click="$event.stopPropagation()"
                       class="flex items-center gap-1 px-1.5 py-0.5 rounded cursor-pointer hover:bg-indigo-50 hover:text-indigo-600 transition"
@@ -1224,9 +1324,9 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   </div>
 
                   {/* Expanded Detail (desktop) */}
-                  <div x-show="expanded[item.id] && !batchMode" x-collapse="" class="mt-3 pt-3" style="border-top: 1px solid rgba(226,232,240,0.6)" x-on:click="$event.stopPropagation()">
+                  <div x-show="expanded[item.id] && !batchMode" x-collapse="" class="mt-3 pt-3 border-t border-slate-200/60 dark:border-slate-700/60" x-on:click="$event.stopPropagation()">
                     {/* Sprint 1 A-10: simple-notes fallback hint when item has no tabs */}
-                    <div x-show="!item.tabs || (!item.tabs.information && !item.tabs.limitations && !item.tabs.defects)" class="mb-2 inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-slate-50 border border-slate-200 text-[11px] text-slate-500">
+                    <div x-show="!item.tabs || (!item.tabs.information && !item.tabs.limitations && !item.tabs.defects)" class="mb-2 inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-[11px] text-slate-500 dark:text-slate-400">
                       <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                       <span>Simple notes mode.</span>
                       <a href="/templates" class="text-indigo-600 hover:underline">Upgrade to tabs →</a>
@@ -1238,14 +1338,13 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                         x-on:input="debounceSave()"
                         data-slash-trigger="true"
                         placeholder="Add notes — type / for snippets"
-                        class="w-full p-3 text-sm rounded-xl border resize-none"
-                        style="background: #f1f5f9; border-color: #e2e8f0; color: #0f172a"
+                        class="w-full p-3 text-sm rounded-xl border resize-none item-notes-textarea"
                         rows={3}
                       ></textarea>
                       <button type="button"
                         x-bind:data-mic-target="'notes-dsk-' + item.id"
                         x-init="window.__rebindMicButtons && window.__rebindMicButtons()"
-                        class="absolute top-2 right-2 w-7 h-7 rounded-lg bg-white/90 border border-slate-200 flex items-center justify-center hover:bg-white"
+                        class="absolute top-2 right-2 w-7 h-7 rounded-lg bg-white/90 dark:bg-slate-700/90 border border-slate-200 dark:border-slate-600 flex items-center justify-center hover:bg-white dark:hover:bg-slate-700"
                         title="Dictate (Web Speech)"
                         aria-label="Dictate notes">
                         <svg class="w-3.5 h-3.5 text-slate-500" fill="currentColor" viewBox="0 0 24 24">
@@ -1282,8 +1381,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
 
                     {/* Spec 5B — Canned Comment Tabs (Information / Limitations / Defects).
                         Only render for v2 'rich' items that ship template-side canned tabs. */}
-                    <div x-show="item.tabs && (item.tabs.information || item.tabs.limitations || item.tabs.defects)" class="mt-4 rounded-xl border" style="border-color: #e2e8f0; background: rgba(255,255,255,0.6);">
-                      <div class="flex items-center gap-1 px-2 py-1.5 border-b" style="border-color: #e2e8f0;">
+                    <div x-show="item.tabs && (item.tabs.information || item.tabs.limitations || item.tabs.defects)" class="mt-4 rounded-xl border canned-comments-wrap">
+                      <div class="flex items-center gap-1 px-2 py-1.5 border-b canned-tab-border">
                         <template x-for="tabName in ['information','limitations','defects']" x-bind:key="tabName">
                           <button type="button"
                             x-on:click="setActiveItemTab(tabName); activeItemId = item.id"
@@ -1298,7 +1397,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                       <div class="p-3 space-y-2">
                         <template x-for="entry in getTabEntries(item.id, (activeItemId === item.id ? activeItemTab : 'information'))" x-bind:key="entry.cannedId">
                           <div class="rounded-lg border p-2.5"
-                            x-bind:class="entry.included ? 'bg-emerald-50 border-emerald-200' : 'bg-white border-slate-200'">
+                            x-bind:class="entry.included ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800' : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700'">
                             <div class="flex items-start gap-2">
                               <input type="checkbox"
                                 x-bind:checked="entry.included"
@@ -1307,7 +1406,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                 aria-label="Include this comment" />
                               <div class="flex-1 min-w-0">
                                 <div class="flex items-center gap-2 flex-wrap">
-                                  <span class="text-xs font-bold text-slate-900" x-text="entry.title"></span>
+                                  <span class="text-xs font-bold text-slate-900 dark:text-slate-100" x-text="entry.title"></span>
                                   {/* Defect-only category pill */}
                                   <template x-if="(activeItemId === item.id ? activeItemTab : 'information') === 'defects'">
                                     <span class="text-[9px] font-bold uppercase px-1.5 py-0.5 rounded text-white"
@@ -1321,8 +1420,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                   x-bind:value="entry.effectiveComment"
                                   x-on:input="setCannedCommentText(item.id, (activeItemId === item.id ? activeItemTab : 'information'), entry.cannedId, $event.target.value)"
                                   rows={2}
-                                  class="mt-1.5 w-full px-2 py-1.5 text-[12px] rounded border bg-white resize-y"
-                                  style="border-color: #e2e8f0; color: #1e293b"
+                                  class="mt-1.5 w-full px-2 py-1.5 text-[12px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 resize-y inline-input"
                                   placeholder="Edit comment text..."></textarea>
                                 {/* Spec 5B P2B — AI Rewrite button (canned). */}
                                 <div x-show="entry.included" class="mt-1 flex items-center justify-end">
@@ -1335,7 +1433,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                   </button>
                                 </div>
                                 {/* Read-only preview when not included */}
-                                <p x-show="!entry.included" class="mt-1 text-[11px] italic text-slate-500 line-clamp-2" x-text="entry.comment"></p>
+                                <p x-show="!entry.included" class="mt-1 text-[11px] italic text-slate-500 dark:text-slate-400 line-clamp-2" x-text="entry.comment"></p>
                                 {/* Defect-only location + category override */}
                                 <template x-if="entry.included && (activeItemId === item.id ? activeItemTab : 'information') === 'defects'">
                                   <div class="mt-2 space-y-2">
@@ -1346,16 +1444,14 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                           x-bind:value="entry.location"
                                           x-on:input="setDefectLocation(item.id, entry.cannedId, $event.target.value)"
                                           placeholder="Northwest corner"
-                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white"
-                                          style="border-color: #e2e8f0" />
+                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input" />
                                       </div>
                                       <div>
                                         <label class="block text-[9px] font-bold uppercase text-slate-400 mb-0.5">Category</label>
                                         <select
                                           x-bind:value="entry.category"
                                           x-on:change="setDefectCategory(item.id, entry.cannedId, $event.target.value)"
-                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white"
-                                          style="border-color: #e2e8f0">
+                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input">
                                           <option value="maintenance">Maintenance</option>
                                           <option value="recommendation">Recommendation</option>
                                           <option value="safety">Safety</option>
@@ -1371,8 +1467,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                       <select
                                         x-bind:value="entry.recommendationId || ''"
                                         x-on:change="setDefectRecommendation(item.id, entry.cannedId, $event.target.value)"
-                                        class="w-full px-2 py-1 text-[11px] rounded border bg-white"
-                                        style="border-color: #e2e8f0"
+                                        class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input"
                                         data-testid="defect-recommendation">
                                         <option value="">No recommendation</option>
                                         <template x-for="grp in window.__OI_RECO_GROUPS || []" x-bind:key="grp.group">
@@ -1394,8 +1489,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                           x-bind:value="entry.estimateLow != null ? Math.round(entry.estimateLow / 100) : ''"
                                           x-on:input="setDefectEstimate(item.id, entry.cannedId, 'low', $event.target.value)"
                                           placeholder="500"
-                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white tabular-nums"
-                                          style="border-color: #e2e8f0"
+                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 tabular-nums inline-input"
                                           data-testid="defect-estimate-low" />
                                       </div>
                                       <div>
@@ -1404,8 +1498,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                           x-bind:value="entry.estimateHigh != null ? Math.round(entry.estimateHigh / 100) : ''"
                                           x-on:input="setDefectEstimate(item.id, entry.cannedId, 'high', $event.target.value)"
                                           placeholder="1500"
-                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white tabular-nums"
-                                          style="border-color: #e2e8f0"
+                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 tabular-nums inline-input"
                                           data-testid="defect-estimate-high" />
                                       </div>
                                     </div>
@@ -1430,14 +1523,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                   x-bind:value="custom.title"
                                   x-on:input="setCustomCommentTitle(item.id, (activeItemId === item.id ? activeItemTab : 'information'), custom.id, $event.target.value)"
                                   placeholder="Title (e.g. Vegetation overgrowth)"
-                                  class="w-full px-2 py-1 text-xs font-bold rounded border bg-white"
-                                  style="border-color: #e2e8f0; color: #1e293b" />
+                                  class="w-full px-2 py-1 text-xs font-bold rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input" />
                                 <textarea
                                   x-bind:value="custom.comment"
                                   x-on:input="setCustomCommentText(item.id, (activeItemId === item.id ? activeItemTab : 'information'), custom.id, $event.target.value)"
                                   rows={2}
-                                  class="w-full px-2 py-1.5 text-[12px] rounded border bg-white resize-y"
-                                  style="border-color: #e2e8f0; color: #1e293b"
+                                  class="w-full px-2 py-1.5 text-[12px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 resize-y inline-input"
                                   placeholder="Comment text..."></textarea>
                                 <template x-if="(activeItemId === item.id ? activeItemTab : 'information') === 'defects'">
                                   <div class="space-y-2">
@@ -1448,16 +1539,14 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                                           x-bind:value="custom.location || ''"
                                           x-on:input="setCustomCommentLocation(item.id, custom.id, $event.target.value)"
                                           placeholder="Northwest corner"
-                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white"
-                                          style="border-color: #e2e8f0" />
+                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input" />
                                       </div>
                                       <div>
                                         <label class="block text-[9px] font-bold uppercase text-slate-400 mb-0.5">Category</label>
                                         <select
                                           x-bind:value="custom.category || 'maintenance'"
                                           x-on:change="setCustomCommentCategory(item.id, custom.id, $event.target.value)"
-                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white"
-                                          style="border-color: #e2e8f0">
+                                          class="w-full px-2 py-1 text-[11px] rounded border bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 inline-input">
                                           <option value="maintenance">Maintenance</option>
                                           <option value="recommendation">Recommendation</option>
                                           <option value="safety">Safety</option>
@@ -1510,8 +1599,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                         </template>
                         <button type="button"
                           x-on:click="addCustomComment(item.id, (activeItemId === item.id ? activeItemTab : 'information'))"
-                          class="w-full mt-1 py-1.5 text-[11px] font-bold rounded-lg border-2 border-dashed text-slate-500 hover:text-slate-800 hover:bg-white/60 transition"
-                          style="border-color: #e2e8f0">
+                          class="w-full mt-1 py-1.5 text-[11px] font-bold rounded-lg border-2 border-dashed border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-white/60 dark:hover:bg-slate-700/60 transition"
+                        >
                           + Add custom comment
                         </button>
                       </div>
@@ -1520,7 +1609,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     {/* Phase T (T15) — photo thumbnails with Annotate overlay */}
                     <div x-show="(results[item.id]?.photos || []).length > 0" class="mt-3 grid grid-cols-4 gap-2">
                       <template x-for="(photo, pi) in (results[item.id]?.photos || [])" x-bind:key="pi">
-                        <div class="relative group aspect-square overflow-hidden rounded-lg" style="background:#e2e8f0;">
+                        <div class="relative group aspect-square overflow-hidden rounded-lg bg-slate-200 dark:bg-slate-700">
                           <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)"
                             class="w-full h-full object-cover" alt="Photo" />
                           <button type="button"
@@ -1539,9 +1628,9 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 x-show="hasSearchQuery && searchMatchCount === 0"
                 style="display:none"
                 data-testid="editor-search-empty-desktop"
-                class="col-span-2 xl:col-span-3 rounded-md bg-white border border-dashed border-slate-200 p-8 text-center"
+                class="col-span-2 xl:col-span-3 rounded-md bg-white dark:bg-slate-800 border border-dashed border-slate-200 dark:border-slate-700 p-8 text-center"
               >
-                <p class="text-sm text-slate-500">No matches for &ldquo;<span class="font-semibold text-slate-700" x-text="searchQuery"></span>&rdquo;.</p>
+                <p class="text-sm text-slate-500 dark:text-slate-400">No matches for &ldquo;<span class="font-semibold text-slate-700 dark:text-slate-200" x-text="searchQuery"></span>&rdquo;.</p>
                 <button x-on:click="clearSearch()" class="mt-2 text-xs font-semibold text-indigo-600 hover:underline">Clear search</button>
               </div>
             </div>
@@ -1553,17 +1642,17 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               instead — see tablet-active-item-drawer below), and while the
               Comment Library drawer is open (Sprint 1 A-1: avoids the
               slash-trigger popover overlapping ACTIVE ITEM). */}
-          <aside x-show="viewMode !== 'focus' && activeItem && !showCommentLibrary && !slashPickerOpen" class="hidden xl:flex w-[280px] sticky top-0 h-screen flex-shrink-0 flex-col border-l overflow-hidden" style="background: rgba(255,255,255,0.6); backdrop-filter: blur(12px); border-color: rgba(226,232,240,0.6);">
-            <header class="px-4 py-3 border-b" style="border-color: rgba(226,232,240,0.5);">
-              <h3 class="text-[10px] font-semibold text-slate-400 uppercase tracking-widest">Active Item</h3>
-              <p class="text-sm font-bold text-slate-900 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
-              <p class="text-[10px] font-mono text-slate-400 mt-0.5" x-text="activeItem?.number || ''"></p>
+          <aside x-show="viewMode !== 'focus' && activeItem && !showCommentLibrary && !slashPickerOpen" class="hidden xl:flex w-[280px] sticky top-0 h-screen flex-shrink-0 flex-col border-l overflow-hidden sidebar-glass">
+            <header class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
+              <h3 class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest">Active Item</h3>
+              <p class="text-sm font-bold text-slate-900 dark:text-slate-100 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
+              <p class="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-0.5" x-text="activeItem?.number || ''"></p>
             </header>
 
             {/* Photos */}
-            <section class="px-4 py-3 border-b" style="border-color: rgba(226,232,240,0.5);">
+            <section class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
               <div class="flex items-center justify-between mb-2">
-                <span class="text-[10px] font-semibold text-slate-500 uppercase tracking-widest">Photos · <span x-text="(results[activeItemId]?.photos || []).length"></span></span>
+                <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Photos · <span x-text="(results[activeItemId]?.photos || []).length"></span></span>
                 <label class="text-[10px] text-indigo-500 hover:underline cursor-pointer">
                   + Add
                   <input type="file" accept="image/*" capture="environment" class="hidden" x-on:change="if (activeItemId) { uploadPhoto(activeItemId, $event); $event.target.value = ''; }" />
@@ -1571,30 +1660,30 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               </div>
               <div class="grid grid-cols-2 gap-1.5" x-show="(results[activeItemId]?.photos || []).length > 0">
                 <template x-for="(photo, pi) in (results[activeItemId]?.photos || []).slice(0, 8)" x-bind:key="pi">
-                  <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100 relative group">
+                  <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100 dark:bg-slate-700 relative group">
                     <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)" class="w-full h-full object-cover" alt="Photo" />
                     <button
                       x-on:click="window.dispatchEvent(new CustomEvent('annotate', { detail: { inspectionId, itemId: activeItemId, photoIndex: pi, imageUrl: '/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.key), existingNodesJson: photo.annotationsJson || null } }))"
-                      class="absolute bottom-0.5 right-0.5 px-1.5 py-0.5 rounded bg-white/90 text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
+                      class="absolute bottom-0.5 right-0.5 px-1.5 py-0.5 rounded bg-white/90 dark:bg-slate-800/90 text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
                       title="Annotate"
                     >✎</button>
                   </div>
                 </template>
               </div>
-              <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 py-2">
-                No photos. Press <kbd class="px-1 bg-slate-100 border rounded font-mono">P</kbd> to add.
+              <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 dark:text-slate-500 py-2">
+                No photos. Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">P</kbd> to add.
               </p>
             </section>
 
             {/* Quick comments */}
             <section class="px-4 py-3 flex-1 overflow-y-auto">
               <div class="flex items-center justify-between mb-2">
-                <span class="text-[10px] font-semibold text-slate-500 uppercase tracking-widest">Quick Comments</span>
+                <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Quick Comments</span>
                 <button x-on:click="openCommentLibrary()" class="text-[10px] text-indigo-500 hover:underline">Browse all</button>
               </div>
               <div class="space-y-1">
                 <template x-for="(c, i) in quickCommentsForActive" x-bind:key="i">
-                  <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 leading-snug border border-slate-200 hover:border-indigo-400 hover:bg-indigo-50 transition-all">
+                  <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 dark:text-slate-200 leading-snug border border-slate-200 dark:border-slate-700 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all">
                     <div class="flex items-start gap-1.5">
                       <span class="px-1 py-0.5 text-[8px] font-bold uppercase rounded text-white shrink-0 mt-0.5"
                         x-bind:style="c.rating === 'satisfactory' ? 'background:#10b981' : (c.rating === 'monitor' ? 'background:#f59e0b' : (c.rating === 'defect' ? 'background:#ef4444' : 'background:#64748b'))"
@@ -1604,18 +1693,18 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   </button>
                 </template>
               </div>
-              <p class="text-[10px] text-slate-400 italic mt-3">
-                Press <kbd class="px-1 bg-slate-100 border rounded font-mono">/</kbd> for full library
+              <p class="text-[10px] text-slate-400 dark:text-slate-500 italic mt-3">
+                Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">/</kbd> for full library
               </p>
             </section>
 
             {/* Keyboard hint footer */}
-            <footer class="px-4 py-2 border-t text-[10px] text-slate-400" style="border-color: rgba(226,232,240,0.5);">
+            <footer class="px-4 py-2 border-t border-slate-200/50 dark:border-slate-700/50 text-[10px] text-slate-400 dark:text-slate-500">
               <div class="flex items-center gap-1.5 flex-wrap">
-                <kbd class="px-1 bg-slate-100 border rounded font-mono">↑↓</kbd> nav
-                <kbd class="px-1 bg-slate-100 border rounded font-mono">1-5</kbd> rate
-                <kbd class="px-1 bg-slate-100 border rounded font-mono">/</kbd> lib
-                <kbd class="px-1 bg-slate-100 border rounded font-mono">?</kbd> all
+                <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">↑↓</kbd> nav
+                <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">1-5</kbd> rate
+                <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">/</kbd> lib
+                <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">?</kbd> all
               </div>
             </footer>
           </aside>
@@ -1637,20 +1726,20 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             x-transition:leave="transition ease-in duration-150"
             x-transition:leave-start="translate-x-0 opacity-100"
             x-transition:leave-end="translate-x-full opacity-0"
-            class="hidden lg:flex xl:hidden fixed inset-y-0 right-0 z-30 w-[320px] flex-col border-l shadow-xl overflow-y-auto"
-            style="background: rgba(255,255,255,0.96); backdrop-filter: blur(12px); border-color: rgba(226,232,240,0.6); display: none;"
+            class="hidden lg:flex xl:hidden fixed inset-y-0 right-0 z-30 w-[320px] flex-col border-l shadow-xl overflow-y-auto sidebar-glass"
+            style="display: none;"
           >
-            <header class="px-4 py-3 border-b flex items-center justify-between" style="border-color: rgba(226,232,240,0.5);">
+            <header class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50 flex items-center justify-between">
               <div class="flex-1 min-w-0">
-                <h3 class="text-[10px] font-semibold text-slate-400 uppercase tracking-widest">Active Item</h3>
-                <p class="text-sm font-bold text-slate-900 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
-                <p class="text-[10px] font-mono text-slate-400 mt-0.5" x-text="activeItem?.number || ''"></p>
+                <h3 class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest">Active Item</h3>
+                <p class="text-sm font-bold text-slate-900 dark:text-slate-100 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
+                <p class="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-0.5" x-text="activeItem?.number || ''"></p>
               </div>
               <button
                 type="button"
                 x-on:click="tabletInspectorOpen = false"
                 aria-label="Close inspector drawer"
-                class="ml-2 w-8 h-8 rounded-md flex items-center justify-center text-slate-500 hover:bg-slate-100"
+                class="ml-2 w-8 h-8 rounded-md flex items-center justify-center text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -1659,9 +1748,9 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             </header>
 
             {/* Photos */}
-            <section class="px-4 py-3 border-b" style="border-color: rgba(226,232,240,0.5);">
+            <section class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
               <div class="flex items-center justify-between mb-2">
-                <span class="text-[10px] font-semibold text-slate-500 uppercase tracking-widest">
+                <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">
                   Photos &middot; <span x-text="(results[activeItemId]?.photos || []).length"></span>
                 </span>
                 <label class="text-[10px] text-indigo-500 hover:underline cursor-pointer">
@@ -1671,25 +1760,25 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
               </div>
               <div class="grid grid-cols-2 gap-1.5" x-show="(results[activeItemId]?.photos || []).length > 0">
                 <template x-for="(photo, pi) in (results[activeItemId]?.photos || []).slice(0, 8)" x-bind:key="pi">
-                  <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100">
+                  <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100 dark:bg-slate-700">
                     <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)" class="w-full h-full object-cover" alt="Photo" />
                   </div>
                 </template>
               </div>
-              <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 py-2">
-                No photos. Press <kbd class="px-1 bg-slate-100 border rounded font-mono">P</kbd> to add.
+              <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 dark:text-slate-500 py-2">
+                No photos. Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">P</kbd> to add.
               </p>
             </section>
 
             {/* Quick comments */}
             <section class="px-4 py-3 flex-1">
               <div class="flex items-center justify-between mb-2">
-                <span class="text-[10px] font-semibold text-slate-500 uppercase tracking-widest">Quick Comments</span>
+                <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Quick Comments</span>
                 <button x-on:click="openCommentLibrary()" class="text-[10px] text-indigo-500 hover:underline">Browse all</button>
               </div>
               <div class="space-y-1">
                 <template x-for="(c, i) in quickCommentsForActive" x-bind:key="i">
-                  <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 leading-snug border border-slate-200 hover:border-indigo-400 hover:bg-indigo-50 transition-all">
+                  <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 dark:text-slate-200 leading-snug border border-slate-200 dark:border-slate-700 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all">
                     <div class="flex items-start gap-1.5">
                       <span class="px-1 py-0.5 text-[8px] font-bold uppercase rounded text-white shrink-0 mt-0.5"
                         x-bind:style="c.rating === 'satisfactory' ? 'background:#10b981' : (c.rating === 'monitor' ? 'background:#f59e0b' : (c.rating === 'defect' ? 'background:#ef4444' : 'background:#64748b'))"
@@ -1699,8 +1788,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   </button>
                 </template>
               </div>
-              <p class="text-[10px] text-slate-400 italic mt-3">
-                Press <kbd class="px-1 bg-slate-100 border rounded font-mono">/</kbd> for full library
+              <p class="text-[10px] text-slate-400 dark:text-slate-500 italic mt-3">
+                Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">/</kbd> for full library
               </p>
             </section>
           </aside>
@@ -1743,8 +1832,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                     <button
                         type="button"
                         x-on:click="showLegacyPublishOptions = false"
-                        class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border bg-white hover:bg-slate-50 transition-all"
-                        style="border-color: #e2e8f0; color: #475569"
+                        class="flex-1 h-10 px-4 text-sm font-semibold rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 transition-all"
                     >
                         Done
                     </button>
@@ -1753,11 +1841,11 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         >
             <div class="space-y-3">
                 <label class="flex items-center justify-between">
-                    <span class="text-sm" style="color: #475569">Require signature</span>
+                    <span class="text-sm text-slate-600 dark:text-slate-300">Require signature</span>
                     <input type="checkbox" x-model="publishOptions.requireSignature" class="rounded" />
                 </label>
                 <label class="flex items-center justify-between">
-                    <span class="text-sm" style="color: #475569">Require payment</span>
+                    <span class="text-sm text-slate-600 dark:text-slate-300">Require payment</span>
                     <input type="checkbox" x-model="publishOptions.requirePayment" class="rounded" />
                 </label>
                 <div>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -533,20 +533,18 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                         the native <input capture> picker. */}
                     <button type="button"
                       x-on:click="openBurstCamera(item.id)"
-                      class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer"
-                      style="background: #eef2ff; color: var(--ih-primary, #6366f1)"
+                      class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400"
                       aria-label="Open burst camera">
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
                       Camera
                     </button>
-                    <button type="button" onclick="openCommentPicker(this)" class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors" style="background: #f0fdf4; color: #16a34a">
+                    <button type="button" onclick="openCommentPicker(this)" class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400">
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3-3-3z"></path></svg>
                       Library
                     </button>
                     <button type="button"
                       x-on:click="suggestComment(item.label, currentSection?.title || '', document.getElementById('notes-mob-' + item.id), $event)"
-                      class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors"
-                      style="background: #fef3c7; color: #b45309">
+                      class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" /></svg>
                       Suggest
                     </button>
@@ -1360,20 +1358,18 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                           the browser blocks getUserMedia. */}
                       <button type="button"
                         x-on:click="openBurstCamera(item.id)"
-                        class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer"
-                        style="background: #eef2ff; color: var(--ih-primary, #6366f1)"
+                        class="flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold cursor-pointer bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400"
                         aria-label="Open burst camera">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
                         Camera
                       </button>
-                      <button type="button" onclick="openCommentPicker(this)" class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors" style="background: #f0fdf4; color: #16a34a">
+                      <button type="button" onclick="openCommentPicker(this)" class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3-3-3z"></path></svg>
                         Library
                       </button>
                       <button type="button"
                         x-on:click="suggestComment(item.label, currentSection?.title || '', document.getElementById('notes-dsk-' + item.id), $event)"
-                        class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors"
-                        style="background: #fef3c7; color: #b45309">
+                        class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold transition-colors bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" /></svg>
                         Suggest
                       </button>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -1959,7 +1959,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         </div>
 
         {/* Photo Annotator Modal (T13) */}
-        <div x-data="photoAnnotator()" {...{'x-on:annotate.window': 'openPhoto($event.detail)'}} x-show="open" x-cloak class="fixed inset-0 z-50 flex flex-col" style="background:rgba(15,23,42,0.92);">
+        <div x-data="photoAnnotator()" {...{'x-on:annotate.window': 'openPhoto($event.detail)'}} x-show="open" x-cloak class="fixed inset-0 z-[70] flex flex-col" style="background:rgba(15,23,42,0.92);">
             {/* Toolbar */}
             <div class="flex flex-wrap items-center justify-between gap-3 px-4 py-3 text-white" style="background:#1e293b;">
                 <div class="flex items-center gap-1 flex-wrap">

--- a/src/templates/pages/inspection/photos.tsx
+++ b/src/templates/pages/inspection/photos.tsx
@@ -56,8 +56,8 @@ export const InspectionPhotosPage = ({
                 >
                     <div class="flex flex-wrap items-end justify-between gap-3">
                         <div>
-                            <h2 class="text-[18px] font-semibold tracking-tight text-slate-900">All photos</h2>
-                            <p class="text-[12px] text-slate-500" x-text="totalPhotos + (totalPhotos === 1 ? ' photo' : ' photos') + ' across ' + sections.length + (sections.length === 1 ? ' section' : ' sections')"></p>
+                            <h2 class="text-[18px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">All photos</h2>
+                            <p class="text-[12px] text-slate-500 dark:text-slate-400" x-text="totalPhotos + (totalPhotos === 1 ? ' photo' : ' photos') + ' across ' + sections.length + (sections.length === 1 ? ' section' : ' sections')"></p>
                         </div>
                         <a
                             x-bind:href={`'/inspections/${inspectionId}/report'`}
@@ -69,27 +69,27 @@ export const InspectionPhotosPage = ({
 
                     <div x-show="loading" class="text-center py-12 text-slate-400 text-[13px]">Loading photos…</div>
 
-                    <div x-show="!loading && totalPhotos === 0" style="display:none" class="text-center py-12 px-6 rounded-lg bg-slate-50 border border-slate-200">
-                        <svg class="w-10 h-10 mx-auto text-slate-300 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14M14 8h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-                        <p class="text-[13px] text-slate-500">No photos uploaded yet.</p>
+                    <div x-show="!loading && totalPhotos === 0" style="display:none" class="text-center py-12 px-6 rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700">
+                        <svg class="w-10 h-10 mx-auto text-slate-300 dark:text-slate-600 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14M14 8h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+                        <p class="text-[13px] text-slate-500 dark:text-slate-400">No photos uploaded yet.</p>
                     </div>
 
                     <template x-for="sec in sections" {...{ 'x-bind:key': 'sec.id' }}>
                         <section x-show="sec.photoCount > 0" style="display:none" class="space-y-3">
-                            <header class="flex items-baseline justify-between border-b border-slate-200 pb-2">
-                                <h3 class="text-[14px] font-bold text-slate-900" x-text="sec.title"></h3>
-                                <span class="text-[11px] text-slate-400 font-mono" x-text="sec.photoCount + ' photos'"></span>
+                            <header class="flex items-baseline justify-between border-b border-slate-200 dark:border-slate-700 pb-2">
+                                <h3 class="text-[14px] font-bold text-slate-900 dark:text-slate-100" x-text="sec.title"></h3>
+                                <span class="text-[11px] text-slate-400 dark:text-slate-500 font-mono" x-text="sec.photoCount + ' photos'"></span>
                             </header>
                             <template x-for="item in sec.items" {...{ 'x-bind:key': 'item.id' }}>
                                 <div x-show="item.photos.length > 0" style="display:none" class="space-y-2">
-                                    <h4 class="text-[12px] font-semibold text-slate-700" x-text="item.label"></h4>
+                                    <h4 class="text-[12px] font-semibold text-slate-700 dark:text-slate-300" x-text="item.label"></h4>
                                     <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
                                         <template x-for="photo in item.photos" {...{ 'x-bind:key': 'photo.url' }}>
                                             <a
                                                 x-bind:href="photo.url"
                                                 target="_blank"
                                                 rel="noopener"
-                                                class="block aspect-square rounded-md overflow-hidden bg-slate-100 ring-1 ring-slate-200 hover:ring-indigo-300 transition-all"
+                                                class="block aspect-square rounded-md overflow-hidden bg-slate-100 dark:bg-slate-700 ring-1 ring-slate-200 dark:ring-slate-600 hover:ring-indigo-300 dark:hover:ring-indigo-500 transition-all"
                                             >
                                                 <img
                                                     x-bind:src="photo.url"

--- a/src/templates/pages/inspection/settings.tsx
+++ b/src/templates/pages/inspection/settings.tsx
@@ -67,10 +67,10 @@ export const InspectionSettingsPage = ({
 
                     <form x-show="!loading" style="display:none" {...{ 'x-on:submit.prevent': 'save()' }} class="space-y-6">
                         <fieldset class="space-y-4">
-                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Schedule</legend>
+                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">Schedule</legend>
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <label class="block">
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Date</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Date</span>
                                     {/* Iter-2 bug #6 — explicit `lang="en"` stops Chrome on
                                         zh-CN OS locales from rendering the native date
                                         placeholder as 「年/月/日」. */}
@@ -79,14 +79,14 @@ export const InspectionSettingsPage = ({
                                         lang="en"
                                         placeholder="YYYY-MM-DD"
                                         x-model="form.date"
-                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
                                     />
                                 </label>
                                 <label class="block">
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Inspector</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Inspector</span>
                                     <select
                                         x-model="form.inspectorId"
-                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
                                     >
                                         <option value="">— Unassigned —</option>
                                         <template x-for="u in inspectors" {...{ 'x-bind:key': 'u.id' }}>
@@ -100,7 +100,7 @@ export const InspectionSettingsPage = ({
                                 signals; never gates the report. */}
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <label class="block">
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Closing Date</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Closing Date</span>
                                     {/* Iter-2 bug #6 — same as the schedule date input above:
                                         explicit `lang="en"` overrides the OS locale so users
                                         on zh-CN do not see 「年/月/日」 as the placeholder. */}
@@ -110,7 +110,7 @@ export const InspectionSettingsPage = ({
                                         placeholder="YYYY-MM-DD"
                                         data-testid="inspection-closing-date"
                                         x-model="form.closingDate"
-                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
                                     />
                                 </label>
                             </div>
@@ -128,25 +128,25 @@ export const InspectionSettingsPage = ({
                             identifier). Referral Source is the merged
                             seed + tenant custom list. */}
                         <fieldset class="space-y-4">
-                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Order &amp; referral</legend>
+                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">Order &amp; referral</legend>
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <label class="block">
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Order ID</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Order ID</span>
                                     <input
                                         type="text"
                                         maxLength={64}
                                         placeholder="—"
                                         data-testid="inspection-order-id"
                                         x-model="form.orderId"
-                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none placeholder:text-slate-300 dark:placeholder:text-slate-600"
                                     />
                                 </label>
                                 <label class="block">
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Referral Source</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Referral Source</span>
                                     <select
                                         data-testid="inspection-referral-source"
                                         x-model="form.referralSource"
-                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                        class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
                                     >
                                         <option value="">— Select source —</option>
                                         {sources.map(s => (
@@ -155,18 +155,18 @@ export const InspectionSettingsPage = ({
                                     </select>
                                 </label>
                             </div>
-                            <p class="text-[12px] text-slate-500">
-                                Add custom referral sources at <a href="/settings/workspace/referral" class="text-indigo-600 hover:underline">Settings → Workspace → Referral Sources</a>.
+                            <p class="text-[12px] text-slate-500 dark:text-slate-400">
+                                Add custom referral sources at <a href="/settings/workspace/referral" class="text-indigo-600 dark:text-indigo-400 hover:underline">Settings → Workspace → Referral Sources</a>.
                             </p>
                         </fieldset>
 
                         <fieldset class="space-y-4">
-                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Template</legend>
+                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">Template</legend>
                             <label class="block">
-                                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Inspection template</span>
+                                <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Inspection template</span>
                                 <select
                                     x-model="form.templateId"
-                                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
+                                    class="mt-1 w-full h-10 px-3 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-[14px] font-medium focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 outline-none"
                                 >
                                     <option value="">— Select template —</option>
                                     <template x-for="t in templates" {...{ 'x-bind:key': 't.id' }}>
@@ -191,10 +191,10 @@ export const InspectionSettingsPage = ({
                         </fieldset>
 
                         <fieldset class="space-y-4">
-                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900">Pricing & gates</legend>
+                            <legend class="text-[16px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">Pricing & gates</legend>
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <label class="block">
-                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Price (cents)</span>
+                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Price (cents)</span>
                                     <input
                                         type="number"
                                         min="0"
@@ -204,11 +204,11 @@ export const InspectionSettingsPage = ({
                                     />
                                 </label>
                                 <div class="flex flex-col gap-2 pt-5">
-                                    <label class="inline-flex items-center gap-2 text-[13px] text-slate-700">
+                                    <label class="inline-flex items-center gap-2 text-[13px] text-slate-700 dark:text-slate-300">
                                         <input type="checkbox" x-model="form.paymentRequired" class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20" />
                                         Payment required to view report
                                     </label>
-                                    <label class="inline-flex items-center gap-2 text-[13px] text-slate-700">
+                                    <label class="inline-flex items-center gap-2 text-[13px] text-slate-700 dark:text-slate-300">
                                         <input type="checkbox" x-model="form.agreementRequired" class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20" />
                                         Agreement signature required
                                     </label>
@@ -216,7 +216,7 @@ export const InspectionSettingsPage = ({
                             </div>
                         </fieldset>
 
-                        <div class="flex items-center justify-end gap-3 border-t border-slate-200 pt-4">
+                        <div class="flex items-center justify-end gap-3 border-t border-slate-200 dark:border-slate-700 pt-4">
                             <span x-show="saveState === 'saving'" class="text-[12px] text-amber-600 font-bold">Saving…</span>
                             <span x-show="saveState === 'saved'"  style="display:none" class="text-[12px] text-emerald-600 font-bold">Saved</span>
                             <span x-show="saveState === 'error'"  style="display:none" class="text-[12px] text-rose-600 font-bold">Error — try again</span>

--- a/src/templates/pages/inspection/signatures.tsx
+++ b/src/templates/pages/inspection/signatures.tsx
@@ -44,27 +44,27 @@ export const InspectionSignaturesPage = ({
             >
                 <div x-data={`inspectionSignaturesPage('${inspectionId}')`} x-init="load()" class="space-y-6">
                     <div class="space-y-1">
-                        <h2 class="text-[18px] font-semibold tracking-tight text-slate-900">Agreements & signatures</h2>
-                        <p class="text-[12px] text-slate-500">Tracks every agreement envelope created for this inspection plus its tamper-evident audit chain.</p>
+                        <h2 class="text-[18px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">Agreements & signatures</h2>
+                        <p class="text-[12px] text-slate-500 dark:text-slate-400">Tracks every agreement envelope created for this inspection plus its tamper-evident audit chain.</p>
                     </div>
 
-                    <div x-show="loading" class="text-center py-12 text-slate-400 text-[13px]">Loading…</div>
+                    <div x-show="loading" class="text-center py-12 text-slate-400 dark:text-slate-500 text-[13px]">Loading…</div>
 
-                    <div x-show="!loading && envelopes.length === 0" style="display:none" class="text-center py-12 px-6 rounded-lg bg-slate-50 border border-slate-200">
-                        <p class="text-[13px] text-slate-500">No agreement envelopes attached to this inspection yet.</p>
-                        <a href="/agreements" class="inline-block mt-3 text-[12px] font-bold text-indigo-600 hover:underline">Create an agreement</a>
+                    <div x-show="!loading && envelopes.length === 0" style="display:none" class="text-center py-12 px-6 rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700">
+                        <p class="text-[13px] text-slate-500 dark:text-slate-400">No agreement envelopes attached to this inspection yet.</p>
+                        <a href="/agreements" class="inline-block mt-3 text-[12px] font-bold text-indigo-600 dark:text-indigo-400 hover:underline">Create an agreement</a>
                     </div>
 
                     <template x-for="env in envelopes" {...{ 'x-bind:key': 'env.id' }}>
-                        <article class="rounded-lg border border-slate-200 bg-white p-5 space-y-4">
+                        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5 space-y-4">
                             <header class="flex flex-wrap items-start justify-between gap-3">
                                 <div class="min-w-0">
-                                    <h3 class="text-[14px] font-bold text-slate-900 truncate" x-text="env.agreementName"></h3>
-                                    <p class="text-[12px] text-slate-500" x-text="env.clientEmail"></p>
+                                    <h3 class="text-[14px] font-bold text-slate-900 dark:text-slate-100 truncate" x-text="env.agreementName"></h3>
+                                    <p class="text-[12px] text-slate-500 dark:text-slate-400" x-text="env.clientEmail"></p>
                                 </div>
                                 <span
                                     class="px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-[0.2em] ring-1 ring-inset"
-                                    {...{ 'x-bind:class': "{'bg-emerald-50 text-emerald-700 ring-emerald-200': env.status==='signed','bg-amber-50 text-amber-700 ring-amber-200': env.status==='viewed' || env.status==='sent','bg-slate-100 text-slate-600 ring-slate-200': env.status==='pending','bg-rose-50 text-rose-700 ring-rose-200': env.status==='declined' || env.status==='expired'}" }}
+                                    {...{ 'x-bind:class': "{'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-800': env.status==='signed','bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 ring-amber-200 dark:ring-amber-800': env.status==='viewed' || env.status==='sent','bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 ring-slate-200 dark:ring-slate-600': env.status==='pending','bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400 ring-rose-200 dark:ring-rose-800': env.status==='declined' || env.status==='expired'}" }}
                                     x-text="env.status"
                                 ></span>
                             </header>
@@ -74,25 +74,25 @@ export const InspectionSignaturesPage = ({
                                     x-bind:href={"'/agreements/sign/' + env.token"}
                                     target="_blank"
                                     rel="noopener"
-                                    class="inline-flex items-center gap-1 px-2.5 h-7 rounded-md bg-slate-100 text-slate-700 font-semibold hover:bg-slate-200 transition-colors"
+                                    class="inline-flex items-center gap-1 px-2.5 h-7 rounded-md bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 font-semibold hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
                                 >View envelope</a>
                                 <a
                                     x-show="env.status === 'signed'"
                                     x-bind:href={"'/verify/' + env.id"}
                                     target="_blank"
                                     rel="noopener"
-                                    class="inline-flex items-center gap-1 px-2.5 h-7 rounded-md bg-indigo-50 text-indigo-700 font-semibold hover:bg-indigo-100 transition-colors"
+                                    class="inline-flex items-center gap-1 px-2.5 h-7 rounded-md bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 font-semibold hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors"
                                 >Open public verifier</a>
                             </div>
 
-                            <div x-show="env.events && env.events.length > 0" style="display:none" class="border-t border-slate-100 pt-3">
-                                <h4 class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 mb-2">Audit chain</h4>
+                            <div x-show="env.events && env.events.length > 0" style="display:none" class="border-t border-slate-100 dark:border-slate-700 pt-3">
+                                <h4 class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-2">Audit chain</h4>
                                 <ol class="space-y-1.5">
                                     <template x-for="ev in env.events" {...{ 'x-bind:key': 'ev.hash' }}>
                                         <li class="flex items-center gap-2 text-[12px]">
                                             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 flex-shrink-0"></span>
-                                            <span class="font-mono text-slate-500" x-text="new Date(ev.createdAtUtc).toLocaleString()"></span>
-                                            <span class="font-semibold text-slate-700" x-text="ev.event"></span>
+                                            <span class="font-mono text-slate-500 dark:text-slate-400" x-text="new Date(ev.createdAtUtc).toLocaleString()"></span>
+                                            <span class="font-semibold text-slate-700 dark:text-slate-300" x-text="ev.event"></span>
                                         </li>
                                     </template>
                                 </ol>

--- a/src/templates/pages/inspection/summary.tsx
+++ b/src/templates/pages/inspection/summary.tsx
@@ -44,56 +44,56 @@ export const InspectionSummaryPage = ({
                 <div x-data={`inspectionSummaryPage('${inspectionId}')`} x-init="load()" class="space-y-6">
                     <div class="flex flex-wrap items-end justify-between gap-3">
                         <div>
-                            <h2 class="text-[18px] font-semibold tracking-tight text-slate-900">Defects summary</h2>
-                            <p class="text-[12px] text-slate-500">Read-only preview of the items flagged on this inspection.</p>
+                            <h2 class="text-[18px] font-semibold tracking-tight text-slate-900 dark:text-slate-100">Defects summary</h2>
+                            <p class="text-[12px] text-slate-500 dark:text-slate-400">Read-only preview of the items flagged on this inspection.</p>
                         </div>
                         <a
                             x-bind:href={`'/inspections/${inspectionId}/report'`}
-                            class="inline-flex items-center gap-1.5 px-3 h-9 rounded-md bg-white border border-slate-200 text-slate-700 text-[12px] font-bold hover:bg-slate-50 transition-colors"
+                            class="inline-flex items-center gap-1.5 px-3 h-9 rounded-md bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-300 text-[12px] font-bold hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors"
                         >
                             Edit in report tab
                         </a>
                     </div>
 
-                    <div x-show="loading" class="text-center py-12 text-slate-400 text-[13px]">Loading summary…</div>
+                    <div x-show="loading" class="text-center py-12 text-slate-400 dark:text-slate-500 text-[13px]">Loading summary…</div>
 
                     <div x-show="!loading && stats" style="display:none" class="grid grid-cols-3 gap-3">
-                        <div class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3">
-                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-rose-600">Safety</div>
-                            <div class="text-[22px] font-bold text-rose-700 tabular-nums" x-text="stats?.safety || 0"></div>
+                        <div class="rounded-md border border-rose-200 dark:border-rose-900/50 bg-rose-50 dark:bg-rose-900/20 px-4 py-3">
+                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-rose-600 dark:text-rose-400">Safety</div>
+                            <div class="text-[22px] font-bold text-rose-700 dark:text-rose-300 tabular-nums" x-text="stats?.safety || 0"></div>
                         </div>
-                        <div class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
-                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-600">Recommend</div>
-                            <div class="text-[22px] font-bold text-amber-700 tabular-nums" x-text="stats?.recommendation || 0"></div>
+                        <div class="rounded-md border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/20 px-4 py-3">
+                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-600 dark:text-amber-400">Recommend</div>
+                            <div class="text-[22px] font-bold text-amber-700 dark:text-amber-300 tabular-nums" x-text="stats?.recommendation || 0"></div>
                         </div>
-                        <div class="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
-                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600">Maintenance</div>
-                            <div class="text-[22px] font-bold text-slate-700 tabular-nums" x-text="stats?.maintenance || 0"></div>
+                        <div class="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-4 py-3">
+                            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-400">Maintenance</div>
+                            <div class="text-[22px] font-bold text-slate-700 dark:text-slate-300 tabular-nums" x-text="stats?.maintenance || 0"></div>
                         </div>
                     </div>
 
-                    <div x-show="!loading && totalDefects === 0" style="display:none" class="text-center py-12 px-6 rounded-lg bg-emerald-50 border border-emerald-200">
-                        <p class="text-[13px] text-emerald-700 font-semibold">No defects flagged. The report looks clean.</p>
+                    <div x-show="!loading && totalDefects === 0" style="display:none" class="text-center py-12 px-6 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-900/50">
+                        <p class="text-[13px] text-emerald-700 dark:text-emerald-400 font-semibold">No defects flagged. The report looks clean.</p>
                     </div>
 
                     <template x-for="sec in sectionsWithDefects" {...{ 'x-bind:key': 'sec.id' }}>
                         <section class="space-y-3">
-                            <header class="flex items-baseline justify-between border-b border-slate-200 pb-2">
-                                <h3 class="text-[14px] font-bold text-slate-900" x-text="sec.title"></h3>
-                                <span class="text-[11px] text-slate-400 font-mono" x-text="sec.defectCount + ' defects'"></span>
+                            <header class="flex items-baseline justify-between border-b border-slate-200 dark:border-slate-700 pb-2">
+                                <h3 class="text-[14px] font-bold text-slate-900 dark:text-slate-100" x-text="sec.title"></h3>
+                                <span class="text-[11px] text-slate-400 dark:text-slate-500 font-mono" x-text="sec.defectCount + ' defects'"></span>
                             </header>
                             <ul class="space-y-2">
                                 <template x-for="defect in sec.defects" {...{ 'x-bind:key': 'defect.id' }}>
-                                    <li class="rounded-md bg-white border border-slate-200 px-4 py-3 flex items-start gap-3">
+                                    <li class="rounded-md bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 px-4 py-3 flex items-start gap-3">
                                         <span
                                             class="w-2 h-2 mt-1.5 rounded-full flex-shrink-0"
                                             {...{ 'x-bind:style': "'background:' + (defect.color || '#cbd5e1')" }}
                                         ></span>
                                         <div class="flex-1 min-w-0">
-                                            <p class="text-[13px] font-bold text-slate-900" x-text="defect.itemLabel"></p>
-                                            <p class="text-[12px] text-slate-600 mt-0.5" x-text="defect.text"></p>
+                                            <p class="text-[13px] font-bold text-slate-900 dark:text-slate-100" x-text="defect.itemLabel"></p>
+                                            <p class="text-[12px] text-slate-600 dark:text-slate-400 mt-0.5" x-text="defect.text"></p>
                                         </div>
-                                        <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500" x-text="defect.bucket"></span>
+                                        <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400" x-text="defect.bucket"></span>
                                     </li>
                                 </template>
                             </ul>

--- a/src/templates/pages/login.tsx
+++ b/src/templates/pages/login.tsx
@@ -294,6 +294,40 @@ export const LoginPage = ({ branding }: { branding?: BrandingConfig | undefined 
                         .login-heading { font-size: 1.375rem; }
                         .brand-mark { margin-bottom: 2rem; }
                     }
+
+                    /* ---- Dark mode ---- */
+                    [data-color-scheme="dark"] body {
+                        background: #0f172a;
+                        color: #f1f5f9;
+                    }
+                    [data-color-scheme="dark"] .login-heading { color: #f1f5f9; }
+                    [data-color-scheme="dark"] .login-sub { color: #94a3b8; }
+                    [data-color-scheme="dark"] .form-label { color: #cbd5e1; }
+                    [data-color-scheme="dark"] .form-input {
+                        background: #1e293b;
+                        border-color: #334155;
+                        color: #f1f5f9;
+                    }
+                    [data-color-scheme="dark"] .form-input::placeholder { color: #64748b; }
+                    [data-color-scheme="dark"] .form-input:focus { border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,0.2); }
+                    [data-color-scheme="dark"] .form-input:-webkit-autofill,
+                    [data-color-scheme="dark"] .form-input:-webkit-autofill:hover,
+                    [data-color-scheme="dark"] .form-input:-webkit-autofill:focus {
+                        -webkit-box-shadow: 0 0 0 1000px #1e293b inset;
+                        -webkit-text-fill-color: #f1f5f9;
+                        caret-color: #f1f5f9;
+                    }
+                    [data-color-scheme="dark"] .form-hint { color: #94a3b8; }
+                    [data-color-scheme="dark"] .divider-text { color: #64748b; }
+                    [data-color-scheme="dark"] .divider-line { border-color: #334155; }
+                    [data-color-scheme="dark"] .link-subtle { color: #818cf8; }
+                    [data-color-scheme="dark"] .brand-name { color: #f1f5f9; }
+                    [data-color-scheme="dark"] .footer-text { color: #64748b; }
+                    [data-color-scheme="dark"] .error-box {
+                        background: #450a0a;
+                        border-color: #991b1b;
+                        color: #fca5a5;
+                    }
                 ` }} />
 
                 {gaMeasurementId && (

--- a/src/templates/pages/login.tsx
+++ b/src/templates/pages/login.tsx
@@ -12,6 +12,8 @@ export const LoginPage = ({ branding }: { branding?: BrandingConfig | undefined 
                 <meta charset="UTF-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <title>{`Sign in | ${siteName}`}</title>
+                {/* FOUC prevention: apply stored color scheme before styles render. */}
+                <script dangerouslySetInnerHTML={{ __html: `(function(){var s=localStorage.getItem('ih-color-scheme');var p=window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.setAttribute('data-color-scheme',s==='dark'||(s===null&&p)?'dark':'light');})()`}} />
                 <link rel="stylesheet" href="/fonts.css" />
                 <style dangerouslySetInnerHTML={{ __html: `
                     :root {

--- a/src/templates/pages/marketplace.tsx
+++ b/src/templates/pages/marketplace.tsx
@@ -19,7 +19,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                 {/* R7-25: Spell out the import / update relationship so
                     inspectors aren't unsure whether importing creates a
                     copy they own or links to a remote template. */}
-                <div class="inline-flex items-start gap-2 px-4 py-2 rounded-md bg-slate-50 border border-slate-200 text-[11px] text-slate-600 max-w-2xl">
+                <div class="inline-flex items-start gap-2 px-4 py-2 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-[11px] text-slate-600 dark:text-slate-300 max-w-2xl">
                     <svg class="w-4 h-4 mt-0.5 flex-shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                     <div>
                         <strong>Import = your own copy.</strong> When the publisher updates the template, you'll see "Update available" and can pull the new version (or keep your customizations).
@@ -30,9 +30,9 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                 <div class="flex flex-col sm:flex-row gap-3">
                     <input type="text" x-model="search" {...{ 'x-on:input.debounce.300ms': 'load()' }}
                         placeholder="Search templates..."
-                        class="flex-1 px-4 py-2.5 rounded-xl border border-slate-200 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500" />
+                        class="flex-1 px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500" />
                     <select x-model="category" x-on:change="load()"
-                        class="px-4 py-2.5 rounded-xl border border-slate-200 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
+                        class="px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
                         <option value="">All Categories</option>
                         <option value="residential">Residential</option>
                         <option value="commercial">Commercial</option>
@@ -42,7 +42,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                     </select>
                     {/* Polish 5 — client-side sort */}
                     <select x-model="sort" x-on:change="resort()"
-                        class="px-4 py-2.5 rounded-xl border border-slate-200 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
+                        class="px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-violet-500">
                         <option value="featured">Featured first</option>
                         <option value="recent">Recently added</option>
                         <option value="popular">Most imports</option>
@@ -60,11 +60,11 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                                 <div class="flex items-start justify-between">
                                     <div>
                                         <div class="flex items-center gap-2">
-                                            <h3 class="font-bold text-slate-900 text-lg" x-text="l.name"></h3>
-                                            <span x-show="l.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">★ Featured</span>
+                                            <h3 class="font-bold text-slate-900 dark:text-white text-lg" x-text="l.name"></h3>
+                                            <span x-show="l.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">★ Featured</span>
                                         </div>
                                         <div class="flex items-center gap-2 mt-1">
-                                            <span class="text-xs font-bold text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full capitalize" x-text="l.kind"></span>
+                                            <span class="text-xs font-bold text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-2 py-0.5 rounded-full capitalize" x-text="l.kind"></span>
                                             <span class="text-xs text-slate-400 font-mono" x-text="'v' + l.semver"></span>
                                             <span class="text-xs text-slate-500" x-text="l.itemCount + ' entries'"></span>
                                         </div>
@@ -81,7 +81,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                                         </button>
                                     </template>
                                     <template x-if="l.importedSemver && !l.hasUpdate">
-                                        <span class="px-4 py-1.5 text-sm rounded-md font-bold bg-slate-100 text-slate-400">Imported</span>
+                                        <span class="px-4 py-1.5 text-sm rounded-md font-bold bg-slate-100 dark:bg-slate-700 text-slate-400">Imported</span>
                                     </template>
                                     <template x-if="l.hasUpdate">
                                         <button x-on:click="openUpdateConfirm(l, 'library')"
@@ -104,17 +104,17 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <div class="flex items-start justify-between">
                                 <div>
                                     <div class="flex items-center gap-2">
-                                        <h3 class="font-bold text-slate-900 text-lg" x-text="t.name"></h3>
-                                        <span x-show="t.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">★ Featured</span>
+                                        <h3 class="font-bold text-slate-900 dark:text-white text-lg" x-text="t.name"></h3>
+                                        <span x-show="t.featured" class="text-[10px] font-bold uppercase tracking-widest text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full">★ Featured</span>
                                     </div>
                                     <div class="flex items-center gap-2 mt-1">
-                                        <span class="text-xs font-bold text-violet-600 bg-violet-50 px-2 py-0.5 rounded-full capitalize" x-text="t.category.replace('_',' ')"></span>
+                                        <span class="text-xs font-bold text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-2 py-0.5 rounded-full capitalize" x-text="t.category.replace('_',' ')"></span>
                                         <span class="text-xs text-slate-400 font-mono" x-text="'v' + t.semver"></span>
                                     </div>
                                 </div>
                             </div>
                             <p class="text-sm text-slate-500" x-text="t.changelog || 'Standard inspection template.'"></p>
-                            <div class="flex items-center justify-between mt-auto pt-2 border-t border-slate-100 gap-2">
+                            <div class="flex items-center justify-between mt-auto pt-2 border-t border-slate-100 dark:border-slate-700 gap-2">
                                 <span class="text-xs text-slate-400" x-text="t.downloadCount + ' imports'"></span>
                                 <div class="flex items-center gap-2">
                                     {/* Polish 5 — Preview button */}
@@ -126,7 +126,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                                         </button>
                                     </template>
                                     <template x-if="t.importedSemver && !t.hasUpdate">
-                                        <span class="px-4 py-1.5 rounded-xl bg-slate-100 text-slate-400 text-xs font-bold">Imported</span>
+                                        <span class="px-4 py-1.5 rounded-xl bg-slate-100 dark:bg-slate-700 text-slate-400 text-xs font-bold">Imported</span>
                                     </template>
                                     {/* Round 37 — Update flow (Scheme 2). Opens a confirm
                                         modal explaining "creates a new copy" before POSTing. */}
@@ -150,10 +150,10 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                 {/* Pagination */}
                 <div class="flex items-center justify-center gap-3" x-show="totalPages > 1">
                     <button x-on:click="prevPage()" x-bind:disabled="page <= 1"
-                        class="px-4 py-2 rounded-xl border border-slate-200 text-sm font-bold disabled:opacity-40">Prev</button>
-                    <span class="text-sm text-slate-600 font-semibold" x-text="`Page ${page} of ${totalPages}`"></span>
+                        class="px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 dark:text-slate-300 text-sm font-bold disabled:opacity-40">Prev</button>
+                    <span class="text-sm text-slate-600 dark:text-slate-300 font-semibold" x-text="`Page ${page} of ${totalPages}`"></span>
                     <button x-on:click="nextPage()" x-bind:disabled="page >= totalPages"
-                        class="px-4 py-2 rounded-xl border border-slate-200 text-sm font-bold disabled:opacity-40">Next</button>
+                        class="px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 dark:text-slate-300 text-sm font-bold disabled:opacity-40">Next</button>
                 </div>
 
                 {/* Polish 5 — Preview modal. Footer has Close + Import (conditional),
@@ -168,7 +168,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <button
                                 type="button"
                                 x-on:click="previewOpen = false"
-                                class="h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                class="h-10 px-4 rounded-xl border bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                                 style="border-color: #e2e8f0"
                             >
                                 Close
@@ -193,20 +193,20 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <span class="text-rose-500" x-text="previewDefectTotal + ' defects'"></span>
                         </p>
                         <template x-for="sec in (previewSchema?.sections || [])" {...{ 'x-bind:key': 'sec.id' }}>
-                            <details class="bg-slate-50 rounded-xl p-3" open>
-                                <summary class="cursor-pointer font-bold text-sm text-slate-800 flex items-center justify-between">
+                            <details class="bg-slate-50 dark:bg-slate-800 rounded-xl p-3" open>
+                                <summary class="cursor-pointer font-bold text-sm text-slate-800 dark:text-slate-100 flex items-center justify-between">
                                     <span x-text="sec.title || sec.name || sec.id"></span>
                                     <span class="text-xs text-slate-400" x-text="(sec.items?.length || 0) + ' items'"></span>
                                 </summary>
-                                <ul class="mt-2 space-y-1 text-xs text-slate-600 pl-3">
+                                <ul class="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-400 pl-3">
                                     <template x-for="it in (sec.items || [])" {...{ 'x-bind:key': 'it.id' }}>
                                         <li class="flex items-center gap-2 flex-wrap py-1">
-                                            <span class="w-1 h-1 rounded-full bg-slate-300"></span>
-                                            <span class="font-semibold text-slate-700" x-text="it.label || it.name || it.id"></span>
-                                            <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 text-slate-600" x-text="it.type || 'rich'"></span>
-                                            <span x-show="it._info > 0" class="text-[10px] font-mono text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded" x-text="'info: ' + it._info"></span>
-                                            <span x-show="it._lim > 0" class="text-[10px] font-mono text-sky-700 bg-sky-50 px-1.5 py-0.5 rounded" x-text="'lim: ' + it._lim"></span>
-                                            <span x-show="it._def > 0" class="text-[10px] font-mono text-rose-700 bg-rose-50 px-1.5 py-0.5 rounded" x-text="'def: ' + it._def"></span>
+                                            <span class="w-1 h-1 rounded-full bg-slate-300 dark:bg-slate-600"></span>
+                                            <span class="font-semibold text-slate-700 dark:text-slate-200" x-text="it.label || it.name || it.id"></span>
+                                            <span class="text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300" x-text="it.type || 'rich'"></span>
+                                            <span x-show="it._info > 0" class="text-[10px] font-mono text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-1.5 py-0.5 rounded" x-text="'info: ' + it._info"></span>
+                                            <span x-show="it._lim > 0" class="text-[10px] font-mono text-sky-700 dark:text-sky-400 bg-sky-50 dark:bg-sky-900/30 px-1.5 py-0.5 rounded" x-text="'lim: ' + it._lim"></span>
+                                            <span x-show="it._def > 0" class="text-[10px] font-mono text-rose-700 dark:text-rose-400 bg-rose-50 dark:bg-rose-900/30 px-1.5 py-0.5 rounded" x-text="'def: ' + it._def"></span>
                                         </li>
                                     </template>
                                 </ul>
@@ -228,7 +228,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             <button
                                 type="button"
                                 x-on:click="closeUpdateConfirm()"
-                                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
+                                class="flex-1 h-10 px-4 rounded-xl border bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                                 style="border-color: #e2e8f0"
                             >
                                 Cancel
@@ -243,16 +243,16 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                         </>
                     }
                 >
-                    <div class="space-y-3 text-sm text-slate-700">
+                    <div class="space-y-3 text-sm text-slate-700 dark:text-slate-200">
                         <p>
                             <strong x-text="updateTarget?.name || ''"></strong>
-                            <span class="text-slate-500"> will move from </span>
-                            <span class="font-mono text-xs text-slate-700" x-text="'v' + (updateTarget?.importedSemver || '?')"></span>
-                            <span class="text-slate-500"> to </span>
-                            <span class="font-mono text-xs font-bold text-amber-700" x-text="'v' + (updateTarget?.semver || '?')"></span>.
+                            <span class="text-slate-500 dark:text-slate-400"> will move from </span>
+                            <span class="font-mono text-xs text-slate-700 dark:text-slate-300" x-text="'v' + (updateTarget?.importedSemver || '?')"></span>
+                            <span class="text-slate-500 dark:text-slate-400"> to </span>
+                            <span class="font-mono text-xs font-bold text-amber-700 dark:text-amber-400" x-text="'v' + (updateTarget?.semver || '?')"></span>.
                         </p>
                         <template x-if="updateKind === 'template'">
-                            <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
+                            <p class="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
                                 A new copy will be created with the suffix
                                 <span class="font-mono font-bold" x-text="'(v' + (updateTarget?.semver || '?') + ')'"></span>.
                                 Your current copy is <strong>preserved</strong> so existing
@@ -261,7 +261,7 @@ export const MarketplacePage = ({ branding }: { branding?: BrandingConfig | unde
                             </p>
                         </template>
                         <template x-if="updateKind === 'library'">
-                            <p class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-900">
+                            <p class="bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
                                 The new pack's entries will be <strong>added</strong> alongside
                                 your existing ones. Old entries are <strong>not deleted</strong>.
                                 If you want a clean state, delete the old entries from

--- a/src/templates/pages/metrics.tsx
+++ b/src/templates/pages/metrics.tsx
@@ -19,11 +19,11 @@ export function MetricsPage({ appName, branding }: MetricsPageProps) {
                         <span x-text="data ? `${periodLabel(period)} · ${data.totalInspections} inspections · ${fmt(data.totalRevenue)}` : 'Loading…'"></span>
                     }
                     actions={
-                        <div class="flex gap-1 bg-slate-100 rounded-md p-1">
+                        <div class="flex gap-1 bg-slate-100 dark:bg-slate-700 rounded-md p-1">
                             {(['3m', '6m', '12m'] as const).map(p => (
                                 <button
                                     x-on:click={`period='${p}'; load()`}
-                                    x-bind:class={`period==='${p}' ? 'bg-white shadow-sm text-slate-900' : 'text-slate-400'`}
+                                    x-bind:class={`period==='${p}' ? 'bg-white dark:bg-slate-600 shadow-sm text-slate-900 dark:text-white' : 'text-slate-400 dark:text-slate-500'`}
                                     class="h-6 px-3 rounded text-[12px] font-bold transition-all"
                                 >{p}</button>
                             ))}

--- a/src/templates/pages/not-found.tsx
+++ b/src/templates/pages/not-found.tsx
@@ -87,19 +87,19 @@ export const NotFoundPage = (props: NotFoundPageProps = {}): JSX.Element => {
 
     return (
         <BareLayout title={`${siteName} | ${ctx.title}`} branding={branding}>
-            <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4 py-12">
+            <div class="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-900 px-4 py-12">
                 <div class="max-w-md w-full text-center space-y-6">
                     {branding?.logoUrl && (
                         <img src={branding.logoUrl} alt={siteName} class="h-10 mx-auto opacity-80" />
                     )}
-                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 text-slate-400 mx-auto">
+                    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 mx-auto">
                         <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
                         </svg>
                     </div>
                     <div class="space-y-2">
-                        <h1 class="text-[22px] font-bold tracking-tight text-slate-900">{ctx.title}</h1>
-                        <p class="text-[14px] text-slate-500 leading-relaxed">{ctx.body}</p>
+                        <h1 class="text-[22px] font-bold tracking-tight text-slate-900 dark:text-slate-100">{ctx.title}</h1>
+                        <p class="text-[14px] text-slate-500 dark:text-slate-400 leading-relaxed">{ctx.body}</p>
                     </div>
                     {cta && (
                         <a

--- a/src/templates/pages/rating-systems.tsx
+++ b/src/templates/pages/rating-systems.tsx
@@ -29,15 +29,15 @@ export const RatingSystemsPage = ({ branding }: Props): JSX.Element => {
                 />
 
                 {/* Loading state */}
-                <div x-show="loading" class="text-center py-12 bg-slate-50 rounded-md">
+                <div x-show="loading" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
                     <p class="text-slate-500 font-semibold">Loading rating systems…</p>
                 </div>
 
                 {/* Error banner */}
-                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-[13px] text-rose-700" x-text="error"></div>
+                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-[13px] text-rose-700 dark:text-rose-400" x-text="error"></div>
 
                 {/* Empty state — only shown when load completed and the list is genuinely empty */}
-                <div x-show="!loading && systems.length === 0" style="display:none" class="text-center py-12 bg-slate-50 rounded-md">
+                <div x-show="!loading && systems.length === 0" style="display:none" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
                     <p class="text-slate-500 font-semibold">No rating systems found.</p>
                     <p class="text-slate-400 text-sm mt-2">Reload the page to seed the four canonical systems.</p>
                 </div>
@@ -45,13 +45,13 @@ export const RatingSystemsPage = ({ branding }: Props): JSX.Element => {
                 {/* List */}
                 <div x-show="!loading && systems.length > 0" style="display:none" class="grid grid-cols-1 md:grid-cols-2 gap-3" data-testid="rating-system-list">
                     <template x-for="sys in systems" {...{ 'x-bind:key': 'sys.id' }}>
-                        <div class="p-4 bg-white border border-slate-200 rounded-lg shadow-sm hover:shadow-md transition" x-bind:data-rating-system-id="sys.id" x-bind:data-rating-system-slug="sys.slug">
+                        <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-sm hover:shadow-md transition" x-bind:data-rating-system-id="sys.id" x-bind:data-rating-system-slug="sys.slug">
                             <div class="flex items-start justify-between gap-3">
                                 <div class="flex-1 min-w-0">
                                     <div class="flex items-center gap-2 mb-1 flex-wrap">
-                                        <p class="font-bold text-slate-900" x-text="sys.name"></p>
-                                        <span x-show="sys.isDefault" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200">Default</span>
-                                        <span x-show="sys.isSeed" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 ring-1 ring-slate-200">Seed</span>
+                                        <p class="font-bold text-slate-900 dark:text-slate-100" x-text="sys.name"></p>
+                                        <span x-show="sys.isDefault" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-indigo-50 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400 ring-1 ring-indigo-200 dark:ring-indigo-700">Default</span>
+                                        <span x-show="sys.isSeed" class="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400 ring-1 ring-slate-200 dark:ring-slate-600">Seed</span>
                                     </div>
                                     <p class="text-xs text-slate-500" x-text="sys.description || '(no description)'"></p>
                                     <div class="flex flex-wrap gap-1.5 mt-3">

--- a/src/templates/pages/recommendations.tsx
+++ b/src/templates/pages/recommendations.tsx
@@ -21,7 +21,7 @@ export const RecommendationsPage = ({ branding }: Props): JSX.Element => (
                             x-show="items.length === 0"
                             x-on:click="seedDefaults()"
                             {...{ 'x-bind:disabled': 'loading' }}
-                            class="h-8 px-3 rounded-md bg-indigo-100 text-indigo-700 text-[13px] font-bold hover:bg-indigo-200 disabled:opacity-50 transition-all"
+                            class="h-8 px-3 rounded-md bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 text-[13px] font-bold hover:bg-indigo-200 dark:hover:bg-indigo-900/60 disabled:opacity-50 transition-all"
                         >
                             Seed defaults (80)
                         </button>
@@ -31,7 +31,7 @@ export const RecommendationsPage = ({ branding }: Props): JSX.Element => (
                             type="button"
                             onclick="window.print()"
                             aria-label="Print recommendations as PDF"
-                            class="h-8 px-4 rounded-md bg-white border border-slate-200 text-slate-700 text-[13px] font-bold inline-flex items-center gap-1.5 hover:bg-slate-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
+                            class="h-8 px-4 rounded-md bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-700 dark:text-slate-200 text-[13px] font-bold inline-flex items-center gap-1.5 hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
                         >
                             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"></path></svg>
                             Print as PDF

--- a/src/templates/pages/recommendations.tsx
+++ b/src/templates/pages/recommendations.tsx
@@ -62,14 +62,14 @@ export const RecommendationsPage = ({ branding }: Props): JSX.Element => (
                 </select>
             </div>
 
-            <div x-show="items.length === 0 && !loading" class="text-center py-12 bg-slate-50 rounded-md">
-                <p class="text-slate-500 font-semibold">No recommendations yet.</p>
-                <p class="text-slate-400 text-sm mt-2">Click "Seed defaults" above to load 80 starter entries, or add your own.</p>
+            <div x-show="items.length === 0 && !loading" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+                <p class="text-slate-500 dark:text-slate-400 font-semibold">No recommendations yet.</p>
+                <p class="text-slate-400 dark:text-slate-500 text-sm mt-2">Click "Seed defaults" above to load 80 starter entries, or add your own.</p>
             </div>
 
             <div x-show="items.length > 0" class="grid grid-cols-1 md:grid-cols-2 gap-3 print:hidden">
                 <template x-for="rec in items" {...{ 'x-bind:key': 'rec.id' }}>
-                    <div class="p-4 bg-white border border-slate-200 rounded-lg shadow-sm hover:shadow-md transition">
+                    <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-sm hover:shadow-md transition">
                         <div class="flex items-start justify-between gap-3">
                             <div class="flex-1 min-w-0">
                                 <div class="flex items-center gap-2 mb-1">

--- a/src/templates/pages/reports.tsx
+++ b/src/templates/pages/reports.tsx
@@ -35,7 +35,7 @@ export const ReportsPage = ({ branding }: { branding?: BrandingConfig }) => {
                     <div class="hidden md:block">
                         <table class="w-full">
                             <thead>
-                                <tr class="bg-slate-50/40">
+                                <tr class="bg-slate-50/40 dark:bg-slate-700/50">
                                     <th class="px-6 py-5 text-left text-[10px] font-bold text-slate-400 uppercase tracking-[0.2em]">Property</th>
                                     <th class="px-6 py-5 text-left text-[10px] font-bold text-slate-400 uppercase tracking-[0.2em]">Client</th>
                                     <th class="px-6 py-5 text-left text-[10px] font-bold text-slate-400 uppercase tracking-[0.2em]">Date</th>
@@ -44,7 +44,7 @@ export const ReportsPage = ({ branding }: { branding?: BrandingConfig }) => {
                                     <th class="px-6 py-5"></th>
                                 </tr>
                             </thead>
-                            <tbody id="reportsList" class="divide-y divide-slate-100"></tbody>
+                            <tbody id="reportsList" class="divide-y divide-slate-100 dark:divide-slate-700"></tbody>
                         </table>
                     </div>
                     <div id="reportsCardList" class="md:hidden flex flex-col gap-3 p-4"></div>

--- a/src/templates/pages/settings-workspace.tsx
+++ b/src/templates/pages/settings-workspace.tsx
@@ -257,7 +257,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         data-testid="settings-show-estimates-toggle"
                         x-model="showEstimates"
                         x-on:change="save({ showEstimates: showEstimates })"
-                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 dark:bg-slate-600 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(showEstimates ? { checked: true } : {})}
                     />
@@ -281,7 +281,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         data-testid="settings-enable-repair-list-toggle"
                         x-model="enableRepairList"
                         x-on:change="save({ enableRepairList: enableRepairList })"
-                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 dark:bg-slate-600 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(enableRepairList ? { checked: true } : {})}
                     />
@@ -304,7 +304,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         data-testid="settings-enable-customer-repair-export-toggle"
                         x-model="enableCustomerRepairExport"
                         x-on:change="save({ enableCustomerRepairExport: enableCustomerRepairExport })"
-                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 dark:bg-slate-600 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(enableCustomerRepairExport ? { checked: true } : {})}
                     />
@@ -329,7 +329,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         data-testid="settings-enable-pdf-pipeline-toggle"
                         x-model="enablePdfPipeline"
                         x-on:change="save({ enablePdfPipeline: enablePdfPipeline })"
-                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 dark:bg-slate-600 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(enablePdfPipeline ? { checked: true } : {})}
                     />
@@ -357,7 +357,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         data-testid="settings-block-unpaid-toggle"
                         x-model="blockUnpaid"
                         x-on:change="save({ blockUnpaid: blockUnpaid })"
-                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 dark:bg-slate-600 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(blockUnpaid ? { checked: true } : {})}
                     />
@@ -378,7 +378,7 @@ export const SettingsWorkspaceReportsPage = ({ branding, showEstimates, enableRe
                         data-testid="settings-block-unsigned-agreement-toggle"
                         x-model="blockUnsignedAgreement"
                         x-on:change="save({ blockUnsignedAgreement: blockUnsignedAgreement })"
-                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
+                        class="mt-1 h-5 w-10 rounded-full appearance-none bg-surface-200 dark:bg-slate-600 checked:bg-blueprint-500 transition-colors cursor-pointer relative shrink-0"
                         style="background-position: left center; background-repeat: no-repeat;"
                         {...(blockUnsignedAgreement ? { checked: true } : {})}
                     />

--- a/src/templates/pages/tags.tsx
+++ b/src/templates/pages/tags.tsx
@@ -54,19 +54,19 @@ export const TagsPage = ({ branding }: Props): JSX.Element => {
                 />
 
                 {/* Loading + error */}
-                <div x-show="loading" class="text-center py-12 bg-slate-50 rounded-md text-[13px] text-slate-500 font-semibold">Loading tags…</div>
-                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-[13px] text-rose-700" x-text="error"></div>
+                <div x-show="loading" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md text-[13px] text-slate-500 dark:text-slate-400 font-semibold">Loading tags…</div>
+                <div x-show="error" style="display:none" class="rounded-md border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-[13px] text-rose-700 dark:text-rose-400" x-text="error"></div>
 
                 {/* Empty */}
-                <div x-show="!loading && tags.length === 0" style="display:none" class="text-center py-12 bg-slate-50 rounded-md">
-                    <p class="text-slate-500 font-semibold">No tags yet.</p>
-                    <p class="text-slate-400 text-sm mt-2">Reload to plant the five seed tags, or add your own.</p>
+                <div x-show="!loading && tags.length === 0" style="display:none" class="text-center py-12 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+                    <p class="text-slate-500 dark:text-slate-400 font-semibold">No tags yet.</p>
+                    <p class="text-slate-400 dark:text-slate-500 text-sm mt-2">Reload to plant the five seed tags, or add your own.</p>
                 </div>
 
                 {/* List */}
                 <div x-show="!loading && tags.length > 0" style="display:none" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="tag-list">
                     <template x-for="tag in tags" {...{ 'x-bind:key': 'tag.id' }}>
-                        <div class="p-4 bg-white border border-slate-200 rounded-md shadow-sm hover:shadow transition" x-bind:data-tag-id="tag.id" x-bind:data-tag-name="tag.name">
+                        <div class="p-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md shadow-sm hover:shadow transition" x-bind:data-tag-id="tag.id" x-bind:data-tag-name="tag.name">
                             <div class="flex items-start justify-between gap-3">
                                 <div class="flex-1 min-w-0">
                                     <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-bold ring-1 ring-inset" x-bind:class="colorClass(tag.color)" x-text="tag.name"></span>

--- a/src/templates/pages/tags.tsx
+++ b/src/templates/pages/tags.tsx
@@ -17,14 +17,14 @@ import type { BrandingConfig } from '../../types/auth';
 interface Props { branding?: BrandingConfig | undefined }
 
 const TAG_COLORS: ReadonlyArray<{ value: string; label: string; tw: string }> = [
-    { value: 'slate',    label: 'Slate',    tw: 'bg-slate-100 text-slate-700 ring-slate-200' },
-    { value: 'amber',    label: 'Amber',    tw: 'bg-amber-100 text-amber-700 ring-amber-200' },
-    { value: 'rose',     label: 'Rose',     tw: 'bg-rose-100 text-rose-700 ring-rose-200' },
-    { value: 'indigo',   label: 'Indigo',   tw: 'bg-indigo-100 text-indigo-700 ring-indigo-200' },
-    { value: 'emerald',  label: 'Emerald',  tw: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
-    { value: 'sky',      label: 'Sky',      tw: 'bg-sky-100 text-sky-700 ring-sky-200' },
-    { value: 'fuchsia',  label: 'Fuchsia',  tw: 'bg-fuchsia-100 text-fuchsia-700 ring-fuchsia-200' },
-    { value: 'lime',     label: 'Lime',     tw: 'bg-lime-100 text-lime-700 ring-lime-200' },
+    { value: 'slate',   label: 'Slate',   tw: 'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 ring-slate-200 dark:ring-slate-500' },
+    { value: 'amber',   label: 'Amber',   tw: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 ring-amber-200 dark:ring-amber-700' },
+    { value: 'rose',    label: 'Rose',    tw: 'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300 ring-rose-200 dark:ring-rose-700' },
+    { value: 'indigo',  label: 'Indigo',  tw: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 ring-indigo-200 dark:ring-indigo-700' },
+    { value: 'emerald', label: 'Emerald', tw: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 ring-emerald-200 dark:ring-emerald-700' },
+    { value: 'sky',     label: 'Sky',     tw: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 ring-sky-200 dark:ring-sky-700' },
+    { value: 'fuchsia', label: 'Fuchsia', tw: 'bg-fuchsia-100 dark:bg-fuchsia-900/40 text-fuchsia-700 dark:text-fuchsia-300 ring-fuchsia-200 dark:ring-fuchsia-700' },
+    { value: 'lime',    label: 'Lime',    tw: 'bg-lime-100 dark:bg-lime-900/40 text-lime-700 dark:text-lime-300 ring-lime-200 dark:ring-lime-700' },
 ];
 
 export const TagsPage = ({ branding }: Props): JSX.Element => {

--- a/src/templates/pages/team.tsx
+++ b/src/templates/pages/team.tsx
@@ -21,7 +21,7 @@ export const TeamPage = ({ branding }: { branding?: BrandingConfig | undefined }
                                 <div id="quotaBadge" class="hidden sm:flex items-center gap-2 px-3 h-8 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700">
                                     <span class="w-1 h-1 rounded-full bg-indigo-500"></span>
                                     <span class="text-[11px] font-bold text-slate-400 uppercase tracking-widest leading-none">Seats:</span>
-                                    <span class="text-[12px] font-bold text-slate-900 leading-none">Loading...</span>
+                                    <span class="text-[12px] font-bold text-slate-900 dark:text-slate-100 leading-none">Loading...</span>
                                 </div>
                                 <button
                                     type="button"
@@ -47,7 +47,7 @@ export const TeamPage = ({ branding }: { branding?: BrandingConfig | undefined }
                         </div>
                         <div class="overflow-x-auto custom-scrollbar">
                             <table class="w-full text-left">
-                                <thead class="bg-slate-50/50">
+                                <thead class="bg-slate-50/50 dark:bg-slate-700/50">
                                     <tr>
                                         <th class="py-6 px-10 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Name</th>
                                         <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Role</th>
@@ -99,8 +99,7 @@ export const TeamPage = ({ branding }: { branding?: BrandingConfig | undefined }
                             <button
                                 type="button"
                                 id="closeInviteModalBtn"
-                                class="flex-1 h-10 px-4 rounded-xl border bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-all"
-                                style="border-color: #e2e8f0"
+                                class="flex-1 h-10 px-4 rounded-xl border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-all"
                             >
                                 Cancel
                             </button>
@@ -116,14 +115,14 @@ export const TeamPage = ({ branding }: { branding?: BrandingConfig | undefined }
                 >
                     <form id="inviteForm" class="space-y-4">
                         <div class="space-y-3">
-                            <label for="inviteEmail" class="block text-xs font-bold text-slate-900 ml-1 uppercase tracking-[0.2em]">Email Address</label>
+                            <label for="inviteEmail" class="block text-xs font-bold text-slate-900 dark:text-slate-100 ml-1 uppercase tracking-[0.2em]">Email Address</label>
                             <input type="email" id="inviteEmail" name="email" required placeholder="colleague@example.com"
-                                class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all placeholder:text-slate-300 font-medium text-sm" />
+                                class="w-full px-3 py-2 rounded-md border border-slate-200 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all placeholder:text-slate-300 dark:placeholder:text-slate-500 font-medium text-sm" />
                         </div>
                         <div class="space-y-3">
-                            <label for="inviteRole" class="block text-xs font-bold text-slate-900 ml-1 uppercase tracking-[0.2em]">Role</label>
+                            <label for="inviteRole" class="block text-xs font-bold text-slate-900 dark:text-slate-100 ml-1 uppercase tracking-[0.2em]">Role</label>
                             <select id="inviteRole" name="role"
-                                class="w-full px-3 py-2 rounded-md border border-slate-200 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all appearance-none cursor-pointer font-medium text-sm bg-no-repeat bg-[right_1.5rem_center]">
+                                class="w-full px-3 py-2 rounded-md border border-slate-200 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none transition-all appearance-none cursor-pointer font-medium text-sm bg-no-repeat bg-[right_1.5rem_center]">
                                 <option value="admin">Admin</option>
                                 <option value="inspector">Inspector</option>
                                 <option value="office_staff">Office Staff</option>

--- a/src/templates/pages/template-editor.tsx
+++ b/src/templates/pages/template-editor.tsx
@@ -21,6 +21,98 @@ const EDITOR_CSS = `
 .section-accent { border-left: 3px solid var(--section-color, var(--ih-primary, #6366f1)); }
 .rating-dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
 input:focus, textarea:focus, select:focus { outline: none; box-shadow: 0 0 0 3px rgba(74, 114, 255, 0.15); }
+
+/* ── Dark mode overrides ───────────────────────────────────────────────────
+   Global styles.css overrides bg-surface-50/100 and all inputs/selects,
+   but misses /opacity variants (bg-surface-50/90) and bg-white/50 panels.
+   Semantic class names below restore the correct dark appearance. */
+[data-color-scheme=dark] .editor-header {
+  background-color: rgba(11,17,32,0.92) !important;
+  border-color: rgba(255,255,255,0.08) !important;
+}
+[data-color-scheme=dark] .editor-subheader {
+  background-color: rgba(11,17,32,0.92) !important;
+  border-color: rgba(255,255,255,0.06) !important;
+}
+[data-color-scheme=dark] .editor-side-panel {
+  background-color: rgba(11,17,32,0.55) !important;
+  border-color: rgba(255,255,255,0.07) !important;
+}
+/* Undo global input override for transparent inline title/section editors.
+   Selector specificity must exceed the global rule (0,4,2) — achieved by
+   replicating its :not() chain plus adding the class = (0,5,2). */
+html[data-color-scheme=dark] input.editor-title-input:not([type=checkbox]):not([type=radio]):not([type=range]),
+html[data-color-scheme=dark] input.editor-section-input:not([type=checkbox]):not([type=radio]):not([type=range]) {
+  background-color: transparent !important;
+  border-color: transparent !important;
+}
+html[data-color-scheme=dark] input.editor-title-input:hover,
+html[data-color-scheme=dark] input.editor-section-input:hover { border-bottom-color: rgba(255,255,255,0.18) !important; }
+html[data-color-scheme=dark] input.editor-title-input:focus,
+html[data-color-scheme=dark] input.editor-section-input:focus { border-bottom-color: #4a72ff !important; }
+[data-color-scheme=dark] .bg-grid {
+  background-image: radial-gradient(circle, #334155 0.75px, transparent 0.75px);
+}
+[data-color-scheme=dark] .scrollbar-thin::-webkit-scrollbar-thumb { background: #334155; }
+[data-color-scheme=dark] .glass-warm {
+  background: rgba(15,23,42,0.85) !important;
+  border-color: rgba(255,255,255,0.08) !important;
+}
+[data-color-scheme=dark] .icon-picker-wrap {
+  background-color: #1e293b !important;
+  border-color: rgba(255,255,255,0.1) !important;
+}
+[data-color-scheme=dark] .icon-btn:hover { background: rgba(74,114,255,0.2) !important; border-color: rgba(74,114,255,0.4) !important; }
+[data-color-scheme=dark] .icon-btn.active { background: rgba(74,114,255,0.2) !important; border-color: #4a72ff !important; }
+[data-color-scheme=dark] .editor-canned-panel {
+  background-color: #0f172a !important;
+  border-color: rgba(255,255,255,0.08) !important;
+}
+[data-color-scheme=dark] .editor-canned-panel .bg-surface-50,
+[data-color-scheme=dark] .editor-canned-panel input {
+  background-color: rgba(255,255,255,0.05) !important;
+  border-color: rgba(255,255,255,0.08) !important;
+}
+[data-color-scheme=dark] .editor-props-header {
+  background-color: rgba(11,17,32,0.85) !important;
+  border-color: rgba(255,255,255,0.07) !important;
+}
+/* Section list: selected card (bg-blueprint-50 = light blue → dark indigo tint) */
+[data-color-scheme=dark] #sectionsList .bg-blueprint-50 {
+  background-color: rgba(99,102,241,0.15) !important;
+}
+[data-color-scheme=dark] #sectionsList .text-blueprint-700 {
+  color: #a5b4fc !important;
+}
+/* Item cards: bg-white → dark slate surface */
+[data-color-scheme=dark] #itemsList .bg-white {
+  background-color: #1e293b !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.4) !important;
+}
+/* Item selected highlight: bg-blueprint-50/40 → subtle indigo tint */
+[data-color-scheme=dark] #itemsList .bg-blueprint-50\/40 {
+  background-color: rgba(99,102,241,0.1) !important;
+}
+/* Section icon badge: unselected state has inline bg #f3f1ed (beige) → dark muted */
+[data-color-scheme=dark] #sectionsList > div:not(.bg-blueprint-50) .editor-section-icon {
+  background: rgba(255,255,255,0.07) !important;
+  color: rgba(255,255,255,0.4) !important;
+}
+/* Header blueprint-50 buttons (Comments active state, version badge, etc.) */
+[data-color-scheme=dark] .editor-header .bg-blueprint-50 {
+  background-color: rgba(99,102,241,0.18) !important;
+}
+[data-color-scheme=dark] .editor-header .text-blueprint-600,
+[data-color-scheme=dark] .editor-header .text-blueprint-700 {
+  color: #a5b4fc !important;
+}
+/* Add section (+) button in side panel header */
+[data-color-scheme=dark] .editor-side-panel > div .bg-blueprint-50 {
+  background-color: rgba(99,102,241,0.18) !important;
+}
+[data-color-scheme=dark] .editor-side-panel > div .text-blueprint-600 {
+  color: #a5b4fc !important;
+}
 `;
 
 export const TemplateEditorPage = ({ templateId, branding }: { templateId: string; branding?: BrandingConfig | undefined }): JSX.Element => {
@@ -35,7 +127,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
             <div class="bg-surface-50 bg-grid text-ink-900 antialiased min-h-screen" x-data="templateEditor()" x-cloak data-template-id={templateId}>
 
                 {/* Top Bar */}
-                <header class="sticky top-0 z-50 border-b border-surface-200/60 bg-surface-50/90 backdrop-blur-xl">
+                <header class="editor-header sticky top-0 z-50 border-b border-surface-200/60 bg-surface-50/90 backdrop-blur-xl">
                     <div class="flex items-center justify-between px-6 h-16">
                         <div class="flex items-center gap-4">
                             <a href="/templates" class="w-9 h-9 rounded-xl bg-surface-100 hover:bg-surface-200 flex items-center justify-center transition-colors group">
@@ -43,7 +135,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                             </a>
                             <div class="flex items-center gap-3">
                                 <input type="text" x-model="template.title"
-                                    class="text-xl font-display font-700 bg-transparent border-b-2 border-transparent hover:border-surface-200 focus:border-blueprint-500 px-1 py-0.5 transition-colors min-w-[200px]"
+                                    class="editor-title-input text-xl font-display font-700 bg-transparent border-b-2 border-transparent hover:border-surface-200 focus:border-blueprint-500 px-1 py-0.5 transition-colors min-w-[200px]"
                                     placeholder="Template Name" />
                                 <span class="font-mono text-[10px] font-600 text-ink-400 bg-surface-100 px-2.5 py-1 rounded-lg tracking-wide" x-text="'v' + template.version"></span>
                                 <span x-show="template.source" class="inline-flex items-center gap-1 text-[10px] font-600 px-2 py-0.5 rounded-md"
@@ -85,7 +177,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                 <div class="flex h-[calc(100vh-4rem)]">
 
                     {/* LEFT: Sections Panel */}
-                    <aside class="w-[260px] border-r border-surface-200/60 bg-white/50 flex flex-col flex-shrink-0">
+                    <aside class="editor-side-panel w-[260px] border-r border-surface-200/60 bg-white/50 flex flex-col flex-shrink-0">
                         <div class="px-4 pt-5 pb-3 flex items-center justify-between">
                             <h2 class="text-[11px] font-800 uppercase tracking-[0.12em] text-ink-400 font-display">Sections</h2>
                             <button {...{'@click': 'addSection()'}} class="w-7 h-7 rounded-lg bg-blueprint-50 text-blueprint-600 hover:bg-blueprint-100 flex items-center justify-center transition-colors">
@@ -101,7 +193,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                         <span class="drag-handle text-ink-300 hover:text-ink-500 flex-shrink-0">
                                             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><circle cx="9" cy="6" r="1.5"/><circle cx="15" cy="6" r="1.5"/><circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/><circle cx="9" cy="18" r="1.5"/><circle cx="15" cy="18" r="1.5"/></svg>
                                         </span>
-                                        <span class="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
+                                        <span class="editor-section-icon w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
                                             x-bind:style="selectedSectionId === section.id ? 'background:' + sectionColor(section) + '18; color:' + sectionColor(section) : 'background: #f3f1ed; color: #908a83'">
                                             <template x-if="getSectionIconSvg(section.icon)">
                                                 <span x-html="getSectionIconSvg(section.icon)"></span>
@@ -127,7 +219,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                     <main class="flex-1 overflow-y-auto bg-surface-50/50">
                         <template x-if="selectedSection">
                             <div class="animate-fade-in">
-                                <div class="sticky top-0 z-10 bg-surface-50/90 backdrop-blur-sm border-b border-surface-200/40 px-8 py-5">
+                                <div class="editor-subheader sticky top-0 z-10 bg-surface-50/90 backdrop-blur-sm border-b border-surface-200/40 px-8 py-5">
                                     <div class="flex items-center justify-between">
                                         <div class="flex items-center gap-4">
                                             <div class="relative">
@@ -143,7 +235,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                                 </button>
                                                 <div x-show="showIconPicker" x-cloak {...{'@click.outside': 'showIconPicker = false'}}
                                                     x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
-                                                    class="absolute top-6 left-0 z-50 bg-white rounded-md shadow-2xl border border-surface-200 p-3 w-[280px]">
+                                                    class="icon-picker-wrap absolute top-6 left-0 z-50 bg-white rounded-md shadow-2xl border border-surface-200 p-3 w-[280px]">
                                                     <div class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400 mb-2 px-1">Section Icon</div>
                                                     <div class="icon-picker-grid">
                                                         <template x-for="ic in sectionIconKeys" x-bind:key="ic">
@@ -158,7 +250,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                                 </div>
                                             </div>
                                             <div>
-                                                <input x-model="selectedSection.title" class="text-lg font-display font-700 bg-transparent border-b border-transparent hover:border-surface-200 focus:border-blueprint-500 transition-colors" />
+                                                <input x-model="selectedSection.title" class="editor-section-input text-lg font-display font-700 bg-transparent border-b border-transparent hover:border-surface-200 focus:border-blueprint-500 transition-colors" />
                                                 <div class="flex items-center gap-3 mt-0.5">
                                                     <span x-show="selectedSection.identifier" class="font-mono text-[10px] text-ink-400" x-text="selectedSection.identifier"></span>
                                                     <span x-show="selectedSection.disclaimerText" class="text-[10px] text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded">has disclaimer</span>
@@ -275,12 +367,12 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                     </main>
 
                     {/* RIGHT: Properties Panel */}
-                    <aside class="w-[340px] border-l border-surface-200/60 bg-white/50 flex flex-col flex-shrink-0 overflow-y-auto scrollbar-thin"
+                    <aside class="editor-side-panel w-[340px] border-l border-surface-200/60 bg-white/50 flex flex-col flex-shrink-0 overflow-y-auto scrollbar-thin"
                         x-show="selectedItem" x-transition:enter="transition ease-out duration-200"
                         x-transition:enter-start="opacity-0 translate-x-4" x-transition:enter-end="opacity-100 translate-x-0">
                         <template x-if="selectedItem">
                             <div class="animate-fade-in">
-                                <div class="px-5 py-4 border-b border-surface-200/40 sticky top-0 bg-white/80 backdrop-blur-sm z-10">
+                                <div class="editor-props-header px-5 py-4 border-b border-surface-200/40 sticky top-0 bg-white/80 backdrop-blur-sm z-10">
                                     <div class="flex items-center justify-between mb-1">
                                         <span class="text-[11px] font-800 uppercase tracking-[0.12em] text-ink-400 font-display">Item Properties</span>
                                         <button {...{'@click': 'removeItem(selectedItemId)'}} class="text-ink-300 hover:text-red-500 transition-colors p-1">
@@ -516,7 +608,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
 
                 {/* Canned Comments Slide Panel */}
                 <div x-show="showCannedPanel" x-cloak
-                    class="fixed right-0 top-16 bottom-0 w-[380px] bg-white border-l border-surface-200 shadow-2xl z-40 flex flex-col"
+                    class="editor-canned-panel fixed right-0 top-16 bottom-0 w-[380px] bg-white border-l border-surface-200 shadow-2xl z-40 flex flex-col"
                     x-transition:enter="transition ease-out duration-200" x-transition:enter-start="translate-x-full" x-transition:enter-end="translate-x-0"
                     x-transition:leave="transition ease-in duration-150" x-transition:leave-start="translate-x-0" x-transition:leave-end="translate-x-full">
                     <div class="px-5 py-4 border-b border-surface-200/60 flex items-center justify-between">

--- a/src/templates/pages/template-editor.tsx
+++ b/src/templates/pages/template-editor.tsx
@@ -64,6 +64,9 @@ html[data-color-scheme=dark] input.editor-section-input:focus { border-bottom-co
 }
 [data-color-scheme=dark] .icon-btn:hover { background: rgba(74,114,255,0.2) !important; border-color: rgba(74,114,255,0.4) !important; }
 [data-color-scheme=dark] .icon-btn.active { background: rgba(74,114,255,0.2) !important; border-color: #4a72ff !important; }
+[data-color-scheme=dark] .editor-main {
+  background-color: rgba(11,17,32,0.6) !important;
+}
 [data-color-scheme=dark] .editor-canned-panel {
   background-color: #0f172a !important;
   border-color: rgba(255,255,255,0.08) !important;
@@ -216,7 +219,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                     </aside>
 
                     {/* CENTER: Items Panel */}
-                    <main class="flex-1 overflow-y-auto bg-surface-50/50">
+                    <main class="editor-main flex-1 overflow-y-auto bg-surface-50/50">
                         <template x-if="selectedSection">
                             <div class="animate-fade-in">
                                 <div class="editor-subheader sticky top-0 z-10 bg-surface-50/90 backdrop-blur-sm border-b border-surface-200/40 px-8 py-5">

--- a/src/templates/pages/templates.tsx
+++ b/src/templates/pages/templates.tsx
@@ -38,14 +38,14 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                     <div class="overflow-x-auto">
                         <table class="min-w-full">
                             <thead>
-                                <tr class="bg-slate-50/50">
-                                    <th scope="col" class="py-6 pl-10 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Name</th>
-                                    <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Version</th>
-                                    <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400">Items</th>
+                                <tr class="bg-slate-50/50 dark:bg-slate-800/50">
+                                    <th scope="col" class="py-6 pl-10 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Name</th>
+                                    <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Version</th>
+                                    <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Items</th>
                                     <th scope="col" class="relative py-6 pl-3 pr-10"><span class="sr-only">Actions</span></th>
                                 </tr>
                             </thead>
-                            <tbody id="templatesList" class="divide-y divide-slate-100">
+                            <tbody id="templatesList" class="divide-y divide-slate-100 dark:divide-slate-700/50">
                                 <tr id="loadingRow">
                                     <td colspan={4} class="py-32 text-center">
                                         <div class="flex flex-col items-center gap-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    content: ['./src/**/*.{ts,tsx,html}'],
+    content: ['./src/**/*.{ts,tsx,html}', './public/js/**/*.js'],
     darkMode: ['selector', '[data-color-scheme="dark"]'],
     theme: {
         extend: {


### PR DESCRIPTION
## Summary

Two design-driven keyboard additions from Design System 0520
inspector-app/InspectionEditor.jsx §220 RATINGS loop:

- **M11.1** `R` / Shift+R — clone the previous item's rating + notes onto the active item. Finds the nearest earlier item in the current section that already carries a rating and replaces the active item's results entry with a deep copy. Toast when no prior item is rated.
- **M11.2** `J` / `j` — next item alias for ArrowDown. `k` — previous item alias for ArrowUp. (Capital `K` is already bound to view-mode toggle earlier in the handler, so only lowercase `k` aliases ArrowUp.)

Saves via the existing `debounceSave()` pipeline so dirty-state and autosave stay coherent.

## Deferred

`M11.3` — inline `/leak` snippet popover inside the textarea — is a separate commit (different surface than the current `/` which opens the Comment Library drawer outside the field).

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [ ] Reviewer: load an inspection edit page, rate item 1 as Sat → focus item 2 → press R → item 2 inherits the rating + notes
- [ ] Reviewer: press J/K/ArrowDown/ArrowUp — all four navigate as expected
- [ ] Reviewer: press capital K — view mode still toggles (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)