### PR TITLE
fix(template-editor): create + edit work end-to-end; v2 schema only

### DIFF
--- a/public/js/template-editor.js
+++ b/public/js/template-editor.js
@@ -260,6 +260,7 @@ function templateEditor() {
                     body: JSON.stringify({
                         name: this.template.title,
                         schema: {
+                            schemaVersion: 2,
                             sections: this.template.sections,
                             ratingSystem: this.template.ratingSystem
                         }
@@ -347,6 +348,13 @@ function templateEditor() {
                 this.template.title = tpl.name || '';
                 this.template.version = tpl.version || 1;
                 const schema = typeof tpl.schema === 'string' ? JSON.parse(tpl.schema) : (tpl.schema || {});
+                // Legacy v1: flat array of items, no sections. Pre-launch we
+                // reject v1 in the validator — surface that explicitly here
+                // instead of rendering an empty editor.
+                if (Array.isArray(schema) || schema.schemaVersion !== 2) {
+                    this.loadError = 'This template uses a legacy schema and cannot be edited. Please delete it and create a new one.';
+                    return;
+                }
                 if (schema.sections && Array.isArray(schema.sections)) {
                     // Normalize field names: API may use "name" but editor uses "title"/"label"
                     this.template.sections = schema.sections.map(function(sec) {

--- a/public/js/templates.js
+++ b/public/js/templates.js
@@ -152,8 +152,9 @@ async function deleteTemplate(id) {
         allTemplates = allTemplates.filter(t => t.id !== id);
         renderTemplates();
     } else {
-        const err = await res.json();
-        modalAlert('Error: ' + (err.error || 'Failed to delete'), 'Error');
+        const err = await res.json().catch(() => ({}));
+        const msg = err?.error?.message || err?.error || err?.message || 'Failed to delete';
+        modalAlert('Error: ' + msg, 'Error');
     }
 }
 
@@ -178,7 +179,7 @@ async function submitTemplate() {
         const res = await authFetch('/api/inspections/templates', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name, schema: { sections: [], ratingLevels: [] } })
+            body: JSON.stringify({ name, schema: { schemaVersion: 2, sections: [] } })
         });
         if (res.ok) {
             const result = await res.json();
@@ -190,8 +191,9 @@ async function submitTemplate() {
                 loadTemplates();
             }
         } else {
-            const err = await res.json();
-            modalAlert('Error: ' + (err.error || 'Failed to create'), 'Error');
+            const err = await res.json().catch(() => ({}));
+            const msg = err?.error?.message || err?.error || err?.message || 'Failed to create';
+            modalAlert('Error: ' + msg, 'Error');
         }
     } catch (e) {
         modalAlert('Connection error: ' + e.message, 'Error');

--- a/src/templates/pages/template-editor.tsx
+++ b/src/templates/pages/template-editor.tsx
@@ -176,6 +176,16 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                     </div>
                 </header>
 
+                {/* Load error banner — surfaces legacy v1 schema or load failures */}
+                <div x-show="loadError" class="px-6 py-4 bg-amber-50 border-b border-amber-200 text-amber-800 flex items-start gap-3" x-cloak>
+                    <svg class="w-5 h-5 mt-0.5 flex-shrink-0 text-amber-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                    <div class="flex-1">
+                        <p class="font-700 text-sm">Cannot edit this template</p>
+                        <p class="text-sm mt-1" x-text="loadError"></p>
+                    </div>
+                    <a href="/templates" class="px-3 py-1.5 rounded-lg bg-white text-amber-700 text-xs font-700 hover:bg-amber-100 transition-colors">Back to Templates</a>
+                </div>
+
                 {/* Main 3-Panel Layout */}
                 <div class="flex h-[calc(100vh-4rem)]">
 

--- a/tests/standalone-api.spec.ts
+++ b/tests/standalone-api.spec.ts
@@ -109,13 +109,23 @@ test.describe.serial('Standalone API Tests', () => {
     // ── Template CRUD ─────────────────────────────────────────────────────────
 
     test('API-03: POST /api/inspections/templates creates template', async ({ request }) => {
+        const richItem = (id: string, label: string) => ({
+            id, label, type: 'rich' as const,
+            ratingOptions: ['Inspected', 'Repair'],
+            tabs: { information: [], limitations: [], defects: [] },
+        });
         const res = await apiPost(request, '/api/inspections/templates', adminToken, {
             name: 'E2E Standard Residential',
-            schema: JSON.stringify([
-                { id: 'roof', label: 'Roof', type: 'pass_fail' },
-                { id: 'plumbing', label: 'Plumbing', type: 'pass_fail' },
-                { id: 'electrical', label: 'Electrical', type: 'pass_fail' },
-            ]),
+            schema: {
+                schemaVersion: 2,
+                sections: [
+                    {
+                        id: 's_general',
+                        title: 'General',
+                        items: [richItem('roof', 'Roof'), richItem('plumbing', 'Plumbing'), richItem('electrical', 'Electrical')],
+                    },
+                ],
+            },
         });
         expect(res.status(), 'Template creation must return 201').toBe(201);
         const body = await res.json();

--- a/tests/standalone-browser.spec.ts
+++ b/tests/standalone-browser.spec.ts
@@ -99,12 +99,23 @@ test.describe.serial('Standalone Browser Tests', () => {
         adminToken = await loginApi(request, ADMIN_EMAIL, ADMIN_PASSWORD);
 
         // 2. Create template
+        const richItem = (id: string, label: string) => ({
+            id, label, type: 'rich' as const,
+            ratingOptions: ['Inspected', 'Repair'],
+            tabs: { information: [], limitations: [], defects: [] },
+        });
         const tplRes = await apiPost(request, '/api/inspections/templates', adminToken, {
             name: 'Browser Test Template',
-            schema: JSON.stringify([
-                { id: 'roof', label: 'Roof', type: 'pass_fail' },
-                { id: 'plumbing', label: 'Plumbing', type: 'pass_fail' },
-            ]),
+            schema: {
+                schemaVersion: 2,
+                sections: [
+                    {
+                        id: 's_general',
+                        title: 'General',
+                        items: [richItem('roof', 'Roof'), richItem('plumbing', 'Plumbing')],
+                    },
+                ],
+            },
         });
         expect(tplRes.status()).toBe(201);
         createdTemplateId = (await tplRes.json()).data?.template?.id;

--- a/tests/standalone-mobile.spec.ts
+++ b/tests/standalone-mobile.spec.ts
@@ -68,7 +68,21 @@ test.describe.serial('Standalone Mobile (iPhone 375x812)', () => {
         if (list.length === 0) {
             // Create a template + inspection so the mobile UI tests have something to render
             const tplRes = await request.post(`${BASE_URL}/api/inspections/templates`, {
-                data: { name: 'Mobile Test Template', schema: JSON.stringify([{ id: 'roof', label: 'Roof', type: 'pass_fail' }]) },
+                data: {
+                    name: 'Mobile Test Template',
+                    schema: {
+                        schemaVersion: 2,
+                        sections: [{
+                            id: 's_general',
+                            title: 'General',
+                            items: [{
+                                id: 'roof', label: 'Roof', type: 'rich',
+                                ratingOptions: ['Inspected', 'Repair'],
+                                tabs: { information: [], limitations: [], defects: [] },
+                            }],
+                        }],
+                    },
+                },
                 headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` },
             });
             const tplId = (await tplRes.json()).data?.template?.id;


### PR DESCRIPTION
## Summary

- Creating a template from the New Template modal was failing with `Error: [object Object]` because the JS payload omitted `schemaVersion: 2` (rejected by the strict Zod validator) and the alert concatenated the structured error object instead of `error.message`.
- Saving a freshly-created template from the editor hit the same issue — the PUT body also omitted `schemaVersion: 2`.
- When the editor encounters a legacy v1 schema (flat array, no `schemaVersion: 2`), it now surfaces an explicit "Cannot edit this template — delete and recreate" banner instead of silently rendering an empty section panel.
- Migrated three E2E test fixtures (`standalone-api`, `standalone-browser`, `standalone-mobile`) off the long-dead v1 `pass_fail` shape onto canonical v2 so they exercise the same code path real users hit.

No new schema, no compatibility shim — v2 stays the single canonical format.

## Test plan
- [x] `npm run type-check` (0 errors)
- [x] `npm run lint` (templates.js + template-editor.js clean)
- [x] Chrome: create "Commercial Inspection 2024" → redirected to editor (was failing with object-stringified alert)
- [x] Chrome: open legacy v1 template → amber banner with "Back to Templates" link renders
- [ ] Re-run E2E suite in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)