### PR TITLE
feat: tenant suspension middleware + amber banner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { users } from './lib/db/schema';
 import * as schema from './lib/db/schema';
 
 import { brandingMiddleware } from './lib/middleware/branding';
+import { enforceTenantActive } from './lib/middleware/tenant-status-guard';
 import { inspectorPaletteMiddleware } from './lib/middleware/inspector-palette';
 import { touchLastActiveMiddleware } from './lib/middleware/touch-last-active';
 import { tenantRouter } from './features/tenant-routing';
@@ -239,6 +240,7 @@ app.use('*', securityHeaders);
 app.use('*', diMiddleware);
 app.use('*', tenantRouter);
 app.use('*', brandingMiddleware);
+app.use('*', enforceTenantActive);
 
 // Static asset extensions — these bypass JWT verification. We use a strict allowlist
 // rather than path.includes('.') so a dot inside a path segment (e.g. "/inspections/foo.bar")

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -20,6 +20,7 @@ export enum ErrorCode {
     // client can surface a clear "open AI settings" path instead of a
     // generic 503.
     AI_NOT_CONFIGURED = 'ai_not_configured',
+    TENANT_SUSPENDED = 'tenant_suspended',
 }
 
 /**
@@ -62,4 +63,6 @@ export const Errors = {
     ServiceUnavailable: (msg: string, details?: unknown) => new AppError(503, ErrorCode.SERVICE_UNAVAILABLE, msg, details),
     AINotConfigured: (msg: string = 'AI is not configured. Set GEMINI_API_KEY in Settings.') =>
         new AppError(503, ErrorCode.AI_NOT_CONFIGURED, msg),
+    TenantSuspended: (msg: string = 'This workspace has been suspended. Existing content remains accessible in read-only mode. Contact your administrator to restore full access.') =>
+        new AppError(403, ErrorCode.TENANT_SUSPENDED, msg),
 };

--- a/src/lib/middleware/branding.ts
+++ b/src/lib/middleware/branding.ts
@@ -20,6 +20,7 @@ export const brandingMiddleware: MiddlewareHandler<HonoConfig> = async (c, next)
     const profile = c.var.profile;
     const isSharedSaas = profile?.mode === 'saas' && profile?.saasTopology === 'shared';
     const portalBaseUrl = c.env.PORTAL_API_URL ? c.env.PORTAL_API_URL.replace(/\/$/, '') : null;
+    const tenantStatus = c.get('tenantStatus') ?? 'active';
 
     // Default system branding (fallback)
     const defaultBranding: BrandingConfig = {
@@ -31,6 +32,7 @@ export const brandingMiddleware: MiddlewareHandler<HonoConfig> = async (c, next)
         gaMeasurementId: c.env.GA_MEASUREMENT_ID || null,
         isSharedSaas,
         portalBaseUrl,
+        tenantStatus,
     };
 
     if (!tenantId) {
@@ -81,6 +83,7 @@ export const brandingMiddleware: MiddlewareHandler<HonoConfig> = async (c, next)
             // value on the next request without waiting for the KV TTL.
             isSharedSaas,
             portalBaseUrl,
+            tenantStatus,
         } : defaultBranding;
 
         c.set('branding', branding);

--- a/src/lib/middleware/tenant-status-guard.ts
+++ b/src/lib/middleware/tenant-status-guard.ts
@@ -1,0 +1,29 @@
+import { MiddlewareHandler } from 'hono';
+import { HonoConfig } from '../../types/hono';
+import { Errors } from '../errors';
+
+const SUSPEND_EXEMPT_PREFIXES = [
+    '/api/auth/',
+    '/api/integration/',
+    '/status',
+    '/sso',
+];
+
+const READ_ONLY_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export const enforceTenantActive: MiddlewareHandler<HonoConfig> = async (c, next) => {
+    const tenantStatus = c.get('tenantStatus');
+    if (!tenantStatus || tenantStatus !== 'suspended') {
+        return next();
+    }
+    if (READ_ONLY_METHODS.has(c.req.method)) {
+        return next();
+    }
+    const path = c.req.path;
+    for (const prefix of SUSPEND_EXEMPT_PREFIXES) {
+        if (path.startsWith(prefix) || path === prefix) {
+            return next();
+        }
+    }
+    throw Errors.TenantSuspended();
+};

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -179,6 +179,34 @@ export const MainLayout = (props: {
                 {...(extraHead ? { extraHead } : {})}
             />
             <body class="bg-[#f8fafc] dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased min-h-screen" x-data="{ mobileMenu: false }">
+                {branding?.tenantStatus === 'suspended' && (
+                    <div id="suspensionBanner" class="bg-amber-50 dark:bg-amber-900/30 border-b border-amber-200 dark:border-amber-700 px-4 py-3 flex items-center justify-center gap-3 relative z-50">
+                        <svg class="w-5 h-5 flex-shrink-0 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
+                        <p class="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                            This workspace is suspended. You can view existing content but cannot create or edit inspections. Contact your administrator.
+                        </p>
+                        <button type="button" id="dismissSuspensionBanner" class="ml-auto flex-shrink-0 p-1 rounded-lg text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-800/50 hover:text-amber-800 dark:hover:text-amber-200 transition-colors" aria-label="Dismiss">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                        </button>
+                    </div>
+                )}
+                {branding?.tenantStatus === 'suspended' && (
+                    <script dangerouslySetInnerHTML={{ __html: `
+                        (function() {
+                            var banner = document.getElementById('suspensionBanner');
+                            var btn = document.getElementById('dismissSuspensionBanner');
+                            if (sessionStorage.getItem('oi-suspension-dismissed')) {
+                                if (banner) banner.style.display = 'none';
+                            }
+                            if (btn) {
+                                btn.addEventListener('click', function() {
+                                    sessionStorage.setItem('oi-suspension-dismissed', '1');
+                                    if (banner) banner.style.display = 'none';
+                                });
+                            }
+                        })();
+                    ` }} />
+                )}
                 {/* Mobile Header Bar */}
                 <div class="lg:hidden sticky top-0 z-40 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700 px-4 py-3 flex items-center justify-between">
                     <div class="flex items-center gap-3">

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -49,6 +49,9 @@ export interface BrandingConfig {
      *  time. Null when running standalone or when `PORTAL_API_URL` is
      *  unset (in which case the bounce/switch UI degrades to a no-op). */
     portalBaseUrl?: string | null | undefined;
+    /** Current tenant lifecycle status. Used by MainLayout to show a
+     *  suspension banner when status === 'suspended'. */
+    tenantStatus?: string | undefined;
 }
 
 import { ScopedDB } from '../lib/db/scoped';


### PR DESCRIPTION
## Summary

Adds read-only enforcement for suspended tenants. Home inspection reports have legal significance — tenants cannot be hard-deleted. Instead, suspended tenants retain full read access but are blocked from creating or editing content.

## Changes

### New: `src/lib/middleware/tenant-status-guard.ts`
- `enforceTenantActive` middleware reads `tenantStatus` from context (populated by tenant-router)
- GET/HEAD/OPTIONS always pass through (read-only access preserved)
- POST/PUT/PATCH/DELETE return 403 `TENANT_SUSPENDED` when tenant is suspended
- Exempt paths: `/api/auth/*`, `/api/integration/*`, `/status`, `/sso`

### Modified: `src/lib/errors.ts`
- `TENANT_SUSPENDED` added to `ErrorCode` enum
- `Errors.TenantSuspended()` factory returns 403 with descriptive message

### Modified: `src/types/auth.ts`
- `tenantStatus?: string` added to `BrandingConfig` so layouts can read suspension state

### Modified: `src/lib/middleware/branding.ts`
- Populates `tenantStatus` from `c.get('tenantStatus')` (defaulting to `'active'`)

### Modified: `src/index.ts`
- Registers `enforceTenantActive` after `brandingMiddleware`, before JWT middleware

### Modified: `src/templates/layouts/main-layout.tsx`
- Amber suspension banner when `branding.tenantStatus === 'suspended'`
- Dismissible per session via `sessionStorage`

## Compatibility
- Standalone deploys: no change — `tenantStatus` is unset, middleware passes through
- Active tenants: no change — middleware only triggers on `'suspended'`

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] Deployed to prod (`app.inspectorhub.io`) — no regression on active tenants
- [x] Companion portal PR: console suspend/unsuspend buttons + status sync to core

🤖 Generated with [Claude Code](https://claude.com/claude-code)