### PR TITLE
feat(template-schema): expand v2 to keep editor's full feature set

### DIFF
--- a/public/js/template-editor.js
+++ b/public/js/template-editor.js
@@ -250,11 +250,11 @@ function templateEditor() {
             }
         },
 
-        // Normalize editor state to the strict v2 schema before PUT.
-        // The editor carries UI-only fields (priority, identifier, source,
-        // options, attributes, ...) that the server rejects with
-        // unrecognized_keys; strip them here so the editor stays free to
-        // hold transient state without polluting saved JSON.
+        // Normalize editor state to v2 schema shape before PUT. The
+        // schema accepts every field the editor surfaces, so this mostly
+        // drops UI-only scratch state (priority, _choicesStr, isOverview,
+        // _ratingOptionsText, ...) and clamps missing required values to
+        // safe defaults.
         toV2Payload() {
             const pickInfo = (c) => ({
                 id: c.id, title: c.title || '', comment: c.comment || '',
@@ -268,23 +268,61 @@ function templateEditor() {
                 photos: Array.isArray(c.photos) ? c.photos : [],
                 default: !!c.default,
             });
+            const pickAttribute = (a) => {
+                const out = {
+                    id: a.id, name: a.name || '',
+                    type: a.type || 'text',
+                };
+                if (a.choices && a.choices.length) out.choices = a.choices;
+                if (a.unit) out.unit = a.unit;
+                if (typeof a.required === 'boolean')      out.required = a.required;
+                if (typeof a.isSafety === 'boolean')      out.isSafety = a.isSafety;
+                if (typeof a.isDefect === 'boolean')      out.isDefect = a.isDefect;
+                if (a.recommendation != null)             out.recommendation = a.recommendation;
+                if (a.estimateMin != null)                out.estimateMin = a.estimateMin;
+                if (a.estimateMax != null)                out.estimateMax = a.estimateMax;
+                return out;
+            };
+            const pickOptions = (opts) => {
+                if (!opts || typeof opts !== 'object') return null;
+                const o = {};
+                if (opts.min != null)        o.min = opts.min;
+                if (opts.max != null)        o.max = opts.max;
+                if (opts.unit)               o.unit = opts.unit;
+                if (opts.step != null)       o.step = opts.step;
+                if (opts.placeholder)        o.placeholder = opts.placeholder;
+                if (opts.maxLength != null)  o.maxLength = opts.maxLength;
+                if (opts.choices && opts.choices.length) o.choices = opts.choices;
+                if (opts.minPhotos != null)  o.minPhotos = opts.minPhotos;
+                return Object.keys(o).length ? o : null;
+            };
             const pickItem = (it) => {
-                const base = {
-                    id: it.id, label: it.label || '',
-                    type: it.type === 'text' ? 'text' : 'rich',
-                };
-                if (it.icon) base.icon = it.icon;
-                if (it.number) base.number = it.number;
-                if (base.type === 'text') return base;
-                base.ratingOptions = Array.isArray(it.ratingOptions) && it.ratingOptions.length
-                    ? it.ratingOptions
-                    : ['Inspected'];
-                const tabs = it.tabs || {};
-                base.tabs = {
-                    information: (tabs.information || []).map(pickInfo),
-                    limitations: (tabs.limitations || []).map(pickInfo),
-                    defects:     (tabs.defects     || []).map(pickDefect),
-                };
+                const validTypes = ['rich', 'text', 'boolean', 'textarea', 'number', 'select', 'multi_select', 'date', 'photo_only'];
+                const type = validTypes.includes(it.type) ? it.type : 'rich';
+                const base = { id: it.id, label: it.label || '', type };
+                if (it.description)        base.description = it.description;
+                if (it.icon)               base.icon = it.icon;
+                if (it.number)             base.number = it.number;
+                if (typeof it.required === 'boolean') base.required = it.required;
+                if (typeof it.isSafety === 'boolean') base.isSafety = it.isSafety;
+                if (it.defaultRecommendation)            base.defaultRecommendation = it.defaultRecommendation;
+                if (it.defaultEstimateMin != null)       base.defaultEstimateMin = it.defaultEstimateMin;
+                if (it.defaultEstimateMax != null)       base.defaultEstimateMax = it.defaultEstimateMax;
+                if (it.attributes && it.attributes.length) base.attributes = it.attributes.map(pickAttribute);
+                if (it.source && it.source.platform && it.source.externalId) base.source = { platform: it.source.platform, externalId: it.source.externalId };
+                if (type === 'rich') {
+                    base.ratingOptions = Array.isArray(it.ratingOptions) && it.ratingOptions.length
+                        ? it.ratingOptions : ['Inspected'];
+                    const tabs = it.tabs || {};
+                    base.tabs = {
+                        information: (tabs.information || []).map(pickInfo),
+                        limitations: (tabs.limitations || []).map(pickInfo),
+                        defects:     (tabs.defects     || []).map(pickDefect),
+                    };
+                } else if (type !== 'boolean' && type !== 'date') {
+                    const o = pickOptions(it.options);
+                    if (o) base.options = o;
+                }
                 return base;
             };
             const pickSection = (s) => {
@@ -292,9 +330,10 @@ function templateEditor() {
                     id: s.id, title: s.title || '',
                     items: (s.items || []).map(pickItem),
                 };
-                if (s.icon) out.icon = s.icon;
-                if (s.disclaimerText) out.disclaimerText = s.disclaimerText;
-                if (s.alwaysPageBreak) out.alwaysPageBreak = !!s.alwaysPageBreak;
+                if (s.icon)             out.icon = s.icon;
+                if (s.identifier)       out.identifier = s.identifier;
+                if (s.disclaimerText)   out.disclaimerText = s.disclaimerText;
+                if (s.alwaysPageBreak)  out.alwaysPageBreak = !!s.alwaysPageBreak;
                 return out;
             };
             const payload = {

--- a/src/lib/validations/template.schema.ts
+++ b/src/lib/validations/template.schema.ts
@@ -3,10 +3,14 @@ import { z } from '@hono/zod-openapi';
 /**
  * Spec 5B — Template schema (v2) validation.
  *
- * The system has not launched in production, so v1 (`type:'rating'` flat
- * items) is rejected outright. Templates MUST be v2: `schemaVersion: 2`,
- * items of type `'rich'` (or `'text'` for free-form notes items), with
- * three tabs of canned comments per `'rich'` item.
+ * v2 is the single canonical template format. v1 (`type:'rating'` flat
+ * items) is rejected outright at the validator boundary — pre-launch we
+ * don't ship a migration shim. The shape below is intentionally broad:
+ * every input that the template editor surfaces (rich + 8 other item
+ * types, item attributes, default-recommendation, estimate ranges,
+ * import-source metadata, per-section disclaimers, ...) is part of the
+ * persisted schema so the editor never asks an inspector for data we
+ * silently drop on the wire.
  */
 
 const DefectCategoryEnum = z.enum(['maintenance', 'recommendation', 'safety']);
@@ -34,44 +38,136 @@ const ItemTabsSchema = z.object({
     defects:     z.array(CannedDefectSchema),
 }).strict();
 
-// S3-5 — tighten item label / section title to surface obviously-bogus
-// imports (e.g. someone pasting an entire paragraph as a "label"). The
-// limits comfortably accommodate every shipped seed template; current
-// longest label is 47 chars and longest section title is 34 chars.
+/** Per-item sub-properties — only meaningful on the non-rich types. */
+const ItemOptionsSchema = z.object({
+    min:         z.number().nullable().optional(),
+    max:         z.number().nullable().optional(),
+    unit:        z.string().optional(),
+    step:        z.number().nullable().optional(),
+    placeholder: z.string().optional(),
+    maxLength:   z.number().nullable().optional(),
+    choices:     z.array(z.string()).optional(),
+    minPhotos:   z.number().nullable().optional(),
+}).strict();
+
+/** Optional sub-fields nested under an item, e.g. tonnage on an HVAC unit. */
+const ItemAttributeTypeEnum = z.enum(['boolean', 'text', 'number', 'select', 'multi_select', 'date']);
+const ItemAttributeSchema = z.object({
+    id:             z.string().min(1),
+    name:           z.string().min(1),
+    type:           ItemAttributeTypeEnum,
+    choices:        z.array(z.string()).optional(),
+    unit:           z.string().optional(),
+    required:       z.boolean().optional(),
+    isSafety:       z.boolean().optional(),
+    isDefect:       z.boolean().optional(),
+    recommendation: z.string().nullable().optional(),
+    estimateMin:    z.number().nullable().optional(),
+    estimateMax:    z.number().nullable().optional(),
+}).strict();
+
+/** Provenance for templates imported from upstream platforms. */
+const ItemSourceSchema = z.object({
+    platform:   z.string().min(1),
+    externalId: z.string().min(1),
+}).strict();
+
+/** Common fields shared by every item type. */
+const BaseItemFields = {
+    id:                    z.string().min(1),
+    label:                 z.string().min(1).max(100),
+    description:           z.string().optional(),
+    icon:                  z.string().optional(),
+    number:                z.string().optional(),
+    required:              z.boolean().optional(),
+    isSafety:              z.boolean().optional(),
+    defaultRecommendation: z.string().optional(),
+    defaultEstimateMin:    z.number().nullable().optional(),
+    defaultEstimateMax:    z.number().nullable().optional(),
+    attributes:            z.array(ItemAttributeSchema).optional(),
+    source:                ItemSourceSchema.nullable().optional(),
+} as const;
+
 const RichItemSchema = z.object({
-    id:            z.string().min(1),
-    label:         z.string().min(1).max(100),
+    ...BaseItemFields,
     type:          z.literal('rich'),
     ratingOptions: z.array(z.string().min(1)).min(1),
     tabs:          ItemTabsSchema,
-    icon:          z.string().optional(),
-    number:        z.string().optional(),
 }).strict();
 
 const TextItemSchema = z.object({
-    id:     z.string().min(1),
-    label:  z.string().min(1).max(100),
-    type:   z.literal('text'),
-    icon:   z.string().optional(),
-    number: z.string().optional(),
+    ...BaseItemFields,
+    type:    z.literal('text'),
+    options: ItemOptionsSchema.optional(),
 }).strict();
 
-const TemplateItemSchema = z.discriminatedUnion('type', [RichItemSchema, TextItemSchema]);
+const BooleanItemSchema = z.object({
+    ...BaseItemFields,
+    type: z.literal('boolean'),
+}).strict();
 
+const TextareaItemSchema = z.object({
+    ...BaseItemFields,
+    type:    z.literal('textarea'),
+    options: ItemOptionsSchema.optional(),
+}).strict();
+
+const NumberItemSchema = z.object({
+    ...BaseItemFields,
+    type:    z.literal('number'),
+    options: ItemOptionsSchema.optional(),
+}).strict();
+
+const SelectItemSchema = z.object({
+    ...BaseItemFields,
+    type:    z.literal('select'),
+    options: ItemOptionsSchema.optional(),
+}).strict();
+
+const MultiSelectItemSchema = z.object({
+    ...BaseItemFields,
+    type:    z.literal('multi_select'),
+    options: ItemOptionsSchema.optional(),
+}).strict();
+
+const DateItemSchema = z.object({
+    ...BaseItemFields,
+    type: z.literal('date'),
+}).strict();
+
+const PhotoOnlyItemSchema = z.object({
+    ...BaseItemFields,
+    type:    z.literal('photo_only'),
+    options: ItemOptionsSchema.optional(),
+}).strict();
+
+const TemplateItemSchema = z.discriminatedUnion('type', [
+    RichItemSchema,
+    TextItemSchema,
+    BooleanItemSchema,
+    TextareaItemSchema,
+    NumberItemSchema,
+    SelectItemSchema,
+    MultiSelectItemSchema,
+    DateItemSchema,
+    PhotoOnlyItemSchema,
+]);
+
+// S3-5 — tighten section title to surface obviously-bogus imports
+// (e.g. someone pasting an entire paragraph as a "title"). Current
+// longest seed section title is 34 chars.
 const TemplateSectionSchema = z.object({
-    id:    z.string().min(1),
-    title: z.string().min(1).max(50),
-    icon:  z.string().optional(),
-    items: z.array(TemplateItemSchema),
+    id:         z.string().min(1),
+    title:      z.string().min(1).max(50),
+    icon:       z.string().optional(),
+    identifier: z.string().optional(),
+    items:      z.array(TemplateItemSchema),
     // Track E2 (Spectora App.A) — per-section legal disclaimer rendered at
     // the bottom of the section in the published report. Null/empty when
     // unset. Free-form text (≤ 4 KB) so tenants can paste boilerplate.
-    disclaimerText: z.string().max(4000).nullable().optional(),
+    disclaimerText:  z.string().max(4000).nullable().optional(),
     // Track E2 — when true, the published report forces a page break BEFORE
-    // this section in PDF output. Used for cover-letter style sections that
-    // must start on a fresh sheet. Defaults to false (the existing CSS
-    // already breaks per-section by default — this flag is an explicit
-    // marker so future "no-break" overrides have a clean signal to honor).
+    // this section in PDF output.
     alwaysPageBreak: z.boolean().optional(),
 }).strict();
 

--- a/src/templates/pages/template-editor.tsx
+++ b/src/templates/pages/template-editor.tsx
@@ -265,6 +265,7 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                             <div>
                                                 <input x-model="selectedSection.title" class="editor-section-input text-lg font-display font-700 bg-transparent border-b border-transparent hover:border-surface-200 focus:border-blueprint-500 transition-colors" />
                                                 <div class="flex items-center gap-3 mt-0.5">
+                                                    <span x-show="selectedSection.identifier" class="font-mono text-[10px] text-ink-400" x-text="selectedSection.identifier"></span>
                                                     <span x-show="selectedSection.disclaimerText" class="text-[10px] text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded">has disclaimer</span>
                                                 </div>
                                             </div>
@@ -294,19 +295,41 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                                 <div class="flex-1 min-w-0">
                                                     <div class="flex items-center gap-2">
                                                         <span class="text-sm font-600" x-text="item.label"></span>
+                                                        <span x-show="item.required" class="text-[9px] font-700 text-red-500 bg-red-50 px-1.5 py-0.5 rounded uppercase">req</span>
+                                                        <span x-show="item.isSafety" class="text-[9px] font-700 text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded uppercase">safety</span>
                                                     </div>
                                                     <div class="flex items-center gap-3 mt-1">
                                                         <span class="inline-flex items-center gap-1 text-[10px] font-mono font-500 text-ink-400 bg-surface-100 px-2 py-0.5 rounded">
                                                             <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h8m-8 6h16"/></svg>
                                                             <span x-text="item.type"></span>
                                                         </span>
-                                                        <span x-show="item.type === 'rich' && item.tabs" class="text-[10px] font-mono text-ink-400">
-                                                            <span x-text="(item.tabs?.information?.length || 0) + (item.tabs?.limitations?.length || 0) + (item.tabs?.defects?.length || 0)"></span> canned
+                                                        <span x-show="item.attributes && item.attributes.length" class="text-[10px] font-mono text-ink-400">
+                                                            <span x-text="item.attributes.length"></span> attrs
                                                         </span>
+                                                        <span x-show="item.source" class="text-[10px] px-1.5 py-0.5 rounded"
+                                                            x-bind:class="item.source?.platform === 'spectora' ? 'bg-orange-50 text-orange-500' : 'bg-emerald-50 text-emerald-500'"
+                                                            x-text="item.source?.platform"></span>
                                                     </div>
                                                 </div>
                                                 <div class="flex items-center gap-2">
+                                                    <span x-show="item.defaultRecommendation" class="text-[10px] text-blue-500 bg-blue-50 px-2 py-0.5 rounded-md font-500" x-text="item.defaultRecommendation"></span>
                                                     <svg class="w-4 h-4 text-ink-300 transition-transform" x-bind:class="selectedItemId === item.id ? 'rotate-90' : ''" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+                                                </div>
+                                            </div>
+
+                                            <div x-show="selectedItemId === item.id && item.attributes && item.attributes.length > 0" x-collapse
+                                                class="px-5 pb-4 border-t border-surface-100">
+                                                <div class="mt-3 space-y-1.5">
+                                                    <div class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400 mb-2">Attributes</div>
+                                                    <template x-for="attr in item.attributes" x-bind:key="attr.id">
+                                                        <div class="flex items-center gap-3 py-1.5 px-3 rounded-lg bg-surface-50 text-sm">
+                                                            <span class="w-16 text-[10px] font-mono text-ink-400 uppercase" x-text="attr.type"></span>
+                                                            <span class="font-500 text-ink-700 flex-1 truncate" x-text="attr.name"></span>
+                                                            <span x-show="attr.choices && attr.choices.length" class="text-[10px] text-ink-400" x-text="attr.choices.length + ' opts'"></span>
+                                                            <span x-show="attr.isSafety" class="w-1.5 h-1.5 rounded-full bg-amber-400"></span>
+                                                            <span x-show="attr.isDefect" class="w-1.5 h-1.5 rounded-full bg-red-400"></span>
+                                                        </div>
+                                                    </template>
                                                 </div>
                                             </div>
                                         </div>
@@ -378,26 +401,129 @@ export const TemplateEditorPage = ({ templateId, branding }: { templateId: strin
                                         <input type="text" x-model="selectedItem.label" class="w-full px-3 py-2.5 text-sm font-500 rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors" />
                                     </div>
                                     <div class="space-y-1.5">
+                                        <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Description</label>
+                                        <textarea x-model="selectedItem.description" rows={2} class="w-full px-3 py-2.5 text-sm rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors resize-none"></textarea>
+                                    </div>
+                                    <div class="space-y-1.5">
                                         <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Input Type</label>
                                         <select x-model="selectedItem.type" class="w-full px-3 py-2.5 text-sm font-500 rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors appearance-none"
                                             style="background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 fill=%22none%22 viewBox=%220 0 24 24%22 stroke=%22%236b6560%22%3E%3Cpath stroke-linecap=%22round%22 stroke-linejoin=%22round%22 stroke-width=%222%22 d=%22M19 9l-7 7-7-7%22/%3E%3C/svg%3E'); background-repeat: no-repeat; background-position: right 12px center; background-size: 16px; padding-right: 36px;">
-                                            <option value="rich">Rich (rating + canned comments)</option>
-                                            <option value="text">Text (free-form notes)</option>
+                                            <option value="rich">Rich (rating + tabs)</option>
+                                            <option value="boolean">Boolean (yes/no)</option>
+                                            <option value="text">Text (single line)</option>
+                                            <option value="textarea">Textarea (multi-line)</option>
+                                            <option value="number">Number</option>
+                                            <option value="select">Select (dropdown)</option>
+                                            <option value="multi_select">Multi-Select (checkboxes)</option>
+                                            <option value="date">Date</option>
+                                            <option value="photo_only">Photo Only</option>
                                         </select>
                                     </div>
-                                    <div x-show="selectedItem.type === 'rich'" class="space-y-1.5">
-                                        <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Rating Options</label>
-                                        <textarea
-                                            {...{'x-model': 'selectedItem._ratingOptionsText'}}
-                                            {...{'x-init': "selectedItem._ratingOptionsText = (selectedItem.ratingOptions || []).join('\\n')"}}
-                                            {...{'@input': "selectedItem.ratingOptions = selectedItem._ratingOptionsText.split('\\n').map(s => s.trim()).filter(Boolean)"}}
-                                            rows={5}
+                                    <div x-show="selectedItem.type === 'select' || selectedItem.type === 'multi_select'" class="space-y-1.5">
+                                        <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Choices</label>
+                                        <textarea x-model="choicesText" {...{'@input': 'updateChoices()'}} rows={3}
                                             class="w-full px-3 py-2.5 text-sm font-mono rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors resize-none"
-                                            placeholder="Inspected&#10;Repair&#10;Safety Hazard"></textarea>
-                                        <p class="text-[10px] text-ink-400 font-500">One option per line. Inspector picks one per item during inspection.</p>
+                                            placeholder="One choice per line..."></textarea>
                                     </div>
-                                    <div x-show="selectedItem.type === 'rich'" class="p-3 rounded-xl bg-surface-50 border border-surface-200/50 text-[11px] text-ink-500 leading-relaxed">
-                                        Canned comments (Information / Limitations / Defects) round-trip through the API; UI for editing them inline is on the roadmap. For now, seed them via template import or the Comments panel.
+                                    <div x-show="selectedItem.type === 'number'" class="grid grid-cols-3 gap-2">
+                                        <div class="space-y-1">
+                                            <label class="text-[9px] font-700 uppercase tracking-[0.1em] text-ink-400">Min</label>
+                                            <input type="number" {...{'x-model.number': 'selectedItem.options.min'}} class="w-full px-2 py-2 text-sm font-mono rounded-lg border border-surface-200 bg-white text-center" />
+                                        </div>
+                                        <div class="space-y-1">
+                                            <label class="text-[9px] font-700 uppercase tracking-[0.1em] text-ink-400">Max</label>
+                                            <input type="number" {...{'x-model.number': 'selectedItem.options.max'}} class="w-full px-2 py-2 text-sm font-mono rounded-lg border border-surface-200 bg-white text-center" />
+                                        </div>
+                                        <div class="space-y-1">
+                                            <label class="text-[9px] font-700 uppercase tracking-[0.1em] text-ink-400">Unit</label>
+                                            <input type="text" x-model="selectedItem.options.unit" class="w-full px-2 py-2 text-sm rounded-lg border border-surface-200 bg-white" placeholder="sqft" />
+                                        </div>
+                                    </div>
+                                    <hr class="border-surface-200/60" />
+                                    <div class="space-y-3">
+                                        <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Flags</label>
+                                        <label class="flex items-center gap-3 cursor-pointer group">
+                                            <input type="checkbox" x-model="selectedItem.required" class="w-4 h-4 rounded border-surface-200 text-blueprint-600 focus:ring-blueprint-500" />
+                                            <span class="text-sm font-500 text-ink-600 group-hover:text-ink-900 transition-colors">Required</span>
+                                        </label>
+                                        <label class="flex items-center gap-3 cursor-pointer group">
+                                            <input type="checkbox" x-model="selectedItem.isSafety" class="w-4 h-4 rounded border-surface-200 text-amber-500 focus:ring-amber-500" />
+                                            <span class="text-sm font-500 text-ink-600 group-hover:text-ink-900 transition-colors">Safety Item</span>
+                                        </label>
+                                    </div>
+                                    <hr class="border-surface-200/60" />
+                                    <div class="space-y-1.5">
+                                        <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Default Recommendation</label>
+                                        <select x-model="selectedItem.defaultRecommendation" class="w-full px-3 py-2.5 text-sm rounded-xl border border-surface-200 bg-white focus:border-blueprint-500 transition-colors"
+                                            style="background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 fill=%22none%22 viewBox=%220 0 24 24%22 stroke=%22%236b6560%22%3E%3Cpath stroke-linecap=%22round%22 stroke-linejoin=%22round%22 stroke-width=%222%22 d=%22M19 9l-7 7-7-7%22/%3E%3C/svg%3E'); background-repeat: no-repeat; background-position: right 12px center; background-size: 16px; padding-right: 36px;">
+                                            <option value="">None</option>
+                                            <template x-for="r in recommendationTypes" x-bind:key="r">
+                                                <option x-bind:value="r" x-text="r.replace(/_/g, ' ')"></option>
+                                            </template>
+                                        </select>
+                                    </div>
+                                    <div class="grid grid-cols-2 gap-3">
+                                        <div class="space-y-1">
+                                            <label class="text-[9px] font-700 uppercase tracking-[0.1em] text-ink-400">Est. Min ($)</label>
+                                            <input type="number" {...{'x-model.number': 'selectedItem.defaultEstimateMin'}} class="w-full px-3 py-2 text-sm font-mono rounded-lg border border-surface-200 bg-white" placeholder="0" />
+                                        </div>
+                                        <div class="space-y-1">
+                                            <label class="text-[9px] font-700 uppercase tracking-[0.1em] text-ink-400">Est. Max ($)</label>
+                                            <input type="number" {...{'x-model.number': 'selectedItem.defaultEstimateMax'}} class="w-full px-3 py-2 text-sm font-mono rounded-lg border border-surface-200 bg-white" placeholder="0" />
+                                        </div>
+                                    </div>
+                                    <hr class="border-surface-200/60" />
+                                    <div class="space-y-3">
+                                        <div class="flex items-center justify-between">
+                                            <label class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400">Attributes</label>
+                                            <button {...{'@click': 'addAttribute()'}} class="text-[10px] font-600 text-blueprint-600 hover:text-blueprint-700 transition-colors flex items-center gap-1">
+                                                <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" d="M12 5v14m7-7H5"/></svg>
+                                                Add
+                                            </button>
+                                        </div>
+                                        <template x-for="(attr, ai) in selectedItem.attributes" x-bind:key="attr.id">
+                                            <div class="p-3 rounded-xl bg-surface-50 space-y-2 animate-scale-in">
+                                                <div class="flex items-center justify-between">
+                                                    <input type="text" x-model="attr.name" class="text-sm font-500 bg-transparent border-b border-transparent hover:border-surface-200 focus:border-blueprint-500 flex-1 transition-colors" placeholder="Attribute name" />
+                                                    <button {...{'@click': 'selectedItem.attributes.splice(ai, 1)'}} class="text-ink-300 hover:text-red-500 transition-colors ml-2 p-0.5">
+                                                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                                                    </button>
+                                                </div>
+                                                <div class="flex items-center gap-2">
+                                                    <select x-model="attr.type" class="text-[10px] font-mono px-2 py-1 rounded-md border border-surface-200 bg-white">
+                                                        <option value="boolean">boolean</option>
+                                                        <option value="text">text</option>
+                                                        <option value="number">number</option>
+                                                        <option value="select">select</option>
+                                                        <option value="multi_select">multi_select</option>
+                                                        <option value="date">date</option>
+                                                    </select>
+                                                    <label class="flex items-center gap-1 text-[10px] text-ink-400">
+                                                        <input type="checkbox" x-model="attr.isSafety" class="w-3 h-3 rounded" /> safety
+                                                    </label>
+                                                    <label class="flex items-center gap-1 text-[10px] text-ink-400">
+                                                        <input type="checkbox" x-model="attr.isDefect" class="w-3 h-3 rounded" /> defect
+                                                    </label>
+                                                </div>
+                                                <div x-show="attr.type === 'select' || attr.type === 'multi_select'">
+                                                    <input type="text" x-model="attr._choicesStr" {...{'@input': "attr.choices = attr._choicesStr.split(',').map(s=>s.trim()).filter(Boolean)"}}
+                                                        class="w-full text-[11px] font-mono px-2 py-1.5 rounded-md border border-surface-200 bg-white"
+                                                        placeholder="Choice 1, Choice 2, ..." />
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <div x-show="!selectedItem.attributes || !selectedItem.attributes.length" class="text-center py-4">
+                                            <p class="text-[11px] text-ink-300">No attributes defined</p>
+                                        </div>
+                                    </div>
+                                    <div x-show="selectedItem.source" class="mt-4 p-3 rounded-xl bg-surface-50 border border-surface-200/50">
+                                        <div class="text-[10px] font-700 uppercase tracking-[0.1em] text-ink-400 mb-2">Import Source</div>
+                                        <div class="flex items-center gap-2">
+                                            <span class="text-[10px] font-600 px-2 py-0.5 rounded"
+                                                x-bind:class="selectedItem.source?.platform === 'spectora' ? 'bg-orange-50 text-orange-600' : 'bg-emerald-50 text-emerald-600'"
+                                                x-text="selectedItem.source?.platform"></span>
+                                            <span class="font-mono text-[10px] text-ink-300" x-text="selectedItem.source?.externalId"></span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/src/types/template-schema.ts
+++ b/src/types/template-schema.ts
@@ -49,28 +49,89 @@ export interface ItemTabs {
     defects: CannedDefect[];
 }
 
-/** Item types. v2 uses 'rich' for rated inspectable items, 'text' for
- *  free-text-only items (e.g. "Overall Condition Notes"). */
-export type ItemType = 'rich' | 'text';
+/** Item types — `rich` is the headline interactive type (rating + three
+ *  canned-comment tabs). The 8 simpler types cover non-rated data points
+ *  the editor surfaces (booleans, numbers with min/max/unit, single- and
+ *  multi-select with choices, date pickers, photo-only fields, and plain
+ *  text / textarea inputs). */
+export type ItemType =
+    | 'rich'
+    | 'text'
+    | 'boolean'
+    | 'textarea'
+    | 'number'
+    | 'select'
+    | 'multi_select'
+    | 'date'
+    | 'photo_only';
+
+export type ItemAttributeType =
+    | 'boolean' | 'text' | 'number' | 'select' | 'multi_select' | 'date';
+
+/** Optional sub-fields nested under an item, e.g. tonnage on an HVAC unit. */
+export interface ItemAttribute {
+    id: string;
+    name: string;
+    type: ItemAttributeType;
+    choices?: string[];
+    unit?: string;
+    required?: boolean;
+    isSafety?: boolean;
+    isDefect?: boolean;
+    recommendation?: string | null;
+    estimateMin?: number | null;
+    estimateMax?: number | null;
+}
+
+/** Per-item sub-properties — only meaningful on non-rich types. */
+export interface ItemOptions {
+    min?: number | null;
+    max?: number | null;
+    unit?: string;
+    step?: number | null;
+    placeholder?: string;
+    maxLength?: number | null;
+    choices?: string[];
+    minPhotos?: number | null;
+}
+
+/** Provenance for templates imported from upstream platforms. */
+export interface ItemSource {
+    platform: string;
+    externalId: string;
+}
 
 export interface TemplateItem {
     id: string;
     label: string;
     type: ItemType;
+    description?: string;
     /** Rating options shown at the top of an item card. Required for 'rich'. */
     ratingOptions?: string[];
     /** Three tabs of canned comments. Required for 'rich'. */
     tabs?: ItemTabs;
+    /** Sub-properties on non-rich types (min/max/choices/...). */
+    options?: ItemOptions;
     /** Optional icon key + display number (used by some templates). */
     icon?: string;
     number?: string;
+    required?: boolean;
+    isSafety?: boolean;
+    defaultRecommendation?: string;
+    defaultEstimateMin?: number | null;
+    defaultEstimateMax?: number | null;
+    attributes?: ItemAttribute[];
+    source?: ItemSource | null;
 }
 
 export interface TemplateSection {
     id: string;
     title: string;
     icon?: string;
+    identifier?: string;
     items: TemplateItem[];
+    disclaimerText?: string | null;
+    alwaysPageBreak?: boolean;
 }
 
 export interface RatingLevel {


### PR DESCRIPTION
## Summary

Reverts the dead-UI deletion from PR #50 and instead grows the v2 schema so every field the editor surfaces round-trips end-to-end instead of being silently dropped on the wire. The design-system 0520 explorations don't deeply analyze every feature, and the live editor's surface reflects real inspector needs.

v2 stays the single canonical schema. No v1 compat layer.

### Schema changes
- Items become a 9-way discriminated union (`rich | text | boolean | textarea | number | select | multi_select | date | photo_only`); non-rich types carry an optional `options` sub-object (min/max/unit/step/placeholder/maxLength/choices/minPhotos).
- Per-item: `description`, `required`, `isSafety`, `defaultRecommendation`, `defaultEstimateMin/Max`, `attributes[]`, `source`.
- Per-attribute: id, name, 6-value type enum, choices, unit, required, isSafety, isDefect, recommendation, estimateMin/Max.
- Section: optional `identifier`.

### Editor
- \`toV2Payload\` passes new fields through with pickAttribute / pickOptions helpers.
- TS types mirror the Zod schema.

### Test plan
- [x] \`npm run type-check\` (0 errors)
- [x] Chrome end-to-end: Roof Covering with description / required=true / defaultRecommendation='roofer' / estimate \$300-\$8000 / 2 attrs persists
- [x] Number + Date items in Fireplaces persist
- [x] Existing v2 templates load unchanged (all new fields are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)