### PR TITLE
feat: P1 enhancements — Icon system + Card view + Batch rating (Gap 6+7+8)

### DIFF
--- a/public/js/inspection-edit.js
+++ b/public/js/inspection-edit.js
@@ -2258,7 +2258,22 @@ function inspectionEditor(inspectionId) {
     },
 
     toggleBatchSelect(itemId) {
-      this.batchSelected[itemId] = !this.batchSelected[itemId];
+      if (window.event?.shiftKey && this._lastBatchClicked) {
+        // Range select: find indices of _lastBatchClicked and itemId in currentSectionItems
+        var items = this.currentSectionItems;
+        var startIdx = items.findIndex(function(i) { return i.id === this._lastBatchClicked; }.bind(this));
+        var endIdx = items.findIndex(function(i) { return i.id === itemId; });
+        if (startIdx >= 0 && endIdx >= 0) {
+          var lo = startIdx < endIdx ? startIdx : endIdx;
+          var hi = startIdx < endIdx ? endIdx : startIdx;
+          for (var i = lo; i <= hi; i++) {
+            this.batchSelected[items[i].id] = true;
+          }
+        }
+      } else {
+        this.batchSelected[itemId] = !this.batchSelected[itemId];
+      }
+      this._lastBatchClicked = itemId;
     },
 
     batchSelectAll() {
@@ -2269,14 +2284,35 @@ function inspectionEditor(inspectionId) {
     },
 
     batchSetRating(levelId) {
+      var self = this;
       var items = this.currentSectionItems;
+      var priorRatings = {};
+      var count = 0;
       for (var i = 0; i < items.length; i++) {
         if (this.batchSelected[items[i].id]) {
+          var r = this._getResult(items[i].id);
+          priorRatings[items[i].id] = r ? r.rating : null;
           this.setRating(items[i].id, levelId);
+          count++;
         }
       }
       this.batchMode = false;
       this.batchSelected = {};
+      if (count > 0 && typeof showToast === 'function') {
+        var prev = Object.assign({}, priorRatings);
+        showToast('Rated ' + count + ' items as ' + levelId, false, {
+          undoLabel: 'Undo',
+          undoFn: function() {
+            for (var id in prev) {
+              var fk = self._fk(id);
+              if (self.results[fk]) self.results[fk].rating = prev[id];
+              if (self.results[id]) self.results[id].rating = prev[id];
+            }
+            self.debounceSave();
+            showToast('Undone');
+          }
+        });
+      }
     },
 
     debounceSave() {

--- a/public/js/templates.js
+++ b/public/js/templates.js
@@ -105,6 +105,7 @@ function renderTemplates() {
               </div>
             </td>
           </tr>`;
+        renderCardGrid();
         return;
     }
     tbody.innerHTML = allTemplates.map(t => {
@@ -126,7 +127,7 @@ function renderTemplates() {
               </div>
             </td>
             <td class="px-6 py-6">
-              <span class="inline-flex items-center rounded-lg border border-indigo-100 dark:border-indigo-800 px-3 py-1 text-[10px] font-bold uppercase tracking-widest bg-indigo-50/50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">v${t.version}.0</span>
+              <button onclick="openHistoryModal('${t.id}', '${t.name.replace(/'/g, "\\'")}')" class="inline-flex items-center rounded-lg border border-indigo-100 dark:border-indigo-800 px-3 py-1 text-[10px] font-bold uppercase tracking-widest bg-indigo-50/50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors cursor-pointer" title="View edit history">v${t.version}.0</button>
             </td>
             <td class="px-6 py-6 text-sm text-slate-500 font-bold">${itemCount} items</td>
             <td class="py-6 pl-3 pr-10 text-right">
@@ -143,6 +144,94 @@ function renderTemplates() {
             </td>
           </tr>`;
     }).join('');
+    renderCardGrid();
+}
+
+// ─── Card grid view ────────────────────────────────────────────────────────────
+function renderCardGrid() {
+    const grid = document.getElementById('templatesCardGrid');
+    if (!grid) return;
+
+    if (allTemplates.length === 0) {
+        grid.innerHTML = `
+          <div class="col-span-full py-32 text-center">
+            <div class="flex flex-col items-center gap-6">
+              <div class="w-20 h-20 rounded-lg bg-indigo-50 dark:bg-indigo-950 flex items-center justify-center">
+                <svg class="w-10 h-10 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+              </div>
+              <div>
+                <p class="text-lg font-bold text-slate-900 dark:text-slate-100 tracking-tight">No templates yet</p>
+                <p class="text-sm text-slate-400 font-medium mt-1">Create a checklist template for your inspections.</p>
+              </div>
+              <button onclick="showCreateModal()" class="px-6 py-3 rounded-xl bg-indigo-600 text-white text-xs font-bold uppercase tracking-widest hover:bg-slate-900 transition-all active:scale-95">New Template</button>
+            </div>
+          </div>`;
+        return;
+    }
+
+    grid.innerHTML = allTemplates.map(t => {
+        const itemCount = t.itemCount ?? countSchemaItems(t.schema);
+        const desc = t.description ? `<p class="text-[11px] text-slate-500 dark:text-slate-400 line-clamp-2 mt-1">${t.description}</p>` : '';
+        const usedCount = t.usageCount ?? 0;
+        return `
+          <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 flex flex-col gap-2 hover:border-indigo-300 dark:hover:border-indigo-700 transition-colors">
+            <div>
+              <a href="/templates/${t.id}/edit" class="text-[14px] font-bold text-slate-900 dark:text-slate-100 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">${t.name}</a>
+              ${desc}
+            </div>
+            <div class="flex items-center gap-2 text-[10px] font-mono text-slate-400 dark:text-slate-500">
+              <button onclick="openHistoryModal('${t.id}', '${t.name.replace(/'/g, "\\'")}')" class="inline-flex items-center rounded border border-indigo-100 dark:border-indigo-800 px-1.5 py-0.5 bg-indigo-50/50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors cursor-pointer" title="View edit history">v${t.version}.0</button>
+              <span>${itemCount} items</span>
+              <span>used ${usedCount}&times;</span>
+            </div>
+            <div class="flex items-center gap-3 pt-1 border-t border-slate-100 dark:border-slate-700 mt-auto">
+              <a href="/templates/${t.id}/edit" class="text-[11px] font-bold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors">Edit</a>
+              <button onclick="duplicateTemplate('${t.id}')" class="text-[11px] font-bold text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Duplicate</button>
+              <button onclick="deleteTemplate('${t.id}')" class="text-[11px] font-bold text-slate-400 dark:text-slate-500 hover:text-red-500 transition-colors ml-auto">Disable</button>
+            </div>
+          </div>`;
+    }).join('');
+}
+
+// ─── History modal helper ──────────────────────────────────────────────────────
+function openHistoryModal(templateId, templateName) {
+    const el = document.querySelector('.animate-slide-in');
+    if (el && window.Alpine) {
+        const data = window.Alpine.$data(el);
+        if (data) {
+            data.showHistoryId = templateId;
+            data.showHistoryName = templateName;
+        }
+    }
+}
+
+// ─── Duplicate template ────────────────────────────────────────────────────────
+async function duplicateTemplate(id) {
+    const t = allTemplates.find(x => x.id === id);
+    if (!t) return;
+    const newName = (t.name || 'Template') + ' (Copy)';
+    try {
+        const res = await authFetch('/api/inspections/templates', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: newName, schema: t.schema || { schemaVersion: 2, sections: [] } })
+        });
+        if (res.ok) {
+            const result = await res.json();
+            const newId = result?.data?.template?.id;
+            if (newId) {
+                window.location.href = '/templates/' + newId + '/edit';
+            } else {
+                loadTemplates();
+            }
+        } else {
+            const err = await res.json().catch(() => ({}));
+            const msg = err?.error?.message || err?.error || err?.message || 'Failed to duplicate';
+            modalAlert('Error: ' + msg, 'Error');
+        }
+    } catch (e) {
+        modalAlert('Connection error: ' + e.message, 'Error');
+    }
 }
 
 async function deleteTemplate(id) {

--- a/public/js/toast.js
+++ b/public/js/toast.js
@@ -1,5 +1,5 @@
 // Shared toast notification utility
-function showToast(msg, isError) {
+function showToast(msg, isError, opts) {
     var el = document.getElementById('statusToast');
     if (!el) {
         el = document.createElement('div');
@@ -9,6 +9,14 @@ function showToast(msg, isError) {
     el.textContent = msg;
     el.className = 'fixed bottom-8 right-8 flex items-center gap-3 px-6 py-4 rounded-md shadow-2xl text-sm font-bold text-white z-50 transition-all ' +
         (isError ? 'bg-red-600' : 'bg-emerald-600');
+    // If opts.undoFn provided, add an undo button
+    if (opts && opts.undoFn) {
+        var undoBtn = document.createElement('button');
+        undoBtn.textContent = opts.undoLabel || 'Undo';
+        undoBtn.style.cssText = 'margin-left:12px;font-weight:700;text-decoration:underline;cursor:pointer;background:none;border:none;color:inherit;font-size:inherit;';
+        undoBtn.onclick = function() { opts.undoFn(); el.style.display = 'none'; };
+        el.appendChild(undoBtn);
+    }
     el.style.display = '';
     clearTimeout(el._timer);
     el._timer = setTimeout(function() { el.style.display = 'none'; }, 3500);

--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -1,0 +1,71 @@
+/**
+ * Gap 7 — Centralized icon registry.
+ *
+ * 27 Heroicons-outline paths in a single constant. The Icon JSX component
+ * renders them as <svg> with configurable size and strokeWidth.
+ *
+ * Canonical source: Design System 0523 components.jsx ICON_PATHS.
+ *
+ * Usage in Hono JSX templates:
+ *   import { Icon } from '../../lib/icons';
+ *   <Icon name="dashboard" size={16} />
+ */
+
+export const ICON_PATHS: Record<string, string> = {
+    dashboard:  '<rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/>',
+    calendar:   '<rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/>',
+    contacts:   '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/>',
+    check:      '<path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>',
+    message:    '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>',
+    store:      '<rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18"/>',
+    bell:       '<path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0"/>',
+    search:     '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.35-4.35"/>',
+    arrowR:     '<path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>',
+    chevR:      '<path d="m9 18 6-6-6-6"/>',
+    chevL:      '<path d="m15 18-6-6 6-6"/>',
+    chevD:      '<path d="M19 9l-7 7-7-7"/>',
+    plus:       '<path d="M12 5v14M5 12h14"/>',
+    x:          '<path d="M6 18L18 6M6 6l12 12"/>',
+    edit:       '<path d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>',
+    share:      '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="m8.59 13.51 6.83 3.98M15.41 6.51l-6.82 3.98"/>',
+    mail:       '<path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>',
+    camera:     '<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>',
+    mic:        '<rect x="9" y="2" width="6" height="11" rx="3"/><path d="M19 10v1a7 7 0 0 1-14 0v-1M12 18v3M8 21h8"/>',
+    print:      '<path d="M6 9V2h12v7M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><path d="M6 14h12v8H6z"/>',
+    back:       '<path d="m12 19-7-7 7-7"/><path d="M19 12H5"/>',
+    moon:       '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>',
+    sun:        '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>',
+    filter:     '<path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z"/>',
+    panel:      '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/>',
+    card:       '<rect x="2" y="5" width="20" height="14" rx="2"/><path d="M2 10h20"/>',
+    zap:        '<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>',
+    clock:      '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/>',
+    panelRC:    '<rect x="3" y="3" width="18" height="18" rx="2"/><line x1="15" y1="3" x2="15" y2="21"/><polyline points="10 9 7 12 10 15"/>',
+    panelRO:    '<rect x="3" y="3" width="18" height="18" rx="2"/><line x1="15" y1="3" x2="15" y2="21"/><polyline points="7 9 10 12 7 15"/>',
+};
+
+export type IconName = keyof typeof ICON_PATHS;
+
+export function Icon({ name, size = 16, class: className = '', strokeWidth = 2 }: {
+    name: string;
+    size?: number;
+    class?: string;
+    strokeWidth?: number;
+}): JSX.Element | null {
+    const path = ICON_PATHS[name];
+    if (!path) return null;
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width={strokeWidth}
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class={className}
+            dangerouslySetInnerHTML={{ __html: path }}
+        />
+    ) as unknown as JSX.Element;
+}

--- a/src/templates/pages/templates.tsx
+++ b/src/templates/pages/templates.tsx
@@ -9,7 +9,7 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
 
     return (
         <MainLayout title={`${siteName} | Templates`} branding={branding}>
-            <div class="animate-slide-in space-y-[18px]">
+            <div class="animate-slide-in space-y-[18px]" x-data="{ view: 'list', showHistoryId: null, showHistoryName: '' }">
                 <div x-data="templatesMeta">
                     <PageHeader
                         eyebrow="LIBRARY · TEMPLATES"
@@ -18,6 +18,21 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                         meta={<span x-text="metaText"></span>}
                         actions={
                             <div class="flex items-center gap-2">
+                                {/* View toggle: Cards / List */}
+                                <div class="bg-slate-100 dark:bg-slate-700 rounded-md p-0.5 inline-flex">
+                                    <button
+                                        type="button"
+                                        x-on:click="view = 'card'"
+                                        x-bind:class="view === 'card' ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm' : 'text-slate-500'"
+                                        class="px-2.5 py-1 rounded text-[12px] font-bold transition-all"
+                                    >Cards</button>
+                                    <button
+                                        type="button"
+                                        x-on:click="view = 'list'"
+                                        x-bind:class="view === 'list' ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 shadow-sm' : 'text-slate-500'"
+                                        class="px-2.5 py-1 rounded text-[12px] font-bold transition-all"
+                                    >List</button>
+                                </div>
                                 <button
                                     type="button"
                                     onclick="showImportSpectoraModal()"
@@ -44,8 +59,8 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                     has been imported more than once (Sprint 1 B-8). */}
                 <MarketplaceDuplicateBanner />
 
-                {/* Templates List */}
-                <div class="glass-panel rounded-xl overflow-hidden shadow-md/5">
+                {/* Templates List (table view) */}
+                <div x-show="view === 'list'" class="glass-panel rounded-xl overflow-hidden shadow-md/5">
                     <div class="overflow-x-auto">
                         <table class="min-w-full">
                             <thead>
@@ -67,6 +82,56 @@ export const TemplatesPage = ({ branding }: { branding?: BrandingConfig | undefi
                                 </tr>
                             </tbody>
                         </table>
+                    </div>
+                </div>
+
+                {/* Templates Card Grid view */}
+                <div x-show="view === 'card'" x-cloak id="templatesCardGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {/* Cards rendered by templates.js renderCardGrid() */}
+                </div>
+
+                {/* Template History Modal */}
+                <div
+                    x-show="showHistoryId"
+                    x-cloak
+                    {...{
+                        'x-transition:enter':       'transition ease-out duration-200',
+                        'x-transition:enter-start': 'opacity-0',
+                        'x-transition:enter-end':   'opacity-100',
+                        'x-transition:leave':       'transition ease-in duration-150',
+                        'x-transition:leave-start': 'opacity-100',
+                        'x-transition:leave-end':   'opacity-0',
+                        'x-on:keydown.escape.window': 'showHistoryId = null',
+                    }}
+                    x-on:click="if ($event.target === $el) showHistoryId = null"
+                    class="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4 overflow-y-auto"
+                    role="dialog"
+                    aria-modal="true"
+                >
+                    <div class="bg-white dark:bg-slate-800 rounded-md shadow-xl w-full max-w-md p-4 max-h-[90vh] overflow-y-auto" {...{'x-on:click.stop': ''}}>
+                        <header class="flex items-start justify-between gap-3 mb-4">
+                            <div class="min-w-0 flex-1">
+                                <h2 class="text-lg font-bold text-slate-900 dark:text-slate-100 truncate">Edit history</h2>
+                                <p class="text-sm text-slate-500 dark:text-slate-400 mt-0.5 truncate" x-text="showHistoryName"></p>
+                            </div>
+                            <button
+                                type="button"
+                                aria-label="Close dialog"
+                                class="w-8 h-8 rounded-xl bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 flex items-center justify-center text-slate-500 dark:text-slate-400 flex-shrink-0"
+                                x-on:click="showHistoryId = null"
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </header>
+                        <div class="py-8 text-center">
+                            <div class="w-12 h-12 mx-auto mb-3 rounded-lg bg-slate-100 dark:bg-slate-700 flex items-center justify-center">
+                                <svg class="w-6 h-6 text-slate-300 dark:text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                            </div>
+                            <p class="text-sm font-bold text-slate-400 dark:text-slate-500">No version history yet.</p>
+                            <p class="text-xs text-slate-400 dark:text-slate-500 mt-1">Version history will appear here as edits are made.</p>
+                        </div>
                     </div>
                 </div>
 

--- a/tests/unit/icons.spec.ts
+++ b/tests/unit/icons.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { ICON_PATHS, Icon } from '../../src/lib/icons';
+
+describe('ICON_PATHS', () => {
+    it('has at least 27 entries', () => {
+        expect(Object.keys(ICON_PATHS).length).toBeGreaterThanOrEqual(27);
+    });
+
+    it('includes all design spec icons', () => {
+        const expected = [
+            'dashboard', 'calendar', 'contacts', 'check', 'message', 'store',
+            'bell', 'search', 'arrowR', 'chevR', 'chevL', 'chevD', 'plus', 'x',
+            'edit', 'share', 'mail', 'camera', 'mic', 'print', 'back', 'moon',
+            'sun', 'filter', 'panel', 'card', 'zap', 'clock', 'panelRC', 'panelRO',
+        ];
+        for (const name of expected) {
+            expect(ICON_PATHS, `missing icon: ${name}`).toHaveProperty(name);
+        }
+    });
+
+    it('every path is a non-empty string', () => {
+        for (const [name, path] of Object.entries(ICON_PATHS)) {
+            expect(typeof path, `${name} should be string`).toBe('string');
+            expect(path.length, `${name} should be non-empty`).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('Icon component', () => {
+    it('returns null for unknown icon name', () => {
+        expect(Icon({ name: 'nonexistent' })).toBeNull();
+    });
+
+    it('returns non-null for known icon', () => {
+        const result = Icon({ name: 'check', size: 20 });
+        expect(result).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

P1 feature enhancements — completing all remaining P1 gaps.

- **Gap 7**: Centralized Icon system (`icons.tsx`) with 30 ICON_PATHS + `Icon` JSX component. 5 tests.
- **Gap 8**: Templates card grid view + Cards/List toggle + TemplateHistoryModal placeholder.
- **Gap 6**: Shift+click range selection in batch mode + undo toast (`showToast` extended with `undoFn`).
- **Gap 5**: Already implemented (urgency badges in inspection-row.tsx L56-80).
- **Gap 9**: Already merged in PR #83 (Shortcuts popover).

## Test plan

- [x] tsc --noEmit clean
- [x] vitest 172 passed, 1243 tests, 0 failures

Generated with [Claude Code](https://claude.com/claude-code)