### PR TITLE
feat: FIELD placeholder system + publish gate (Gap 4)

### DIFF
--- a/public/js/editor-fields.js
+++ b/public/js/editor-fields.js
@@ -1,0 +1,70 @@
+/**
+ * Gap 4A — FIELD placeholder vocabulary + Tab cycling.
+ *
+ * Loaded sync in inspection-edit so the textarea keydown handler
+ * can intercept Tab/Shift+Tab to cycle through [FIELD] placeholders.
+ *
+ * Usage:
+ *   OIFields.FIELD_RE          — regex matching [A-Z_]+ placeholders
+ *   OIFields.VOCABULARY        — array of {tag, hint} entries
+ *   OIFields.findOpenFields(text) — returns [{tag, index, length}]
+ *   OIFields.hasOpenFields(text)  — boolean shortcut
+ *   OIFields.cycleField(textarea, reverse) — Tab/Shift+Tab jump
+ */
+(function () {
+    'use strict';
+
+    var FIELD_RE = /\[[A-Z_]+\]/g;
+
+    var VOCABULARY = [
+        { tag: 'LOCATION',  hint: 'Where in the home — e.g. "north bathroom ceiling", "slot 14"' },
+        { tag: 'DEADLINE',  hint: 'Date or event by which repair is needed — e.g. "close of escrow"' },
+        { tag: 'TIMEFRAME', hint: 'Maintenance window — e.g. "next 12 months"' },
+        { tag: 'N',         hint: 'Numeric count — e.g. "2", "4 of 6"' },
+    ];
+
+    function findOpenFields(text) {
+        if (!text) return [];
+        var results = [];
+        var m;
+        FIELD_RE.lastIndex = 0;
+        while ((m = FIELD_RE.exec(text)) !== null) {
+            results.push({ tag: m[0].slice(1, -1), index: m.index, length: m[0].length });
+        }
+        return results;
+    }
+
+    function hasOpenFields(text) {
+        FIELD_RE.lastIndex = 0;
+        return FIELD_RE.test(text);
+    }
+
+    function cycleField(textarea, reverse) {
+        var text = textarea.value;
+        var fields = findOpenFields(text);
+        if (fields.length === 0) return false;
+
+        var cur = textarea.selectionEnd;
+        var target;
+
+        if (reverse) {
+            var candidates = fields.filter(function (f) { return f.index < cur - 1; });
+            target = candidates.length > 0 ? candidates[candidates.length - 1] : fields[fields.length - 1];
+        } else {
+            var forward = fields.filter(function (f) { return f.index >= cur; });
+            target = forward.length > 0 ? forward[0] : fields[0];
+        }
+
+        textarea.focus();
+        textarea.setSelectionRange(target.index, target.index + target.length);
+        return true;
+    }
+
+    window.OIFields = {
+        FIELD_RE: FIELD_RE,
+        VOCABULARY: VOCABULARY,
+        findOpenFields: findOpenFields,
+        hasOpenFields: hasOpenFields,
+        cycleField: cycleField,
+    };
+})();

--- a/public/js/preflight.js
+++ b/public/js/preflight.js
@@ -14,6 +14,7 @@
                 apprenticeReviewed: false, apprenticePending: 0,
                 propertyFactsComplete: false, missingFacts: [],
                 coverPhotoSet: false, agreementSigned: false,
+                noOpenFields: true, openFieldCount: 0,
             },
             loading: false,
             error: '',
@@ -22,7 +23,7 @@
                 const c = this.checks;
                 return c.allRated && c.apprenticeReviewed
                     && c.propertyFactsComplete && c.coverPhotoSet
-                    && c.agreementSigned;
+                    && c.agreementSigned && c.noOpenFields;
             },
 
             async init() {

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -34,6 +34,7 @@ export interface PreflightInspectionInput {
 export interface PreflightItem {
     rating?: unknown;
     value?:  unknown;
+    notes?:  string;
 }
 
 export interface PreflightResult {
@@ -45,6 +46,8 @@ export interface PreflightResult {
     missingFacts:          string[];
     coverPhotoSet:         boolean;
     agreementSigned:       boolean;
+    noOpenFields:          boolean;
+    openFieldCount:        number;
 }
 
 export function computePreflightFromData(
@@ -65,6 +68,15 @@ export function computePreflightFromData(
     // Subsystem C dependency — when the count is undefined the
     // apprentice_reviews table is presumed absent and the gate passes.
     const pending = pendingApprenticeCount ?? 0;
+    const FIELD_RE = /\[[A-Z_]+\]/g;
+    let openFieldCount = 0;
+    for (const item of entries) {
+        if (typeof item.notes === 'string') {
+            const matches = item.notes.match(FIELD_RE);
+            if (matches) openFieldCount += matches.length;
+        }
+    }
+
     return {
         allRated,
         unratedCount,
@@ -74,5 +86,7 @@ export function computePreflightFromData(
         missingFacts,
         coverPhotoSet:         inspection.coverPhotoId != null,
         agreementSigned:       inspection.agreementSignedAt != null,
+        noOpenFields:          openFieldCount === 0,
+        openFieldCount,
     };
 }

--- a/src/templates/components/fields-to-fill.tsx
+++ b/src/templates/components/fields-to-fill.tsx
@@ -1,0 +1,44 @@
+/**
+ * Gap 4B — Fields-to-fill chip bar.
+ *
+ * Appears below the comment textarea when the note contains unresolved
+ * [FIELD] placeholders. Each chip is clickable → focuses textarea and
+ * selects that placeholder. Shows Tab/Shift+Tab cycling hint.
+ *
+ * Alpine reads from parent inspectionEditor:
+ *   activeItemNote — the current note text
+ *   OIFields.findOpenFields() — parses placeholders
+ *
+ * Visibility: x-show="OIFields.hasOpenFields(activeItemNote)"
+ */
+import type { FC } from 'hono/jsx';
+
+export const FieldsToFill: FC = () => (
+    <div
+        x-show="typeof OIFields !== 'undefined' && OIFields.hasOpenFields(getItemNotes(activeItemId))"
+        x-cloak
+        class="flex flex-wrap items-center gap-2 px-2.5 py-2 rounded-lg border border-dashed"
+        style="border-color: var(--ih-primary, #6366f1); background: var(--ih-primary-tint, rgba(99,102,241,0.1));"
+    >
+        <span class="ih-eyebrow flex-shrink-0" style="color: var(--ih-primary, #6366f1);">
+            Fields to fill
+        </span>
+
+        <template
+            x-for="(f, i) in (typeof OIFields !== 'undefined' ? OIFields.findOpenFields(getItemNotes(activeItemId)) : [])"
+            {...{ 'x-bind:key': 'f.tag + i' }}
+        >
+            <button
+                type="button"
+                {...{ 'x-on:click': "jumpToField(f.index, f.length)" }}
+                class="inline-flex items-center px-1.5 py-0.5 rounded border border-dashed text-[11px] font-mono font-bold cursor-pointer transition-colors"
+                style="border-color: var(--ih-primary, #6366f1); color: var(--ih-primary, #6366f1); background: var(--ih-primary-tint, rgba(99,102,241,0.1));"
+                x-text="'[' + f.tag + ']'"
+            ></button>
+        </template>
+
+        <span class="ml-auto text-[10px] text-slate-400 dark:text-slate-500 flex-shrink-0">
+            <kbd class="ih-kbd">Tab</kbd> next · <kbd class="ih-kbd">⇧Tab</kbd> prev
+        </span>
+    </div>
+);

--- a/src/templates/components/preflight-checks.tsx
+++ b/src/templates/components/preflight-checks.tsx
@@ -71,6 +71,9 @@ export const PreflightChecks: FC = () => (
                 action={{ kind: 'dispatch', event: 'open-cover-photo-picker', label: 'Set →' }} />
             <CheckRow passed="checks.agreementSigned" label="Buyer agreement signed"
                 action={{ kind: 'dispatch', event: 'open-agreement-flow', label: 'Send →' }} />
+            <CheckRow passed="checks.noOpenFields" label="No unresolved [FIELD] placeholders"
+                detail="checks.openFieldCount + ' placeholder' + (checks.openFieldCount === 1 ? '' : 's')"
+                action={{ kind: 'dispatch', event: 'scroll-to-first-open-field', label: 'Fix →' }} />
         </ul>
 
         <span x-show="loading" aria-busy="true" class="inline-block ih-skeleton ih-skeleton--text" style="width: 4rem; height: 0.875rem; vertical-align: middle;"><span class="sr-only">Loading…</span></span>

--- a/tests/unit/editor-fields.spec.ts
+++ b/tests/unit/editor-fields.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(__dirname, '../../public/js/editor-fields.js'), 'utf8');
+
+let OIFields: {
+    FIELD_RE: RegExp;
+    VOCABULARY: Array<{ tag: string; hint: string }>;
+    findOpenFields: (text: string) => Array<{ tag: string; index: number; length: number }>;
+    hasOpenFields: (text: string) => boolean;
+};
+
+beforeAll(() => {
+    const window: Record<string, unknown> = {};
+    const fn = new Function('window', src);
+    fn(window);
+    OIFields = window.OIFields as typeof OIFields;
+});
+
+describe('OIFields.VOCABULARY', () => {
+    it('has 4 entries', () => {
+        expect(OIFields.VOCABULARY).toHaveLength(4);
+    });
+
+    it('includes LOCATION, DEADLINE, TIMEFRAME, N', () => {
+        const tags = OIFields.VOCABULARY.map(v => v.tag);
+        expect(tags).toContain('LOCATION');
+        expect(tags).toContain('DEADLINE');
+        expect(tags).toContain('TIMEFRAME');
+        expect(tags).toContain('N');
+    });
+});
+
+describe('OIFields.findOpenFields', () => {
+    it('finds placeholders in text', () => {
+        const text = 'Leak at [LOCATION], repair within [TIMEFRAME].';
+        const fields = OIFields.findOpenFields(text);
+        expect(fields).toHaveLength(2);
+        expect(fields[0].tag).toBe('LOCATION');
+        expect(fields[1].tag).toBe('TIMEFRAME');
+    });
+
+    it('returns empty for text without placeholders', () => {
+        expect(OIFields.findOpenFields('No fields here.')).toHaveLength(0);
+    });
+
+    it('returns empty for null/empty', () => {
+        expect(OIFields.findOpenFields('')).toHaveLength(0);
+        expect(OIFields.findOpenFields(null as unknown as string)).toHaveLength(0);
+    });
+
+    it('captures index and length', () => {
+        const text = 'Found [N] issues.';
+        const fields = OIFields.findOpenFields(text);
+        expect(fields[0].index).toBe(6);
+        expect(fields[0].length).toBe(3);
+    });
+
+    it('finds multiple occurrences of same placeholder', () => {
+        const text = '[LOCATION] to [LOCATION]';
+        const fields = OIFields.findOpenFields(text);
+        expect(fields).toHaveLength(2);
+    });
+});
+
+describe('OIFields.hasOpenFields', () => {
+    it('returns true when placeholders exist', () => {
+        expect(OIFields.hasOpenFields('Fix [LOCATION] soon.')).toBe(true);
+    });
+
+    it('returns false when no placeholders', () => {
+        expect(OIFields.hasOpenFields('All clear.')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Implements the FIELD placeholder system per Design System 0523
DESIGN_HANDOFF sections 17.2, 17.4–17.6, and 18.

### Changes

- **Gap 4A** (`editor-fields.js`): `OIFields` global with `FIELD_RE`,
  `VOCABULARY` (LOCATION/DEADLINE/TIMEFRAME/N), `findOpenFields()`,
  `hasOpenFields()`, `cycleField()` for Tab/Shift+Tab. 9 unit tests.

- **Gap 4B** (`fields-to-fill.tsx`): Chip bar below textarea when note
  contains `[FIELD]` placeholders. Clickable chips jump to placeholder.
  Tab/Shift+Tab hint. Dashed indigo border + primary tint bg.

- **Gap 4C** (preflight): 6th publish gate `noOpenFields` — scans all
  item notes for unresolved `[FIELD]` placeholders. Blocks publish
  until all resolved. Server (`preflight.ts`) + client (`preflight.js`)
  + UI (`preflight-checks.tsx`).

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 171 passed, 1238 tests, 0 failures
- [ ] Manual: insert snippet with [LOCATION], verify chip bar appears
- [ ] Manual: Tab cycles through placeholders
- [ ] Manual: try to publish with open fields, verify gate blocks

Generated with [Claude Code](https://claude.com/claude-code)