### PR TITLE
feat(import): Spectora converter handles rating_levels, disclaimer, description

### DIFF
--- a/src/lib/spectora-import.ts
+++ b/src/lib/spectora-import.ts
@@ -18,7 +18,7 @@
  * the v2 `source` field so re-imports can detect already-mapped rows.
  */
 
-import type { TemplateSchemaV2, TemplateSection, TemplateItem, CannedInfoComment, CannedDefect } from '../types/template-schema';
+import type { TemplateSchemaV2, TemplateSection, TemplateItem, RatingLevel, CannedInfoComment, CannedDefect } from '../types/template-schema';
 
 const SPECTORA_PLATFORM = 'spectora';
 
@@ -27,6 +27,21 @@ export interface SpectoraTemplate {
     id?: string;
     name?: string;
     sections?: SpectoraSection[];
+    /** Custom rating levels defined at template level. */
+    rating_levels?: SpectoraRatingLevel[];
+    ratingLevels?: SpectoraRatingLevel[];
+}
+
+export interface SpectoraRatingLevel {
+    id?: string;
+    name?: string;
+    label?: string;
+    abbreviation?: string;
+    color?: string;
+    is_defect?: boolean;
+    isDefect?: boolean;
+    default?: boolean;
+    description?: string;
 }
 
 export interface SpectoraSection {
@@ -35,12 +50,17 @@ export interface SpectoraSection {
     title?: string;
     identifier?: string;
     items?: SpectoraItem[];
+    /** Legal text rendered at the bottom of the section in the published report. */
+    disclaimer?: string;
+    disclaimer_text?: string;
 }
 
 export interface SpectoraItem {
     id?: string;
     name?: string;
     label?: string;
+    /** Free-text description shown under the item label. */
+    description?: string;
     comments?: SpectoraComment[];
 }
 
@@ -169,11 +189,15 @@ export function convertSpectoraTemplate(input: SpectoraTemplate): ConvertResult 
                 ratingOptions: ['Satisfactory', 'Monitor', 'Defect', 'Not Inspected', 'Not Present'],
                 tabs,
             };
+            const description = (it.description ?? '').toString().trim();
+            if (description) item.description = description;
             if (it.id) item.source = { platform: SPECTORA_PLATFORM, externalId: String(it.id) };
             return item;
         });
         const section: TemplateSection = { id: sectionId, title: sectionTitle, items };
         if (s.identifier) section.identifier = String(s.identifier);
+        const disclaimer = (s.disclaimer ?? s.disclaimer_text ?? '').toString().trim();
+        if (disclaimer) section.disclaimerText = disclaimer.slice(0, 4000);
         if (s.id) section.source = { platform: SPECTORA_PLATFORM, externalId: String(s.id) };
         return section;
     });
@@ -182,5 +206,32 @@ export function convertSpectoraTemplate(input: SpectoraTemplate): ConvertResult 
         schemaVersion: 2,
         sections,
     };
+
+    // Custom rating levels from Spectora (top-level), if present. Map onto
+    // v2 RatingSystem.levels with the Spectora `is_defect` flag preserved
+    // and severity inferred from the `is_defect` bit (Spectora doesn't
+    // distinguish marginal vs significant — assume significant when
+    // is_defect, marginal otherwise; inspector can refine in the editor).
+    const rawLevels = input.rating_levels ?? input.ratingLevels;
+    if (Array.isArray(rawLevels) && rawLevels.length > 0) {
+        const levels: RatingLevel[] = rawLevels.map((rl, i) => {
+            const id = (rl.id ?? `L${i + 1}`).toString();
+            const label = (rl.label ?? rl.name ?? id).toString();
+            const isDefect = !!(rl.is_defect ?? rl.isDefect);
+            const lvl: RatingLevel = { id, label };
+            if (rl.abbreviation) lvl.abbreviation = rl.abbreviation;
+            if (rl.color)        lvl.color = rl.color;
+            lvl.severity = isDefect ? 'significant' : 'marginal';
+            lvl.isDefect = isDefect;
+            if (rl.default)      lvl.default = true;
+            if (rl.description)  lvl.description = rl.description;
+            return lvl;
+        });
+        const defaultLevel = levels.find(l => l.default);
+        template.ratingSystem = {
+            levels,
+            ...(defaultLevel ? { defaultLevelId: defaultLevel.id } : {}),
+        };
+    }
     return { template, stats };
 }

--- a/tests/unit/spectora-import.spec.ts
+++ b/tests/unit/spectora-import.spec.ts
@@ -103,3 +103,71 @@ describe('convertSpectoraTemplate', () => {
         expect(stats.unknownCommentTypes).toEqual(['NOTE_FOR_BUILDER']);
     });
 });
+
+describe('convertSpectoraTemplate — extended fields', () => {
+    it('passes item.description through to v2 item.description', () => {
+        const { template } = convertSpectoraTemplate({
+            sections: [{
+                name: 'S',
+                items: [{ name: 'Item', description: '  Outer water barrier  ', comments: [] }],
+            }],
+        });
+        expect(template.sections[0]!.items[0]!.description).toBe('Outer water barrier');
+    });
+
+    it('maps section.disclaimer (or disclaimer_text) to v2 section.disclaimerText', () => {
+        const { template } = convertSpectoraTemplate({
+            sections: [
+                { name: 'A', disclaimer: 'Visual inspection only.', items: [] },
+                { name: 'B', disclaimer_text: 'Snake-cased variant.', items: [] },
+                { name: 'C', items: [] },
+            ],
+        });
+        expect(template.sections[0]!.disclaimerText).toBe('Visual inspection only.');
+        expect(template.sections[1]!.disclaimerText).toBe('Snake-cased variant.');
+        expect(template.sections[2]!.disclaimerText).toBeUndefined();
+    });
+
+    it('truncates section.disclaimer past 4 KB to the schema cap', () => {
+        const longText = 'x'.repeat(5000);
+        const { template } = convertSpectoraTemplate({
+            sections: [{ name: 'Long', disclaimer: longText, items: [] }],
+        });
+        expect(template.sections[0]!.disclaimerText!.length).toBe(4000);
+    });
+
+    it('maps top-level rating_levels to ratingSystem.levels with severity inferred from is_defect', () => {
+        const { template } = convertSpectoraTemplate({
+            sections: [],
+            rating_levels: [
+                { id: 'S', label: 'Satisfactory', abbreviation: 'S', color: '#22c55e', default: true },
+                { id: 'M', label: 'Monitor',      abbreviation: 'M', color: '#f59e0b' },
+                { id: 'D', label: 'Defect',       abbreviation: 'D', color: '#ef4444', is_defect: true },
+            ],
+        });
+        const rs = template.ratingSystem;
+        expect(rs).toBeDefined();
+        expect(rs!.levels).toHaveLength(3);
+        expect(rs!.levels[0]!.default).toBe(true);
+        expect(rs!.levels[0]!.severity).toBe('marginal'); // not is_defect
+        expect(rs!.levels[2]!.severity).toBe('significant'); // is_defect
+        expect(rs!.levels[2]!.isDefect).toBe(true);
+        expect(rs!.defaultLevelId).toBe('S');
+    });
+
+    it('accepts camelCase ratingLevels as an alias for rating_levels', () => {
+        const { template } = convertSpectoraTemplate({
+            sections: [],
+            ratingLevels: [
+                { id: 'X', label: 'X-rating', isDefect: false },
+            ],
+        });
+        expect(template.ratingSystem!.levels).toHaveLength(1);
+        expect(template.ratingSystem!.levels[0]!.id).toBe('X');
+    });
+
+    it('omits ratingSystem when neither rating_levels nor ratingLevels is provided', () => {
+        const { template } = convertSpectoraTemplate({ sections: [] });
+        expect(template.ratingSystem).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Extends #58 converter to map 3 more fields real Spectora exports carry: top-level rating_levels → ratingSystem.levels (with severity inferred from is_defect); section.disclaimer → section.disclaimerText (clamped to 4 KB); item.description → item.description (trimmed). Both rating_levels and ratingLevels casings accepted. 6 new Vitest cases (12/12 total).