### PR TITLE
fix(report.template): keep non-rich items that have only a captured value

### DIFF
--- a/src/templates/pages/report.template.tsx
+++ b/src/templates/pages/report.template.tsx
@@ -341,12 +341,17 @@ export function renderProfessionalReport(data: {
                                 const photoCap = 8;
 
                                 // Sub-spec D Task 5 — collapse empty items: no rating + only the
-                                // "No notes recorded." placeholder + no photos. These are dead
-                                // weight in the report and clutter the Summary view.
+                                // "No notes recorded." placeholder + no photos + no captured
+                                // value. These are dead weight in the report and clutter the
+                                // Summary view. Non-rich item types (number/date/boolean/...)
+                                // ride on `res.value`, so an item with a value but no rating
+                                // is *not* empty — keep it.
                                 const hasRating = !!itemRatingId;
                                 const hasNotes  = !!(res.notes && res.notes !== 'No notes recorded.');
                                 const hasPhotos = photos.length > 0;
-                                if (!hasRating && !hasNotes && !hasPhotos) return null;
+                                const v = (res as { value?: unknown }).value;
+                                const hasValue  = v !== undefined && v !== null && v !== '' && !(Array.isArray(v) && v.length === 0);
+                                if (!hasRating && !hasNotes && !hasPhotos && !hasValue) return null;
 
                                 // Defect category mapping (Sub-spec D Task 2 / 5):
                                 // bucket=defect   -> recommendation (per render-path heuristic)

--- a/tests/unit/report-section-viewer.spec.ts
+++ b/tests/unit/report-section-viewer.spec.ts
@@ -157,7 +157,7 @@ describe('ReportCardStackPage — non-rich item value display (PR #64)', () => {
     function withValueItems(items: Array<Record<string, unknown>>) {
         return {
             ...baseProps,
-            sections: [{ id: 'mixed', title: 'Mixed', icon: null, defectCount: 0, items }],
+            sections: [{ id: 'mixed', title: 'Mixed', icon: null, defectCount: 0, items: items as never }],
         } as Parameters<typeof ReportCardStackPage>[0];
     }
 


### PR DESCRIPTION
PR #63 added value display to renderProfessionalReport (/api/inspections/:id/report + agent share links), but Sub-spec D collapse rule was dropping items without rating/notes/photos — so number/date items the inspector filled never rendered. Adds hasValue to the collapse predicate. Verified Number of Fireplaces + Last Cleaning Date now render on the inspector-side report. 18/18 spec cases pass.