### PR TITLE
feat(template-schema): accept section.source for imports

### DIFF
--- a/public/js/template-editor.js
+++ b/public/js/template-editor.js
@@ -334,6 +334,7 @@ function templateEditor() {
                 if (s.identifier)       out.identifier = s.identifier;
                 if (s.disclaimerText)   out.disclaimerText = s.disclaimerText;
                 if (s.alwaysPageBreak)  out.alwaysPageBreak = !!s.alwaysPageBreak;
+                if (s.source && s.source.platform && s.source.externalId) out.source = { platform: s.source.platform, externalId: s.source.externalId };
                 return out;
             };
             const payload = {

--- a/src/lib/validations/template.schema.ts
+++ b/src/lib/validations/template.schema.ts
@@ -169,6 +169,10 @@ const TemplateSectionSchema = z.object({
     // Track E2 — when true, the published report forces a page break BEFORE
     // this section in PDF output.
     alwaysPageBreak: z.boolean().optional(),
+    // Provenance from upstream platform imports (e.g. Spectora). The editor
+    // surfaces this as a small colored dot next to the section title so
+    // imported sections are visually distinguishable.
+    source:          ItemSourceSchema.nullable().optional(),
 }).strict();
 
 const RatingLevelSchema = z.object({

--- a/src/types/template-schema.ts
+++ b/src/types/template-schema.ts
@@ -132,6 +132,7 @@ export interface TemplateSection {
     items: TemplateItem[];
     disclaimerText?: string | null;
     alwaysPageBreak?: boolean;
+    source?: ItemSource | null;
 }
 
 export interface RatingLevel {


### PR DESCRIPTION
Editor renders a colored provenance dot on sections with source.platform === 'spectora' or 'itb', but the strict v2 schema only allowed source on items. Adding source (same shape as items) to TemplateSectionSchema + TS interface + toV2Payload pass-through. Verified Roof.source = {platform:'spectora', externalId:'...'} round-trips.