### PR TITLE
feat(templates): Import from Spectora button + paste-JSON modal

### DIFF
--- a/public/js/templates.js
+++ b/public/js/templates.js
@@ -167,6 +167,67 @@ function closeModal() {
     document.getElementById('tplName').value = '';
 }
 
+function showImportSpectoraModal() {
+    document.getElementById('importSpectoraModal').classList.remove('hidden');
+}
+
+function closeImportSpectoraModal() {
+    document.getElementById('importSpectoraModal').classList.add('hidden');
+    document.getElementById('importName').value = '';
+    document.getElementById('importPayload').value = '';
+    const result = document.getElementById('importResult');
+    if (result) { result.classList.add('hidden'); result.textContent = ''; }
+}
+
+async function submitImportSpectora() {
+    const name = document.getElementById('importName').value.trim();
+    const raw  = document.getElementById('importPayload').value.trim();
+    if (!name) { modalAlert('Please enter a template name.', 'Validation'); return; }
+    if (!raw)  { modalAlert('Please paste a Spectora export JSON.', 'Validation'); return; }
+    let parsed;
+    try { parsed = JSON.parse(raw); }
+    catch (e) { modalAlert('Invalid JSON: ' + e.message, 'Validation'); return; }
+
+    const btn = document.getElementById('submitImportBtn');
+    btn.disabled = true;
+    btn.textContent = 'Importing...';
+
+    try {
+        const res = await authFetch('/api/inspections/templates/import-spectora', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, spectora: parsed })
+        });
+        if (res.ok) {
+            const result = await res.json();
+            const newId = result?.data?.template?.id;
+            const stats = result?.data?.stats;
+            if (stats) {
+                const note = document.getElementById('importResult');
+                if (note) {
+                    note.textContent = 'Imported · ' + stats.sections + ' sections, ' + stats.items + ' items, ' + (stats.information + stats.defects + stats.limitations) + ' comments mapped' + (stats.unknownCommentTypes?.length ? ' (unknown kinds: ' + stats.unknownCommentTypes.join(', ') + ')' : '');
+                    note.classList.remove('hidden');
+                }
+            }
+            if (newId) {
+                setTimeout(() => { window.location.href = '/templates/' + newId + '/edit'; }, 600);
+            } else {
+                loadTemplates();
+                closeImportSpectoraModal();
+            }
+        } else {
+            const err = await res.json().catch(() => ({}));
+            const msg = err?.error?.message || err?.error || err?.message || 'Import failed';
+            modalAlert('Error: ' + msg, 'Error');
+        }
+    } catch (e) {
+        modalAlert('Connection error: ' + e.message, 'Error');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Import';
+    }
+}
+
 async function submitTemplate() {
     const name = document.getElementById('tplName').value.trim();
     if (!name) { modalAlert('Please enter a template name.', 'Validation'); return; }

--- a/src/templates/pages/templates.tsx
+++ b/src/templates/pages/templates.tsx
@@ -17,14 +17,25 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                         title="Inspection Templates"
                         meta={<span x-text="metaText"></span>}
                         actions={
-                            <button
-                                type="button"
-                                onclick="showCreateModal()"
-                                class="h-8 px-4 rounded-md bg-indigo-600 text-white font-bold text-[13px] hover:bg-indigo-700 active:scale-95 transition-all inline-flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
-                            >
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
-                                New Template
-                            </button>
+                            <div class="flex items-center gap-2">
+                                <button
+                                    type="button"
+                                    onclick="showImportSpectoraModal()"
+                                    class="h-8 px-3 rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 font-bold text-[13px] hover:border-orange-300 hover:text-orange-600 dark:hover:text-orange-400 active:scale-95 transition-all inline-flex items-center gap-1.5 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
+                                    title="Import a Spectora template export"
+                                >
+                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path></svg>
+                                    Import Spectora
+                                </button>
+                                <button
+                                    type="button"
+                                    onclick="showCreateModal()"
+                                    class="h-8 px-4 rounded-md bg-indigo-600 text-white font-bold text-[13px] hover:bg-indigo-700 active:scale-95 transition-all inline-flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                                >
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
+                                    New Template
+                                </button>
+                            </div>
                         }
                     />
                 </div>
@@ -83,6 +94,45 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                         <p class="text-sm text-slate-400 font-medium leading-relaxed">
                             After creating the template, you will be taken to the visual editor where you can add sections and inspection items.
                         </p>
+                    </div>
+                </Modal>
+
+                {/* Import from Spectora Modal — wraps POST /api/inspections/
+                    templates/import-spectora. Paste the raw Spectora export
+                    JSON; we run convertSpectoraTemplate server-side and
+                    create the new template in one shot. */}
+                <Modal
+                    id="importSpectoraModal"
+                    title="Import from Spectora"
+                    subtitle="Paste a Spectora template export — we'll convert it to v2."
+                    size="xl"
+                    footer={
+                        <ModalFooter
+                            onCancelJs="closeImportSpectoraModal()"
+                            onConfirmJs="submitImportSpectora()"
+                            confirmText="Import"
+                            confirmId="submitImportBtn"
+                        />
+                    }
+                >
+                    <div class="space-y-4">
+                        <div class="space-y-2">
+                            <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Template Name</label>
+                            <input type="text" id="importName" placeholder="e.g., Spectora Commercial 2024"
+                                class="premium-input w-full px-3 py-2.5 rounded-md border-2 border-slate-100 focus:border-orange-500 focus:ring-4 focus:ring-orange-50 outline-none transition-all font-semibold" />
+                        </div>
+                        <div class="space-y-2">
+                            <label class="text-[10px] font-bold uppercase tracking-widest text-slate-400 ml-1">Spectora Export JSON</label>
+                            <textarea id="importPayload" rows={10}
+                                placeholder='{"name":"...","sections":[{"name":"Roof","items":[{"name":"Roof Covering","comments":[...]}]}]}'
+                                class="premium-input w-full px-3 py-2.5 rounded-md border-2 border-slate-100 focus:border-orange-500 focus:ring-4 focus:ring-orange-50 outline-none transition-all font-mono text-xs resize-y"></textarea>
+                        </div>
+                        <p class="text-xs text-slate-400 font-medium leading-relaxed">
+                            Spectora's 4 comment buckets (INFORMATIONAL / SATISFACTORY / MONITOR / DEFECT) collapse to OpenInspection's 3 tabs.
+                            SATISFACTORY comments get a "Satisfactory ·" prefix; MONITOR becomes a recommendation defect; DEFECT becomes a safety defect.
+                            Unknown comment kinds land under Information with the kind preserved in the title.
+                        </p>
+                        <div id="importResult" class="hidden p-3 rounded-md bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-800 text-emerald-700 dark:text-emerald-300 text-xs font-medium"></div>
                     </div>
                 </Modal>
 


### PR DESCRIPTION
Wraps the import-spectora endpoint (#59) in user-facing UI on /templates: secondary 'Import Spectora' button next to 'New Template', modal with name input + paste textarea + small 4→3 bucket mapping caption. submitImportSpectora validates JSON client-side, POSTs, surfaces stats summary briefly, then redirects to new template editor. Verified end-to-end with 1-section fixture: identifiers persist as source.{platform:'spectora', externalId}, DEFECT → category='safety'.