### PR TITLE
feat(template-schema): accept full ratingSystem shape

### DIFF
--- a/public/js/template-editor.js
+++ b/public/js/template-editor.js
@@ -341,17 +341,22 @@ function templateEditor() {
                 sections: (this.template.sections || []).map(pickSection),
             };
             if (this.template.ratingSystem && Array.isArray(this.template.ratingSystem.levels)) {
-                payload.ratingSystem = {
+                const rs = {
                     levels: this.template.ratingSystem.levels.map(l => {
                         const lv = { id: l.id, label: l.label || '' };
                         if (l.abbreviation) lv.abbreviation = l.abbreviation;
                         if (l.color)        lv.color        = l.color;
                         if (l.severity)     lv.severity     = l.severity;
                         if (typeof l.isDefect === 'boolean') lv.isDefect = l.isDefect;
+                        if (typeof l.default  === 'boolean') lv.default  = l.default;
                         if (l.description)  lv.description  = l.description;
                         return lv;
                     }),
                 };
+                if (this.template.ratingSystem.name)           rs.name = this.template.ratingSystem.name;
+                if (this.template.ratingSystem.defaultLevelId) rs.defaultLevelId = this.template.ratingSystem.defaultLevelId;
+                if (this.template.ratingSystem.source !== undefined) rs.source = this.template.ratingSystem.source;
+                payload.ratingSystem = rs;
             }
             return payload;
         },

--- a/src/lib/validations/template.schema.ts
+++ b/src/lib/validations/template.schema.ts
@@ -178,7 +178,15 @@ const RatingLevelSchema = z.object({
     color:        z.string().optional(),
     severity:     z.enum(['good', 'minor', 'marginal', 'significant']).optional(),
     isDefect:     z.boolean().optional(),
+    default:      z.boolean().optional(),
     description:  z.string().optional(),
+}).strict();
+
+const RatingSystemSchema = z.object({
+    name:           z.string().optional(),
+    defaultLevelId: z.string().optional(),
+    source:         z.string().nullable().optional(),
+    levels:         z.array(RatingLevelSchema),
 }).strict();
 
 /**
@@ -187,7 +195,7 @@ const RatingLevelSchema = z.object({
 export const TemplateSchemaV2Schema = z.object({
     schemaVersion: z.literal(2),
     sections:      z.array(TemplateSectionSchema),
-    ratingSystem:  z.object({ levels: z.array(RatingLevelSchema) }).optional(),
+    ratingSystem:  RatingSystemSchema.optional(),
 }).strict();
 
 /**

--- a/src/types/template-schema.ts
+++ b/src/types/template-schema.ts
@@ -141,13 +141,21 @@ export interface RatingLevel {
     color?: string;
     severity?: 'good' | 'minor' | 'marginal' | 'significant';
     isDefect?: boolean;
+    default?: boolean;
     description?: string;
+}
+
+export interface RatingSystem {
+    name?: string;
+    defaultLevelId?: string;
+    source?: string | null;
+    levels: RatingLevel[];
 }
 
 export interface TemplateSchemaV2 {
     schemaVersion: 2;
     sections: TemplateSection[];
-    ratingSystem?: { levels: RatingLevel[] };
+    ratingSystem?: RatingSystem;
 }
 
 /**


### PR DESCRIPTION
Editor seeds rating system with name, defaultLevelId, source, and a default flag per level — but toV2Payload was stripping everything except levels[] because the strict Zod schema only listed { levels }. Verified: custom 3-level rating system persists fully (name, defaultLevelId, per-level default) end-to-end.