### PR TITLE
fix(report-utils): completionPercent counts non-rich item values

### DIFF
--- a/src/lib/report-utils.ts
+++ b/src/lib/report-utils.ts
@@ -106,7 +106,7 @@ export function computeReportStats(
     completionPercent: 0,
   };
 
-  let ratedCount = 0;
+  let completedCount = 0;
 
   for (const section of sections) {
     let sectionDefects = 0;
@@ -117,13 +117,25 @@ export function computeReportStats(
       const bucket = getRatingBucket(ratingId, levels);
       stats[bucket]++;
       if (bucket === 'defect') sectionDefects++;
-      if (ratingId) ratedCount++;
+      // Mirror inspection-edit.js: an item counts toward completion when a
+      // rating is set OR a non-empty value is captured (non-rich types
+      // boolean / number / text / textarea / date / select / multi_select
+      // / photo_only persist their input on result.value).
+      if (ratingId) {
+        completedCount++;
+      } else {
+        const v = result?.value;
+        if (v !== undefined && v !== null && v !== ''
+            && !(Array.isArray(v) && v.length === 0)) {
+          completedCount++;
+        }
+      }
     }
     stats.sectionDefects[section.id] = sectionDefects;
   }
 
   stats.completionPercent =
-    stats.total > 0 ? Math.round((ratedCount / stats.total) * 100) : 0;
+    stats.total > 0 ? Math.round((completedCount / stats.total) * 100) : 0;
 
   return stats;
 }

--- a/tests/unit/report-utils.spec.ts
+++ b/tests/unit/report-utils.spec.ts
@@ -91,6 +91,37 @@ describe('computeReportStats', () => {
     expect(partial.completionPercent).toBe(25);
   });
 
+  it('counts non-rich item values toward completionPercent', () => {
+    // 1 rated + 1 with numeric value + 1 empty + 1 missing = 2 / 4 = 50%
+    const mixed = computeReportStats(sections, {
+      i1: { rating: 'S' },
+      i2: { value: 1995 },
+      i3: { value: '' },
+    }, defaultLevels);
+    expect(mixed.completionPercent).toBe(50);
+
+    // Strings, booleans, dates, and non-empty multi_select arrays all count.
+    const allValues = computeReportStats(sections, {
+      i1: { value: 'note text' },
+      i2: { value: true },
+      i3: { value: '2026-04-15' },
+      i4: { value: ['Electric', 'Gas'] },
+    }, defaultLevels);
+    expect(allValues.completionPercent).toBe(100);
+
+    // false boolean is a legitimate captured value — still counts.
+    const falseyValue = computeReportStats(sections, {
+      i1: { value: false },
+    }, defaultLevels);
+    expect(falseyValue.completionPercent).toBe(25);
+
+    // Empty multi_select array does NOT count (nothing actually picked).
+    const emptyArray = computeReportStats(sections, {
+      i1: { value: [] as unknown as string[] },
+    }, defaultLevels);
+    expect(emptyArray.completionPercent).toBe(0);
+  });
+
   it('handles legacy 3-level format (no ratingSystem)', () => {
     const legacyResults: Record<string, { rating?: string }> = {
       i1: { rating: 'Defect' },


### PR DESCRIPTION
Mirror-image of PR #67 — computeReportStats now also counts items where inspector captured non-empty value. 15/15 tests.