### PR TITLE
feat: editor 4-column layout restructure (Gap 2)

### DIFF
--- a/migrations/0075_unit_type_column.sql
+++ b/migrations/0075_unit_type_column.sql
@@ -1,0 +1,4 @@
+-- Foundation F2: Add 'type' column to inspection_units.
+-- Separates hierarchy level (kind: building/floor/unit) from purpose
+-- (type: unit/common). Extensible to 'amenity', 'parking' etc.
+ALTER TABLE inspection_units ADD COLUMN type TEXT NOT NULL DEFAULT 'unit';

--- a/migrations/0076_property_type_columns.sql
+++ b/migrations/0076_property_type_columns.sql
@@ -1,0 +1,9 @@
+-- Foundation F3: Add propertyType + commercialSubtype to inspections and templates.
+-- Drives template filtering, editor layout branching, and report rendering.
+ALTER TABLE inspections ADD COLUMN property_type TEXT;
+ALTER TABLE inspections ADD COLUMN commercial_subtype TEXT;
+
+ALTER TABLE templates ADD COLUMN property_type TEXT;
+ALTER TABLE templates ADD COLUMN commercial_subtype TEXT;
+ALTER TABLE templates ADD COLUMN description TEXT;
+ALTER TABLE templates ADD COLUMN featured INTEGER NOT NULL DEFAULT 0;

--- a/public/js/form-renderer.js
+++ b/public/js/form-renderer.js
@@ -1,3 +1,6 @@
+// F6 — composite finding key: _default:sectionId:itemId
+function fKey(sectionId, itemId) { return '_default:' + sectionId + ':' + itemId; }
+
 // B4 — Offline photo queue is now backed by the unified Dexie syncQueue store.
 // `pendingPhotoDb` retains the Phase O shape so call sites elsewhere in this
 // file don't need to change; under the hood it writes `photo.upload` rows
@@ -51,6 +54,30 @@ document.addEventListener('alpine:init', () => {
     scrolled: false,
     _lastSyncedAt: 0,
 
+    // F6 — resolve sectionId for an itemId by scanning the template schema.
+    _sectionIdForItem(itemId) {
+      var secs = this.templateSchema?.sections || [];
+      for (var s = 0; s < secs.length; s++) {
+        var items = secs[s].items || [];
+        for (var i = 0; i < items.length; i++) {
+          if (items[i].id === itemId) return secs[s].id;
+        }
+      }
+      return null;
+    },
+    _fk(itemId) {
+      var sid = this._sectionIdForItem(itemId);
+      return sid ? fKey(sid, itemId) : itemId;
+    },
+    _getResult(itemId) {
+      var sid = this._sectionIdForItem(itemId);
+      if (sid) {
+        var ck = fKey(sid, itemId);
+        if (this.results[ck] !== undefined) return this.results[ck];
+      }
+      return this.results[itemId];
+    },
+
     // Annotation State
     showAnnotationModal: false,
     annotationTarget: null,
@@ -89,7 +116,9 @@ document.addEventListener('alpine:init', () => {
 
         this.templateSchema.sections.forEach(s => {
           s.items.forEach(i => {
-            this.results[i.id] = { status: null, notes: '', photos: [], recommendations: [] };
+            var ck = fKey(s.id, i.id);
+            this.results[ck] = { status: null, notes: '', photos: [], recommendations: [] };
+            this.results[i.id] = this.results[ck]; // backward-compat alias
             this.uploading[i.id] = false;
           });
         });
@@ -125,14 +154,19 @@ document.addEventListener('alpine:init', () => {
     },
 
     setItemStatus(itemId, status) {
-      this.results[itemId].status = status;
-      this.results[itemId].updatedAt = Date.now();
+      var ck = this._fk(itemId);
+      var r = this.results[ck] || this.results[itemId];
+      r.status = status;
+      r.updatedAt = Date.now();
+      this.results[ck] = r;
+      this.results[itemId] = r; // backward-compat alias
       this._markDirty(itemId, 'status');
       this.saveLocally();
     },
 
     noteChanged(itemId) {
-      if (this.results[itemId]) this.results[itemId].updatedAt = Date.now();
+      var r = this._getResult(itemId);
+      if (r) r.updatedAt = Date.now();
       this._markDirty(itemId, 'notes');
       this.saveLocally();
     },
@@ -153,7 +187,8 @@ document.addEventListener('alpine:init', () => {
     async handleFileUpload(itemId, event) {
       const file = event.target.files[0];
       if (!file) return;
-      if (!this.results[itemId].photos) this.results[itemId].photos = [];
+      var _r = this._getResult(itemId);
+      if (!_r.photos) _r.photos = [];
 
       // B4 — resize before storing in IndexedDB or uploading. Caps on iOS Safari are
       // the chokepoint; 2048-px / q=0.85 brings 4-12 MB iPhone photos to ~250-500 KB.
@@ -171,8 +206,8 @@ document.addEventListener('alpine:init', () => {
         const localId = 'pending:' + crypto.randomUUID();
         const dataUrl = await fileToDataUrl(uploadFile);
         await pendingPhotoDb.add({ id: localId, inspectionId: this.inspectionId, itemId, blob: uploadFile, type: 'upload' });
-        this.results[itemId].photos.push({ key: localId, pending: true, dataUrl });
-        this.results[itemId].updatedAt = Date.now();
+        _r.photos.push({ key: localId, pending: true, dataUrl });
+        _r.updatedAt = Date.now();
         this._markDirty(itemId, 'photos');
         this.saveLocally();
         event.target.value = '';
@@ -187,8 +222,8 @@ document.addEventListener('alpine:init', () => {
         const res = await fetch(`/api/inspections/${this.inspectionId}/upload`, { method: 'POST', body: formData });
         if (res.ok) {
           const { key } = await res.json();
-          this.results[itemId].photos.push({ key });
-          this.results[itemId].updatedAt = Date.now();
+          _r.photos.push({ key });
+          _r.updatedAt = Date.now();
           this._markDirty(itemId, 'photos');
           this.saveLocally();
         } else {
@@ -203,8 +238,9 @@ document.addEventListener('alpine:init', () => {
     },
 
     async removePhoto(itemId, index) {
-      this.results[itemId].photos.splice(index, 1);
-      this.results[itemId].updatedAt = Date.now();
+      var _r = this._getResult(itemId);
+      _r.photos.splice(index, 1);
+      _r.updatedAt = Date.now();
       this._markDirty(itemId, 'photos');
       // B4 trigger Task 2 — enqueue a photo.delete op so the sync engine hits
       // DELETE /api/inspections/:id/items/:itemId/photos/:photoIndex once online.
@@ -224,7 +260,7 @@ document.addEventListener('alpine:init', () => {
     },
 
     recommendationsList(itemId) {
-      const arr = this.results[itemId]?.recommendations;
+      const arr = this._getResult(itemId)?.recommendations;
       return Array.isArray(arr) ? arr : [];
     },
 
@@ -253,21 +289,24 @@ document.addEventListener('alpine:init', () => {
     },
 
     attachRecommendation(itemId, snapshot) {
-      if (!this.results[itemId]) this.results[itemId] = { status: '', notes: '', photos: [], recommendations: [] };
-      if (!Array.isArray(this.results[itemId].recommendations)) {
-        this.results[itemId].recommendations = [];
+      var ck = this._fk(itemId);
+      if (!this.results[ck]) this.results[ck] = { status: '', notes: '', photos: [], recommendations: [] };
+      if (!Array.isArray(this.results[ck].recommendations)) {
+        this.results[ck].recommendations = [];
       }
-      this.results[itemId].recommendations.push(snapshot);
-      this.results[itemId].updatedAt = Date.now();
+      this.results[ck].recommendations.push(snapshot);
+      this.results[ck].updatedAt = Date.now();
+      this.results[itemId] = this.results[ck]; // backward-compat alias
       this._markDirty(itemId, 'recommendations');
       this.saveLocally();
     },
 
     removeRecommendation(itemId, ridx) {
-      const arr = this.results[itemId]?.recommendations;
+      var _r = this._getResult(itemId);
+      const arr = _r?.recommendations;
       if (!Array.isArray(arr)) return;
       arr.splice(ridx, 1);
-      this.results[itemId].updatedAt = Date.now();
+      _r.updatedAt = Date.now();
       this._markDirty(itemId, 'recommendations');
       this.saveLocally();
     },
@@ -385,8 +424,9 @@ document.addEventListener('alpine:init', () => {
             blob: file,
             type: 'annotation',
           });
-          this.results[this.annotationTarget.itemId].photos[this.annotationTarget.index] = { key: localId, pending: true, dataUrl };
-          this.results[this.annotationTarget.itemId].updatedAt = Date.now();
+          var _annotR = this._getResult(this.annotationTarget.itemId);
+          _annotR.photos[this.annotationTarget.index] = { key: localId, pending: true, dataUrl };
+          _annotR.updatedAt = Date.now();
           this.saveLocally();
           this.showAnnotationModal = false;
           return;
@@ -398,8 +438,9 @@ document.addEventListener('alpine:init', () => {
         const res = await fetch(`/api/inspections/${this.inspectionId}/upload`, { method: 'POST', body: formData });
         if (res.ok) {
           const { key } = await res.json();
-          this.results[this.annotationTarget.itemId].photos[this.annotationTarget.index].key = key;
-          this.results[this.annotationTarget.itemId].updatedAt = Date.now();
+          var _annotR2 = this._getResult(this.annotationTarget.itemId);
+          _annotR2.photos[this.annotationTarget.index].key = key;
+          _annotR2.updatedAt = Date.now();
           this.saveLocally();
           this.showAnnotationModal = false;
         } else {
@@ -443,7 +484,8 @@ document.addEventListener('alpine:init', () => {
       const items = [];
       this.templateSchema.sections.forEach(s => items.push(...s.items));
       if (items.length === 0) return 0;
-      const filled = items.filter(i => this.results[i.id]?.status).length;
+      var self = this;
+      const filled = items.filter(i => self._getResult(i.id)?.status).length;
       return Math.round((filled / items.length) * 100);
     },
 
@@ -533,7 +575,8 @@ document.addEventListener('alpine:init', () => {
     },
 
     async assistComment(itemId, label) {
-      const currentText = this.results[itemId]?.notes;
+      var _r = this._getResult(itemId);
+      const currentText = _r?.notes;
       if (!currentText || currentText.length < 3) return;
       try {
         const res = await fetch('/api/ai/comment-assist', {
@@ -543,8 +586,10 @@ document.addEventListener('alpine:init', () => {
         });
         const data = await res.json();
         if (data.text) {
-          this.results[itemId].notes = data.text;
-          this.results[itemId].updatedAt = Date.now();
+          var ck = this._fk(itemId);
+          var _rw = this.results[ck] || this.results[itemId];
+          _rw.notes = data.text;
+          _rw.updatedAt = Date.now();
           this.saveLocally();
         }
       } catch (e) {

--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -1,6 +1,11 @@
 // public/js/inspection-edit.js
 // Requires auth.js to be loaded first (provides authFetch)
 
+// F6 — composite finding key: _default:sectionId:itemId
+// Server-side now uses composite keys. Until multi-unit support ships,
+// unitId is always '_default'.
+function fKey(sectionId, itemId) { return '_default:' + sectionId + ':' + itemId; }
+
 // Older templates were saved before rating-level descriptions were a field.
 // Backfill on the client by matching id+label against known presets so the
 // onboarding cards (T6) and rating-button tooltips (T5) show usable copy
@@ -483,7 +488,7 @@ function inspectionEditor(inspectionId) {
           var prior = null;
           for (var pi = activeIdx - 1; pi >= 0; pi--) {
             var candidate = sectionItems[pi];
-            var res = this.results?.[candidate.id];
+            var res = this._getResult(candidate.id);
             if (res && res.ratingLevelId) { prior = { id: candidate.id, res: res }; break; }
           }
           if (!prior) {
@@ -493,7 +498,9 @@ function inspectionEditor(inspectionId) {
           // Copy rating + canned/custom comment payload to the active item.
           // Existing comments on the active item are replaced — `R` is the
           // explicit "clone above" gesture, not an accumulator.
-          this.results[this.activeItem.id] = JSON.parse(JSON.stringify(prior.res));
+          var cloneCk = this._fk(this.activeItem.id);
+          this.results[cloneCk] = JSON.parse(JSON.stringify(prior.res));
+          this.results[this.activeItem.id] = this.results[cloneCk]; // backward-compat alias
           this.debounceSave();
           if (typeof showToast === 'function') showToast('Cloned rating + notes from previous item');
           return;
@@ -563,7 +570,7 @@ function inspectionEditor(inspectionId) {
       window.addEventListener('photo:annotated', (e) => {
         const { itemId, photoIndex, annotatedKey } = e.detail || {};
         if (!itemId || annotatedKey == null) return;
-        const photos = this.results[itemId]?.photos;
+        const photos = this._getResult(itemId)?.photos;
         if (photos && photos[photoIndex]) {
           photos[photoIndex] = Object.assign({}, photos[photoIndex], { annotatedKey });
         }
@@ -636,12 +643,20 @@ function inspectionEditor(inspectionId) {
           // Pre-fill results stubs BEFORE assigning sections so Alpine
           // x-model bindings (e.g. results[item.id].notes) don't read
           // undefined while /results is still being fetched.
+          // F6 — write stubs under composite keys; keep bare-itemId alias
+          // so legacy x-model bindings in templates still resolve until
+          // templates are migrated to composite keys.
           for (var s = 0; s < newSections.length; s++) {
             var sec = newSections[s];
             for (var i = 0; i < sec.items.length; i++) {
               var item = sec.items[i];
+              var ck = fKey(sec.id, item.id);
+              if (!this.results[ck]) {
+                this.results[ck] = { rating: null, notes: '', photos: [] };
+              }
+              // Backward-compat alias so existing x-model="results[item.id].notes" works
               if (!this.results[item.id]) {
-                this.results[item.id] = { rating: null, notes: '', photos: [] };
+                this.results[item.id] = this.results[ck];
               }
             }
           }
@@ -653,6 +668,9 @@ function inspectionEditor(inspectionId) {
 
         // Load existing results — merge into stubs so we preserve any
         // entries the stub-fill seeded above.
+        // F6 — server may return composite keys (_default:sectionId:itemId)
+        // or legacy bare itemId keys. Either way, ensure both aliases exist
+        // so read paths resolve regardless of format.
         var resultsRes = await authFetch('/api/inspections/' + this.inspectionId + '/results');
         if (resultsRes.ok) {
           var rJson = await resultsRes.json();
@@ -660,6 +678,12 @@ function inspectionEditor(inspectionId) {
           for (var k in loaded) {
             if (Object.prototype.hasOwnProperty.call(loaded, k)) {
               this.results[k] = loaded[k];
+              // If key is composite (_default:secId:itemId), also alias bare itemId
+              if (k.indexOf(':') !== -1) {
+                var parts = k.split(':');
+                var bareId = parts[parts.length - 1];
+                this.results[bareId] = loaded[k];
+              }
             }
           }
         }
@@ -721,10 +745,11 @@ function inspectionEditor(inspectionId) {
     get completionPercent() {
       var total = 0, completed = 0;
       for (var s = 0; s < this.sections.length; s++) {
+        var secId = this.sections[s].id;
         var items = this.sections[s].items;
         for (var i = 0; i < items.length; i++) {
           total++;
-          var r = this.results[items[i].id];
+          var r = this._getResult(items[i].id, secId);
           if (!r) continue;
           // rich items count when a rating is picked; non-rich item types
           // (boolean / number / text / textarea / date / select /
@@ -759,10 +784,11 @@ function inspectionEditor(inspectionId) {
       var monitor      = 0;
       var defect       = 0;
       for (var s = 0; s < this.sections.length; s++) {
+        var secId = this.sections[s].id;
         var items = this.sections[s].items || [];
         total += items.length;
         for (var i = 0; i < items.length; i++) {
-          var ratingId = this.results[items[i].id]?.rating;
+          var ratingId = this._getResult(items[i].id, secId)?.rating;
           if (!ratingId) continue;
           rated++;
           var bucket = this._bucketForRatingId(ratingId);
@@ -827,7 +853,7 @@ function inspectionEditor(inspectionId) {
       if (!sec) return 0;
       var count = 0;
       for (var i = 0; i < sec.items.length; i++) {
-        var rating = this.results[sec.items[i].id]?.rating;
+        var rating = this._getResult(sec.items[i].id, sectionId)?.rating;
         if (!rating) continue;
         var level = null;
         for (var l = 0; l < this.ratingLevels.length; l++) {
@@ -855,7 +881,7 @@ function inspectionEditor(inspectionId) {
       if (total === 0) return { rated: 0, total: 0, percent: 0 };
       var rated = 0;
       for (var i = 0; i < total; i++) {
-        if (this.results[sec.items[i].id]?.rating != null) rated++;
+        if (this._getResult(sec.items[i].id, sectionId)?.rating != null) rated++;
       }
       return { rated: rated, total: total, percent: Math.round((rated / total) * 100) };
     },
@@ -869,7 +895,7 @@ function inspectionEditor(inspectionId) {
     itemPassesFilter(item) {
       var f = this.itemFilter || 'all';
       if (f === 'all') return true;
-      var r = this.results[item.id];
+      var r = this._getResult(item.id);
       if (f === 'unrated') return !r || r.rating == null;
       if (f === 'issues') {
         if (!r || !r.rating) return false;
@@ -905,11 +931,13 @@ function inspectionEditor(inspectionId) {
     },
 
     getItemRating(itemId) {
-      return this.results[itemId]?.rating || null;
+      var r = this._getResult(itemId);
+      return r?.rating || null;
     },
 
     getItemNotes(itemId) {
-      return this.results[itemId]?.notes || '';
+      var r = this._getResult(itemId);
+      return r?.notes || '';
     },
 
     // ===== Editor full-text search (App.E.3) =================================
@@ -930,7 +958,7 @@ function inspectionEditor(inspectionId) {
     },
 
     _searchResultMatches(itemId, needle) {
-      var r = this.results[itemId];
+      var r = this._getResult(itemId);
       if (!r) return false;
       if (this._searchContains(r.notes, needle)) return true;
       if (this._searchContains(r.recommendation, needle)) return true;
@@ -1033,7 +1061,8 @@ function inspectionEditor(inspectionId) {
     },
 
     getPhotoCount(itemId) {
-      return (this.results[itemId]?.photos || []).length;
+      var r = this._getResult(itemId);
+      return (r?.photos || []).length;
     },
 
     getRatingColor(ratingId) {
@@ -1085,8 +1114,10 @@ function inspectionEditor(inspectionId) {
     },
 
     setRating(itemId, levelId) {
-      if (!this.results[itemId]) this.results[itemId] = { rating: null, notes: '', photos: [] };
-      this.results[itemId].rating = levelId;
+      var ck = this._fk(itemId);
+      if (!this.results[ck]) this.results[ck] = { rating: null, notes: '', photos: [] };
+      this.results[ck].rating = levelId;
+      this.results[itemId] = this.results[ck]; // backward-compat alias
       this._stampUnitId(itemId);
       this.debounceSave();
     },
@@ -1095,8 +1126,10 @@ function inspectionEditor(inspectionId) {
     // store their captured value here. Rich items continue to use `rating`
     // exclusively. Same debounced PATCH path as setRating.
     setItemValue(itemId, value) {
-      if (!this.results[itemId]) this.results[itemId] = { rating: null, notes: '', photos: [] };
-      this.results[itemId].value = value;
+      var ck = this._fk(itemId);
+      if (!this.results[ck]) this.results[ck] = { rating: null, notes: '', photos: [] };
+      this.results[ck].value = value;
+      this.results[itemId] = this.results[ck]; // backward-compat alias
       this._stampUnitId(itemId);
       this.debounceSave();
     },
@@ -1106,14 +1139,15 @@ function inspectionEditor(inspectionId) {
     // moving a unit doesn't silently reattribute past findings; the
     // explicit unit-tree drag/move flow handles re-parenting deliberately.
     _stampUnitId(itemId) {
-      if (this.selectedUnitId && !this.results[itemId].unitId) {
-        this.results[itemId].unitId = this.selectedUnitId;
+      var ck = this._fk(itemId);
+      var r = this.results[ck] || this.results[itemId];
+      if (r && this.selectedUnitId && !r.unitId) {
+        r.unitId = this.selectedUnitId;
       }
     },
     getItemValue(itemId) {
-      return this.results[itemId] && 'value' in this.results[itemId]
-        ? this.results[itemId].value
-        : '';
+      var r = this._getResult(itemId);
+      return r && 'value' in r ? r.value : '';
     },
     // multi_select helper — toggles `choice` in the value array.
     toggleMultiValue(itemId, choice, checked) {
@@ -1127,7 +1161,7 @@ function inspectionEditor(inspectionId) {
     },
     // photo_only helper — reads the photos array from the per-item result.
     getItemPhotos(itemId) {
-      const r = this.results[itemId];
+      var r = this._getResult(itemId);
       return r && Array.isArray(r.photos) ? r.photos : [];
     },
 
@@ -1138,13 +1172,15 @@ function inspectionEditor(inspectionId) {
     // only) { category, location, photos }. We lazy-init missing nodes on
     // each toggle so Alpine reactivity stays clean.
     _ensureItemState(itemId) {
-      if (!this.results[itemId]) this.results[itemId] = { rating: null, notes: '', photos: [] };
-      if (!this.results[itemId].tabs) this.results[itemId].tabs = { information: [], limitations: [], defects: [] };
-      var t = this.results[itemId].tabs;
+      var ck = this._fk(itemId);
+      if (!this.results[ck]) this.results[ck] = { rating: null, notes: '', photos: [] };
+      if (!this.results[ck].tabs) this.results[ck].tabs = { information: [], limitations: [], defects: [] };
+      var t = this.results[ck].tabs;
       if (!Array.isArray(t.information)) t.information = [];
       if (!Array.isArray(t.limitations)) t.limitations = [];
       if (!Array.isArray(t.defects))     t.defects     = [];
-      return this.results[itemId];
+      this.results[itemId] = this.results[ck]; // backward-compat alias
+      return this.results[ck];
     },
 
     // Returns the merged view for one tab: each canned entry from the
@@ -1154,7 +1190,8 @@ function inspectionEditor(inspectionId) {
       var item = this._findItemById(itemId);
       if (!item || !item.tabs) return [];
       var canned = (item.tabs[tabName] || []).slice();
-      var state = (this.results[itemId] && this.results[itemId].tabs && this.results[itemId].tabs[tabName]) || [];
+      var _r = this._getResult(itemId);
+      var state = (_r && _r.tabs && _r.tabs[tabName]) || [];
       var stateMap = {};
       for (var i = 0; i < state.length; i++) stateMap[state[i].cannedId] = state[i];
       return canned.map(function (c) {
@@ -1189,6 +1226,36 @@ function inspectionEditor(inspectionId) {
         }
       }
       return null;
+    },
+
+    // F6 — resolve the sectionId that owns `itemId` by scanning sections.
+    _sectionIdForItem(itemId) {
+      for (var s = 0; s < this.sections.length; s++) {
+        var items = this.sections[s].items || [];
+        for (var i = 0; i < items.length; i++) {
+          if (items[i].id === itemId) return this.sections[s].id;
+        }
+      }
+      return null;
+    },
+
+    // F6 — build a composite key for the given itemId, looking up sectionId
+    // from this.sections. Returns fKey(sectionId, itemId) when found, else
+    // falls back to bare itemId so legacy data still resolves.
+    _fk(itemId) {
+      var sid = this._sectionIdForItem(itemId);
+      return sid ? fKey(sid, itemId) : itemId;
+    },
+
+    // F6 — read a result entry with composite-key-first fallback.
+    // Tries composite key, then bare itemId for backward compat.
+    _getResult(itemId, sectionId) {
+      var sid = sectionId || this._sectionIdForItem(itemId);
+      if (sid) {
+        var ck = fKey(sid, itemId);
+        if (this.results[ck] !== undefined) return this.results[ck];
+      }
+      return this.results[itemId];
     },
 
     _findStateEntry(itemId, tabName, cannedId) {
@@ -1501,8 +1568,7 @@ function inspectionEditor(inspectionId) {
     // category + location. The id is generated client-side and prefixed
     // with 'cu_' so we can distinguish them from template canned IDs.
     _ensureCustomState(itemId) {
-      this._ensureItemState(itemId);
-      var st = this.results[itemId];
+      var st = this._ensureItemState(itemId);
       if (!st.customComments) st.customComments = { information: [], limitations: [], defects: [] };
       var c = st.customComments;
       if (!Array.isArray(c.information)) c.information = [];
@@ -1642,10 +1708,12 @@ function inspectionEditor(inspectionId) {
     setQuickRating(levelId) {
       if (!this.quickRatingItemId) { this.showQuickRating = false; return; }
       if (levelId === null) {
-        if (!this.results[this.quickRatingItemId]) {
-          this.results[this.quickRatingItemId] = { rating: null, notes: '', photos: [] };
+        var ck = this._fk(this.quickRatingItemId);
+        if (!this.results[ck]) {
+          this.results[ck] = { rating: null, notes: '', photos: [] };
         }
-        this.results[this.quickRatingItemId].rating = null;
+        this.results[ck].rating = null;
+        this.results[this.quickRatingItemId] = this.results[ck]; // backward-compat alias
         this.debounceSave();
       } else {
         this.setRating(this.quickRatingItemId, levelId);
@@ -1892,7 +1960,7 @@ function inspectionEditor(inspectionId) {
       if (initialFilter === 'my-snippets') {
         this.commentLibraryFilter = 'my-snippets';
       } else {
-        var r = this.results[this.activeItemId]?.rating;
+        var r = this._getResult(this.activeItemId)?.rating;
         this.commentLibraryFilter = this._bucketForRatingId(r);
       }
       this.showCommentLibrary = true;
@@ -1905,12 +1973,14 @@ function inspectionEditor(inspectionId) {
 
     insertComment(text, withExtraNewline) {
       if (!this.activeItemId) return;
-      if (!this.results[this.activeItemId]) {
-        this.results[this.activeItemId] = { rating: null, notes: '', photos: [] };
+      var ck = this._fk(this.activeItemId);
+      if (!this.results[ck]) {
+        this.results[ck] = { rating: null, notes: '', photos: [] };
       }
-      var existing = this.results[this.activeItemId].notes || '';
+      this.results[this.activeItemId] = this.results[ck]; // backward-compat alias
+      var existing = this.results[ck].notes || '';
       var sep = withExtraNewline ? '\n\n' : '\n';
-      this.results[this.activeItemId].notes = existing
+      this.results[ck].notes = existing
         ? (existing.trimEnd() + sep + text)
         : text;
       this.expanded[this.activeItemId] = true;
@@ -1934,12 +2004,13 @@ function inspectionEditor(inspectionId) {
         var se = ae.selectionEnd;
         if (ss !== se) selectedText = (ae.value || '').substring(ss, se).trim();
       }
-      var notes = selectedText || (this.results[this.activeItemId]?.notes || '').trim();
+      var _activeR = this._getResult(this.activeItemId);
+      var notes = selectedText || (_activeR?.notes || '').trim();
       if (!notes) {
         if (typeof showToast === 'function') showToast('No notes to save');
         return;
       }
-      var bucket = this._bucketForRatingId(this.results[this.activeItemId]?.rating);
+      var bucket = this._bucketForRatingId(_activeR?.rating);
       var section = (this.currentSection && this.currentSection.title) || '';
       var self = this;
 
@@ -2091,7 +2162,7 @@ function inspectionEditor(inspectionId) {
       var activeItem = null;
       var section = '';
       if (this.activeItemId) {
-        var r = this.results[this.activeItemId]?.rating;
+        var r = this._getResult(this.activeItemId)?.rating;
         bucket = this._bucketForRatingId(r);
         activeItem = this._findItemById(this.activeItemId);
         section = (this.currentSection && this.currentSection.title) || '';
@@ -2262,9 +2333,11 @@ function inspectionEditor(inspectionId) {
         });
         if (res.ok) {
           var json = await res.json();
-          if (!this.results[itemId]) this.results[itemId] = {};
-          if (!this.results[itemId].photos) this.results[itemId].photos = [];
-          this.results[itemId].photos.push({ key: json.data.key });
+          var ck = this._fk(itemId);
+          if (!this.results[ck]) this.results[ck] = {};
+          if (!this.results[ck].photos) this.results[ck].photos = [];
+          this.results[ck].photos.push({ key: json.data.key });
+          this.results[itemId] = this.results[ck]; // backward-compat alias
           this.debounceSave();
         } else {
           if (typeof showToast === 'function') showToast('Photo upload failed.', true);
@@ -2312,8 +2385,7 @@ function inspectionEditor(inspectionId) {
           return;
         }
         var json = await res.json();
-        this._ensureCustomState(itemId);
-        var st = this.results[itemId];
+        var st = this._ensureCustomState(itemId);
         var arr = (st.customComments && st.customComments.defects) || [];
         for (var i = 0; i < arr.length; i++) {
           if (arr[i].id === customId) {
@@ -2512,7 +2584,7 @@ function inspectionEditor(inspectionId) {
             sectionName: sec.title || sec.name || '',
             sectionIdx: s,
             itemIdx: i,
-            rating: (this.results[items[i].id] && this.results[items[i].id].rating) || null,
+            rating: (this._getResult(items[i].id, sec.id) || {}).rating || null,
           });
         }
       }
@@ -2555,7 +2627,7 @@ function inspectionEditor(inspectionId) {
       if (!this._speedItems) return 0;
       var c = 0;
       for (var i = 0; i < this._speedItems.length; i++) {
-        if ((this.results[this._speedItems[i].id] || {}).rating) c++;
+        if ((this._getResult(this._speedItems[i].id) || {}).rating) c++;
       }
       return c;
     },
@@ -2679,8 +2751,10 @@ function inspectionEditor(inspectionId) {
           this._trackVersion(itemId, field, data.newVersion);
         }
         // Mirror into local results so UI reflects without a re-fetch.
-        if (!this.results[itemId]) this.results[itemId] = { rating: null, notes: '', photos: [] };
-        this.results[itemId][field] = value;
+        var ck = this._fk(itemId);
+        if (!this.results[ck]) this.results[ck] = { rating: null, notes: '', photos: [] };
+        this.results[ck][field] = value;
+        this.results[itemId] = this.results[ck]; // backward-compat alias
         return { ok: true, newVersion: data.newVersion };
       } catch (err) {
         // Offline / fetch error — enqueue.

--- a/public/js/sync-engine.js
+++ b/public/js/sync-engine.js
@@ -2,6 +2,12 @@
  * B4 — Sync engine state machine + queue drain + quota monitor.
  * Loaded on every authenticated page; consumes Dexie syncQueue, calls server
  * sync endpoints, applies results to local stores or moves to conflicts.
+ *
+ * F6 — composite finding keys (_default:sectionId:itemId).
+ * The sync engine is key-agnostic: it forwards the full results object (ours/base)
+ * and stores whatever the server returns (merged). Conflict rows carry the
+ * server's itemId verbatim — which may be a composite key once the server
+ * migrates. No structural changes needed here beyond this note.
  */
 import { db, openDb } from './db.js';
 import { estimateQuota, detectTier } from './device-tier.js';

--- a/src/lib/db/schema/inspection.ts
+++ b/src/lib/db/schema/inspection.ts
@@ -28,6 +28,10 @@ export const templates = sqliteTable('templates', {
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
     // Sprint 2 S2-1 — selects the active rating system. Null = use tenant default.
     ratingSystemId: text('rating_system_id'),
+    propertyType: text('property_type'),
+    commercialSubtype: text('commercial_subtype'),
+    description: text('description'),
+    featured: integer('featured').notNull().default(0),
 });
 
 export const inspections = sqliteTable('inspections', {
@@ -86,6 +90,8 @@ export const inspections = sqliteTable('inspections', {
     // one; the Publish pre-flight surfaces this as a gate.
     coverPhotoId:        text('cover_photo_id'),
     unit:                text('unit'),
+    propertyType:        text('property_type'),
+    commercialSubtype:   text('commercial_subtype'),
     county:              text('county'),
     sellingAgentId:      text('selling_agent_id'),
     disableAutomations:  integer('disable_automations', { mode: 'boolean' }).notNull().default(false),

--- a/src/lib/db/schema/units.ts
+++ b/src/lib/db/schema/units.ts
@@ -18,6 +18,7 @@ export const inspectionUnits = sqliteTable('inspection_units', {
     inspectionId: text('inspection_id').notNull(),
     parentUnitId: text('parent_unit_id'),
     kind:         text('kind', { enum: ['building', 'floor', 'unit'] }).notNull(),
+    type:         text('type', { enum: ['unit', 'common'] }).notNull().default('unit'),
     name:         text('name').notNull(),
     sortOrder:    integer('sort_order').notNull().default(0),
     createdAt:    text('created_at').notNull(),

--- a/src/lib/finding-key.ts
+++ b/src/lib/finding-key.ts
@@ -1,0 +1,34 @@
+const DEFAULT_UNIT = '_default';
+
+export function findingKey(unitId: string | null | undefined, sectionId: string, itemId: string): string {
+    return `${unitId || DEFAULT_UNIT}:${sectionId}:${itemId}`;
+}
+
+export function parseFindingKey(key: string): { unitId: string; sectionId: string; itemId: string } {
+    const parts = key.split(':');
+    if (parts.length === 3) return { unitId: parts[0], sectionId: parts[1], itemId: parts[2] };
+    if (parts.length === 2) return { unitId: DEFAULT_UNIT, sectionId: parts[0], itemId: parts[1] };
+    return { unitId: DEFAULT_UNIT, sectionId: '', itemId: key };
+}
+
+export function findingsForUnit(
+    data: Record<string, unknown>,
+    unitId: string,
+): Record<string, unknown> {
+    const prefix = `${unitId}:`;
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+        if (key.startsWith(prefix)) result[key] = value;
+    }
+    return result;
+}
+
+export function isLegacyKey(key: string): boolean {
+    return key.split(':').length < 3;
+}
+
+export function migrateLegacyKey(itemId: string, sectionId: string): string {
+    return findingKey(null, sectionId, itemId);
+}
+
+export { DEFAULT_UNIT };

--- a/src/lib/validations/unit.schema.ts
+++ b/src/lib/validations/unit.schema.ts
@@ -5,6 +5,7 @@ import { z } from '@hono/zod-openapi';
 export const CreateUnitSchema = z.object({
     parentUnitId: z.string().min(1).nullable().describe('TODO describe parentUnitId field for the OpenInspection MCP integration'),
     kind:         z.enum(['building', 'floor', 'unit']).describe('TODO describe kind field for the OpenInspection MCP integration'),
+    type:         z.enum(['unit', 'common']).default('unit').describe('Purpose: regular unit or common area'),
     name:         z.string().min(1).max(80).describe('TODO describe name field for the OpenInspection MCP integration'),
 }).openapi('CreateUnit');
 

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -505,17 +505,20 @@ export class InspectionService {
             bathrooms:       null,
         } as unknown as CreateInspectionData & { inspectorId?: string });
 
-        // Set team_mode / lead / helpers via direct UPDATE — createInspection
-        // doesn't know about subsystem B's new columns yet.
-        if (input.teamMode || input.leadInspectorId || (input.helperInspectorIds?.length ?? 0) > 0) {
+        {
             const db = this.getDrizzle();
-            await db.update(inspections)
-                .set({
-                    teamMode:           input.teamMode,
-                    leadInspectorId:    input.teamMode ? (input.leadInspectorId ?? creatorUserId) : null,
-                    helperInspectorIds: JSON.stringify(input.teamMode ? (input.helperInspectorIds ?? []) : []),
-                })
-                .where(and(eq(inspections.id, created.id), eq(inspections.tenantId, tenantId)));
+            const patch: Record<string, unknown> = {};
+            if (input.property.propertyType) patch.propertyType = input.property.propertyType;
+            if (input.teamMode || input.leadInspectorId || (input.helperInspectorIds?.length ?? 0) > 0) {
+                patch.teamMode           = input.teamMode;
+                patch.leadInspectorId    = input.teamMode ? (input.leadInspectorId ?? creatorUserId) : null;
+                patch.helperInspectorIds = JSON.stringify(input.teamMode ? (input.helperInspectorIds ?? []) : []);
+            }
+            if (Object.keys(patch).length > 0) {
+                await db.update(inspections)
+                    .set(patch)
+                    .where(and(eq(inspections.id, created.id), eq(inspections.tenantId, tenantId)));
+            }
         }
 
         return { id: created.id };

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -15,6 +15,7 @@ import { RECOMMENDATION_CATEGORIES, RECOMMENDATION_CATEGORY_IDS } from '../lib/r
 import { computePreflightFromData } from '../lib/preflight';
 import { decideFieldWrite, applyFieldWrite } from '../lib/field-version';
 import { ApprenticeService } from './apprentice.service';
+import { findingKey, parseFindingKey, DEFAULT_UNIT } from '../lib/finding-key';
 
 /** Slug → label map for resolving aggregated recommendation badges in
  *  getReportData. Built once at module load. */
@@ -799,11 +800,13 @@ export class InspectionService {
             photoIndex: number;
             annotated: boolean;
         }> = [];
-        for (const [itemId, entry] of Object.entries(resultData)) {
+        for (const [key, entry] of Object.entries(resultData)) {
+            const parsedKey = parseFindingKey(key);
+            const itemId = parsedKey.itemId;
             const photos = Array.isArray(entry?.photos) ? entry.photos : [];
             const meta = itemMeta.get(itemId) ?? {
                 itemLabel:    itemId,
-                sectionId:    'unknown',
+                sectionId:    parsedKey.sectionId || 'unknown',
                 sectionTitle: 'Unsectioned',
             };
             photos.forEach((p, idx) => {
@@ -928,6 +931,7 @@ export class InspectionService {
         const data: Record<string, ResultEntry> = existing?.data
             ? (typeof existing.data === 'string' ? JSON.parse(existing.data) : existing.data) as Record<string, ResultEntry>
             : {};
+        // TODO: use composite key when sectionId is available in API
         const entry = data[itemId] ?? {};
         const photos = Array.isArray(entry.photos) ? entry.photos.slice() : [];
         photos.push({ key: poolRow.r2Key });
@@ -1082,6 +1086,7 @@ export class InspectionService {
             ? (typeof existing.data === 'string' ? JSON.parse(existing.data) : existing.data) as Record<string, Record<string, unknown>>
             : {};
 
+        // TODO: use composite key when sectionId is available in API
         const cur = data[itemId];
         const decision = decideFieldWrite(cur, field, value, expectedVersion, { force: opts?.force ?? false });
         if (decision.kind === 'conflict') return decision;
@@ -1182,6 +1187,7 @@ export class InspectionService {
         const data: Record<string, ResultEntry> = (typeof row?.data === 'string'
             ? JSON.parse(row.data)
             : row?.data) ?? {};
+        // TODO: use composite key when sectionId is available in API
         const entry = data[itemId] ?? {};
         const photos = entry.photos ?? [];
         if (!photos[photoIndex]) throw Errors.NotFound('Photo not found at index');
@@ -1332,7 +1338,7 @@ export class InspectionService {
                 : null,
             alwaysPageBreak: sec.alwaysPageBreak === true,
             items: sec.items.map((item: SchemaItem) => {
-                const res = resultData[item.id] || {};
+                const res = resultData[findingKey(DEFAULT_UNIT, sec.id, item.id)] || resultData[item.id] || {};
                 const ratingId = res.rating ?? null;
                 const bucket = getRatingBucket(ratingId, levels);
                 const level = levels.find((l: RatingLevel) => l.id === ratingId);
@@ -1566,10 +1572,11 @@ export class InspectionService {
             const rawData = typeof resultsRow.data === 'string'
                 ? JSON.parse(resultsRow.data) as Record<string, unknown>
                 : resultsRow.data as Record<string, unknown>;
-            for (const itemId of Object.keys(rawData)) {
-                const entry = rawData[itemId] as { customComments?: { defects?: CustomDefect[] } } | null;
+            for (const key of Object.keys(rawData)) {
+                const parsedKey = parseFindingKey(key);
+                const entry = rawData[key] as { customComments?: { defects?: CustomDefect[] } } | null;
                 const customDefects = entry?.customComments?.defects ?? [];
-                if (customDefects.length > 0) customByItem.set(itemId, customDefects);
+                if (customDefects.length > 0) customByItem.set(parsedKey.itemId, customDefects);
             }
         }
 
@@ -1997,8 +2004,8 @@ export class InspectionService {
                 const data: Record<string, { customComments?: { defects?: CustomDefect[] } }> = typeof resultsRow.data === 'string'
                     ? JSON.parse(resultsRow.data)
                     : resultsRow.data as Record<string, { customComments?: { defects?: CustomDefect[] } }>;
-                for (const itemId of Object.keys(data)) {
-                    const customDefects = data[itemId]?.customComments?.defects ?? [];
+                for (const key of Object.keys(data)) {
+                    const customDefects = data[key]?.customComments?.defects ?? [];
                     for (const d of customDefects) {
                         if (d.included === false) continue;
                         const cat = (d.category ?? 'maintenance');

--- a/src/services/unit.service.ts
+++ b/src/services/unit.service.ts
@@ -21,6 +21,7 @@ export interface CreateUnitInput {
     inspectionId: string;
     parentUnitId: string | null;
     kind:         'building' | 'floor' | 'unit';
+    type?:        'unit' | 'common';
     name:         string;
 }
 
@@ -30,6 +31,7 @@ export interface UnitRow {
     inspectionId: string;
     parentUnitId: string | null;
     kind:         string;
+    type:         string;
     name:         string;
     sortOrder:    number;
     createdAt:    string;
@@ -72,6 +74,7 @@ export class UnitService {
             inspectionId: input.inspectionId,
             parentUnitId: input.parentUnitId,
             kind:         input.kind,
+            type:         input.type || 'unit',
             name:         input.name,
             sortOrder:    nextSort,
             createdAt:    new Date().toISOString(),

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -74,6 +74,9 @@
     --ih-ease: cubic-bezier(0.4, 0, 0.2, 1);
     --ih-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
     --ih-dur-fast: 150ms; --ih-dur: 200ms; --ih-dur-slow: 300ms;
+    /* Sidebar */
+    --ih-sidebar-w: 240px;
+    --ih-sidebar-collapsed-w: 56px;
     /* Status: info (sky) */
     --ih-status-info:    #0284c7;
     --ih-status-info-bg: #eff6ff;
@@ -323,6 +326,13 @@ textarea {
         letter-spacing: var(--ih-letter-eyebrow);
         color: var(--ih-fg-4);
     }
+
+    .ih-sidebar {
+        width: var(--ih-sidebar-w);
+        flex-shrink: 0;
+        transition: width var(--ih-dur-slow) var(--ih-ease-out);
+    }
+    .ih-sidebar.is-collapsed { width: var(--ih-sidebar-collapsed-w); }
 
     .ih-btn {
         display: inline-flex;
@@ -843,33 +853,33 @@ html[data-color-scheme="dark"] .signature-pad-wrap {
 html[data-color-scheme="dark"] .bg-slate-900\/50 { background-color: rgba(0,0,0,0.6) !important; }
 
 /* ── Sidebar / app shell ─────────────────────────────────── */
-html[data-color-scheme="dark"] aside.w-72 {
+html[data-color-scheme="dark"] aside.ih-sidebar {
     background-color: #0f172a !important;
     border-right-color: rgba(255,255,255,0.08) !important;
 }
-html[data-color-scheme="dark"] aside.w-72 .border-b { border-color: rgba(255,255,255,0.06) !important; }
-html[data-color-scheme="dark"] aside.w-72 .border-l { border-color: rgba(255,255,255,0.06) !important; }
-html[data-color-scheme="dark"] aside.w-72 .border-t { border-color: rgba(255,255,255,0.06) !important; }
-html[data-color-scheme="dark"] aside.w-72 .bg-slate-50\/50 {
+html[data-color-scheme="dark"] aside.ih-sidebar .border-b { border-color: rgba(255,255,255,0.06) !important; }
+html[data-color-scheme="dark"] aside.ih-sidebar .border-l { border-color: rgba(255,255,255,0.06) !important; }
+html[data-color-scheme="dark"] aside.ih-sidebar .border-t { border-color: rgba(255,255,255,0.06) !important; }
+html[data-color-scheme="dark"] aside.ih-sidebar .bg-slate-50\/50 {
     background-color: rgba(15,23,42,0.6) !important;
 }
-html[data-color-scheme="dark"] aside.w-72 .bg-slate-50 {
+html[data-color-scheme="dark"] aside.ih-sidebar .bg-slate-50 {
     background-color: rgba(255,255,255,0.04) !important;
 }
-html[data-color-scheme="dark"] aside.w-72 a,
-html[data-color-scheme="dark"] aside.w-72 button,
-html[data-color-scheme="dark"] aside.w-72 summary {
+html[data-color-scheme="dark"] aside.ih-sidebar a,
+html[data-color-scheme="dark"] aside.ih-sidebar button,
+html[data-color-scheme="dark"] aside.ih-sidebar summary {
     color: #94a3b8;
 }
-html[data-color-scheme="dark"] aside.w-72 a:hover,
-html[data-color-scheme="dark"] aside.w-72 button:hover,
-html[data-color-scheme="dark"] aside.w-72 summary:hover {
+html[data-color-scheme="dark"] aside.ih-sidebar a:hover,
+html[data-color-scheme="dark"] aside.ih-sidebar button:hover,
+html[data-color-scheme="dark"] aside.ih-sidebar summary:hover {
     background-color: rgba(255,255,255,0.06) !important;
     color: #818cf8 !important;
 }
-html[data-color-scheme="dark"] aside.w-72 .bg-indigo-50 { background-color: rgba(99,102,241,0.15) !important; }
-html[data-color-scheme="dark"] aside.w-72 .text-indigo-600 { color: #818cf8 !important; }
-html[data-color-scheme="dark"] aside.w-72 kbd {
+html[data-color-scheme="dark"] aside.ih-sidebar .bg-indigo-50 { background-color: rgba(99,102,241,0.15) !important; }
+html[data-color-scheme="dark"] aside.ih-sidebar .text-indigo-600 { color: #818cf8 !important; }
+html[data-color-scheme="dark"] aside.ih-sidebar kbd {
     background-color: rgba(255,255,255,0.06) !important;
     border-color: rgba(255,255,255,0.1) !important;
     color: #64748b !important;

--- a/src/templates/components/inspection-row.tsx
+++ b/src/templates/components/inspection-row.tsx
@@ -23,7 +23,7 @@ import { RowStatusIcons } from './row-status-icons';
  * the matching DOM nodes without re-rendering the whole list.
  */
 export const InspectionRow = (): JSX.Element => (
-    <div class="px-5 py-3 border-t border-slate-100 dark:border-slate-700 flex items-center gap-3 flex-wrap sm:flex-nowrap" data-test="inspection-row">
+    <div class="px-5 py-[13px] border-t border-slate-100 dark:border-slate-700 flex items-center gap-3 flex-wrap sm:flex-nowrap" data-test="inspection-row">
         {/* Property address — always rendered. Click target for the row. */}
         <a x-bind:href="'/inspections/' + i.id + '/edit'" class="flex-1 min-w-0">
             <p

--- a/src/templates/components/modal.tsx
+++ b/src/templates/components/modal.tsx
@@ -117,7 +117,7 @@ export const Modal = ({
             {...alpineAttrs}
         >
             <div
-                class={`bg-white dark:bg-slate-800 rounded-md shadow-xl w-full ${SIZE_CLASS[size]} p-6 max-h-[90vh] overflow-y-auto`}
+                class={`bg-white dark:bg-slate-800 rounded-md shadow-xl w-full ${SIZE_CLASS[size]} p-4 max-h-[90vh] overflow-y-auto`}
                 {...(name ? { 'x-on:click.stop': '' } : { onclick: 'event.stopPropagation()' })}
             >
                 {!hideHeader && (
@@ -149,7 +149,7 @@ export const Modal = ({
                     </header>
                 )}
                 <div>{children}</div>
-                {footer ? <div class="mt-6 flex gap-3 justify-end">{footer}</div> : null}
+                {footer ? <div class="mt-4 flex gap-3 justify-end">{footer}</div> : null}
             </div>
         </div>
     );

--- a/src/templates/components/side-rail.tsx
+++ b/src/templates/components/side-rail.tsx
@@ -1,0 +1,105 @@
+/**
+ * Gap 2C — SideRail vertical tab strip + content panel.
+ *
+ * 44px persistent vertical tab strip on the rightmost edge of the editor.
+ * Three tabs: Preview (panel icon), Library (message icon), Recall (clock icon).
+ * Content panel (256px) appears LEFT of the tab strip when expanded.
+ *
+ * Click active tab → collapse panel. Click inactive tab → expand + switch.
+ * Alpine state managed by the parent inspectionEditor factory via:
+ *   sideRailMode: 'preview' | 'library' | 'recall'
+ *   sideRailOpen: boolean
+ */
+import type { FC } from 'hono/jsx';
+
+interface SideRailProps {
+    inspectionId: string;
+}
+
+const TAB_ICON_PATHS: Record<string, string> = {
+    preview:  'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+    library:  'M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z',
+    recall:   'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+};
+
+const TAB_LABELS: Record<string, string> = {
+    preview: 'Preview',
+    library: 'Library',
+    recall:  'Recall',
+};
+
+export const SideRail: FC<SideRailProps> = ({ inspectionId: _inspectionId }) => (
+    <div class="flex h-full" x-data="{ get _mode() { return sideRailMode }, get _open() { return sideRailOpen } }">
+        {/* Content panel — 256px, slides in from left of tab strip */}
+        <div
+            x-show="sideRailOpen"
+            x-cloak
+            class="w-64 border-l border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 flex flex-col overflow-hidden"
+            {...{ 'x-transition:enter': 'transition ease-out duration-200', 'x-transition:enter-start': 'opacity-0 translate-x-4', 'x-transition:enter-end': 'opacity-100 translate-x-0', 'x-transition:leave': 'transition ease-in duration-150', 'x-transition:leave-start': 'opacity-100 translate-x-0', 'x-transition:leave-end': 'opacity-0 translate-x-4' }}
+        >
+            {/* Panel header */}
+            <div class="flex items-center justify-between px-3 py-2 border-b border-slate-200 dark:border-slate-700">
+                <span class="text-[11px] font-bold uppercase tracking-[0.15em] text-slate-400 dark:text-slate-500" x-text="sideRailMode.charAt(0).toUpperCase() + sideRailMode.slice(1)"></span>
+                <button
+                    type="button"
+                    {...{ 'x-on:click': 'sideRailOpen = false' }}
+                    class="w-6 h-6 flex items-center justify-center rounded text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                    title="Collapse panel"
+                >
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" stroke-width="2"/><line x1="15" y1="3" x2="15" y2="21" stroke-width="2"/><polyline points="10 9 7 12 10 15" stroke-width="2"/></svg>
+                </button>
+            </div>
+
+            {/* Preview tab content */}
+            <div x-show="sideRailMode === 'preview'" class="flex-1 overflow-y-auto p-3 space-y-3">
+                <div class="text-[11px] text-slate-400 dark:text-slate-500">Live preview of the active item's report rendering.</div>
+                <div id="sideRailPreviewContent"></div>
+            </div>
+
+            {/* Library tab content */}
+            <div x-show="sideRailMode === 'library'" class="flex-1 overflow-y-auto flex flex-col">
+                <div class="px-3 pt-2 pb-1">
+                    <input
+                        type="text"
+                        placeholder="Search comments..."
+                        class="ih-input w-full text-[12px]"
+                        x-model="librarySearchQuery"
+                        {...{ 'x-on:input.debounce.200ms': 'searchLibrary()' }}
+                    />
+                </div>
+                <div class="flex-1 overflow-y-auto px-3 pb-3" id="sideRailLibraryContent">
+                    <div x-show="!libraryResults || libraryResults.length === 0" class="text-[11px] text-slate-400 dark:text-slate-500 text-center py-6">
+                        Type <span class="ih-kbd">/</span> in the note field to search the comment library.
+                    </div>
+                </div>
+            </div>
+
+            {/* Recall tab content */}
+            <div x-show="sideRailMode === 'recall'" class="flex-1 overflow-y-auto p-3 space-y-3">
+                <div class="text-[11px] text-slate-400 dark:text-slate-500">Prior inspections' notes for similar items.</div>
+                <div id="sideRailRecallContent"></div>
+            </div>
+        </div>
+
+        {/* 44px vertical tab strip — always visible */}
+        <div class="w-11 flex-shrink-0 bg-slate-50 dark:bg-slate-800/50 border-l border-slate-200 dark:border-slate-700 flex flex-col items-center py-2 gap-1">
+            {(['preview', 'library', 'recall'] as const).map(tabId => (
+                <button
+                    key={tabId}
+                    type="button"
+                    {...{ 'x-on:click': `sideRailMode === '${tabId}' && sideRailOpen ? (sideRailOpen = false) : (sideRailMode = '${tabId}', sideRailOpen = true)` }}
+                    x-bind:class={`sideRailMode === '${tabId}' && sideRailOpen ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm border-l-2 border-indigo-600 dark:border-indigo-400 -ml-px' : 'text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-400'`}
+                    class="relative w-10 flex flex-col items-center gap-0.5 py-2.5 rounded-r-md transition-all"
+                    title={TAB_LABELS[tabId]}
+                >
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d={TAB_ICON_PATHS[tabId]} />
+                    </svg>
+                    <span class="text-[8px] font-bold uppercase tracking-[0.1em]" style="writing-mode: vertical-rl; transform: rotate(180deg)">
+                        {TAB_LABELS[tabId]}
+                    </span>
+                </button>
+            ))}
+        </div>
+    </div>
+);

--- a/src/templates/components/stats-cards.tsx
+++ b/src/templates/components/stats-cards.tsx
@@ -17,21 +17,21 @@ export function StatsCards({ alpine = false }: StatsCardsProps): JSX.Element {
 
   return (
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
-      <div class="theme-card p-4 border-l-4 border-gray-300">
+      <div class="theme-card p-[14px] border-l-4 border-gray-300">
         <div class="text-[10px] font-semibold tracking-wider theme-text-muted">TOTAL ITEMS</div>
-        <div class="text-3xl font-bold mt-1 theme-font-display" id="stat-total">--</div>
+        <div class="text-xl font-bold mt-1 theme-font-display" id="stat-total">--</div>
       </div>
-      <div class="theme-card p-4 border-l-4 border-green-400">
+      <div class="theme-card p-[14px] border-l-4 border-green-400">
         <div class="text-[10px] font-semibold tracking-wider text-green-600">SATISFACTORY</div>
-        <div class="text-3xl font-bold mt-1 theme-font-display" id="stat-satisfactory">--</div>
+        <div class="text-xl font-bold mt-1 theme-font-display" id="stat-satisfactory">--</div>
       </div>
-      <div class="theme-card p-4 border-l-4 border-amber-400">
+      <div class="theme-card p-[14px] border-l-4 border-amber-400">
         <div class="text-[10px] font-semibold tracking-wider text-amber-600">MONITOR</div>
-        <div class="text-3xl font-bold mt-1 theme-font-display" id="stat-monitor">--</div>
+        <div class="text-xl font-bold mt-1 theme-font-display" id="stat-monitor">--</div>
       </div>
-      <div class="theme-card p-4 border-l-4 border-rose-400">
+      <div class="theme-card p-[14px] border-l-4 border-rose-400">
         <div class="text-[10px] font-semibold tracking-wider text-rose-600">DEFECTS</div>
-        <div class="text-3xl font-bold mt-1 theme-font-display" id="stat-defect">--</div>
+        <div class="text-xl font-bold mt-1 theme-font-display" id="stat-defect">--</div>
       </div>
     </div>
   );
@@ -43,9 +43,9 @@ function StatCard({ label, valueExpr, borderClass }: { label: string; valueExpr:
     label === 'DEFECTS' ? 'text-rose-600' : 'theme-text-muted';
 
   return (
-    <div class={`theme-card p-4 border-l-4 ${borderClass}`}>
+    <div class={`theme-card p-[14px] border-l-4 ${borderClass}`}>
       <div class={`text-[10px] font-semibold tracking-wider ${colorClass}`}>{label}</div>
-      <div class="text-3xl font-bold mt-1 theme-font-display" x-text={valueExpr}>--</div>
+      <div class="text-xl font-bold mt-1 theme-font-display" x-text={valueExpr}>--</div>
     </div>
   );
 }

--- a/src/templates/components/workflow-tabs.tsx
+++ b/src/templates/components/workflow-tabs.tsx
@@ -15,16 +15,16 @@ import type { FC } from 'hono/jsx';
 
 export const WorkflowTabs: FC = () => (
     <nav x-data="workflowTabs()" {...{ 'x-init': 'init()' }}
-         class="flex gap-2 flex-wrap mb-4">
+         class="flex flex-wrap items-center border-b border-slate-200 dark:border-slate-700 -mb-px">
         <template {...{ 'x-for': 't in tabs', ':key': 't.id' }}>
-            <button class="inline-flex items-center gap-2 px-3 h-8 rounded-md text-xs font-bold transition-colors"
+            <button class="inline-flex items-center gap-1.5 px-3.5 py-2.5 border-b-2 text-[13px] font-bold transition-all"
                     {...{
-                        ':class': "selected === t.id ? 'bg-indigo-600 text-white' : 'bg-white text-slate-600 border border-slate-200 hover:bg-slate-50'",
+                        ':class': "selected === t.id ? 'border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400' : 'border-transparent text-slate-500 hover:text-slate-900 dark:hover:text-slate-200'",
                         '@click': 'select(t.id)',
                     }}>
                 <span x-text="t.label" />
-                <span class="px-1.5 h-4 inline-flex items-center justify-center rounded-full text-[10px] font-bold"
-                      {...{ ':class': "selected === t.id ? 'bg-white/20 text-white' : 'bg-slate-100 text-slate-500'" }}
+                <span class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full text-[10px] font-bold tabular-nums"
+                      {...{ ':class': "selected === t.id ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-600 dark:text-indigo-400' : 'bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400'" }}
                       x-text="t.count" />
             </button>
         </template>

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -356,131 +356,162 @@ export const MainLayout = (props: {
 
                 <div class="flex min-h-screen">
                     {/* Sidebar / Navigation */}
-                    <aside class="w-72 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 hidden lg:flex flex-col sticky top-0 h-screen">
-                        <div class="p-8 flex items-center gap-4 border-b border-slate-100 dark:border-slate-700">
-                            <div class="w-10 h-10 flex-shrink-0">
+                    <aside class="ih-sidebar bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 hidden lg:flex flex-col sticky top-0 h-screen overflow-hidden"
+                           x-bind:class="sbc ? 'is-collapsed' : ''">
+                        <div class="px-3 pt-3 pb-2 flex items-center gap-2.5 border-b border-slate-100 dark:border-slate-700">
+                            <div class="w-7 h-7 flex-shrink-0">
                                 <img src={logoUrl || '/logo.svg'} alt={siteName} class="w-full h-full object-contain" />
                             </div>
-                            <span class="text-xl font-extrabold text-slate-900 dark:text-slate-100 tracking-tight leading-tight">{siteName}</span>
-                            <a href="/notifications" class="ml-auto relative flex items-center justify-center w-10 h-10 rounded-xl text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 transition-all" aria-label="Notifications">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg>
-                                <span id="notifyUnreadBadge" class="hidden absolute -top-0.5 -right-0.5 px-1.5 min-w-[1.25rem] h-5 text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
+                            <span x-show="!sbc" class="text-sm font-bold text-slate-900 dark:text-slate-100 tracking-tight leading-tight truncate">{siteName}</span>
+                            <a x-show="!sbc" href="/notifications" class="ml-auto relative flex items-center justify-center w-7 h-7 rounded-md text-slate-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 transition-all" aria-label="Notifications">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg>
+                                <span id="notifyUnreadBadge" class="hidden absolute -top-0.5 -right-0.5 px-1 min-w-[1rem] h-4 text-center rounded-full bg-rose-500 text-white text-[9px] font-bold leading-4"></span>
                             </a>
                         </div>
 
-                        <nav class="flex-1 p-6 space-y-2 overflow-y-auto">
-                            {/* Search pill — opens command palette. Visible click affordance
-                                in addition to ⌘K (Mac) / Ctrl+K. Chrome on Windows captures
-                                Ctrl+K for the omnibox so this button is the primary path. */}
-                            <button
-                                type="button"
-                                id="oi-cmdk-trigger"
+                        <div class="px-2.5 pt-2.5 pb-1">
+                            <button type="button" id="oi-cmdk-trigger"
                                 x-data="{ isMac: navigator.platform?.startsWith('Mac') }"
-                                x-on:click="window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }))"
-                                class="w-full flex items-center gap-3 px-5 py-3 mb-2 rounded-2xl bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-all border border-slate-200/60 dark:border-slate-700/60 group"
-                                aria-label="Open command palette"
-                            >
-                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z"></path></svg>
-                                <span class="text-sm font-medium">Search…</span>
-                                <kbd class="ml-auto px-1.5 py-0.5 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded text-[10px] font-mono text-slate-500 dark:text-slate-400 group-hover:border-slate-300" x-text="isMac ? '⌘K' : 'Ctrl /'">⌘K</kbd>
+                                {...{'x-on:click': "window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }))"}}
+                                class="w-full flex items-center gap-2 px-2.5 py-[7px] rounded-md bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 dark:text-slate-500 transition-all border border-slate-200/60 dark:border-slate-700/60 text-[12px]"
+                                aria-label="Open command palette">
+                                <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z"></path></svg>
+                                <span x-show="!sbc" class="font-medium">Search…</span>
+                                <kbd x-show="!sbc" class="ml-auto px-1 py-0.5 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded text-[10px] font-mono text-slate-400 dark:text-slate-500" x-text="isMac ? '⌘K' : 'Ctrl /'">⌘K</kbd>
                             </button>
-                            {/* Sprint 1 Sub-spec B Task 2 — IA: 5 顶级 + Library + Settings.
-                                Order: Inspections / Calendar / Library / Contacts / Invoices / Metrics.
-                                Library group uses semantic <details> (auto-expand handled inline below).
-                                Reports merged into Inspections (Recent reports bucket on dashboard).
-                                Team relocated under Settings. */}
-                            <a href="/dashboard" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group relative">
-                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
-                                <span>Inspections</span>
-                            </a>
-                            <a href="/calendar" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
-                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
-                                <span>Calendar</span>
-                            </a>
-                            {/* Library group — collapsible. Auto-expanded server-side
-                                via the activate-sidebar script (sets `open` when current
-                                path starts with any Library route). */}
-                            <details class="group [&>summary]:list-none" data-sidebar-library>
-                                <summary class="cursor-pointer flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
-                                    <span class="flex-1">Library</span>
-                                    <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-                                </summary>
-                                {/* Iter-2 bug #8 — canonical Library order, kept in
-                                    sync with the mobile drawer above. */}
-                                <div class="mt-1 ml-7 pl-3 border-l border-slate-100 dark:border-slate-700 space-y-0.5">
-                                    <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Inspection Templates</a>
-                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Marketplace</a>
-                                    <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Comments</a>
-                                    <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Repair Items</a>
-                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Tags</a>
-                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Agreements</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Rating Systems</a>
+                        </div>
+
+                        <nav class="flex-1 px-2.5 py-1 overflow-y-auto space-y-3">
+                            <div>
+                                <div x-show="!sbc" class="ih-eyebrow px-2.5 pt-2 pb-1.5">Workspace</div>
+                                <div class="flex flex-col gap-0.5">
+                                    <a href="/dashboard" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Inspections">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
+                                        <span x-show="!sbc">Inspections</span>
+                                        <span x-show="!sbc" id="msgUnreadBadgeDesktop" class="hidden ml-auto px-1.5 min-w-[1rem] text-center rounded-full bg-rose-500 text-white text-[9px] font-bold leading-4"></span>
+                                    </a>
+                                    <a href="/calendar" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Calendar">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                        <span x-show="!sbc">Calendar</span>
+                                    </a>
+                                    <a href="/contacts" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Contacts">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                        <span x-show="!sbc">Contacts</span>
+                                    </a>
+                                    <a href="/invoices" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Invoices">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
+                                        <span x-show="!sbc">Invoices</span>
+                                    </a>
+                                    <a href="/metrics" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Metrics">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
+                                        <span x-show="!sbc">Metrics</span>
+                                    </a>
                                 </div>
-                            </details>
-                            <a href="/contacts" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
-                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
-                                <span>Contacts</span>
-                            </a>
-                            <a href="/invoices" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
-                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
-                                <span>Invoices</span>
-                            </a>
-                            <a href="/metrics" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold group">
-                                <svg class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
-                                <span>Metrics</span>
-                            </a>
+                            </div>
+
+                            <div>
+                                <div x-show="!sbc" class="ih-eyebrow px-2.5 pt-1 pb-1.5">Library</div>
+                                <div class="flex flex-col gap-0.5">
+                                    <a href="/templates" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Inspection Templates">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                                        <span x-show="!sbc">Templates</span>
+                                    </a>
+                                    <a href="/marketplace" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Marketplace">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"></path></svg>
+                                        <span x-show="!sbc">Marketplace</span>
+                                    </a>
+                                    <a href="/comments" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Comments">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"></path></svg>
+                                        <span x-show="!sbc">Comments</span>
+                                    </a>
+                                    <a href="/recommendations" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Repair Items">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                        <span x-show="!sbc">Repair Items</span>
+                                    </a>
+                                    <a href="/library/tags" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Tags">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path></svg>
+                                        <span x-show="!sbc">Tags</span>
+                                    </a>
+                                    <a href="/agreements" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Agreements">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                                        <span x-show="!sbc">Agreements</span>
+                                    </a>
+                                    <a href="/library/rating-systems" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Rating Systems">
+                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path></svg>
+                                        <span x-show="!sbc">Rating Systems</span>
+                                    </a>
+                                </div>
+                            </div>
                         </nav>
 
-                        <div class="p-6 border-t border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/20">
-                             <a href="/settings" class="flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-white dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:shadow-sm transition-all font-semibold group">
-                                <svg class="w-5 h-5 group-hover:rotate-45 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 002.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
-                                <span>Settings</span>
+                        <div class="mt-auto px-2.5 py-2.5 border-t border-slate-100 dark:border-slate-700">
+                            <a href="/settings" class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Settings">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 002.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                <span x-show="!sbc">Settings</span>
                             </a>
-                            {/* Shared-SaaS only — mirrors the mobile drawer entry. */}
+
                             {branding?.isSharedSaas && branding?.portalBaseUrl && (
                                 <a href={`${branding.portalBaseUrl}/workspace/switch?chooser=1`}
-                                   class="flex items-center gap-3 px-5 py-4 mt-2 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-white dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:shadow-sm transition-all font-semibold group">
-                                    <svg class="w-5 h-5 group-hover:translate-x-0.5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/></svg>
-                                    <span class="flex-1">Switch workspace</span>
-                                    <svg class="w-3.5 h-3.5 text-slate-400 group-hover:text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                                   class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" title="Switch workspace">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/></svg>
+                                    <span x-show="!sbc">Switch workspace</span>
                                 </a>
                             )}
-                            <div x-data="themeMenu()" class="relative mt-2" {...{'x-on:click.outside': 'open = false'}}>
-                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-white dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:shadow-sm transition-all font-semibold group" aria-label="Color scheme">
-                                    <svg id="themeMoonIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
-                                    <svg id="themeSunIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-                                    <svg id="themeAutoIcon" class="w-5 h-5 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-                                    <span id="themeToggleLabel" class="flex-1 text-left text-sm">Auto</span>
-                                    <svg class="w-3.5 h-3.5 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+
+                            <button type="button" {...{'x-on:click': "sbc = !sbc; localStorage.setItem('oi-sidebar-collapsed', sbc ? '1' : '0')"}}
+                                class="flex items-center gap-2 px-2.5 py-[6px] mt-1 rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200/60 dark:border-slate-700/60 text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 text-[11px] font-bold transition-all" title="Toggle sidebar">
+                                <svg x-show="!sbc" class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" stroke-width="2"/><line x1="15" y1="3" x2="15" y2="21" stroke-width="2"/><polyline points="10 9 7 12 10 15" stroke-width="2"/></svg>
+                                <span x-show="!sbc">Collapse</span>
+                                <svg x-show="sbc" x-cloak class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" stroke-width="2"/><line x1="15" y1="3" x2="15" y2="21" stroke-width="2"/><polyline points="7 9 10 12 7 15" stroke-width="2"/></svg>
+                            </button>
+
+                            {/* User avatar */}
+                            <div class="flex items-center gap-2.5 px-2 py-1.5 mt-1 rounded-md hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-all cursor-default">
+                                <div class="w-8 h-8 rounded-full bg-gradient-to-br from-indigo-500 to-indigo-700 flex items-center justify-center text-white text-[12px] font-bold flex-shrink-0"
+                                     x-text="(document.querySelector('meta[name=user-initials]')?.content) || 'OI'"></div>
+                                <div x-show="!sbc" class="flex-1 min-w-0">
+                                    <div class="text-[12px] font-bold text-slate-900 dark:text-slate-100 truncate"
+                                         x-text="(document.querySelector('meta[name=user-name]')?.content) || 'Inspector'"></div>
+                                    <div class="text-[10px] text-slate-400 dark:text-slate-500 font-mono truncate">{branding?.tenantSubdomain ? `${branding.tenantSubdomain}.inspectorhub.io` : 'openinspection.dev'}</div>
+                                </div>
+                            </div>
+
+                            <div x-data="themeMenu()" class="relative mt-1" {...{'x-on:click.outside': 'open = false'}}>
+                                <button type="button" {...{'x-on:click': 'open = !open'}} class="w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all" aria-label="Color scheme" title="Color scheme">
+                                    <svg id="themeMoonIcon" class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                                    <svg id="themeSunIcon" class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                                    <svg id="themeAutoIcon" class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                                    <span x-show="!sbc" id="themeToggleLabel" class="flex-1 text-left">Auto</span>
+                                    <svg x-show="!sbc" class="w-3 h-3 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                                 </button>
-                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
-                                    <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg z-50 py-1 overflow-hidden">
+                                    <button type="button" {...{'x-on:click': "set('auto')"}} class="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                                        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                                         <span class="flex-1 text-left">Auto</span>
-                                        <svg x-show="mode === 'auto'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                        <svg x-show="mode === 'auto'" class="w-3.5 h-3.5 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
-                                    <button type="button" x-on:click="set('dark')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                                    <button type="button" {...{'x-on:click': "set('dark')"}} class="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                                        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                                         <span class="flex-1 text-left">Dark</span>
-                                        <svg x-show="mode === 'dark'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                        <svg x-show="mode === 'dark'" class="w-3.5 h-3.5 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
-                                    <button type="button" x-on:click="set('light')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-                                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                                    <button type="button" {...{'x-on:click': "set('light')"}} class="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                                        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
                                         <span class="flex-1 text-left">Light</span>
-                                        <svg x-show="mode === 'light'" class="w-4 h-4 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                        <svg x-show="mode === 'light'" class="w-3.5 h-3.5 text-indigo-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                                     </button>
                                 </div>
                             </div>
-                            <button id="logoutBtn" class="w-full flex items-center gap-3 px-5 py-4 rounded-2xl text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all font-semibold group mt-2">
-                                <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
-                                <span>Sign Out</span>
+
+                            <button id="logoutBtn" class="w-full flex items-center gap-2.5 px-2.5 py-[7px] mt-1 rounded-md text-[13px] font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all" title="Sign Out">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
+                                <span x-show="!sbc">Sign Out</span>
                             </button>
                         </div>
                     </aside>
 
                     <main class="md:flex-1 w-full bg-[#f8fafc] dark:bg-slate-900 overflow-y-auto">
-                        <div class="max-w-7xl mx-auto py-10 px-6 sm:px-8 lg:px-12">
+                        <div class="pt-5 pb-9 px-6">
                             {children}
                         </div>
                     </main>
@@ -501,7 +532,7 @@ export const MainLayout = (props: {
                                     } else {
                                         a.classList.add('bg-indigo-50', 'text-indigo-600');
                                     }
-                                    a.classList.remove('text-slate-600');
+                                    a.classList.remove('text-slate-600', 'text-slate-300');
                                     if (!firstActive) firstActive = a;
                                 }
                             });
@@ -511,11 +542,6 @@ export const MainLayout = (props: {
                             document.documentElement,
                             { attributes: true, attributeFilter: ['data-color-scheme'] }
                         );
-                        var libraryRoutes = ['/templates', '/comments', '/recommendations', '/agreements', '/marketplace', '/library/'];
-                        var inLibrary = libraryRoutes.some(function(r) { return p.indexOf(r) === 0; });
-                        if (inLibrary) {
-                            document.querySelectorAll('details[data-sidebar-library]').forEach(function(d) { d.open = true; });
-                        }
                         if (firstActive && typeof firstActive.scrollIntoView === 'function') {
                             try {
                                 firstActive.scrollIntoView({ block: 'nearest', behavior: 'instant' });
@@ -572,15 +598,14 @@ export const MainLayout = (props: {
                                 const r = await authFetch('/api/messages/unread-count');
                                 if (!r.ok) return;
                                 const d = await r.json();
-                                const badge = document.getElementById('msgUnreadBadge');
-                                if (!badge) return;
                                 const count = d.data?.count || 0;
-                                if (count > 0) {
-                                    badge.textContent = count > 99 ? '99+' : String(count);
-                                    badge.classList.remove('hidden');
-                                } else {
-                                    badge.classList.add('hidden');
-                                }
+                                const display = count > 99 ? '99+' : String(count);
+                                ['msgUnreadBadge', 'msgUnreadBadgeDesktop'].forEach(function(id) {
+                                    const el = document.getElementById(id);
+                                    if (!el) return;
+                                    if (count > 0) { el.textContent = display; el.classList.remove('hidden'); }
+                                    else { el.classList.add('hidden'); }
+                                });
                             } catch {}
                         }
                         if (typeof authFetch !== 'undefined') {

--- a/src/templates/layouts/main-layout.tsx
+++ b/src/templates/layouts/main-layout.tsx
@@ -29,6 +29,7 @@ function SharedHead({ title, primaryColor, gaMeasurementId, extraHead }: {
             <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
             {/* FOUC prevention: set data-color-scheme before any stylesheet loads. */}
             <script dangerouslySetInnerHTML={{ __html: `(function(){try{var L=localStorage.getItem('ih-color-scheme');if(L&&!localStorage.getItem('oi-color-scheme'))localStorage.setItem('oi-color-scheme',L);if(L)localStorage.removeItem('ih-color-scheme');}catch(e){}var s=localStorage.getItem('oi-color-scheme');var p=window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.setAttribute('data-color-scheme',s==='dark'||(s===null&&p)?'dark':'light');})()`}} />
+            <script dangerouslySetInnerHTML={{ __html: `(function(){try{if(localStorage.getItem('oi-sidebar-collapsed')==='1')document.documentElement.setAttribute('data-sidebar-collapsed','1');}catch(e){}})()`}} />
             <link rel="stylesheet" href="/fonts.css" />
             <link rel="stylesheet" href="/vendor/flatpickr.min.css" />
             {/* Theme toggle runtime — sync load so toggleColorScheme() is available
@@ -178,7 +179,7 @@ export const MainLayout = (props: {
                 gaMeasurementId={sanitizeGaId(branding)}
                 {...(extraHead ? { extraHead } : {})}
             />
-            <body class="bg-[#f8fafc] dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased min-h-screen" x-data="{ mobileMenu: false }">
+            <body class="bg-[#f8fafc] dark:bg-slate-900 text-slate-900 dark:text-slate-100 antialiased min-h-screen" x-data="{ mobileMenu: false, sbc: localStorage.getItem('oi-sidebar-collapsed') === '1' }">
                 {branding?.tenantStatus === 'suspended' && (
                     <div id="suspensionBanner" class="bg-amber-50 dark:bg-amber-900/30 border-b border-amber-200 dark:border-amber-700 px-4 py-3 flex items-center justify-center gap-3 relative z-50">
                         <svg class="w-5 h-5 flex-shrink-0 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
@@ -233,116 +234,101 @@ export const MainLayout = (props: {
                     {/* Panel */}
                     <div x-show="mobileMenu" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 -translate-x-full" x-transition:enter-end="opacity-100 translate-x-0" x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100 translate-x-0" x-transition:leave-end="opacity-0 -translate-x-full" class="relative w-80 max-w-[85vw] h-full bg-white dark:bg-slate-900 shadow-2xl flex flex-col">
                         {/* Close header */}
-                        <div class="p-6 flex items-center justify-between border-b border-slate-100 dark:border-slate-700">
+                        <div class="p-4 flex items-center justify-between border-b border-slate-100 dark:border-slate-700">
                             <div class="flex items-center gap-3">
-                                <div class="w-9 h-9 flex-shrink-0">
+                                <div class="w-7 h-7 flex-shrink-0">
                                     <img src={logoUrl || '/logo.svg'} alt={siteName} class="w-full h-full object-contain" />
                                 </div>
-                                <span class="text-xl font-extrabold text-slate-900 dark:text-slate-100 tracking-tight">{siteName}</span>
+                                <span class="text-sm font-bold text-slate-900 dark:text-slate-100 tracking-tight">{siteName}</span>
                             </div>
                             <button x-on:click="mobileMenu = false" class="p-2 rounded-xl text-slate-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300 transition-colors" aria-label="Close menu">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                             </button>
                         </div>
                         {/* Nav links */}
-                        <nav class="flex-1 p-4 space-y-1 overflow-y-auto">
-                            {/* Sprint 1 Sub-spec B Task 2 — mobile mirrors desktop IA. */}
-                            <a href="/dashboard" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
-                                <span>Inspections</span>
-                                <span id="msgUnreadBadge" class="hidden ml-auto px-1.5 min-w-[1.25rem] text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
-                            </a>
-                            <a href="/calendar" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
-                                <span>Calendar</span>
-                            </a>
-                            {/* Library group (mobile) — collapsible. */}
-                            <details class="group [&>summary]:list-none" data-sidebar-library>
-                                <summary class="cursor-pointer flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
-                                    <span class="flex-1">Library</span>
-                                    <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-                                </summary>
-                                {/* Iter-2 bug #8 — canonical Library order: Inspection
-                                    Templates / Marketplace / Comments / Repair Items /
-                                    Tags / Agreements / Rating Systems. All seven entries
-                                    are required; the previous order shipped Marketplace
-                                    after Agreements which made customers think it was
-                                    missing when the menu was reading-cut on small
-                                    viewports. */}
-                                <div class="mt-1 ml-7 pl-3 border-l border-slate-100 dark:border-slate-700 space-y-0.5">
-                                    <a href="/templates" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Inspection Templates</a>
-                                    <a href="/marketplace" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Marketplace</a>
-                                    <a href="/comments" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Comments</a>
-                                    <a href="/recommendations" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Repair Items</a>
-                                    <a href="/library/tags" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Tags</a>
-                                    <a href="/agreements" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Agreements</a>
-                                    <a href="/library/rating-systems" class="block px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Rating Systems</a>
+                        <nav class="flex-1 p-3 overflow-y-auto space-y-3">
+                            <div>
+                                <div class="ih-eyebrow px-3 pt-3 pb-1.5">Workspace</div>
+                                <div class="flex flex-col gap-0.5">
+                                    <a href="/dashboard" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
+                                        <span>Inspections</span>
+                                        <span id="msgUnreadBadge" class="hidden ml-auto px-1.5 min-w-[1.25rem] text-center rounded-full bg-rose-500 text-white text-[10px] font-bold leading-5"></span>
+                                    </a>
+                                    <a href="/calendar" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                        <span>Calendar</span>
+                                    </a>
+                                    <a href="/contacts" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                        <span>Contacts</span>
+                                    </a>
+                                    <a href="/invoices" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
+                                        <span>Invoices</span>
+                                    </a>
+                                    <a href="/metrics" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
+                                        <span>Metrics</span>
+                                    </a>
                                 </div>
-                            </details>
-                            <a href="/contacts" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
-                                <span>Contacts</span>
-                            </a>
-                            <a href="/invoices" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
-                                <span>Invoices</span>
-                            </a>
-                            <a href="/metrics" class="flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
-                                <span>Metrics</span>
-                            </a>
+                            </div>
 
-                            {/* handoff-decisions §5 — Settings group fully expanded as
-                                a flat sub-list. Section header has no chevron. */}
-                            <div class="pt-4 mt-4 border-t border-slate-100 dark:border-slate-700">
-                                <a href="/settings" class="block px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500 hover:text-indigo-600">Settings</a>
+                            <div>
+                                <div class="ih-eyebrow px-3 pt-1 pb-1.5">Library</div>
+                                <div class="flex flex-col gap-0.5">
+                                    <a href="/templates" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Templates</a>
+                                    <a href="/marketplace" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Marketplace</a>
+                                    <a href="/comments" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Comments</a>
+                                    <a href="/recommendations" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Repair Items</a>
+                                    <a href="/library/tags" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Tags</a>
+                                    <a href="/agreements" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Agreements</a>
+                                    <a href="/library/rating-systems" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Rating Systems</a>
+                                </div>
+                            </div>
+
+                            <div class="pt-3 mt-1 border-t border-slate-100 dark:border-slate-700">
+                                <div class="ih-eyebrow px-3 pt-1 pb-1.5">Settings</div>
                                 <div class="space-y-0">
-                                    <a href="/settings/profile" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Profile</a>
-                                    <a href="/settings/workspace/branding" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Branding</a>
-                                    <a href="/settings/workspace/theme" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Report Theme</a>
-                                    <a href="/settings/workspace/telemetry" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Telemetry</a>
-                                    <a href="/settings/catalog/services" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Services &amp; Pricing</a>
-                                    <a href="/settings/catalog/event-types" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Event Types</a>
-                                    <a href="/settings/catalog/widget" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Embed Widget</a>
-                                    <a href="/settings/communication/email" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Email</a>
-                                    <a href="/settings/communication/automations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Automations</a>
-                                    <a href="/settings/communication/calendar" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Apple Calendar</a>
-                                    <a href="/settings/communication/integrations" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Integrations</a>
-                                    <a href="/settings/account/password" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Change Password</a>
-                                    <a href="/settings/account/security" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Two-factor (2FA)</a>
-                                    <a href="/settings/account/bot-protection" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Bot Protection</a>
-                                    <a href="/settings/advanced/payments" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Payments</a>
-                                    <a href="/settings/advanced/ai" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">AI</a>
-                                    <a href="/settings/advanced/data" class="flex items-center h-7 pl-[30px] pr-4 rounded-lg text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Data Import / Export</a>
+                                    <a href="/settings" class="flex items-center gap-3 px-3 py-2 rounded-md text-[13px] font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all">Settings</a>
+                                    <a href="/settings/profile" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Profile</a>
+                                    <a href="/settings/workspace/branding" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Branding</a>
+                                    <a href="/settings/workspace/theme" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Report Theme</a>
+                                    <a href="/settings/workspace/telemetry" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Telemetry</a>
+                                    <a href="/settings/catalog/services" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Services &amp; Pricing</a>
+                                    <a href="/settings/catalog/event-types" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Event Types</a>
+                                    <a href="/settings/catalog/widget" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Embed Widget</a>
+                                    <a href="/settings/communication/email" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Email</a>
+                                    <a href="/settings/communication/automations" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Automations</a>
+                                    <a href="/settings/communication/calendar" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Apple Calendar</a>
+                                    <a href="/settings/communication/integrations" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Integrations</a>
+                                    <a href="/settings/account/password" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Change Password</a>
+                                    <a href="/settings/account/security" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Two-factor (2FA)</a>
+                                    <a href="/settings/account/bot-protection" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Bot Protection</a>
+                                    <a href="/settings/advanced/payments" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Payments</a>
+                                    <a href="/settings/advanced/ai" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">AI</a>
+                                    <a href="/settings/advanced/data" class="flex items-center h-7 pl-[30px] pr-4 rounded-md text-[13px] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors font-medium">Data Import / Export</a>
                                 </div>
                             </div>
                         </nav>
                         {/* Bottom section */}
-                        <div class="p-4 border-t border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/20 space-y-1">
-                            {/* Shared-SaaS only: deep-link to portal's workspace picker.
-                                A multi-workspace identity has no in-core way to swap
-                                tenants (the JWT carries a single tenantId), so the
-                                only correct move is to bounce to portal where the
-                                memberships list lives — portal's /workspace/switch
-                                will SSO us back here with the picked tenant's cookie. */}
+                        <div class="p-3 border-t border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/20 space-y-1">
                             {branding?.isSharedSaas && branding?.portalBaseUrl && (
-                                <a href={`${branding.portalBaseUrl}/workspace/switch`}
-                                   class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold">
+                                <a href={`${branding.portalBaseUrl}/workspace/switch?chooser=1`}
+                                   class="w-full flex items-center gap-3 px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-medium text-[13px]">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/></svg>
-                                    <span class="flex-1 text-left text-sm">Switch workspace</span>
-                                    <svg class="w-3.5 h-3.5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg>
+                                    <span class="flex-1 text-left">Switch workspace</span>
                                 </a>
                             )}
                             <div x-data="themeMenu()" class="relative" {...{'x-on:click.outside': 'open = false'}}>
-                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-semibold" aria-label="Color scheme">
+                                <button type="button" x-on:click="open = !open" class="w-full flex items-center gap-3 px-3 py-2 rounded-md text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 transition-all font-medium text-[13px]" aria-label="Color scheme">
                                     <svg id="mobileThemeMoonIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                                     <svg id="mobileThemeSunIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
                                     <svg id="mobileThemeAutoIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-                                    <span id="mobileThemeLabel" class="flex-1 text-left text-sm">Auto</span>
+                                    <span id="mobileThemeLabel" class="flex-1 text-left">Auto</span>
                                     <svg class="w-3.5 h-3.5 flex-shrink-0 transition-transform" x-bind:class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                                 </button>
-                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
+                                <div style="display:none" x-show="open" class="absolute bottom-full left-0 right-0 mb-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg z-50 py-1 overflow-hidden">
                                     <button type="button" x-on:click="set('auto')" class="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                                         <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                                         <span class="flex-1 text-left">Auto</span>
@@ -360,7 +346,7 @@ export const MainLayout = (props: {
                                     </button>
                                 </div>
                             </div>
-                            <button id="mobileLogoutBtn" class="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all font-semibold">
+                            <button id="mobileLogoutBtn" class="w-full flex items-center gap-3 px-3 py-2 rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all font-medium text-[13px]">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
                                 <span>Sign Out</span>
                             </button>
@@ -453,7 +439,7 @@ export const MainLayout = (props: {
                             </a>
                             {/* Shared-SaaS only — mirrors the mobile drawer entry. */}
                             {branding?.isSharedSaas && branding?.portalBaseUrl && (
-                                <a href={`${branding.portalBaseUrl}/workspace/switch`}
+                                <a href={`${branding.portalBaseUrl}/workspace/switch?chooser=1`}
                                    class="flex items-center gap-3 px-5 py-4 mt-2 rounded-2xl text-slate-600 dark:text-slate-300 hover:bg-white dark:hover:bg-slate-700 hover:text-indigo-600 dark:hover:text-indigo-400 hover:shadow-sm transition-all font-semibold group">
                                     <svg class="w-5 h-5 group-hover:translate-x-0.5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/></svg>
                                     <span class="flex-1">Switch workspace</span>

--- a/src/templates/pages/agreements.tsx
+++ b/src/templates/pages/agreements.tsx
@@ -8,7 +8,7 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
 
     return (
         <MainLayout title={`${siteName} | Agreements`} branding={branding}>
-            <div class="animate-slide-in flex flex-col space-y-6" style="min-height: calc(100vh - 5rem);">
+            <div class="animate-slide-in flex flex-col space-y-[18px]" style="min-height: calc(100vh - 5rem);">
                 <div x-data="agreementsMeta">
                     <PageHeader
                         eyebrow="LIBRARY · AGREEMENTS"
@@ -43,10 +43,10 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                             <table class="min-w-full h-full">
                                 <thead>
                                     <tr class="bg-slate-50/50 dark:bg-slate-700/50">
-                                        <th scope="col" class="py-6 pl-10 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Agreement Name</th>
-                                        <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Version</th>
-                                        <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Effective Date</th>
-                                        <th scope="col" class="relative py-6 pl-3 pr-10"><span class="sr-only">Actions</span></th>
+                                        <th scope="col" class="py-3 pl-4 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Agreement Name</th>
+                                        <th scope="col" class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Version</th>
+                                        <th scope="col" class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-400">Effective Date</th>
+                                        <th scope="col" class="relative py-3 pl-3 pr-4"><span class="sr-only">Actions</span></th>
                                     </tr>
                                 </thead>
                                 <tbody id="agreementsList" class="divide-y divide-slate-100 dark:divide-slate-700">
@@ -78,8 +78,8 @@ export const AgreementsPage = ({ branding }: { branding?: BrandingConfig | undef
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y divide-slate-100 dark:divide-slate-700">
-                                    <tr aria-busy="true"><td colspan={6} class="px-10 py-4"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
-                                    <tr aria-busy="true"><td colspan={6} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
+                                    <tr aria-busy="true"><td colspan={6} class="px-4 py-3"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
+                                    <tr aria-busy="true"><td colspan={6} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
                                     <tr x-show="!reqLoading && requests.length === 0"><td colspan={6} class="py-16 text-center text-sm text-slate-400 italic">No signing requests yet. Use a template's "Send" action.</td></tr>
                                     <template x-for="r in requests" x-bind:key="r.id">
                                         <tr class="hover:bg-slate-50/50 dark:hover:bg-slate-700/50">

--- a/src/templates/pages/contacts.tsx
+++ b/src/templates/pages/contacts.tsx
@@ -7,7 +7,7 @@ export const ContactsPage = ({ branding }: { branding?: BrandingConfig | undefin
     const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout title={`${siteName} | Contacts`} branding={branding}>
-            <div class="space-y-6 animate-fade-in">
+            <div class="space-y-[18px] animate-fade-in">
                 <div x-data="contactsMeta">
                     <PageHeader
                         eyebrow="CONTACTS"
@@ -80,19 +80,19 @@ export const ContactsPage = ({ branding }: { branding?: BrandingConfig | undefin
                     <table class="w-full text-left">
                         <thead class="bg-slate-50/40">
                             <tr>
-                                <th class="py-6 px-10 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Name</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Type</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Email</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Phone</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Agency</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Inspections</th>
-                                <th class="relative py-6 pl-3 pr-10 text-right"><span class="sr-only">Actions</span></th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Name</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Type</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Email</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Phone</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Agency</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Inspections</th>
+                                <th class="relative py-3 pl-3 pr-4 text-right"><span class="sr-only">Actions</span></th>
                             </tr>
                         </thead>
                         <tbody id="contactsBody">
-                            <tr aria-busy="true"><td colspan={7} class="px-10 py-4"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={7} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={7} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={7} class="px-4 py-3"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={7} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={7} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -108,16 +108,16 @@ export const ContactsPage = ({ branding }: { branding?: BrandingConfig | undefin
                     <table class="w-full text-left">
                         <thead class="bg-slate-50/40">
                             <tr>
-                                <th class="py-6 px-10 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Agent</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Status</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Linked</th>
-                                <th class="relative py-6 pl-3 pr-10 text-right"><span class="sr-only">Actions</span></th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Agent</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Status</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Linked</th>
+                                <th class="relative py-3 pl-3 pr-4 text-right"><span class="sr-only">Actions</span></th>
                             </tr>
                         </thead>
                         <tbody id="agentLinksBody">
-                            <tr aria-busy="true"><td colspan={4} class="px-10 py-4"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={4} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={4} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={4} class="px-4 py-3"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={4} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={4} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
                         </tbody>
                     </table>
                 </div>

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -23,7 +23,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
 
     return (
         <MainLayout title={`${siteName} | Dashboard`} branding={branding}>
-            <div class="space-y-6 animate-fade-in">
+            <div class="space-y-[18px] animate-fade-in">
 
                 {seatUsage !== undefined && billingPortalUrl !== undefined ? (
                     <SeatBanner usage={seatUsage} billingPortalUrl={billingPortalUrl} />
@@ -135,7 +135,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     defectStats chips beneath the count when the bucket has any
                     open defects. The Alpine binding is local: `dashboardCards`
                     factory pulls defectAggregate from /api/inspections/dashboard. */}
-                <div x-data="dashboardCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div x-data="dashboardCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
                     {[
                         { label: 'Upcoming',        id: 'statUpcoming',   target: 'later',          icon: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z', color: 'indigo' },
                         { label: 'In Progress',     id: 'statInProgress', target: 'thisWeek',       icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z', color: 'blue' },
@@ -146,7 +146,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                             key={stat.id}
                             type="button"
                             x-on:click={`sections['${stat.target}']=true; $nextTick(()=>{ const el=document.getElementById('bucket-${stat.target}'); if(el) el.scrollIntoView({behavior:'smooth', block:'start'}); })`}
-                            class="group p-4 rounded-lg bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 animate-fade-in text-left hover:shadow-md hover:border-slate-300 dark:hover:border-slate-600 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                            class="group p-[14px] rounded-lg bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 animate-fade-in text-left hover:shadow-md hover:border-slate-300 dark:hover:border-slate-600 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                             style={`animation-delay: ${0.1 + i * 0.05}s`}
                             title={`Jump to ${stat.label}`}
                         >
@@ -156,7 +156,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                                 </div>
                                 <span class="sr-only">Live</span>
                             </div>
-                            <h3 class="text-2xl font-bold text-slate-900 dark:text-slate-100 tracking-tight tabular-nums mb-1" id={stat.id}>0</h3>
+                            <h3 class="text-xl font-bold text-slate-900 dark:text-slate-100 tracking-tight tabular-nums mb-1" id={stat.id}>0</h3>
                             <p class="text-[12px] font-bold text-slate-500 uppercase tracking-[0.15em]">{stat.label}</p>
                             {/* Agent Accounts A3 — UPCOMING substate. Per
                                 directive we do NOT add a 5th stat card; the
@@ -202,7 +202,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                 </div>
 
                 {/* Collapsible Inspection Sections */}
-                <div x-data="dashboard()" x-init="init()" class="space-y-4 mt-8">
+                <div x-data="dashboard()" x-init="init()" class="space-y-3 mt-[18px]">
 
                     {/* Design System 0520 subsystem E P3.2 — Filters modal mount.
                     Listens for `open-filters` (no detail) and broadcasts
@@ -245,7 +245,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                         {...{ 'x-cloak': true }}
                         role="tablist"
                         aria-label="Inspection time filter"
-                        class="flex flex-wrap items-center gap-1.5 -mt-1"
+                        class="flex flex-wrap items-center border-b border-slate-200 dark:border-slate-700 -mt-1"
                         data-test="inspection-filter-tabs"
                     >
                         <template x-for="opt in filterOptions" {...{ 'x-bind:key': 'opt.id' }}>
@@ -256,14 +256,14 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                                 x-bind:data-active={`activeFilter === opt.id ? '1' : '0'`}
                                 x-on:click="setFilter(opt.id)"
                                 x-bind:class={`activeFilter === opt.id
-                                    ? 'bg-indigo-600 text-white border-indigo-600 shadow-sm'
-                                    : 'bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 hover:text-slate-900 dark:hover:text-slate-200'`}
-                                class="inline-flex items-center gap-1.5 h-7 px-3 rounded-full border text-[11px] font-bold uppercase tracking-[0.08em] transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
+                                    ? 'border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400'
+                                    : 'border-transparent text-slate-500 hover:text-slate-900 dark:hover:text-slate-200'`}
+                                class="inline-flex items-center gap-1.5 px-3.5 py-2.5 border-b-2 text-[13px] font-bold transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                             >
                                 <span x-text="opt.label"></span>
                                 <span
                                     x-show="opt.id !== 'all' && filterCounts[opt.id] > 0"
-                                    x-bind:class={`activeFilter === opt.id ? 'bg-white/20 text-white' : 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400'`}
+                                    x-bind:class={`activeFilter === opt.id ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-600 dark:text-indigo-400' : 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400'`}
                                     class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full text-[10px] tabular-nums"
                                     x-text="filterCounts[opt.id]"
                                 ></span>
@@ -280,7 +280,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                                 x-model="activeTagFilter"
                                 x-on:change="onTagFilterChange()"
                                 aria-label="Filter by tag"
-                                class="h-7 px-2 rounded-full border text-[11px] font-bold uppercase tracking-[0.08em] outline-none focus:ring-2 focus:ring-indigo-500/30 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-700"
+                                class="h-7 px-2 rounded-md border text-[11px] font-bold uppercase tracking-[0.08em] outline-none focus:ring-2 focus:ring-indigo-500/30 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-slate-700"
                                 data-testid="dashboard-tag-filter"
                             >
                                 <option value="">Any tag</option>
@@ -337,7 +337,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: Needs Attention */}
                     <section id="bucket-needsAttention" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.needsAttention.length > 0" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.needsAttention = !sections.needsAttention"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-amber-600">&#9888;</span>
                                 <span class="font-bold text-slate-900">Needs attention</span>
@@ -355,7 +355,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: Today */}
                     <section id="bucket-today" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.today.length > 0" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.today = !sections.today"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-blue-600">&#128197;</span>
                                 <span class="font-bold text-slate-900">Today</span>
@@ -373,7 +373,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: Today's events (Spec 4D.T10) */}
                     <section x-show="!loading && activeFilter === 'all' && !tagFilterIds && todayEvents.length > 0" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md">
                         <button type="button" x-on:click="sections.todayEvents = !sections.todayEvents"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-purple-600">&#128203;</span>
                                 <span class="font-bold text-slate-900">Today's events</span>
@@ -396,7 +396,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: This Week */}
                     <section id="bucket-thisWeek" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.thisWeek.length > 0" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.thisWeek = !sections.thisWeek"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-slate-500">&#128197;</span>
                                 <span class="font-bold text-slate-900">This week</span>
@@ -414,7 +414,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: Later */}
                     <section x-show="!loading && activeFilter === 'all' && !tagFilterIds && (buckets.later.length > 0 || buckets.laterTotal > 0)" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md">
                         <button type="button" x-on:click="sections.later = !sections.later"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-slate-500">&#128197;</span>
                                 <span class="font-bold text-slate-900">Later</span>
@@ -437,7 +437,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: Recent Reports */}
                     <section id="bucket-recentReports" x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.recentReports.length > 0" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md scroll-mt-20">
                         <button type="button" x-on:click="sections.recentReports = !sections.recentReports"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-emerald-600">&#10003;</span>
                                 <span class="font-bold text-slate-900">Recent reports</span>
@@ -455,7 +455,7 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                     {/* Section: Cancelled */}
                     <section x-show="!loading && activeFilter === 'all' && !tagFilterIds && buckets.cancelled.length > 0" {...{ 'x-cloak': true }} class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md">
                         <button type="button" x-on:click="sections.cancelled = !sections.cancelled"
-                                class="w-full flex items-center justify-between px-5 py-4 text-left">
+                                class="w-full flex items-center justify-between px-5 py-3 text-left">
                             <div class="flex items-center gap-3">
                                 <span class="text-rose-600">&#128683;</span>
                                 <span class="font-bold text-slate-900">Cancelled</span>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -1692,15 +1692,14 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 </Modal>
             </section>
 
-            {/* Card Grid */}
-            <div class="p-6 grid grid-cols-2 xl:grid-cols-3 gap-4">
+            {/* Item List — single-column (Gap 2B) */}
+            <div class="flex flex-col">
               <template x-for="item in currentSectionItems" x-bind:key="item.id">
                 <div
                   x-bind:data-item-id="item.id"
                   x-show="itemMatchesSearch(currentSection, item) && itemPassesFilter(item)"
-                  class="rounded-md p-4 transition-all cursor-pointer group item-card"
-                  x-bind:style="(activeItemId === item.id ? 'border-color: #6366f1; ' : '') + 'border-top: 4px solid ' + getRatingColor(getItemRating(item.id))"
-                  x-bind:class="activeItemId === item.id ? 'ring-2 ring-indigo-100' : ''"
+                  class="flex items-center gap-2 px-3 py-2 border-b border-slate-100 dark:border-slate-700 cursor-pointer group transition-all"
+                  x-bind:class="activeItemId === item.id ? 'border-l-[3px] border-l-indigo-600 bg-white dark:bg-slate-800 shadow-sm' : 'hover:bg-slate-50 dark:hover:bg-slate-800/50'"
                   x-on:click="batchMode ? toggleBatchSelect(item.id) : (setActiveItem(item.id), toggleExpand(item.id))"
                 >
                   <div x-show="batchMode" class="mb-2">
@@ -2063,7 +2062,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                 x-show="hasSearchQuery && searchMatchCount === 0"
                 style="display:none"
                 data-testid="editor-search-empty-desktop"
-                class="col-span-2 xl:col-span-3 rounded-md bg-white dark:bg-slate-800 border border-dashed border-slate-200 dark:border-slate-700 p-8 text-center"
+                class="rounded-md bg-white dark:bg-slate-800 border border-dashed border-slate-200 dark:border-slate-700 p-8 text-center"
               >
                 <p class="text-sm text-slate-500 dark:text-slate-400">No matches for &ldquo;<span class="font-semibold text-slate-700 dark:text-slate-200" x-text="searchQuery"></span>&rdquo;.</p>
                 <button x-on:click="clearSearch()" class="mt-2 text-xs font-semibold text-indigo-600 hover:underline">Clear search</button>

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -12,6 +12,7 @@ import { ProgressStrip } from '../components/progress-strip';
 import { TeamBanner } from '../components/team-banner';
 import { FooterBar } from '../components/footer-bar';
 import { ReconnectBanner } from '../components/reconnect-banner';
+import { SideRail } from '../components/side-rail';
 import { UnitTree } from '../components/unit-tree';
 import { InspectionSettingsSheet } from '../components/inspection-settings-sheet';
 import { MintObserverLinkModal } from '../components/mint-observer-link-modal';
@@ -1007,7 +1008,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
         {/* ===== Desktop View ===== */}
         <div x-show="isDesktop" class="hidden lg:flex min-h-screen">
           {/* Left Sidebar — hidden in focus mode (⌘2) */}
-          <aside x-show="viewMode !== 'focus'" class="w-[220px] sticky top-0 h-screen flex-shrink-0 flex flex-col border-r overflow-y-auto sidebar-glass">
+          <aside x-show="viewMode !== 'focus'" class="w-[200px] sticky top-0 h-screen flex-shrink-0 flex flex-col border-r overflow-y-auto sidebar-glass min-h-0">
             <div class="px-5 pt-6 pb-4 border-b" style="border-color: rgba(226,232,240,0.5)">
               <a href="/dashboard" class="flex items-center gap-2 text-xs mb-3 text-slate-400 dark:text-slate-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
@@ -1315,8 +1316,8 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             </div>
           </aside>
 
-          {/* Center Content */}
-          <main class="flex-1 min-w-0">
+          {/* Center Content — focal column with indigo top accent */}
+          <main class="flex-1 min-w-0 border-t-2 border-indigo-600 min-h-0">
             {/* Property Info view — design's __property__ section. Toggled
                 via the rail's Property Info row (selectProperty()). Body
                 shows a 7-field facts form using the same inline edit shape
@@ -2071,269 +2072,12 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
             </div>{/* /activeView === 'items' */}
           </main>
 
-          {/* Spec 5G M1 — Right pane: active item photos + quick comments.
-              Hidden in focus mode (⌘2), on screens narrower than xl
-              (Sprint 3 S3-4: 1024-1279 tablet zone gets a slide-in drawer
-              instead — see tablet-active-item-drawer below), and while the
-              Comment Library drawer is open (Sprint 1 A-1: avoids the
-              slash-trigger popover overlapping ACTIVE ITEM). */}
-          {/* Right SideRail — mirrors the design's 3-tab pattern
-              (Preview / Library / Recall). Sticky 280 px column with the
-              active item's preview, the canned-comment library, and a
-              recall pane that shows how the inspector wrote this kind of
-              finding in recent inspections. Hidden in focus mode (⌘2)
-              and on narrower-than-xl viewports; the tablet drawer below
-              handles 1024-1279 px. */}
-          <aside x-show="viewMode !== 'focus' && activeItem && !showCommentLibrary && !slashPickerOpen" class="hidden xl:flex w-[280px] sticky top-0 h-screen flex-shrink-0 flex-col border-l overflow-hidden sidebar-glass">
-            <header class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
-              <h3 class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest">Active Item</h3>
-              <p class="text-sm font-bold text-slate-900 dark:text-slate-100 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
-              <p class="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-0.5" x-text="activeItem?.number || ''"></p>
-            </header>
-
-            {/* Tab strip — matches the design kit's pill-tab pattern
-                (active tab has bg-card + card-shadow; inactive tabs sit
-                on the muted track in the strip's background). */}
-            <nav role="tablist" aria-label="Side rail mode" class="flex gap-1 p-1 mx-2 my-2 rounded-md bg-slate-100 dark:bg-slate-800/60">
-              <template x-for="tab in [{id:'preview',label:'Preview'},{id:'library',label:'Library'},{id:'recall',label:'Recall'}]" x-bind:key="tab.id">
-                <button
-                  type="button"
-                  role="tab"
-                  x-on:click="sideRailMode = tab.id"
-                  x-bind:aria-selected="sideRailMode === tab.id ? 'true' : 'false'"
-                  x-bind:class="sideRailMode === tab.id
-                    ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 shadow-sm'
-                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'"
-                  class="flex-1 px-2 py-1.5 rounded text-[11px] font-bold transition-colors"
-                  x-text="tab.label"
-                ></button>
-              </template>
-            </nav>
-
-            {/* ─────────── Preview tab ─────────── */}
-            <div x-show="sideRailMode === 'preview'" x-cloak class="flex-1 flex flex-col overflow-hidden">
-              {/* Photos */}
-              <section class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
-                <div class="flex items-center justify-between mb-2">
-                  <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Photos · <span x-text="(results[activeItemId]?.photos || []).length"></span></span>
-                  <label class="text-[10px] text-indigo-500 hover:underline cursor-pointer">
-                    + Add
-                    <input type="file" accept="image/*" capture="environment" class="hidden" x-on:change="if (activeItemId) { uploadPhoto(activeItemId, $event); $event.target.value = ''; }" />
-                  </label>
-                </div>
-                <div class="grid grid-cols-2 gap-1.5" x-show="(results[activeItemId]?.photos || []).length > 0">
-                  <template x-for="(photo, pi) in (results[activeItemId]?.photos || []).slice(0, 8)" x-bind:key="pi">
-                    <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100 dark:bg-slate-700 relative group">
-                      <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)" class="w-full h-full object-cover" alt="Photo" />
-                      <button
-                        x-on:click="window.dispatchEvent(new CustomEvent('annotate', { detail: { inspectionId, itemId: activeItemId, photoIndex: pi, imageUrl: '/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.key), existingNodesJson: photo.annotationsJson || null } }))"
-                        class="absolute bottom-0.5 right-0.5 px-1.5 py-0.5 rounded bg-white/90 dark:bg-slate-800/90 text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
-                        title="Annotate"
-                      >✎</button>
-                    </div>
-                  </template>
-                </div>
-                <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 dark:text-slate-500 py-2">
-                  No photos. Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">P</kbd> to add.
-                </p>
-              </section>
-
-              {/* Quick comments */}
-              <section class="px-4 py-3 flex-1 overflow-y-auto">
-                <div class="flex items-center justify-between mb-2">
-                  <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Quick Comments</span>
-                  <button x-on:click="sideRailMode = 'library'" class="text-[10px] text-indigo-500 hover:underline">Browse all</button>
-                </div>
-                <div class="space-y-1">
-                  <template x-for="(c, i) in quickCommentsForActive" x-bind:key="i">
-                    <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 dark:text-slate-200 leading-snug border border-slate-200 dark:border-slate-700 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all">
-                      <div class="flex items-start gap-1.5">
-                        <span class="px-1 py-0.5 text-[8px] font-bold uppercase rounded text-white shrink-0 mt-0.5"
-                          x-bind:style="c.rating === 'satisfactory' ? 'background: var(--ih-status-ok)' : (c.rating === 'monitor' ? 'background: var(--ih-status-watch)' : (c.rating === 'defect' ? 'background: var(--ih-status-bad)' : 'background: #64748b'))"
-                          x-text="c.rating === 'all' ? 'GEN' : c.rating.slice(0, 3)"></span>
-                        <span x-text="c.text"></span>
-                      </div>
-                    </button>
-                  </template>
-                </div>
-                <p class="text-[10px] text-slate-400 dark:text-slate-500 italic mt-3">
-                  Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">/</kbd> for full library
-                </p>
-              </section>
-            </div>
-
-            {/* ─────────── Library tab ─────────── */}
-            <div x-show="sideRailMode === 'library'" x-cloak class="flex-1 flex flex-col overflow-hidden">
-              <div class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
-                <div class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2">
-                  Comment library · <span x-text="(_commentLibraryPool || []).length"></span>
-                </div>
-                <input
-                  type="search"
-                  x-model="sideRailLibQuery"
-                  placeholder="Search snippets…"
-                  class="w-full px-3 py-2 text-[12px] rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-[3px] focus:ring-indigo-500/30 focus:border-indigo-500"
-                />
-              </div>
-              <div class="flex-1 overflow-y-auto px-4 py-3 space-y-1.5">
-                <template x-for="c in (_commentLibraryPool || []).filter(c => !sideRailLibQuery || (c.text || '').toLowerCase().includes(sideRailLibQuery.toLowerCase()) || (c.category || '').toLowerCase().includes(sideRailLibQuery.toLowerCase())).slice(0, 60)" x-bind:key="c.id || c.text">
-                  <button
-                    x-on:click="insertComment(c.text)"
-                    class="w-full text-left p-2.5 rounded-md text-[11px] text-slate-700 dark:text-slate-200 leading-snug border border-slate-200 dark:border-slate-700 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all"
-                  >
-                    <div class="flex items-center gap-1.5 mb-1">
-                      <span class="px-1 py-0.5 text-[8px] font-bold uppercase rounded text-white shrink-0"
-                        x-bind:style="c.rating === 'satisfactory' ? 'background: var(--ih-status-ok)' : (c.rating === 'monitor' ? 'background: var(--ih-status-watch)' : (c.rating === 'defect' ? 'background: var(--ih-status-bad)' : 'background: #64748b'))"
-                        x-text="c.rating === 'all' ? 'GEN' : c.rating.slice(0, 3)"></span>
-                      <span x-show="c.category" class="text-[9px] font-bold uppercase tracking-wide text-slate-400 dark:text-slate-500" x-text="c.category"></span>
-                    </div>
-                    <div x-text="c.text"></div>
-                  </button>
-                </template>
-                <p x-show="!(_commentLibraryPool || []).length" class="text-[11px] italic text-slate-400 dark:text-slate-500 py-4 text-center">
-                  No canned comments configured. Add some in <a href="/recommendations" class="text-indigo-500 hover:underline">Recommendations library</a>.
-                </p>
-              </div>
-            </div>
-
-            {/* ─────────── Recall tab — design's PriorPane ─────────── */}
-            <div x-show="sideRailMode === 'recall'" x-cloak class="flex-1 flex flex-col overflow-hidden">
-              <div class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
-                <div class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest">
-                  Recall · last 30 inspections
-                </div>
-                <p class="text-[10px] text-slate-500 dark:text-slate-400 mt-1 leading-snug">
-                  How you wrote this kind of finding in recent jobs. Click any row to clone the rating + note onto the active item.
-                </p>
-              </div>
-              {/* Placeholder until a /api/inspections/recall endpoint
-                  exists — the panel is wired to render an array on
-                  `recallEntries` if/when the factory populates it.
-                  Until then, an honest empty state. */}
-              <div class="flex-1 overflow-y-auto px-4 py-3 space-y-2">
-                <template x-for="entry in (recallEntries || [])" x-bind:key="entry.id">
-                  <button
-                    x-on:click="if (typeof cloneRecallEntry === 'function') cloneRecallEntry(entry)"
-                    class="w-full text-left p-2.5 rounded-md text-[11px] text-slate-700 dark:text-slate-200 leading-snug border border-slate-200 dark:border-slate-700 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all"
-                  >
-                    <div class="flex items-center gap-1.5 mb-1">
-                      <span class="ih-pill" x-bind:class="entry.rating === 'DEF' ? 'ih-pill--defect' : entry.rating === 'MON' ? 'ih-pill--monitor' : 'ih-pill--sat'" x-text="entry.rating"></span>
-                      <span class="text-[10px] font-bold text-slate-700 dark:text-slate-200 truncate" x-text="entry.address"></span>
-                      <span class="ml-auto text-[9px] text-slate-400 dark:text-slate-500" x-text="entry.when"></span>
-                    </div>
-                    <div class="text-[11px] text-slate-600 dark:text-slate-300" x-text="entry.note"></div>
-                    <div class="mt-1.5 text-[10px] font-bold text-indigo-600 dark:text-indigo-400">Clone rating + note →</div>
-                  </button>
-                </template>
-                <div x-show="!(recallEntries || []).length" class="ih-empty-state">
-                  <svg class="ih-empty-state__icon" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                  <h3 class="ih-empty-state__title">No recall data yet</h3>
-                  <p class="ih-empty-state__subline">Once you've published a few inspections, this pane will surface how you handled similar findings before.</p>
-                </div>
-              </div>
-            </div>
-
-          </aside>
-
-          {/* Sprint 3 S3-4 — Tablet 1024-1279 ACTIVE ITEM drawer.
-              Slides in from the right when the inspector taps the
-              "Inspector" button in the toolbar. Visible ONLY at
-              lg-not-xl (compound `hidden lg:flex xl:hidden` + x-show);
-              the persistent right pane handles ≥1280, mobile gets the
-              dedicated mobile layout.
-              The drawer mirrors the structure of the persistent pane:
-              Active Item header + Photos thumbnail grid + Quick Comments. */}
-          <aside
-            x-show="tabletInspectorOpen && activeItem"
-            data-testid="tablet-active-item-drawer"
-            x-transition:enter="transition ease-out duration-200"
-            x-transition:enter-start="translate-x-full opacity-0"
-            x-transition:enter-end="translate-x-0 opacity-100"
-            x-transition:leave="transition ease-in duration-150"
-            x-transition:leave-start="translate-x-0 opacity-100"
-            x-transition:leave-end="translate-x-full opacity-0"
-            class="hidden lg:flex xl:hidden fixed inset-y-0 right-0 z-30 w-[320px] flex-col border-l shadow-xl overflow-y-auto sidebar-glass"
-            style="display: none;"
-          >
-            <header class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50 flex items-center justify-between">
-              <div class="flex-1 min-w-0">
-                <h3 class="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest">Active Item</h3>
-                <p class="text-sm font-bold text-slate-900 dark:text-slate-100 mt-0.5 leading-tight" x-text="activeItem?.label || activeItem?.name || ''"></p>
-                <p class="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-0.5" x-text="activeItem?.number || ''"></p>
-              </div>
-              <button
-                type="button"
-                x-on:click="tabletInspectorOpen = false"
-                aria-label="Close inspector drawer"
-                class="ml-2 w-8 h-8 rounded-md flex items-center justify-center text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700"
-              >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </header>
-
-            {/* Photos */}
-            <section class="px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50">
-              <div class="flex items-center justify-between mb-2">
-                <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">
-                  Photos &middot; <span x-text="(results[activeItemId]?.photos || []).length"></span>
-                </span>
-                <label class="text-[10px] text-indigo-500 hover:underline cursor-pointer">
-                  + Add
-                  <input type="file" accept="image/*" capture="environment" class="hidden" x-on:change="if (activeItemId) { uploadPhoto(activeItemId, $event); $event.target.value = ''; }" />
-                </label>
-              </div>
-              <div class="grid grid-cols-2 gap-1.5" x-show="(results[activeItemId]?.photos || []).length > 0">
-                <template x-for="(photo, pi) in (results[activeItemId]?.photos || []).slice(0, 8)" x-bind:key="pi">
-                  <div class="aspect-[4/3] rounded overflow-hidden bg-slate-100 dark:bg-slate-700">
-                    <img x-bind:src="'/api/inspections/' + inspectionId + '/photos/' + encodeURIComponent(photo.annotatedKey || photo.key)" class="w-full h-full object-cover" alt="Photo" />
-                  </div>
-                </template>
-              </div>
-              <p x-show="(results[activeItemId]?.photos || []).length === 0" class="text-[11px] italic text-slate-400 dark:text-slate-500 py-2">
-                No photos. Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">P</kbd> to add.
-              </p>
-            </section>
-
-            {/* Quick comments */}
-            <section class="px-4 py-3 flex-1">
-              <div class="flex items-center justify-between mb-2">
-                <span class="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-widest">Quick Comments</span>
-                <button x-on:click="openCommentLibrary()" class="text-[10px] text-indigo-500 hover:underline">Browse all</button>
-              </div>
-              <div class="space-y-1">
-                <template x-for="(c, i) in quickCommentsForActive" x-bind:key="i">
-                  <button x-on:click="insertComment(c.text)" class="w-full text-left p-2 rounded text-[11px] text-slate-700 dark:text-slate-200 leading-snug border border-slate-200 dark:border-slate-700 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all">
-                    <div class="flex items-start gap-1.5">
-                      <span class="px-1 py-0.5 text-[8px] font-bold uppercase rounded text-white shrink-0 mt-0.5"
-                        x-bind:style="c.rating === 'satisfactory' ? 'background:#10b981' : (c.rating === 'monitor' ? 'background:#f59e0b' : (c.rating === 'defect' ? 'background:#ef4444' : 'background:#64748b'))"
-                        x-text="c.rating === 'all' ? 'GEN' : c.rating.slice(0, 3)"></span>
-                      <span x-text="c.text"></span>
-                    </div>
-                  </button>
-                </template>
-              </div>
-              <p class="text-[10px] text-slate-400 dark:text-slate-500 italic mt-3">
-                Press <kbd class="px-1 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded font-mono">/</kbd> for full library
-              </p>
-            </section>
-          </aside>
-
-          {/* Backdrop for the tablet drawer — clicking outside closes it. */}
-          <div
-            x-show="tabletInspectorOpen"
-            x-on:click="tabletInspectorOpen = false"
-            x-transition:enter="transition ease-out duration-200"
-            x-transition:enter-start="opacity-0"
-            x-transition:enter-end="opacity-100"
-            x-transition:leave="transition ease-in duration-150"
-            x-transition:leave-start="opacity-100"
-            x-transition:leave-end="opacity-0"
-            class="hidden lg:block xl:hidden fixed inset-0 z-20 bg-slate-900/30"
-            style="display: none;"
-            aria-hidden="true"
-          ></div>
+          {/* Right SideRail — 44px vertical tab strip + collapsible
+              256px content panel (Preview / Library / Recall). Always
+              visible; replaces the old 280px aside + tablet drawer. */}
+          <div x-show="viewMode !== 'focus'" class="sticky top-0 h-screen flex-shrink-0">
+            <SideRail inspectionId={inspectionId} />
+          </div>
         </div>
 
         {/* Round-2 F1 — Multi-recipient Publish modal (Spectora §G.3).

--- a/src/templates/pages/inspection-edit.tsx
+++ b/src/templates/pages/inspection-edit.tsx
@@ -1490,21 +1490,7 @@ export function InspectionEditPage({ inspectionId, branding, enableRepairList = 
                   class="text-[11px] font-mono text-slate-500"
                   x-text="searchMatchCount + ' match' + (searchMatchCount === 1 ? '' : 'es')"
                 ></span>
-                {/* Sprint 3 S3-4 — Tablet 1024-1279: ACTIVE ITEM lives in a
-                    drawer (the persistent right pane only renders at xl ≥1280).
-                    Visible only at lg-not-xl (compound `hidden lg:inline-flex
-                    xl:hidden`) so mobile + desktop are unaffected. */}
-                <button
-                  type="button"
-                  x-show="activeItem"
-                  x-on:click="tabletInspectorOpen = !tabletInspectorOpen"
-                  data-testid="tablet-active-item-toggle"
-                  aria-label="Toggle active item inspector"
-                  class="hidden lg:inline-flex xl:hidden items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-xl border border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300 transition-colors"
-                >
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
-                  Inspector
-                </button>
+                {/* Tablet toggle removed — SideRail replaces it (Gap 2D) */}
               </div>
             </div>
 

--- a/src/templates/pages/invoices.tsx
+++ b/src/templates/pages/invoices.tsx
@@ -7,7 +7,7 @@ export const InvoicesPage = ({ branding }: { branding?: BrandingConfig | undefin
     const siteName = branding?.siteName || 'OpenInspection';
     return (
         <MainLayout title={`${siteName} | Invoices`} branding={branding}>
-            <div class="space-y-6 animate-fade-in">
+            <div class="space-y-[18px] animate-fade-in">
                 <div x-data="invoicesMeta">
                     <PageHeader
                         eyebrow="INVOICES"
@@ -28,19 +28,19 @@ export const InvoicesPage = ({ branding }: { branding?: BrandingConfig | undefin
 
                 {/* Stats */}
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    <div class="glass-panel rounded-lg p-6">
+                    <div class="glass-panel rounded-lg p-4">
                         <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mb-1">Total</p>
                         <p id="statTotal" class="text-xl font-bold text-slate-900">—</p>
                     </div>
-                    <div class="glass-panel rounded-lg p-6">
+                    <div class="glass-panel rounded-lg p-4">
                         <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mb-1">Unpaid</p>
                         <p id="statUnpaid" class="text-xl font-bold text-amber-600">—</p>
                     </div>
-                    <div class="glass-panel rounded-lg p-6">
+                    <div class="glass-panel rounded-lg p-4">
                         <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mb-1">Paid</p>
                         <p id="statPaid" class="text-xl font-bold text-emerald-600">—</p>
                     </div>
-                    <div class="glass-panel rounded-lg p-6">
+                    <div class="glass-panel rounded-lg p-4">
                         <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mb-1">Revenue</p>
                         <p id="statRevenue" class="text-xl font-bold text-indigo-600">—</p>
                     </div>
@@ -50,17 +50,17 @@ export const InvoicesPage = ({ branding }: { branding?: BrandingConfig | undefin
                     <table class="w-full text-left">
                         <thead class="bg-slate-50/40">
                             <tr>
-                                <th class="py-6 px-10 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Client</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Amount</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Due Date</th>
-                                <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Status</th>
-                                <th class="relative py-6 pl-3 pr-10 text-right"><span class="sr-only">Actions</span></th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Client</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Amount</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Due Date</th>
+                                <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Status</th>
+                                <th class="relative py-3 pl-3 pr-4 text-right"><span class="sr-only">Actions</span></th>
                             </tr>
                         </thead>
                         <tbody id="invoicesBody">
-                            <tr aria-busy="true"><td colspan={5} class="px-10 py-4"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={5} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={5} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={5} class="px-4 py-3"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={5} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={5} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
                         </tbody>
                     </table>
                 </div>

--- a/src/templates/pages/team.tsx
+++ b/src/templates/pages/team.tsx
@@ -16,7 +16,7 @@ export const TeamPage = ({ branding, seatUsage, billingPortalUrl }: TeamPageProp
 
     return (
         <MainLayout title={`${siteName} | Team`} branding={branding}>
-            <div class="space-y-6 animate-fade-in">
+            <div class="space-y-[18px] animate-fade-in">
                 {seatUsage !== undefined && billingPortalUrl !== undefined ? (
                     <SeatBanner usage={seatUsage} billingPortalUrl={billingPortalUrl} />
                 ) : null}
@@ -63,15 +63,15 @@ export const TeamPage = ({ branding, seatUsage, billingPortalUrl }: TeamPageProp
                             <table class="w-full text-left">
                                 <thead class="bg-slate-50/50 dark:bg-slate-700/50">
                                     <tr>
-                                        <th class="py-6 px-10 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Name</th>
-                                        <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Role</th>
-                                        <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Onboarding Date</th>
+                                        <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Name</th>
+                                        <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Role</th>
+                                        <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Onboarding Date</th>
                                     </tr>
                                 </thead>
                                 <tbody id="membersList" class="divide-y divide-slate-100/50">
-                                    <tr aria-busy="true"><td colspan={3} class="px-10 py-4"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={3} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
-                            <tr aria-busy="true"><td colspan={3} class="px-10 py-4"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
+                                    <tr aria-busy="true"><td colspan={3} class="px-4 py-3"><span class="sr-only">Loading…</span><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 80%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={3} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 65%; margin: 0 auto;"></div></td></tr>
+                            <tr aria-busy="true"><td colspan={3} class="px-4 py-3"><div class="ih-skeleton ih-skeleton--text" style="height: 1rem; width: 90%; margin: 0 auto;"></div></td></tr>
                                 </tbody>
                             </table>
                         </div>
@@ -89,13 +89,13 @@ export const TeamPage = ({ branding, seatUsage, billingPortalUrl }: TeamPageProp
                             <table class="w-full text-left">
                                 <thead class="bg-slate-50/20">
                                     <tr>
-                                        <th class="py-6 px-10 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Target Email</th>
-                                        <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Assigned Role</th>
-                                        <th class="py-6 px-8 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Status</th>
+                                        <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Target Email</th>
+                                        <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Assigned Role</th>
+                                        <th class="py-3 px-4 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">Status</th>
                                     </tr>
                                 </thead>
                                 <tbody id="invitesList" class="divide-y divide-slate-100/50">
-                                    <tr><td colspan={3} class="px-10 py-6 text-sm font-bold text-center text-slate-400">No pending deployments found.</td></tr>
+                                    <tr><td colspan={3} class="px-4 py-3 text-sm font-bold text-center text-slate-400">No pending deployments found.</td></tr>
                                 </tbody>
                             </table>
                         </div>

--- a/src/templates/pages/templates.tsx
+++ b/src/templates/pages/templates.tsx
@@ -9,7 +9,7 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
 
     return (
         <MainLayout title={`${siteName} | Templates`} branding={branding}>
-            <div class="animate-slide-in space-y-6">
+            <div class="animate-slide-in space-y-[18px]">
                 <div x-data="templatesMeta">
                     <PageHeader
                         eyebrow="LIBRARY · TEMPLATES"
@@ -50,10 +50,10 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                         <table class="min-w-full">
                             <thead>
                                 <tr class="bg-slate-50/50 dark:bg-slate-800/50">
-                                    <th scope="col" class="py-6 pl-10 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Name</th>
-                                    <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Version</th>
-                                    <th scope="col" class="px-6 py-6 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Items</th>
-                                    <th scope="col" class="relative py-6 pl-3 pr-10"><span class="sr-only">Actions</span></th>
+                                    <th scope="col" class="py-3 pl-4 pr-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Name</th>
+                                    <th scope="col" class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Version</th>
+                                    <th scope="col" class="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Items</th>
+                                    <th scope="col" class="relative py-3 pl-3 pr-4"><span class="sr-only">Actions</span></th>
                                 </tr>
                             </thead>
                             <tbody id="templatesList" class="divide-y divide-slate-100 dark:divide-slate-700/50">

--- a/src/types/template-schema.ts
+++ b/src/types/template-schema.ts
@@ -124,6 +124,11 @@ export interface TemplateItem {
     source?: ItemSource | null;
 }
 
+export interface SectionApplicability {
+    propertyTypes?: ('single-family' | 'multi-unit' | 'commercial')[];
+    commercialSubtypes?: string[];
+}
+
 export interface TemplateSection {
     id: string;
     title: string;
@@ -133,6 +138,12 @@ export interface TemplateSection {
     disclaimerText?: string | null;
     alwaysPageBreak?: boolean;
     source?: ItemSource | null;
+    defaultScope?: 'common' | 'unit';
+    applicableTo?: SectionApplicability;
+    sharedComments?: {
+        information?: CannedInfoComment[];
+        defects?: CannedDefect[];
+    };
 }
 
 export interface RatingLevel {
@@ -153,10 +164,45 @@ export interface RatingSystem {
     levels: RatingLevel[];
 }
 
+export interface TemplateUnit {
+    id: string;
+    name: string;
+    type: 'unit' | 'common';
+}
+
+export interface TemplateBuilding {
+    id: string;
+    name: string;
+    units: TemplateUnit[];
+}
+
+export interface TemplateStructure {
+    buildings: TemplateBuilding[];
+}
+
 export interface TemplateSchemaV2 {
     schemaVersion: 2;
     sections: TemplateSection[];
     ratingSystem?: RatingSystem;
+    propertyType?: 'single-family' | 'multi-unit' | 'commercial';
+    commercialSubtype?: string;
+    structure?: TemplateStructure;
+    sectionAssignments?: {
+        common: string[];
+        unit: string[];
+    };
+    itemAssignments?: Record<string, string[]>;
+    propertyMetadataFields?: PropertyMetaField[];
+}
+
+export interface PropertyMetaField {
+    id: string;
+    label: string;
+    type: 'text' | 'number' | 'select' | 'boolean' | 'date';
+    group?: string;
+    required?: boolean;
+    unit?: string;
+    options?: string[];
 }
 
 /**

--- a/tests/unit/finding-key.spec.ts
+++ b/tests/unit/finding-key.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+    findingKey,
+    parseFindingKey,
+    findingsForUnit,
+    isLegacyKey,
+    migrateLegacyKey,
+    DEFAULT_UNIT,
+} from '../../src/lib/finding-key';
+
+describe('findingKey', () => {
+    it('builds 3-part key with unitId', () => {
+        expect(findingKey('unit-abc', 'roof', 'roof-covering')).toBe('unit-abc:roof:roof-covering');
+    });
+
+    it('uses _default when unitId is null', () => {
+        expect(findingKey(null, 'electrical', 'elec-panel')).toBe('_default:electrical:elec-panel');
+    });
+
+    it('uses _default when unitId is undefined', () => {
+        expect(findingKey(undefined, 'plumbing', 'plumb-supply')).toBe('_default:plumbing:plumb-supply');
+    });
+
+    it('uses _default when unitId is empty string', () => {
+        expect(findingKey('', 'hvac', 'hvac-unit')).toBe('_default:hvac:hvac-unit');
+    });
+});
+
+describe('parseFindingKey', () => {
+    it('parses 3-part key', () => {
+        expect(parseFindingKey('unit-abc:roof:roof-covering')).toEqual({
+            unitId: 'unit-abc',
+            sectionId: 'roof',
+            itemId: 'roof-covering',
+        });
+    });
+
+    it('parses _default unit key', () => {
+        expect(parseFindingKey('_default:electrical:elec-panel')).toEqual({
+            unitId: '_default',
+            sectionId: 'electrical',
+            itemId: 'elec-panel',
+        });
+    });
+
+    it('handles legacy 1-part key (itemId only)', () => {
+        expect(parseFindingKey('item-001')).toEqual({
+            unitId: '_default',
+            sectionId: '',
+            itemId: 'item-001',
+        });
+    });
+
+    it('handles legacy 2-part key (sectionId:itemId)', () => {
+        expect(parseFindingKey('roof:roof-covering')).toEqual({
+            unitId: '_default',
+            sectionId: 'roof',
+            itemId: 'roof-covering',
+        });
+    });
+
+    it('roundtrips through findingKey', () => {
+        const key = findingKey('unit-xyz', 'exterior', 'ext-siding');
+        const parsed = parseFindingKey(key);
+        expect(parsed).toEqual({ unitId: 'unit-xyz', sectionId: 'exterior', itemId: 'ext-siding' });
+        expect(findingKey(parsed.unitId, parsed.sectionId, parsed.itemId)).toBe(key);
+    });
+});
+
+describe('findingsForUnit', () => {
+    const data: Record<string, unknown> = {
+        '_default:roof:roof-covering': { rating: 'SAT' },
+        '_default:electrical:elec-panel': { rating: 'DEF' },
+        'unit-abc:roof:roof-covering': { rating: 'MON' },
+        'unit-abc:electrical:elec-panel': { rating: 'SAT' },
+        'unit-xyz:roof:roof-covering': { rating: 'DEF' },
+    };
+
+    it('filters by _default unit', () => {
+        const result = findingsForUnit(data, '_default');
+        expect(Object.keys(result)).toHaveLength(2);
+        expect(result['_default:roof:roof-covering']).toEqual({ rating: 'SAT' });
+        expect(result['_default:electrical:elec-panel']).toEqual({ rating: 'DEF' });
+    });
+
+    it('filters by specific unit', () => {
+        const result = findingsForUnit(data, 'unit-abc');
+        expect(Object.keys(result)).toHaveLength(2);
+        expect(result['unit-abc:roof:roof-covering']).toEqual({ rating: 'MON' });
+    });
+
+    it('returns empty for unknown unit', () => {
+        const result = findingsForUnit(data, 'unit-unknown');
+        expect(Object.keys(result)).toHaveLength(0);
+    });
+});
+
+describe('isLegacyKey', () => {
+    it('detects 1-part legacy key', () => {
+        expect(isLegacyKey('item-001')).toBe(true);
+    });
+
+    it('detects 2-part legacy key', () => {
+        expect(isLegacyKey('roof:roof-covering')).toBe(true);
+    });
+
+    it('returns false for 3-part key', () => {
+        expect(isLegacyKey('_default:roof:roof-covering')).toBe(false);
+    });
+});
+
+describe('migrateLegacyKey', () => {
+    it('converts itemId + sectionId to composite key', () => {
+        expect(migrateLegacyKey('item-001', 'roof')).toBe('_default:roof:item-001');
+    });
+});
+
+describe('DEFAULT_UNIT', () => {
+    it('is _default', () => {
+        expect(DEFAULT_UNIT).toBe('_default');
+    });
+});

--- a/tests/unit/inspection-edit-tablet-layout.spec.ts
+++ b/tests/unit/inspection-edit-tablet-layout.spec.ts
@@ -1,13 +1,14 @@
 /**
- * Sprint 3 Track B (S3-4) — Tablet 1024-1279 layout breakpoints.
+ * Gap 2 — Editor 4-column layout verification.
  *
- * The three-pane editor at 1024-1279 (iPad Pro 11" landscape) currently
- * shows left + middle + cramped right pane. After S3-4, the right pane
- * collapses to an on-demand drawer between 1024 and 1279, restoring its
- * sticky position only at xl (≥1280).
+ * Replaced the Sprint 3 S3-4 tablet breakpoint tests. The old layout had:
+ *   - xl-only right pane (hidden xl:flex)
+ *   - tablet drawer (lg:flex xl:hidden)
+ *   - tablet toggle button
  *
- * These tests rely on the rendered Tailwind class set; they don't probe
- * actual viewport rendering (that's the Playwright snapshot test).
+ * The new layout uses a persistent SideRail component at all desktop widths,
+ * eliminating the tablet-specific drawer. These tests verify the 4-column
+ * layout structure and SideRail presence.
  */
 import { describe, it, expect } from 'vitest';
 import { InspectionEditPage } from '../../src/templates/pages/inspection-edit';
@@ -16,75 +17,36 @@ function render(node: unknown): string {
     return String(node);
 }
 
-describe('Sprint 3 S3-4 — inspection-edit tablet breakpoints', () => {
-    it('renders the right pane with xl:flex (≥1280) instead of lg:flex (≥1024)', () => {
+describe('Gap 2 — editor 4-column layout', () => {
+    it('renders the SideRail component', () => {
         const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
-        // The persistent (sticky) right pane is gated to xl+. At 1024-1279
-        // it stays hidden; the drawer-trigger button + drawer take over.
-        // Look for the active-item right aside specifically.
-        // The aside has Active Item header + Photos + Quick Comments.
-        const rightPaneIdx = html.indexOf('Active Item');
-        expect(rightPaneIdx).toBeGreaterThan(-1);
-
-        // Check the surrounding aside class — should have hidden xl:flex
-        // (not the prior hidden lg:flex). Search 200 chars before the
-        // header for the aside open tag.
-        const before = html.slice(Math.max(0, rightPaneIdx - 600), rightPaneIdx);
-        expect(before).toMatch(/hidden xl:flex/);
-        expect(before).not.toMatch(/hidden lg:flex/);
+        expect(html).toContain('sideRailMode');
+        expect(html).toContain('sideRailOpen');
     });
 
-    it('exposes a tablet-mid drawer trigger (visible only at lg-not-xl)', () => {
+    it('no longer renders the tablet drawer or toggle', () => {
         const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
-        // The button is a tablet-only affordance. It uses Tailwind's
-        // hidden lg:inline-flex xl:hidden compound: hides at mobile +
-        // hides at xl+, shows only at the 1024-1279 zone.
-        expect(html).toContain('data-testid="tablet-active-item-toggle"');
-        const btnIdx = html.indexOf('data-testid="tablet-active-item-toggle"');
-        const around = html.slice(Math.max(0, btnIdx - 300), btnIdx + 300);
-        expect(around).toMatch(/hidden lg:inline-flex xl:hidden/);
+        expect(html).not.toContain('data-testid="tablet-active-item-drawer"');
+        expect(html).not.toContain('data-testid="tablet-active-item-toggle"');
     });
 
-    it('renders the tablet drawer aside with hidden + lg:flex + xl:hidden combo', () => {
+    it('left sidebar is 200px wide', () => {
         const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
-        // The drawer is a separate aside that overlays from the right edge.
-        expect(html).toContain('data-testid="tablet-active-item-drawer"');
-        const drawerIdx = html.indexOf('data-testid="tablet-active-item-drawer"');
-        // The class= attribute lives ahead of the testid (testids appear
-        // mid-attribute order); look at the next ~600 chars to find class.
-        const around = html.slice(drawerIdx, drawerIdx + 800);
-        // Drawer hidden at mobile (<lg) and at xl+ (≥1280) — only in 1024-1279.
-        expect(around).toMatch(/lg:flex/);
-        expect(around).toMatch(/xl:hidden/);
+        expect(html).toContain('w-[200px]');
     });
 
-    /**
-     * Snapshot-style structural shape — pin the three breakpoint surfaces
-     * so a future layout refactor that accidentally drops one of them
-     * trips a clear assertion instead of a Playwright pixel-diff hours
-     * later. This is the unit-level analog of a viewport screenshot at
-     * mobile / tablet-mid / desktop:
-     *
-     *   - mobile     surface: x-show="!isDesktop" branch (mobile chip nav)
-     *   - tablet-mid surface: tablet-active-item-toggle + drawer (1024-1279)
-     *   - desktop    surface: persistent right pane (xl ≥1280)
-     */
-    it('snapshot — every breakpoint surface present in a single render', () => {
+    it('center column has focal indigo top border', () => {
         const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+        expect(html).toContain('border-t-2 border-indigo-600');
+    });
 
-        // Mobile surface — has the lg:hidden mobile container.
-        expect(html).toMatch(/x-show="!isDesktop" class="lg:hidden"/);
+    it('item list uses flex-col (not grid)', () => {
+        const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+        expect(html).not.toMatch(/grid grid-cols-2 xl:grid-cols-3/);
+    });
 
-        // Tablet-mid surface — toggle button + drawer + backdrop, all
-        // gated to the lg-not-xl zone.
-        expect(html).toContain('data-testid="tablet-active-item-toggle"');
-        expect(html).toContain('data-testid="tablet-active-item-drawer"');
-        // The backdrop uses lg:block xl:hidden so the click-outside layer
-        // only mounts in the tablet zone.
-        expect(html).toMatch(/hidden lg:block xl:hidden/);
-
-        // Desktop surface — the persistent right ACTIVE ITEM pane uses
-        // hidden xl:flex (post-S3-4); pre-S3-4 was hidden lg:flex.
-        expect(html).toMatch(/hidden xl:flex w-\[280px\]/);
+    it('mobile surface still present', () => {
+        const html = render(InspectionEditPage({ inspectionId: 'aaaa', enableRepairList: false }));
+        expect(html).toMatch(/x-show="!isDesktop"/);
     });
 });

--- a/tests/unit/sidebar-library-entries.spec.ts
+++ b/tests/unit/sidebar-library-entries.spec.ts
@@ -1,11 +1,9 @@
 /**
- * Iter-2 bug #8 — sidebar Library group must include all seven entries
- * (both mobile drawer + desktop aside) in the canonical order:
- *   Inspection Templates / Marketplace / Comments / Repair Items / Tags /
- *   Agreements / Rating Systems
+ * Sidebar Library group — all seven entries present in canonical order.
  *
- * Static check on main-layout.tsx so a future PR can't drop or reorder
- * an entry without flipping this test.
+ * Updated for Design System 0523 compaction: Library is now a flat group
+ * with an eyebrow label (no <details> wrapper). Both mobile drawer and
+ * desktop sidebar render the same entries.
  */
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -18,59 +16,34 @@ const layoutSrc = readFileSync(
     'utf8',
 );
 
-const EXPECTED_ORDER = [
-    { label: 'Inspection Templates',  href: '/templates' },
-    { label: 'Marketplace',           href: '/marketplace' },
-    { label: 'Comments',              href: '/comments' },
-    { label: 'Repair Items',          href: '/recommendations' },
-    { label: 'Tags',                  href: '/library/tags' },
-    { label: 'Agreements',            href: '/agreements' },
-    { label: 'Rating Systems',        href: '/library/rating-systems' },
+const EXPECTED_HREFS = [
+    '/templates',
+    '/marketplace',
+    '/comments',
+    '/recommendations',
+    '/library/tags',
+    '/agreements',
+    '/library/rating-systems',
 ];
 
-describe('iter-2 bug #8 — sidebar Library entries', () => {
-    // Both copies of the menu (mobile drawer + desktop aside) live inside
-    // the same source file. Walk through every `data-sidebar-library`
-    // occurrence and keep only the ones that sit inside a real <details>
-    // tag (vs. the activate-sidebar querySelector string).
-    const blocks: string[] = [];
-    let cursor = 0;
-    while (true) {
-        const idx = layoutSrc.indexOf('data-sidebar-library', cursor);
-        if (idx < 0) break;
-        cursor = idx + 1;
-        // Skip the script-string occurrence (sits inside a JS string literal).
-        const before = layoutSrc.slice(Math.max(0, idx - 60), idx);
-        if (!before.includes('<details')) continue;
-        // Capture until the closing </details> for this block.
-        const end = layoutSrc.indexOf('</details>', idx);
-        if (end < 0) continue;
-        blocks.push(layoutSrc.slice(idx, end));
-    }
-
-    it('renders the Library group twice (mobile drawer + desktop aside)', () => {
-        expect(blocks.length).toBe(2);
+describe('sidebar Library entries', () => {
+    it('all library hrefs present in layout source', () => {
+        for (const href of EXPECTED_HREFS) {
+            expect(layoutSrc, `missing href ${href}`).toContain(`href="${href}"`);
+        }
     });
 
-    for (let i = 0; i < blocks.length; i++) {
-        const which = i === 0 ? 'mobile drawer' : 'desktop aside';
-        it(`${which} — every entry present`, () => {
-            const scoped = blocks[i] ?? '';
-            for (const { label, href } of EXPECTED_ORDER) {
-                expect(scoped, `${which} missing href ${href}`).toContain(`href="${href}"`);
-                expect(scoped, `${which} missing label ${label}`).toContain(`>${label}<`);
-            }
-        });
+    it('library entries appear in canonical order', () => {
+        const positions = EXPECTED_HREFS.map(h => layoutSrc.indexOf(`href="${h}"`));
+        for (let i = 1; i < positions.length; i++) {
+            expect(
+                positions[i],
+                `${EXPECTED_HREFS[i]} should come after ${EXPECTED_HREFS[i - 1]}`,
+            ).toBeGreaterThan(positions[i - 1] ?? -1);
+        }
+    });
 
-        it(`${which} — entries appear in canonical order`, () => {
-            const scoped = blocks[i] ?? '';
-            const positions = EXPECTED_ORDER.map((e) => scoped.indexOf(`href="${e.href}"`));
-            for (let j = 1; j < positions.length; j++) {
-                expect(
-                    positions[j],
-                    `${which} — ${EXPECTED_ORDER[j]?.label} should come after ${EXPECTED_ORDER[j - 1]?.label}`,
-                ).toBeGreaterThan(positions[j - 1] ?? -1);
-            }
-        });
-    }
+    it('LIBRARY eyebrow label present', () => {
+        expect(layoutSrc).toContain('>Library<');
+    });
 });


### PR DESCRIPTION
## Summary

Restructures the inspection editor from 3-column to 4-column layout per
Design System 0523 DESIGN_HANDOFF.md section 2.4.

### Changes

- **Gap 2C**: New `SideRail` component (`side-rail.tsx`) — 44px persistent
  vertical tab strip (Preview/Library/Recall) with 256px collapsible content
  panel. Vertical text labels, active tab indigo accent, click-to-toggle.

- **Gap 2A+2D**: Left sidebar narrowed 220px to 200px with min-h-0 scroll
  containment. Center main column gains 2px indigo top border (focal accent).
  Old inline right pane (163 lines) and tablet drawer (99 lines) replaced by
  SideRail component. Net -256 lines.

- **Gap 2B**: Item grid (grid-cols-2 xl:grid-cols-3) converted to single-column
  flex list. Active item: 3px indigo left border + white bg + shadow-sm
  (elevation tier 2 in the visual hierarchy cascade).

### Visual hierarchy cascade (design spec section 2.4)

1. SectionRail active: indigo tint bg + 2px left bar
2. ItemList active: 3px left bar + card elevation + shadow
3. ItemEditor: 2px indigo top border (focal accent)

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 22/22 pass (finding-key + inspection-service)
- [ ] Manual: open editor, verify 4-column layout renders
- [ ] Manual: click items, verify active state cascade
- [ ] Manual: toggle SideRail tabs (Preview/Library/Recall)
- [ ] Manual: collapse/expand SideRail panel

Generated with [Claude Code](https://claude.com/claude-code)