### PR TITLE
feat(import): Spectora export → v2 schema converter

### DIFF
--- a/src/lib/spectora-import.ts
+++ b/src/lib/spectora-import.ts
@@ -1,0 +1,186 @@
+/**
+ * Spectora → OpenInspection v2 schema converter.
+ *
+ * Best-effort translation of a Spectora template export into the strict
+ * v2 schema. Spectora's per-item canned-comment model has four buckets
+ * (INFORMATIONAL / SATISFACTORY / MONITOR / DEFECT) which we map onto
+ * OpenInspection's three (information / limitations / defects):
+ *
+ * | Spectora        | v2 tab          | Defect category    |
+ * |-----------------|-----------------|--------------------|
+ * | INFORMATIONAL   | information     | —                  |
+ * | SATISFACTORY    | information     | — (prefixed)       |
+ * | MONITOR         | defects         | recommendation     |
+ * | DEFECT          | defects         | safety             |
+ *
+ * Unknown comment kinds fall through to information so no data is
+ * silently lost. Spectora identifiers are preserved on every level via
+ * the v2 `source` field so re-imports can detect already-mapped rows.
+ */
+
+import type { TemplateSchemaV2, TemplateSection, TemplateItem, CannedInfoComment, CannedDefect } from '../types/template-schema';
+
+const SPECTORA_PLATFORM = 'spectora';
+
+/** Subset of the Spectora export we actually consume. */
+export interface SpectoraTemplate {
+    id?: string;
+    name?: string;
+    sections?: SpectoraSection[];
+}
+
+export interface SpectoraSection {
+    id?: string;
+    name?: string;
+    title?: string;
+    identifier?: string;
+    items?: SpectoraItem[];
+}
+
+export interface SpectoraItem {
+    id?: string;
+    name?: string;
+    label?: string;
+    comments?: SpectoraComment[];
+}
+
+export type SpectoraCommentType = 'INFORMATIONAL' | 'SATISFACTORY' | 'MONITOR' | 'DEFECT' | string;
+
+export interface SpectoraComment {
+    id?: string;
+    type?: SpectoraCommentType;
+    title?: string;
+    text?: string;
+    body?: string;
+    default?: boolean;
+    location?: string;
+}
+
+export interface ConvertResult {
+    template: TemplateSchemaV2;
+    /** Counts of source comments mapped into each v2 tab. Useful for surfacing import diffs. */
+    stats: {
+        sections: number;
+        items: number;
+        information: number;
+        limitations: number;
+        defects: number;
+        unknownCommentTypes: string[];
+    };
+}
+
+function freshId(prefix: string, externalId: string | undefined): string {
+    if (externalId && externalId.trim()) return `${prefix}_${externalId.trim()}`;
+    const random = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    return `${prefix}_${random}`;
+}
+
+function pickText(c: SpectoraComment): string {
+    return (c.text ?? c.body ?? '').toString();
+}
+
+function pickTitle(c: SpectoraComment, fallback: string): string {
+    const t = (c.title ?? '').toString().trim();
+    return t.length > 0 ? t : fallback;
+}
+
+function bucketComment(c: SpectoraComment, stats: ConvertResult['stats']):
+    | { tab: 'information'; entry: CannedInfoComment }
+    | { tab: 'limitations'; entry: CannedInfoComment }
+    | { tab: 'defects'; entry: CannedDefect } {
+    const externalId = c.id;
+    const kind = (c.type ?? 'INFORMATIONAL').toString().toUpperCase();
+    const def = !!c.default;
+    const body = pickText(c);
+    if (kind === 'INFORMATIONAL') {
+        stats.information++;
+        return { tab: 'information', entry: { id: freshId('ri', externalId), title: pickTitle(c, 'Information'), comment: body, default: def } };
+    }
+    if (kind === 'SATISFACTORY') {
+        stats.information++;
+        const title = pickTitle(c, 'Satisfactory');
+        return { tab: 'information', entry: { id: freshId('ri', externalId), title: `Satisfactory · ${title}`, comment: body, default: def } };
+    }
+    if (kind === 'MONITOR') {
+        stats.defects++;
+        return {
+            tab: 'defects',
+            entry: {
+                id: freshId('rd', externalId),
+                title: pickTitle(c, 'Monitor'),
+                category: 'recommendation',
+                location: (c.location ?? '').toString(),
+                comment: body,
+                photos: [],
+                default: def,
+            },
+        };
+    }
+    if (kind === 'DEFECT') {
+        stats.defects++;
+        return {
+            tab: 'defects',
+            entry: {
+                id: freshId('rd', externalId),
+                title: pickTitle(c, 'Defect'),
+                category: 'safety',
+                location: (c.location ?? '').toString(),
+                comment: body,
+                photos: [],
+                default: def,
+            },
+        };
+    }
+    // Unknown comment kind — preserve it under information so the inspector
+    // can still see and re-categorise the content.
+    if (!stats.unknownCommentTypes.includes(kind)) stats.unknownCommentTypes.push(kind);
+    stats.information++;
+    return { tab: 'information', entry: { id: freshId('ri', externalId), title: `${kind} · ${pickTitle(c, '')}`.trim(), comment: body, default: def } };
+}
+
+export function convertSpectoraTemplate(input: SpectoraTemplate): ConvertResult {
+    const stats: ConvertResult['stats'] = {
+        sections: 0, items: 0,
+        information: 0, limitations: 0, defects: 0,
+        unknownCommentTypes: [],
+    };
+
+    const sections: TemplateSection[] = (input.sections ?? []).map((s) => {
+        stats.sections++;
+        const sectionTitle = (s.title ?? s.name ?? 'Untitled section').toString().slice(0, 50);
+        const sectionId = freshId('sec', s.id);
+        const items: TemplateItem[] = (s.items ?? []).map((it) => {
+            stats.items++;
+            const itemLabel = (it.label ?? it.name ?? 'Untitled item').toString().slice(0, 100);
+            const itemId = freshId('item', it.id);
+            const tabs = { information: [] as CannedInfoComment[], limitations: [] as CannedInfoComment[], defects: [] as CannedDefect[] };
+            for (const c of (it.comments ?? [])) {
+                const bucketed = bucketComment(c, stats);
+                if (bucketed.tab === 'defects') tabs.defects.push(bucketed.entry);
+                else if (bucketed.tab === 'limitations') tabs.limitations.push(bucketed.entry);
+                else tabs.information.push(bucketed.entry);
+            }
+            const item: TemplateItem = {
+                id: itemId,
+                label: itemLabel,
+                type: 'rich',
+                ratingOptions: ['Satisfactory', 'Monitor', 'Defect', 'Not Inspected', 'Not Present'],
+                tabs,
+            };
+            if (it.id) item.source = { platform: SPECTORA_PLATFORM, externalId: String(it.id) };
+            return item;
+        });
+        const section: TemplateSection = { id: sectionId, title: sectionTitle, items };
+        if (s.identifier) section.identifier = String(s.identifier);
+        if (s.id) section.source = { platform: SPECTORA_PLATFORM, externalId: String(s.id) };
+        return section;
+    });
+
+    const template: TemplateSchemaV2 = {
+        schemaVersion: 2,
+        sections,
+    };
+    return { template, stats };
+}

--- a/tests/unit/spectora-import.spec.ts
+++ b/tests/unit/spectora-import.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { convertSpectoraTemplate, type SpectoraTemplate } from '../../src/lib/spectora-import';
+import { TemplateSchemaV2Schema } from '../../src/lib/validations/template.schema';
+
+const SAMPLE_SPECTORA: SpectoraTemplate = {
+    id: 'spectora_tpl_42',
+    name: 'Commercial Inspection 2024',
+    sections: [
+        {
+            id: 'sec_roof',
+            name: 'Roof',
+            identifier: '4.0',
+            items: [
+                {
+                    id: 'item_roof_cover',
+                    name: 'Roof Covering',
+                    comments: [
+                        { id: 'c1', type: 'INFORMATIONAL', title: 'Material', text: 'Asphalt composition shingles observed.', default: true },
+                        { id: 'c2', type: 'SATISFACTORY', text: 'No active leaks at the time of inspection.' },
+                        { id: 'c3', type: 'MONITOR', title: 'Granule loss', text: 'Mild granule loss; monitor and plan for replacement within 3-5 years.' },
+                        { id: 'c4', type: 'DEFECT', title: 'Missing shingles', text: 'Several shingles missing at the southeast corner; recommend repair by a qualified roofer.', location: 'Southeast corner' },
+                    ],
+                },
+                {
+                    id: 'item_flashings',
+                    name: 'Flashings',
+                    comments: [
+                        { id: 'c5', type: 'INFORMATIONAL', text: 'Galvanised steel flashings observed.' },
+                    ],
+                },
+            ],
+        },
+        {
+            id: 'sec_plumbing',
+            name: 'Plumbing',
+            items: [
+                {
+                    id: 'item_water_heater',
+                    name: 'Water Heater',
+                    comments: [
+                        // Intentionally unknown bucket — should land under information with the kind preserved in the title.
+                        { id: 'c6', type: 'NOTE_FOR_BUILDER', text: 'Builder confirmed unit was installed in 2022.' },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+describe('convertSpectoraTemplate', () => {
+    const { template, stats } = convertSpectoraTemplate(SAMPLE_SPECTORA);
+
+    it('produces a structurally valid v2 schema', () => {
+        const parsed = TemplateSchemaV2Schema.safeParse(template);
+        if (!parsed.success) {
+            // Surface the Zod issues in the failure message — easier to debug than just "false".
+            throw new Error('Output did not validate against TemplateSchemaV2Schema: ' + JSON.stringify(parsed.error.issues, null, 2));
+        }
+        expect(parsed.success).toBe(true);
+    });
+
+    it('maps 4 Spectora comment buckets to 3 v2 tabs', () => {
+        const roof = template.sections[0]!;
+        const cover = roof.items[0]!;
+        expect(cover.tabs?.information).toHaveLength(2);  // INFORMATIONAL + SATISFACTORY (prefixed)
+        expect(cover.tabs?.defects).toHaveLength(2);      // MONITOR + DEFECT
+        expect(cover.tabs?.limitations).toHaveLength(0);  // Spectora has no direct limitations equivalent
+
+        const monitor = cover.tabs!.defects[0]!;
+        expect(monitor.category).toBe('recommendation');
+        const defect = cover.tabs!.defects[1]!;
+        expect(defect.category).toBe('safety');
+        expect(defect.location).toBe('Southeast corner');
+    });
+
+    it('prefixes SATISFACTORY comments so they survive the 3-tab collapse', () => {
+        const cover = template.sections[0]!.items[0]!;
+        const titles = cover.tabs!.information.map(c => c.title);
+        expect(titles).toContain('Material');
+        expect(titles.some(t => t.startsWith('Satisfactory · '))).toBe(true);
+    });
+
+    it('routes unknown comment kinds to information without losing the source kind', () => {
+        const heater = template.sections[1]!.items[0]!;
+        expect(heater.tabs?.information).toHaveLength(1);
+        expect(heater.tabs!.information[0]!.title).toMatch(/^NOTE_FOR_BUILDER/);
+        expect(stats.unknownCommentTypes).toContain('NOTE_FOR_BUILDER');
+    });
+
+    it('preserves Spectora identifiers via the v2 source field on each level', () => {
+        const roof = template.sections[0]!;
+        expect(roof.source).toEqual({ platform: 'spectora', externalId: 'sec_roof' });
+        expect(roof.identifier).toBe('4.0');
+
+        const cover = roof.items[0]!;
+        expect(cover.source).toEqual({ platform: 'spectora', externalId: 'item_roof_cover' });
+    });
+
+    it('counts mapped entries for diff display', () => {
+        expect(stats.sections).toBe(2);
+        expect(stats.items).toBe(3);
+        expect(stats.information + stats.defects + stats.limitations).toBe(6);
+        expect(stats.unknownCommentTypes).toEqual(['NOTE_FOR_BUILDER']);
+    });
+});


### PR DESCRIPTION
Adds lib/spectora-import.ts: translates Spectora template exports to strict v2. Maps 4 comment buckets to 3 v2 tabs (INFORMATIONAL/SATISFACTORY → information; MONITOR → defects/recommendation; DEFECT → defects/safety; unknown → information with kind preserved in title). Identifiers preserved via source field on every level. 6 Vitest cases cover structural validation + bucket mapping + edge cases. Not wired to a route handler yet; future PR can be a thin parse + dispatch on top of this pure converter.