### PR TITLE
feat: P3 — Resolvers + Comments tagging + Report D7 + InviteSeatModal

### DIFF
--- a/migrations/0078_comments_tagging.sql
+++ b/migrations/0078_comments_tagging.sql
@@ -1,0 +1,6 @@
+-- P3: Comments library tagging enhancement for auto-filter.
+-- Adds structured fields alongside existing free-text category/section.
+ALTER TABLE comments ADD COLUMN section_ids TEXT;       -- JSON array of section IDs
+ALTER TABLE comments ADD COLUMN item_labels TEXT;       -- JSON array of item label keywords
+ALTER TABLE comments ADD COLUMN trigger_code TEXT;      -- short code for '/' trigger
+ALTER TABLE comments ADD COLUMN search_keywords TEXT;   -- denormalized searchable text

--- a/public/js/invite-seat-modal.js
+++ b/public/js/invite-seat-modal.js
@@ -13,6 +13,7 @@
             mode: 'permanent',
             email: '',
             role: 'lead',
+            notify: true,
             mentorId: '',
             sectionIds: [],
             durationSeconds: 86400,
@@ -25,6 +26,19 @@
             // Caller-supplied label (e.g. "Inspection roster · live add")
             // so audit logs / analytics can tell where the invite came from.
             sourceLabel: '',
+
+            roleDesc: {
+                lead:       'Full edit + can publish + approve apprentices',
+                specialist: 'Full edit within assigned sections',
+                apprentice: 'Edits queue for lead review',
+                office:     'Read-only + scheduling',
+            },
+
+            _guestPrices: { 86400: '$1.49', 259200: '$4.47', 604800: '$10.43' },
+
+            get guestPriceLabel() {
+                return this._guestPrices[this.durationSeconds] || '';
+            },
 
             async init() {
                 window.addEventListener('invite-seat-modal:open', (e) => {
@@ -44,6 +58,7 @@
                 this.sourceLabel  = opts.sourceLabel || '';
                 this.email        = '';
                 this.role         = 'lead';
+                this.notify       = true;
                 this.mentorId     = '';
                 this.sectionIds   = [];
                 this.generatedUrl = '';
@@ -94,8 +109,9 @@
                 this.error = '';
                 try {
                     const payload = {
-                        email: this.email,
-                        role:  this.role,
+                        email:  this.email,
+                        role:   this.role,
+                        notify: this.notify,
                     };
                     if (this.role === 'apprentice') payload.mentorId = this.mentorId;
                     if (this.role === 'specialist') payload.assignedSectionIds = this.sectionIds;

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1158,6 +1158,10 @@ adminRoutes.openapi(createCommentRoute, async (c) => {
         section: section ?? null,
         // S2-7 — libraryId tracks marketplace provenance; null for tenant-authored.
         libraryId: null as string | null,
+        sectionIds: null as string | null,
+        itemLabels: null as string | null,
+        triggerCode: null as string | null,
+        searchKeywords: null as string | null,
         createdAt: new Date(),
     };
     await db.insert(comments).values(row);

--- a/src/api/inspections.ts
+++ b/src/api/inspections.ts
@@ -1440,6 +1440,7 @@ inspectionsRoutes.get('/:id/report', async (c) => {
             id:           r.id,
             parentUnitId: r.parentUnitId,
             kind:         r.kind as ReportUnit['kind'],
+            type:         (r.type ?? 'unit') as ReportUnit['type'],
             name:         r.name,
             sortOrder:    r.sortOrder ?? 0,
         }));

--- a/src/lib/db/schema/inspection.ts
+++ b/src/lib/db/schema/inspection.ts
@@ -267,6 +267,10 @@ export const comments = sqliteTable('comments', {
     // tenant-authored comments. Used by replace-mode update to delete only
     // prior-import rows, never touching the tenant's own comments.
     libraryId: text('library_id'),
+    sectionIds: text('section_ids'),
+    itemLabels: text('item_labels'),
+    triggerCode: text('trigger_code'),
+    searchKeywords: text('search_keywords'),
     createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 });
 

--- a/src/lib/inspection-resolvers.ts
+++ b/src/lib/inspection-resolvers.ts
@@ -1,0 +1,90 @@
+/**
+ * P3 — Explicit resolver functions for inspection unit/section/item resolution.
+ *
+ * Pure functions that operate on inspection data structures.
+ * Canonical source: Design System 0523 Catalog.jsx resolvers.
+ */
+
+import type { TemplateSchemaV2, TemplateSection, TemplateBuilding, TemplateUnit } from '../types/template-schema';
+
+export function findUnit(
+    structure: { buildings: TemplateBuilding[] } | undefined,
+    unitId: string,
+): TemplateUnit | null {
+    if (!structure?.buildings) return null;
+    for (const b of structure.buildings) {
+        for (const u of b.units) {
+            if (u.id === unitId) return u;
+        }
+    }
+    return null;
+}
+
+export function findBuildingOfUnit(
+    structure: { buildings: TemplateBuilding[] } | undefined,
+    unitId: string,
+): TemplateBuilding | null {
+    if (!structure?.buildings) return null;
+    for (const b of structure.buildings) {
+        if (b.units.some(u => u.id === unitId)) return b;
+    }
+    return null;
+}
+
+export interface UnitOverride {
+    sectionsIncluded?: string[];
+    sectionsExcluded?: string[];
+    itemsIncluded?: Record<string, string[]>;
+    itemsExcluded?: Record<string, string[]>;
+}
+
+export function resolveUnitSections(
+    schema: TemplateSchemaV2,
+    _unitId: string,
+    unitOverrides?: Record<string, UnitOverride>,
+    unitId?: string,
+): TemplateSection[] {
+    const activeUnitId = unitId || _unitId;
+    const overrides = unitOverrides?.[activeUnitId];
+
+    let sectionIds = schema.sections.map(s => s.id);
+
+    if (overrides?.sectionsExcluded) {
+        sectionIds = sectionIds.filter(id => !overrides.sectionsExcluded!.includes(id));
+    }
+    if (overrides?.sectionsIncluded) {
+        for (const id of overrides.sectionsIncluded) {
+            if (!sectionIds.includes(id)) sectionIds.push(id);
+        }
+    }
+
+    return sectionIds
+        .map(id => schema.sections.find(s => s.id === id))
+        .filter((s): s is TemplateSection => s != null);
+}
+
+export function resolveUnitSectionItems(
+    schema: TemplateSchemaV2,
+    _unitId: string,
+    sectionId: string,
+    unitOverrides?: Record<string, UnitOverride>,
+    unitId?: string,
+): string[] {
+    const activeUnitId = unitId || _unitId;
+    const section = schema.sections.find(s => s.id === sectionId);
+    if (!section) return [];
+
+    let itemIds = section.items.map(i => i.id);
+    const overrides = unitOverrides?.[activeUnitId];
+
+    if (overrides?.itemsExcluded?.[sectionId]) {
+        itemIds = itemIds.filter(id => !overrides.itemsExcluded![sectionId].includes(id));
+    }
+    if (overrides?.itemsIncluded?.[sectionId]) {
+        for (const id of overrides.itemsIncluded[sectionId]) {
+            if (!itemIds.includes(id)) itemIds.push(id);
+        }
+    }
+
+    return itemIds;
+}

--- a/src/services/starter-content.service.ts
+++ b/src/services/starter-content.service.ts
@@ -161,6 +161,10 @@ export async function seedStarterContent(
                 category:     c.category,
                 ratingBucket: c.ratingBucket,
                 section:      c.category,
+                sectionIds:   null,
+                itemLabels:   null,
+                triggerCode:  null,
+                searchKeywords: null,
                 createdAt:    now,
             }).run();
             cannedCommentsSeeded++;

--- a/src/templates/components/invite-seat-modal.tsx
+++ b/src/templates/components/invite-seat-modal.tsx
@@ -38,10 +38,14 @@ export const InviteSeatModal: FC = () => (
             </header>
 
             <div class="p-6 space-y-4">
-                <div x-show="mode === 'permanent'">
+                <div x-show="mode === 'permanent'" class="space-y-3">
                     <label class="block">
                         <span class="ih-eyebrow block mb-1">Email</span>
                         <input class="ih-input w-full" type="email" {...{ 'x-model': 'email' }} />
+                    </label>
+                    <label class="flex items-center gap-2 text-sm">
+                        <input type="checkbox" {...{ 'x-model': 'notify' }} />
+                        Send email notification
                     </label>
                 </div>
 
@@ -54,6 +58,7 @@ export const InviteSeatModal: FC = () => (
                         <option value="office">Office staff</option>
                     </select>
                 </label>
+                <p class="ih-meta mt-1" x-text="roleDesc[role]" />
 
                 <div x-show="role === 'apprentice'">
                     <label class="block">
@@ -86,17 +91,20 @@ export const InviteSeatModal: FC = () => (
                     <span class="ih-eyebrow block mb-1">Duration</span>
                     <div class="flex gap-2 flex-wrap">
                         <label class="flex items-center gap-1 text-sm">
-                            <input type="radio" {...{ 'x-model.number': 'durationSeconds', ':value': '86400' }} />24h
+                            <input type="radio" {...{ 'x-model.number': 'durationSeconds', ':value': '86400' }} />
+                            <span>1 day <span class="ih-meta">$1.49</span></span>
                         </label>
                         <label class="flex items-center gap-1 text-sm">
-                            <input type="radio" {...{ 'x-model.number': 'durationSeconds', ':value': '259200' }} />3d
+                            <input type="radio" {...{ 'x-model.number': 'durationSeconds', ':value': '259200' }} />
+                            <span>3 days <span class="ih-meta">$4.47</span></span>
                         </label>
                         <label class="flex items-center gap-1 text-sm">
-                            <input type="radio" {...{ 'x-model.number': 'durationSeconds', ':value': '604800' }} />7d
+                            <input type="radio" {...{ 'x-model.number': 'durationSeconds', ':value': '604800' }} />
+                            <span>7 days <span class="ih-meta">$10.43</span></span>
                         </label>
                     </div>
                     <p class="ih-meta mt-2">
-                        Guest counts against your team's seat quota while active. No separate charge.
+                        Guest counts against your team's seat quota while active.
                     </p>
 
                     <div x-show="generatedUrl" class="ih-card p-3 mt-3 bg-emerald-50 border border-emerald-200 rounded-md">
@@ -105,6 +113,11 @@ export const InviteSeatModal: FC = () => (
                         <button class="ih-btn ih-btn--sm ih-btn--secondary mt-2"
                                 {...{ '@click': 'copy(generatedUrl)' }}>Copy link</button>
                     </div>
+                </div>
+
+                <div x-show="mode === 'guest'" class="ih-card p-3 bg-amber-50 border border-amber-200 rounded-md text-sm">
+                    <span class="font-medium">Estimated cost:</span>{' '}
+                    <span x-text="guestPriceLabel" />
                 </div>
 
                 <p class="ih-meta text-rose-600" x-show="error" x-text="error" />

--- a/src/templates/components/report-units-summary.tsx
+++ b/src/templates/components/report-units-summary.tsx
@@ -18,6 +18,8 @@ export interface ReportUnit {
     id:           string;
     parentUnitId: string | null;
     kind:         'building' | 'floor' | 'unit';
+    /** 'common' for shared areas (lobby, hallways); 'unit' for individual units. */
+    type:         'unit' | 'common';
     name:         string;
     sortOrder:    number;
 }

--- a/src/templates/pages/report.template.tsx
+++ b/src/templates/pages/report.template.tsx
@@ -3,12 +3,13 @@ import { BrandingConfig } from '../../types/auth';
 import { ReportSidebar, type ReportSidebarSection } from '../components/report-sidebar';
 import { ReportTabBar } from '../components/report-tab-bar';
 import { TeamCredit, type TeamCreditMember } from '../components/team-credit';
-import { ReportUnitsSummary, type ReportUnit } from '../components/report-units-summary';
+import { ReportUnitsSummary, childrenOf, type ReportUnit } from '../components/report-units-summary';
+import { findingKey, DEFAULT_UNIT } from '../../lib/finding-key';
 import { ShareDropdown } from '../components/share-dropdown';
 import { PdfDropdown } from '../components/pdf-dropdown';
 import { ReportStatusPill } from '../components/report-status-pill';
 
-interface InspectionRecord { id: string; propertyAddress: string; clientName?: string | null; clientEmail?: string | null; date: string; price: number; paymentStatus: string; signed?: boolean; status?: string | null; }
+interface InspectionRecord { id: string; propertyAddress: string; clientName?: string | null; clientEmail?: string | null; date: string; price: number; paymentStatus: string; signed?: boolean; status?: string | null; propertyType?: string | null; }
 interface TemplateRecord { schema: string | Record<string, unknown>; }
 interface SchemaItemRaw { id: string; label?: string; name?: string; type?: string; options?: { unit?: string; choices?: string[] } | undefined; }
 interface SchemaSectionRaw { title?: string; name?: string; items: SchemaItemRaw[]; }
@@ -333,7 +334,11 @@ export function renderProfessionalReport(data: {
                 })()
                 : null}
 
-            {/* Inspection Details */}
+            {/* Inspection Details — D7 propertyType-aware rendering.
+                Single-family (or no units): flat section list (unchanged).
+                Multi-unit / commercial: sections grouped by unit, with
+                building → floor → unit headers wrapping the same section
+                rendering logic. */}
             <div class="px-6 py-10 md:px-10 md:py-12 space-y-10 bg-white">
                 {/* Spec 5F.9 — section + item wrappers gain report-pdf-* classes
                     that ONLY apply in @media print (defined in input.css). On
@@ -341,109 +346,211 @@ export function renderProfessionalReport(data: {
                     to a 2-col grid with hairline borders; defect items break
                     back to full-row red bg; photos shrink to 4-col mini grid
                     capped at 8 per item. */}
-                {schema.sections.map((section: SchemaSection) => {
-                    const sectionCounts = sectionDefects.get(section.id) ?? { safety: 0, recommendation: 0, maintenance: 0 };
-                    return (
-                    <section
-                        class="page-break report-pdf-section report-section"
-                        id={`section-${section.id}`}
-                        key={section.id}
-                        data-defect-safety={sectionCounts.safety > 0 ? '1' : '0'}
-                    >
-                        <div class="flex items-center gap-4 mb-16">
-                            <h2 class="text-3xl font-bold tracking-tight text-slate-900 shrink-0">{section.title}</h2>
-                            <div class="flex-grow h-0.5 bg-gradient-to-r from-slate-100 to-transparent"></div>
-                            <span class="text-[10px] font-bold uppercase tracking-[0.4em] text-slate-300">Section {schema.sections.indexOf(section) + 1}</span>
-                        </div>
+                {(() => {
+                    // ---------- shared item renderer (unchanged logic) ----------
+                    const renderItem = (item: SchemaItem, res: ResultItem) => {
+                        const itemRatingId = res.rating || res.status;
+                        const bucket = resolveSeverity(itemRatingId);
+                        const level = itemRatingId ? levelMap.get(itemRatingId) : undefined;
+                        const displayLabel = level?.label || itemRatingId || 'NO DATA';
+                        const itemClass = bucket === 'defect' ? 'report-pdf-item report-pdf-item--defect' : 'report-pdf-item';
+                        const photos = res.photos || [];
+                        const photoCap = 8;
 
-                        <div class="space-y-6 report-pdf-grid">
-                            {section.items.map((item: SchemaItem) => {
-                                const res: ResultItem = resultData[item.id] || {};
-                                const itemRatingId = res.rating || res.status;
-                                const bucket = resolveSeverity(itemRatingId);
-                                const level = itemRatingId ? levelMap.get(itemRatingId) : undefined;
-                                const displayLabel = level?.label || itemRatingId || 'NO DATA';
-                                const itemClass = bucket === 'defect' ? 'report-pdf-item report-pdf-item--defect' : 'report-pdf-item';
-                                const photos = res.photos || [];
-                                const photoCap = 8;
+                        const hasRating = !!itemRatingId;
+                        const hasNotes  = !!(res.notes && res.notes !== 'No notes recorded.');
+                        const hasPhotos = photos.length > 0;
+                        const v = (res as { value?: unknown }).value;
+                        const hasValue  = v !== undefined && v !== null && v !== '' && !(Array.isArray(v) && v.length === 0);
+                        if (!hasRating && !hasNotes && !hasPhotos && !hasValue) return null;
 
-                                // Sub-spec D Task 5 — collapse empty items: no rating + only the
-                                // "No notes recorded." placeholder + no photos + no captured
-                                // value. These are dead weight in the report and clutter the
-                                // Summary view. Non-rich item types (number/date/boolean/...)
-                                // ride on `res.value`, so an item with a value but no rating
-                                // is *not* empty — keep it.
-                                const hasRating = !!itemRatingId;
-                                const hasNotes  = !!(res.notes && res.notes !== 'No notes recorded.');
-                                const hasPhotos = photos.length > 0;
-                                const v = (res as { value?: unknown }).value;
-                                const hasValue  = v !== undefined && v !== null && v !== '' && !(Array.isArray(v) && v.length === 0);
-                                if (!hasRating && !hasNotes && !hasPhotos && !hasValue) return null;
+                        const itemDefectCount = bucket === 'defect' ? 1 : bucket === 'marginal' ? 1 : 0;
+                        const itemSafetyFlag  = '0';
 
-                                // Defect category mapping (Sub-spec D Task 2 / 5):
-                                // bucket=defect   -> recommendation (per render-path heuristic)
-                                // bucket=marginal -> maintenance
-                                // bucket=good/null -> none
-                                const itemDefectCount = bucket === 'defect' ? 1 : bucket === 'marginal' ? 1 : 0;
-                                // Per-render-path: safety category isn't classified at item level
-                                // here (only the v2 defect-tabs path has that data). Mirror the
-                                // section-level zero so the print filter behaves consistently.
-                                const itemSafetyFlag  = '0';
+                        return (
+                            <div
+                                class={`flex flex-col lg:flex-row gap-16 avoid-break group report-item ${itemClass}`}
+                                key={item.id}
+                                data-defects={String(itemDefectCount)}
+                                data-defect-safety={itemSafetyFlag}
+                            >
+                                <div class="flex-grow">
+                                    <div class="flex justify-between items-start gap-4 mb-6">
+                                        <h3 class="text-xl font-bold tracking-tight text-slate-900 group-hover:text-indigo-600 transition-colors">{item.label}</h3>
+                                        <span class={`ih-pill ${bucket === 'good' ? 'ih-pill--sat' : bucket === 'marginal' ? 'ih-pill--monitor' : bucket === 'defect' ? 'ih-pill--defect' : 'ih-pill--gen'}`}>{displayLabel}</span>
+                                    </div>
+                                    {item.type && item.type !== 'rich' && (res as { value?: unknown }).value !== undefined && (res as { value?: unknown }).value !== '' && (res as { value?: unknown }).value !== null && (
+                                        <p class="text-lg text-slate-700 font-semibold mb-3 item-value">
+                                            <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mr-3">{item.type}</span>
+                                            {Array.isArray((res as { value?: unknown }).value)
+                                                ? ((res as { value: unknown[] }).value).join(' · ')
+                                                : (item.type === 'boolean'
+                                                    ? ((res as { value: boolean }).value ? 'Yes' : 'No')
+                                                    : String((res as { value: unknown }).value))}
+                                            {item.options?.unit ? <span class="text-slate-400 ml-2">{item.options.unit}</span> : null}
+                                        </p>
+                                    )}
+                                    <p class="text-xl text-slate-500 leading-relaxed font-medium max-w-3xl item-notes">{res.notes || 'No notes recorded.'}</p>
+                                </div>
 
-                                return (
-                                    <div
-                                        class={`flex flex-col lg:flex-row gap-16 avoid-break group report-item ${itemClass}`}
-                                        key={item.id}
-                                        data-defects={String(itemDefectCount)}
-                                        data-defect-safety={itemSafetyFlag}
-                                    >
-                                        <div class="flex-grow">
-                                            <div class="flex justify-between items-start gap-4 mb-6">
-                                                <h3 class="text-xl font-bold tracking-tight text-slate-900 group-hover:text-indigo-600 transition-colors">{item.label}</h3>
-                                                <span class={`ih-pill ${bucket === 'good' ? 'ih-pill--sat' : bucket === 'marginal' ? 'ih-pill--monitor' : bucket === 'defect' ? 'ih-pill--defect' : 'ih-pill--gen'}`}>{displayLabel}</span>
+                                {photos.length > 0 ? (
+                                    <div class="lg:w-[480px] shrink-0 grid grid-cols-2 gap-4 avoid-break report-pdf-photos">
+                                        {photos.slice(0, photoCap).map((p: { key: string }) => (
+                                            <div class="aspect-square bg-slate-50 rounded-lg overflow-hidden border-4 border-white shadow-md/20 group/photo transition-transform hover:scale-[1.02]" key={p.key}>
+                                                <img src={`/api/inspections/files/${p.key}`} class="w-full h-full object-cover grayscale-[0.2] transition-all group-hover/photo:grayscale-0" />
                                             </div>
-                                            {/* Non-rich item value — boolean/number/text/textarea/date/select/
-                                                multi_select store the captured value on res.value. The customer-
-                                                facing report viewer surfaces it inline so the inspector's entry
-                                                isn't silently hidden behind a rating pill that doesn't apply. */}
-                                            {item.type && item.type !== 'rich' && (res as { value?: unknown }).value !== undefined && (res as { value?: unknown }).value !== '' && (res as { value?: unknown }).value !== null && (
-                                                <p class="text-lg text-slate-700 font-semibold mb-3 item-value">
-                                                    <span class="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400 mr-3">{item.type}</span>
-                                                    {Array.isArray((res as { value?: unknown }).value)
-                                                        ? ((res as { value: unknown[] }).value).join(' · ')
-                                                        : (item.type === 'boolean'
-                                                            ? ((res as { value: boolean }).value ? 'Yes' : 'No')
-                                                            : String((res as { value: unknown }).value))}
-                                                    {item.options?.unit ? <span class="text-slate-400 ml-2">{item.options.unit}</span> : null}
-                                                </p>
-                                            )}
-                                            <p class="text-xl text-slate-500 leading-relaxed font-medium max-w-3xl item-notes">{res.notes || 'No notes recorded.'}</p>
-                                        </div>
-
-                                        {/* High-Resolution Evidence Architecture */}
-                                        {photos.length > 0 ? (
-                                            <div class="lg:w-[480px] shrink-0 grid grid-cols-2 gap-4 avoid-break report-pdf-photos">
-                                                {photos.slice(0, photoCap).map((p: { key: string }) => (
-                                                    <div class="aspect-square bg-slate-50 rounded-lg overflow-hidden border-4 border-white shadow-md/20 group/photo transition-transform hover:scale-[1.02]" key={p.key}>
-                                                        <img src={`/api/inspections/files/${p.key}`} class="w-full h-full object-cover grayscale-[0.2] transition-all group-hover/photo:grayscale-0" />
-                                                    </div>
-                                                ))}
-                                                {photos.length > photoCap && (
-                                                    <div class="hidden print:block col-span-full text-[8pt] text-slate-400 italic">+{photos.length - photoCap} more in web report</div>
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <div class="lg:w-[480px] shrink-0 h-40 border-2 border-dashed border-slate-50 rounded-lg flex items-center justify-center grayscale opacity-20">
-                                                <span class="text-[10px] font-bold uppercase tracking-[0.3em] text-slate-300">No photos</span>
-                                            </div>
+                                        ))}
+                                        {photos.length > photoCap && (
+                                            <div class="hidden print:block col-span-full text-[8pt] text-slate-400 italic">+{photos.length - photoCap} more in web report</div>
                                         )}
                                     </div>
-                                );
-                            })}
-                        </div>
-                    </section>
+                                ) : (
+                                    <div class="lg:w-[480px] shrink-0 h-40 border-2 border-dashed border-slate-50 rounded-lg flex items-center justify-center grayscale opacity-20">
+                                        <span class="text-[10px] font-bold uppercase tracking-[0.3em] text-slate-300">No photos</span>
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    };
+
+                    // ---------- shared section renderer ----------
+                    // resolveKey: given (section, item) → the key into resultData.
+                    // idSuffix: appended to section element ids to disambiguate
+                    //           the same section rendered for different units.
+                    const renderSections = (
+                        resolveKey: (sec: SchemaSection, item: SchemaItem) => string,
+                        idSuffix?: string,
+                    ): JSX.Element[] =>
+                        schema.sections.map((section: SchemaSection) => {
+                            const sectionCounts = sectionDefects.get(section.id) ?? { safety: 0, recommendation: 0, maintenance: 0 };
+                            const sectionElId = idSuffix
+                                ? `section-${section.id}--${idSuffix}`
+                                : `section-${section.id}`;
+
+                            // Pre-filter items to those with any result data under
+                            // the resolved key. Skip sections that are entirely empty
+                            // for this unit so unit blocks stay clean.
+                            const itemsWithResults = section.items.filter((item: SchemaItem) => {
+                                const key = resolveKey(section, item);
+                                return !!resultData[key];
+                            });
+                            if (idSuffix && itemsWithResults.length === 0) return null as unknown as JSX.Element;
+
+                            return (
+                                <section
+                                    class="page-break report-pdf-section report-section"
+                                    id={sectionElId}
+                                    key={sectionElId}
+                                    data-defect-safety={sectionCounts.safety > 0 ? '1' : '0'}
+                                >
+                                    <div class="flex items-center gap-4 mb-16">
+                                        <h2 class="text-3xl font-bold tracking-tight text-slate-900 shrink-0">{section.title}</h2>
+                                        <div class="flex-grow h-0.5 bg-gradient-to-r from-slate-100 to-transparent"></div>
+                                        <span class="text-[10px] font-bold uppercase tracking-[0.4em] text-slate-300">Section {schema.sections.indexOf(section) + 1}</span>
+                                    </div>
+
+                                    <div class="space-y-6 report-pdf-grid">
+                                        {section.items.map((item: SchemaItem) => {
+                                            const key = resolveKey(section, item);
+                                            const res: ResultItem = resultData[key] || {};
+                                            return renderItem(item, res);
+                                        })}
+                                    </div>
+                                </section>
+                            );
+                        }).filter(Boolean);
+
+                    // ---------- D7 dispatch: flat vs unit-grouped ----------
+                    const units = data.units ?? [];
+                    const isMultiUnit = units.length > 0 && (
+                        inspection.propertyType === 'multi-unit'
+                        || inspection.propertyType === 'commercial'
                     );
-                })}
+
+                    if (!isMultiUnit) {
+                        // Single-family / no units — original flat rendering.
+                        // Composite key with fallback to plain item.id for
+                        // backward compat with pre-findingKey result data.
+                        return renderSections(
+                            (sec, item) => resultData[findingKey(DEFAULT_UNIT, sec.id, item.id)] ? findingKey(DEFAULT_UNIT, sec.id, item.id) : item.id,
+                        );
+                    }
+
+                    // ------ Multi-unit / commercial: unit-grouped rendering ------
+                    const buildings = childrenOf(units, null);
+
+                    // Helper: render a leaf unit's sections
+                    const renderUnitBlock = (unit: ReportUnit): JSX.Element => (
+                        <div class="report-unit-group" id={`unit-${unit.id}`} data-unit-id={unit.id}>
+                            <div class="flex items-center gap-3 mb-8 mt-4">
+                                <div class={`w-2 h-6 rounded-full ${unit.type === 'common' ? 'bg-slate-400' : 'bg-indigo-500'}`}></div>
+                                <h3 class="text-xl font-bold tracking-tight text-slate-800">
+                                    {unit.name}
+                                    {unit.type === 'common' && (
+                                        <span class="ml-2 text-xs font-bold uppercase tracking-widest text-slate-400">Common</span>
+                                    )}
+                                </h3>
+                            </div>
+                            <div class="space-y-10 pl-5 border-l-2 border-slate-100">
+                                {renderSections(
+                                    (sec, item) => findingKey(unit.id, sec.id, item.id),
+                                    unit.id,
+                                )}
+                            </div>
+                        </div>
+                    );
+
+                    // Helper: render a floor node (contains leaf units)
+                    const renderFloorBlock = (floor: ReportUnit): JSX.Element => {
+                        const floorUnits = childrenOf(units, floor.id);
+                        // Common areas sort first, then regular units
+                        const common  = floorUnits.filter(u => u.type === 'common');
+                        const regular = floorUnits.filter(u => u.type !== 'common');
+                        return (
+                            <div class="report-floor-group mb-10" id={`unit-${floor.id}`}>
+                                <div class="flex items-center gap-3 mb-6">
+                                    <div class="w-1.5 h-5 bg-slate-600 rounded-full"></div>
+                                    <h3 class="text-lg font-bold uppercase tracking-widest text-slate-500">{floor.name}</h3>
+                                </div>
+                                <div class="space-y-8 pl-4">
+                                    {common.map(u => renderUnitBlock(u))}
+                                    {regular.map(u => renderUnitBlock(u))}
+                                </div>
+                            </div>
+                        );
+                    };
+
+                    return buildings.map(building => {
+                        const children = childrenOf(units, building.id);
+                        // If the building has floor children, render 3-level
+                        // (commercial). Otherwise, children are direct units
+                        // (multi-unit without floor nesting).
+                        const hasFloors = children.some(c => c.kind === 'floor');
+
+                        // Common areas directly under the building (no floor parent)
+                        const directCommon  = children.filter(c => c.kind !== 'floor' && c.type === 'common');
+                        const directUnits   = children.filter(c => c.kind !== 'floor' && c.type !== 'common');
+                        const floors        = children.filter(c => c.kind === 'floor');
+
+                        return (
+                            <div class="report-building-group" id={`unit-${building.id}`} key={building.id}>
+                                <div class="flex items-center gap-4 mb-10 pb-4 border-b-2 border-slate-200">
+                                    <div class="w-10 h-10 bg-slate-900 rounded-lg flex items-center justify-center">
+                                        <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path></svg>
+                                    </div>
+                                    <h2 class="text-2xl font-bold tracking-tight text-slate-900">{building.name}</h2>
+                                </div>
+
+                                <div class="space-y-10">
+                                    {directCommon.map(u => renderUnitBlock(u))}
+                                    {hasFloors
+                                        ? floors.map(f => renderFloorBlock(f))
+                                        : directUnits.map(u => renderUnitBlock(u))}
+                                </div>
+                            </div>
+                        );
+                    });
+                })()}
             </div>
 
             {/* Document Finalization Tier */}

--- a/tests/unit/inspection-resolvers.spec.ts
+++ b/tests/unit/inspection-resolvers.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+    findUnit,
+    findBuildingOfUnit,
+    resolveUnitSections,
+    resolveUnitSectionItems,
+} from '../../src/lib/inspection-resolvers';
+import type { TemplateSchemaV2 } from '../../src/types/template-schema';
+
+const structure = {
+    buildings: [
+        {
+            id: 'b1', name: 'Building A',
+            units: [
+                { id: 'u1', name: 'Unit 101', type: 'unit' as const },
+                { id: 'u2', name: 'Lobby', type: 'common' as const },
+            ],
+        },
+        {
+            id: 'b2', name: 'Building B',
+            units: [{ id: 'u3', name: 'Unit 201', type: 'unit' as const }],
+        },
+    ],
+};
+
+const schema: TemplateSchemaV2 = {
+    schemaVersion: 2,
+    sections: [
+        { id: 'roof', title: 'Roof', items: [{ id: 'roof-1', label: 'Covering', type: 'rich' }, { id: 'roof-2', label: 'Flashing', type: 'rich' }] },
+        { id: 'elec', title: 'Electrical', items: [{ id: 'elec-1', label: 'Panel', type: 'rich' }] },
+        { id: 'hvac', title: 'HVAC', items: [{ id: 'hvac-1', label: 'Unit', type: 'rich' }] },
+    ],
+};
+
+describe('findUnit', () => {
+    it('finds unit by id', () => {
+        expect(findUnit(structure, 'u1')?.name).toBe('Unit 101');
+    });
+    it('returns null for unknown id', () => {
+        expect(findUnit(structure, 'xxx')).toBeNull();
+    });
+    it('returns null for undefined structure', () => {
+        expect(findUnit(undefined, 'u1')).toBeNull();
+    });
+});
+
+describe('findBuildingOfUnit', () => {
+    it('finds building containing unit', () => {
+        expect(findBuildingOfUnit(structure, 'u1')?.name).toBe('Building A');
+        expect(findBuildingOfUnit(structure, 'u3')?.name).toBe('Building B');
+    });
+    it('returns null for unknown unit', () => {
+        expect(findBuildingOfUnit(structure, 'xxx')).toBeNull();
+    });
+});
+
+describe('resolveUnitSections', () => {
+    it('returns all sections without overrides', () => {
+        const result = resolveUnitSections(schema, 'u1');
+        expect(result.map(s => s.id)).toEqual(['roof', 'elec', 'hvac']);
+    });
+
+    it('excludes sections from overrides', () => {
+        const overrides = { u1: { sectionsExcluded: ['hvac'] } };
+        const result = resolveUnitSections(schema, 'u1', overrides);
+        expect(result.map(s => s.id)).toEqual(['roof', 'elec']);
+    });
+
+    it('includes additional sections from overrides', () => {
+        const overrides = { u1: { sectionsIncluded: ['pool'] } };
+        const result = resolveUnitSections(schema, 'u1', overrides);
+        expect(result.map(s => s.id)).toEqual(['roof', 'elec', 'hvac']);
+        // 'pool' not in schema, so filtered out
+    });
+});
+
+describe('resolveUnitSectionItems', () => {
+    it('returns all items without overrides', () => {
+        const result = resolveUnitSectionItems(schema, 'u1', 'roof');
+        expect(result).toEqual(['roof-1', 'roof-2']);
+    });
+
+    it('excludes items from overrides', () => {
+        const overrides = { u1: { itemsExcluded: { roof: ['roof-2'] } } };
+        const result = resolveUnitSectionItems(schema, 'u1', 'roof', overrides);
+        expect(result).toEqual(['roof-1']);
+    });
+
+    it('returns empty for unknown section', () => {
+        expect(resolveUnitSectionItems(schema, 'u1', 'xxx')).toEqual([]);
+    });
+});

--- a/tests/unit/report-units-summary.spec.ts
+++ b/tests/unit/report-units-summary.spec.ts
@@ -10,7 +10,7 @@ import { describe, it, expect } from 'vitest';
 import { childrenOf, type ReportUnit } from '../../src/templates/components/report-units-summary';
 
 const u = (id: string, parent: string | null, kind: 'building'|'floor'|'unit', name: string, order = 0): ReportUnit =>
-    ({ id, parentUnitId: parent, kind, name, sortOrder: order });
+    ({ id, parentUnitId: parent, kind, type: 'unit', name, sortOrder: order });
 
 describe('childrenOf (subsystem D P3)', () => {
     it('returns top-level buildings when parentId is null', () => {
@@ -49,8 +49,8 @@ describe('childrenOf (subsystem D P3)', () => {
 
     it('treats missing sortOrder as 0 (stable insertion order)', () => {
         const tree = [
-            { id: 'b1', parentUnitId: null, kind: 'building' as const, name: 'A', sortOrder: 0 },
-            { id: 'b2', parentUnitId: null, kind: 'building' as const, name: 'B', sortOrder: 0 },
+            { id: 'b1', parentUnitId: null, kind: 'building' as const, type: 'unit' as const, name: 'A', sortOrder: 0 },
+            { id: 'b2', parentUnitId: null, kind: 'building' as const, type: 'unit' as const, name: 'B', sortOrder: 0 },
         ];
         const out = childrenOf(tree, null);
         expect(out.map(x => x.id)).toEqual(['b1', 'b2']);


### PR DESCRIPTION
## Summary

P3 post-launch features completing the Design System 0523 gap checklist.

- **Explicit Resolvers**: findUnit, findBuildingOfUnit, resolveUnitSections, resolveUnitSectionItems with UnitOverride support. 11 tests.
- **Comments tagging**: Migration 0078 adds section_ids, item_labels, trigger_code, search_keywords columns for auto-filter.
- **Report D7**: propertyType-aware rendering (flat/2-level/3-level). Composite finding key lookup. renderItem shared helper.
- **InviteSeatModal**: Role descriptions, guest pricing (.49-.43), notify toggle, pricing preview.
- **ReportUnit**: type field added to interface + API mapping + test fixtures.

## Test plan

- [x] tsc --noEmit clean
- [x] vitest 174 passed, 1273 tests, 0 failures

Generated with [Claude Code](https://claude.com/claude-code)