### PR TITLE
feat: Gap 16 completion + Settings + Comments filter (#88)

### DIFF
--- a/public/js/new-inspection-wizard.js
+++ b/public/js/new-inspection-wizard.js
@@ -12,7 +12,7 @@ window.newInspectionWizard = function () {
     return {
         open: false,
         step: 1,
-        property: { address: '', yearBuilt: null, sqft: null, propertyType: '' },
+        property: { address: '', yearBuilt: null, sqft: null, propertyType: '', commercialSubtype: '' },
         services: ['general'],
         schedule: { date: '', startTime: '09:00', durationMinutes: 180 },
         teamMode: false,
@@ -41,7 +41,7 @@ window.newInspectionWizard = function () {
         openWizard() {
             this.open = true;
             this.step = 1;
-            this.property = { address: '', yearBuilt: null, sqft: null, propertyType: '' };
+            this.property = { address: '', yearBuilt: null, sqft: null, propertyType: '', commercialSubtype: '' };
             this.services = ['general'];
             this.schedule = { date: '', startTime: '09:00', durationMinutes: 180 };
             this.teamMode = false;
@@ -98,6 +98,9 @@ window.newInspectionWizard = function () {
                 if (this.property.yearBuilt) payload.property.yearBuilt = this.property.yearBuilt;
                 if (this.property.sqft)      payload.property.sqft = this.property.sqft;
                 if (this.property.propertyType) payload.property.propertyType = this.property.propertyType;
+                if (this.property.propertyType === 'commercial' && this.property.commercialSubtype) {
+                    payload.property.commercialSubtype = this.property.commercialSubtype;
+                }
                 if (this.teamMode) {
                     if (this.leadInspectorId)        payload.leadInspectorId = this.leadInspectorId;
                     if (this.helperInspectorIds?.length) payload.helperInspectorIds = this.helperInspectorIds;

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,6 +1,6 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
 import { drizzle } from 'drizzle-orm/d1';
-import { eq, and, eq as eqDz, asc as ascDz, desc as descDz } from 'drizzle-orm';
+import { eq, and, like, eq as eqDz, asc as ascDz, desc as descDz } from 'drizzle-orm';
 import * as schema from '../lib/db/schema';
 import { requireRole } from '../lib/middleware/rbac';
 import { auditFromContext } from '../lib/audit';
@@ -1111,7 +1111,7 @@ const listCommentsRoute = createRoute(withMcpMetadata({
 
 adminRoutes.openapi(listCommentsRoute, async (c) => {
     const tenantId = c.get('tenantId');
-    const { rating, section, search } = c.req.valid('query');
+    const { rating, section, sectionId, triggerCode, search } = c.req.valid('query');
     const db = drizzle(c.env.DB);
     // Filters layered defensively: tenantId always first (multi-tenant
     // isolation rule from CLAUDE.md), then optional rating bucket / section
@@ -1119,6 +1119,12 @@ adminRoutes.openapi(listCommentsRoute, async (c) => {
     const conditions = [eq(comments.tenantId, tenantId)];
     if (rating) conditions.push(eq(comments.ratingBucket, rating));
     if (section) conditions.push(eq(comments.section, section));
+    if (sectionId) {
+        conditions.push(like(comments.sectionIds, `%"${sectionId}"%`));
+    }
+    if (triggerCode) {
+        conditions.push(eq(comments.triggerCode, triggerCode));
+    }
     let rows = await db.select().from(comments).where(and(...conditions)).all();
     if (search && search.trim()) {
         const needle = search.trim().toLowerCase();

--- a/src/data/seed-templates/commercial-hospitality.json
+++ b/src/data/seed-templates/commercial-hospitality.json
@@ -1,0 +1,514 @@
+{
+  "id": "seed_commercial_hospitality_v1",
+  "name": "Hospitality Property Inspection",
+  "description": "Commercial hospitality property condition assessment — includes guest rooms, commercial kitchen, and pool/spa facilities.",
+  "version": 2,
+  "schema": {
+    "schemaVersion": 2,
+    "sections": [
+      {
+        "id": "site",
+        "title": "Site",
+        "items": [
+          {
+            "id": "site-grading",
+            "label": "Grading & Drainage",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_site_grading_ok", "title": "Condition", "comment": "Grading & Drainage was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_site_grading_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_site_grading_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Grading & Drainage requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "parking",
+            "label": "Parking & Paving",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_parking_ok", "title": "Condition", "comment": "Parking & Paving was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_parking_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_parking_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Parking & Paving requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "building-envelope",
+        "title": "Building Envelope",
+        "items": [
+          {
+            "id": "roof-c",
+            "label": "Roof",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_roof_c_ok", "title": "Condition", "comment": "Roof was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_roof_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_roof_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Roof requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "facade",
+            "label": "Facade / Cladding",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_facade_ok", "title": "Condition", "comment": "Facade / Cladding was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_facade_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_facade_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Facade / Cladding requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "structure-commercial",
+        "title": "Structure",
+        "items": [
+          {
+            "id": "foundation-c",
+            "label": "Foundation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_foundation_c_ok", "title": "Condition", "comment": "Foundation was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_foundation_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_foundation_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Foundation requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "frame-c",
+            "label": "Structural Frame",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_frame_c_ok", "title": "Condition", "comment": "Structural Frame was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_frame_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_frame_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Structural Frame requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "mep",
+        "title": "Mechanical / Electrical / Plumbing",
+        "items": [
+          {
+            "id": "hvac-c",
+            "label": "HVAC",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hvac_c_ok", "title": "Condition", "comment": "HVAC was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_hvac_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hvac_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "HVAC requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "elec-c",
+            "label": "Electrical Service",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_elec_c_ok", "title": "Condition", "comment": "Electrical Service was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_elec_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_elec_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Electrical Service requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "plumbing-c",
+            "label": "Plumbing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_plumbing_c_ok", "title": "Condition", "comment": "Plumbing was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_plumbing_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_plumbing_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Plumbing requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "fire",
+            "label": "Fire Protection",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fire_ok", "title": "Condition", "comment": "Fire Protection was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fire_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_fire_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Fire Protection requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "elevator",
+            "label": "Vertical Transportation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_elevator_ok", "title": "Condition", "comment": "Vertical Transportation was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_elevator_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_elevator_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Vertical Transportation requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "guest-rooms",
+        "title": "Guest Rooms",
+        "items": [
+          {
+            "id": "room-hvac",
+            "label": "Room HVAC",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_room_hvac_ok", "title": "Condition", "comment": "Guest room HVAC units were inspected in a representative sample and appear in serviceable condition. Thermostats are responsive and airflow is adequate.", "default": true },
+                { "id": "ri_room_hvac_ptac", "title": "PTAC units", "comment": "Guest rooms are equipped with packaged terminal air conditioning (PTAC) units in serviceable condition.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_room_hvac_visual", "title": "Visual scope", "comment": "Inspection limited to a representative sample of guest rooms; not all units were individually tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_room_hvac_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Guest room HVAC units show signs of inadequate cooling/heating, excessive noise, or condensate leaks; recommend service by an HVAC technician.", "photos": [], "default": false },
+                { "id": "rd_room_hvac_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Guest room HVAC unit presents a safety concern due to electrical deficiency or gas leak; recommend immediate lock-out and repair.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "room-plumbing",
+            "label": "Room Plumbing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_room_plumbing_ok", "title": "Condition", "comment": "Guest room plumbing fixtures were inspected in a representative sample. Faucets, drains, and toilets appear in serviceable condition with adequate water pressure.", "default": true },
+                { "id": "ri_room_plumbing_anti_scald", "title": "Anti-scald valves", "comment": "Shower and tub fixtures are equipped with anti-scald mixing valves per code requirements.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_room_plumbing_visual", "title": "Visual scope", "comment": "Inspection limited to a representative sample of guest rooms; concealed piping not evaluated.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_room_plumbing_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Guest room plumbing shows leaks, low pressure, or fixture deterioration; recommend repair by a licensed plumber.", "photos": [], "default": false },
+                { "id": "rd_room_plumbing_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Guest room plumbing presents a safety concern due to missing anti-scald protection or cross-connection risk; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "room-finishes",
+            "label": "Room Finishes",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_room_finishes_ok", "title": "Condition", "comment": "Guest room finishes — flooring, walls, ceilings, and millwork — were inspected in a representative sample and appear in serviceable condition.", "default": true },
+                { "id": "ri_room_finishes_recent", "title": "Recently renovated", "comment": "Guest room finishes appear to have been recently renovated and are in good condition.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_room_finishes_visual", "title": "Visual scope", "comment": "Inspection limited to a representative sample of guest rooms; cosmetic conditions vary room to room.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_room_finishes_repair", "title": "Repair needed", "category": "maintenance", "location": "", "comment": "Guest room finishes show wear, water staining, or damage requiring cosmetic repair or renovation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "room-fire-safety",
+            "label": "Room Fire Safety",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_room_fire_safety_ok", "title": "Condition", "comment": "Guest room fire safety features — smoke detectors, sprinkler heads, and egress signage — were inspected in a representative sample and appear functional.", "default": true },
+                { "id": "ri_room_fire_safety_sprinkler", "title": "Sprinklered", "comment": "Guest rooms are fully sprinklered with heads in serviceable condition.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_room_fire_safety_visual", "title": "Visual scope", "comment": "Inspection limited to visual observation; functional testing of alarm and suppression systems is beyond the scope of this assessment.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_room_fire_safety_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Guest room fire safety devices are missing, obstructed, or appear non-functional; recommend evaluation by a fire protection specialist.", "photos": [], "default": false },
+                { "id": "rd_room_fire_safety_critical", "title": "Safety concern", "category": "safety", "location": "", "comment": "Guest room fire safety deficiency poses an immediate life-safety risk; recommend urgent correction and fire marshal notification.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "kitchen-commercial",
+        "title": "Commercial Kitchen",
+        "items": [
+          {
+            "id": "kitchen-ventilation",
+            "label": "Kitchen Ventilation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_kitchen_vent_ok", "title": "Condition", "comment": "Commercial kitchen exhaust hood and make-up air system were inspected and appear in serviceable condition. Grease filters are present and airflow is adequate.", "default": true },
+                { "id": "ri_kitchen_vent_clean", "title": "Recently cleaned", "comment": "Kitchen exhaust ductwork appears to have been recently cleaned per NFPA 96 schedule.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_kitchen_vent_visual", "title": "Visual scope", "comment": "Inspection limited to visible hood, filters, and ductwork access panels; internal ductwork condition not fully verified.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_kitchen_vent_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Kitchen ventilation system shows grease build-up, damaged filters, or inadequate airflow; recommend cleaning and service per NFPA 96.", "photos": [], "default": false },
+                { "id": "rd_kitchen_vent_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Kitchen ventilation system presents a fire hazard due to excessive grease accumulation; recommend immediate professional cleaning.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "kitchen-fire-suppression",
+            "label": "Kitchen Fire Suppression",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_kitchen_fire_ok", "title": "Condition", "comment": "Kitchen fire suppression system (Ansul/wet chemical) was inspected and appears in serviceable condition with current inspection tags.", "default": true },
+                { "id": "ri_kitchen_fire_tagged", "title": "Current inspection", "comment": "Fire suppression system has a current semi-annual inspection tag from a licensed contractor.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_kitchen_fire_visual", "title": "Visual scope", "comment": "Inspection limited to visible nozzles, tanks, and inspection tags; internal agent charge and fusible links not tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_kitchen_fire_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Kitchen fire suppression system shows expired inspection tags, missing nozzle caps, or improperly aimed nozzles; recommend service by a licensed fire protection contractor.", "photos": [], "default": false },
+                { "id": "rd_kitchen_fire_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Kitchen fire suppression system appears non-functional or has lapsed certification; recommend immediate service and fire marshal notification.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "kitchen-plumbing",
+            "label": "Kitchen Plumbing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_kitchen_plumbing_ok", "title": "Condition", "comment": "Commercial kitchen plumbing — sinks, floor drains, grease trap, and hot water supply — was inspected and appears in serviceable condition.", "default": true },
+                { "id": "ri_kitchen_plumbing_grease", "title": "Grease trap adequate", "comment": "Grease interceptor is properly sized and appears to be on a regular pumping schedule.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_kitchen_plumbing_visual", "title": "Visual scope", "comment": "Inspection limited to visible fixtures and accessible grease trap; underground waste lines not scoped.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_kitchen_plumbing_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Kitchen plumbing shows leaks, slow drains, or grease trap overflow; recommend service by a licensed plumber.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "kitchen-equipment",
+            "label": "Kitchen Equipment",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_kitchen_equip_ok", "title": "Condition", "comment": "Built-in commercial kitchen equipment (walk-in coolers, ovens, dishwashers) was inspected and appears in serviceable condition.", "default": true },
+                { "id": "ri_kitchen_equip_walkin", "title": "Walk-in cooler", "comment": "Walk-in cooler/freezer is maintaining proper temperature with adequate door seals and functional compressor.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_kitchen_equip_visual", "title": "Visual scope", "comment": "Inspection limited to permanently installed equipment; portable small-wares and tenant-owned equipment excluded.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_kitchen_equip_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Built-in kitchen equipment shows malfunction, improper temperature, or worn components; recommend evaluation by a commercial kitchen equipment technician.", "photos": [], "default": false },
+                { "id": "rd_kitchen_equip_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Kitchen equipment presents a safety concern due to gas leak, electrical fault, or refrigerant leak; recommend immediate lock-out and repair.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "pool-spa",
+        "title": "Pool & Spa",
+        "items": [
+          {
+            "id": "pool-equipment",
+            "label": "Pool Equipment",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_pool_equip_ok", "title": "Condition", "comment": "Pool mechanical equipment — pumps, filters, heater, and chemical controller — was inspected and appears in serviceable condition.", "default": true },
+                { "id": "ri_pool_equip_compliant", "title": "VGB compliant", "comment": "Pool drain covers appear compliant with the Virginia Graeme Baker Pool and Spa Safety Act (VGB Act).", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_pool_equip_visual", "title": "Visual scope", "comment": "Inspection limited to visible equipment; water chemistry, flow rates, and turnover calculations not performed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_pool_equip_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Pool equipment shows leaks, corroded fittings, or malfunctioning components; recommend service by a certified pool operator.", "photos": [], "default": false },
+                { "id": "rd_pool_equip_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Pool equipment presents a safety hazard due to non-compliant drain covers, electrical bonding deficiency, or chemical handling violation; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "pool-deck",
+            "label": "Pool Deck",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_pool_deck_ok", "title": "Condition", "comment": "Pool deck surfaces were inspected and appear in serviceable condition with adequate slip-resistant finish and proper drainage.", "default": true },
+                { "id": "ri_pool_deck_code", "title": "Code markings", "comment": "Pool depth markers and safety signage are present and legible per local health code requirements.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_pool_deck_visual", "title": "Visual scope", "comment": "Inspection limited to visible deck surfaces; sub-grade conditions and waterproofing membranes not evaluated.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_pool_deck_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Pool deck shows cracking, settling, or deteriorated non-slip surface; recommend repair to prevent trip hazards.", "photos": [], "default": false },
+                { "id": "rd_pool_deck_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Pool deck presents a safety hazard due to trip hazard, missing depth markers, or sharp edges; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "pool-fencing",
+            "label": "Pool Fencing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_pool_fencing_ok", "title": "Condition", "comment": "Pool barrier fencing and self-closing/self-latching gates were inspected and appear in serviceable condition per applicable code.", "default": true },
+                { "id": "ri_pool_fencing_height", "title": "Code height", "comment": "Pool fencing meets minimum height requirement per local building code.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_pool_fencing_visual", "title": "Visual scope", "comment": "Inspection limited to visible fencing and gate hardware; full perimeter code compliance survey not performed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_pool_fencing_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Pool fencing shows damage, gaps, or non-functional gate hardware; recommend repair to maintain barrier integrity.", "photos": [], "default": false },
+                { "id": "rd_pool_fencing_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Pool fencing is inadequate or gate latch is non-functional, creating an unsupervised access risk; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "spa-equipment",
+            "label": "Spa Equipment",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_spa_equip_ok", "title": "Condition", "comment": "Spa/hot tub equipment — pumps, heater, jets, and controls — was inspected and appears in serviceable condition.", "default": true },
+                { "id": "ri_spa_equip_compliant", "title": "VGB compliant", "comment": "Spa drain covers appear compliant with the VGB Act requirements.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_spa_equip_visual", "title": "Visual scope", "comment": "Inspection limited to visible equipment and controls; internal piping and water chemistry not evaluated.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_spa_equip_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Spa equipment shows jet malfunction, heater issues, or worn seals; recommend service by a certified spa technician.", "photos": [], "default": false },
+                { "id": "rd_spa_equip_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Spa equipment presents a safety hazard due to non-compliant drains, excessive temperature, or electrical bonding deficiency; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "interior-commercial",
+        "title": "Interior - Common Areas",
+        "items": [
+          {
+            "id": "floors-c",
+            "label": "Floors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_floors_c_ok", "title": "Condition", "comment": "Common area floors were inspected and appear in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_floors_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_floors_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Floors require repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "restrooms",
+            "label": "Public Restrooms",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_restrooms_ok", "title": "Condition", "comment": "Public restrooms were inspected and appear in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_restrooms_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_restrooms_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Restrooms require repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "summary-commercial",
+        "title": "Summary & Recommendations",
+        "items": [
+          { "id": "summary-c", "label": "Overall Assessment", "type": "text" },
+          { "id": "deferred", "label": "Deferred Maintenance", "type": "text" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/data/seed-templates/commercial-industrial.json
+++ b/src/data/seed-templates/commercial-industrial.json
@@ -1,0 +1,500 @@
+{
+  "id": "seed_commercial_industrial_v1",
+  "name": "Industrial Property Inspection",
+  "description": "Commercial industrial property condition assessment — includes loading docks, overhead crane equipment, and hazardous materials storage.",
+  "version": 2,
+  "schema": {
+    "schemaVersion": 2,
+    "sections": [
+      {
+        "id": "site",
+        "title": "Site",
+        "items": [
+          {
+            "id": "site-grading",
+            "label": "Grading & Drainage",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_site_grading_ok", "title": "Condition", "comment": "Grading & Drainage was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_site_grading_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_site_grading_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Grading & Drainage requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "parking",
+            "label": "Parking & Paving",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_parking_ok", "title": "Condition", "comment": "Parking & Paving was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_parking_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_parking_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Parking & Paving requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "fencing",
+            "label": "Perimeter Fencing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fencing_ok", "title": "Condition", "comment": "Perimeter fencing and gates were inspected and appear in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fencing_visual", "title": "Visual scope", "comment": "Inspection limited to visible fencing and gate hardware.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_fencing_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Perimeter fencing shows damage, missing sections, or non-functional gate hardware; recommend repair.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "building-envelope",
+        "title": "Building Envelope",
+        "items": [
+          {
+            "id": "roof-c",
+            "label": "Roof",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_roof_c_ok", "title": "Condition", "comment": "Roof was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_roof_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_roof_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Roof requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "facade",
+            "label": "Facade / Cladding",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_facade_ok", "title": "Condition", "comment": "Facade / Cladding was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_facade_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_facade_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Facade / Cladding requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "structure-commercial",
+        "title": "Structure",
+        "items": [
+          {
+            "id": "foundation-c",
+            "label": "Foundation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_foundation_c_ok", "title": "Condition", "comment": "Foundation was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_foundation_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_foundation_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Foundation requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "frame-c",
+            "label": "Structural Frame",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_frame_c_ok", "title": "Condition", "comment": "Structural Frame was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_frame_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_frame_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Structural Frame requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "slab",
+            "label": "Warehouse Slab",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_slab_ok", "title": "Condition", "comment": "Warehouse floor slab was inspected and appears in serviceable condition with adequate load-bearing capacity for intended use.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_slab_visual", "title": "Visual scope", "comment": "Inspection limited to visible slab surfaces; sub-slab conditions and reinforcement not evaluated.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_slab_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Warehouse slab shows cracking, spalling, or joint deterioration; recommend evaluation by a structural engineer.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "mep",
+        "title": "Mechanical / Electrical / Plumbing",
+        "items": [
+          {
+            "id": "hvac-c",
+            "label": "HVAC",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hvac_c_ok", "title": "Condition", "comment": "HVAC was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_hvac_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hvac_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "HVAC requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "elec-c",
+            "label": "Electrical Service",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_elec_c_ok", "title": "Condition", "comment": "Electrical Service was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_elec_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_elec_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Electrical Service requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "plumbing-c",
+            "label": "Plumbing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_plumbing_c_ok", "title": "Condition", "comment": "Plumbing was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_plumbing_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_plumbing_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Plumbing requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "fire",
+            "label": "Fire Protection",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fire_ok", "title": "Condition", "comment": "Fire Protection was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fire_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_fire_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Fire Protection requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "loading-dock",
+        "title": "Loading Dock",
+        "items": [
+          {
+            "id": "dock-doors",
+            "label": "Dock Doors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dock_doors_ok", "title": "Condition", "comment": "Dock doors were inspected and appear in serviceable condition. Overhead doors operate smoothly with functional safety mechanisms.", "default": true },
+                { "id": "ri_dock_doors_insulated", "title": "Insulated doors", "comment": "Dock doors are insulated and equipped with perimeter weather seals.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_dock_doors_visual", "title": "Visual scope", "comment": "Inspection limited to visible door panels, tracks, and hardware; motor internals not tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dock_doors_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Dock doors require repair — damaged panels, worn seals, or malfunctioning opener observed.", "photos": [], "default": false },
+                { "id": "rd_dock_doors_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Dock door presents a safety hazard due to failed safety reversal or broken cable; recommend immediate lock-out and repair.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "dock-levelers",
+            "label": "Dock Levelers",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dock_levelers_ok", "title": "Condition", "comment": "Dock levelers were inspected and appear in serviceable condition. Lip extends and retracts properly.", "default": true },
+                { "id": "ri_dock_levelers_hydraulic", "title": "Hydraulic operation", "comment": "Hydraulic dock levelers operate smoothly with no visible fluid leaks.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_dock_levelers_visual", "title": "Visual scope", "comment": "Inspection limited to surface operation; hydraulic cylinders and pit conditions below deck not fully accessible.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dock_levelers_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Dock levelers show wear, hydraulic leaks, or lip malfunction; recommend service by a loading dock equipment specialist.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "dock-lighting",
+            "label": "Dock Lighting",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dock_lighting_ok", "title": "Condition", "comment": "Dock area lighting was inspected and appears adequate for safe loading and unloading operations.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_dock_lighting_visual", "title": "Visual scope", "comment": "Inspection limited to visible light fixtures and general illumination levels.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dock_lighting_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Dock lighting is insufficient or fixtures are damaged; recommend replacement for safe loading operations.", "photos": [], "default": false },
+                { "id": "rd_dock_lighting_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Dock area has inadequate lighting creating a safety hazard for personnel; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "overhead-equipment",
+        "title": "Overhead Equipment",
+        "items": [
+          {
+            "id": "crane-rails",
+            "label": "Crane Rails",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_crane_rails_ok", "title": "Condition", "comment": "Overhead crane runway rails and support structure were inspected and appear in serviceable condition. Rail alignment appears adequate.", "default": true },
+                { "id": "ri_crane_rails_stops", "title": "End stops present", "comment": "Crane runway end stops are present and securely mounted at both ends of each rail.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_crane_rails_visual", "title": "Visual scope", "comment": "Inspection limited to ground-level visual observation; rail alignment survey and structural load testing not performed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_crane_rails_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Crane rails show misalignment, worn surfaces, or loose fasteners; recommend evaluation by a crane service engineer.", "photos": [], "default": false },
+                { "id": "rd_crane_rails_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Crane rail deficiency presents a safety hazard; recommend immediate lock-out and engineering evaluation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "crane-condition",
+            "label": "Crane Condition",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_crane_cond_ok", "title": "Condition", "comment": "Overhead crane bridge, trolley, and hoist were visually inspected and appear in serviceable condition. Annual inspection tag is current.", "default": true },
+                { "id": "ri_crane_cond_rated", "title": "Rated capacity", "comment": "Crane rated capacity is clearly posted and legible on the bridge.", "default": false },
+                { "id": "ri_crane_cond_inspected", "title": "Current inspection", "comment": "Crane has a current annual inspection per OSHA 1910.179 / ASME B30.2.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_crane_cond_visual", "title": "Visual scope", "comment": "Inspection limited to ground-level visual observation; load testing, brake testing, and electrical inspection not performed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_crane_cond_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Crane shows wear, corrosion, or missing inspection documentation; recommend service by a certified crane inspector.", "photos": [], "default": false },
+                { "id": "rd_crane_cond_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Crane presents a safety hazard due to structural deterioration, lapsed inspection, or missing capacity rating; recommend immediate lock-out.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "crane-controls",
+            "label": "Crane Controls",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_crane_ctrl_ok", "title": "Condition", "comment": "Crane control pendant/radio and disconnect were inspected and appear in serviceable condition. Emergency stop is functional.", "default": true },
+                { "id": "ri_crane_ctrl_lockout", "title": "Lockout present", "comment": "Crane main disconnect is equipped with lockout/tagout provisions per OSHA requirements.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_crane_ctrl_visual", "title": "Visual scope", "comment": "Inspection limited to visible controls and disconnect; internal electrical components not opened or tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_crane_ctrl_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Crane controls show worn buttons, damaged pendant cord, or intermittent operation; recommend service by a qualified crane electrician.", "photos": [], "default": false },
+                { "id": "rd_crane_ctrl_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Crane controls present a safety hazard due to non-functional emergency stop or missing lockout provisions; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "hazmat-storage",
+        "title": "Hazardous Materials Storage",
+        "items": [
+          {
+            "id": "hazmat-containment",
+            "label": "Containment",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hazmat_contain_ok", "title": "Condition", "comment": "Secondary containment systems — berms, dikes, and containment pallets — were inspected and appear in serviceable condition with adequate capacity.", "default": true },
+                { "id": "ri_hazmat_contain_spcc", "title": "SPCC plan posted", "comment": "Spill Prevention, Control, and Countermeasure (SPCC) plan is posted and appears current.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_hazmat_contain_visual", "title": "Visual scope", "comment": "Inspection limited to visible containment structures; liner integrity and capacity calculations not verified.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hazmat_contain_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Secondary containment shows cracks, deterioration, or inadequate capacity; recommend repair and capacity verification.", "photos": [], "default": false },
+                { "id": "rd_hazmat_contain_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Secondary containment is compromised or absent, creating an environmental release risk; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "hazmat-ventilation",
+            "label": "Ventilation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hazmat_vent_ok", "title": "Condition", "comment": "Hazardous materials storage area ventilation was inspected and appears to provide adequate air exchange for stored materials.", "default": true },
+                { "id": "ri_hazmat_vent_explosion", "title": "Explosion-proof", "comment": "Ventilation equipment in hazmat storage area is explosion-proof rated per NEC classification.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_hazmat_vent_visual", "title": "Visual scope", "comment": "Inspection limited to visible ventilation equipment; air change rate calculations and gas monitoring not performed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hazmat_vent_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Hazmat storage ventilation is inadequate or equipment shows deterioration; recommend evaluation by a mechanical engineer.", "photos": [], "default": false },
+                { "id": "rd_hazmat_vent_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Hazmat storage ventilation failure creates a toxic exposure or explosion risk; recommend immediate lock-out and remediation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "hazmat-signage",
+            "label": "Signage & Labeling",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hazmat_signage_ok", "title": "Condition", "comment": "Hazardous materials signage — NFPA diamonds, GHS labels, and SDS station — was inspected and appears current and legible.", "default": true },
+                { "id": "ri_hazmat_signage_sds", "title": "SDS available", "comment": "Safety Data Sheets are maintained at a clearly marked station accessible to all personnel.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_hazmat_signage_visual", "title": "Visual scope", "comment": "Inspection limited to visible signage and labeling; SDS completeness and regulatory compliance not audited.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hazmat_signage_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Hazmat signage is faded, missing, or inaccurate; recommend updating labels and NFPA diamonds per current inventory.", "photos": [], "default": false },
+                { "id": "rd_hazmat_signage_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Missing or inaccurate hazmat signage creates a first-responder safety risk; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "interior-commercial",
+        "title": "Interior - Office Areas",
+        "items": [
+          {
+            "id": "floors-c",
+            "label": "Floors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_floors_c_ok", "title": "Condition", "comment": "Office area floors were inspected and appear in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_floors_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_floors_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Floors require repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "restrooms",
+            "label": "Restrooms",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_restrooms_ok", "title": "Condition", "comment": "Restrooms were inspected and appear in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_restrooms_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_restrooms_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Restrooms require repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "environmental",
+        "title": "Environmental",
+        "items": [
+          { "id": "asbestos", "label": "Asbestos Concerns", "type": "text" },
+          {
+            "id": "mold",
+            "label": "Mold / Moisture",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_mold_ok", "title": "Condition", "comment": "Mold / Moisture was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_mold_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_mold_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Mold / Moisture requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          { "id": "lead", "label": "Lead Paint Concerns", "type": "text" }
+        ]
+      },
+      {
+        "id": "summary-commercial",
+        "title": "Summary & Recommendations",
+        "items": [
+          { "id": "summary-c", "label": "Overall Assessment", "type": "text" },
+          { "id": "deferred", "label": "Deferred Maintenance", "type": "text" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/data/seed-templates/commercial-office.json
+++ b/src/data/seed-templates/commercial-office.json
@@ -1,0 +1,424 @@
+{
+  "id": "seed_commercial_office_v1",
+  "name": "Office Building Inspection",
+  "description": "Commercial office building condition assessment — includes data/telecom infrastructure and server room systems.",
+  "version": 2,
+  "schema": {
+    "schemaVersion": 2,
+    "sections": [
+      {
+        "id": "site",
+        "title": "Site",
+        "items": [
+          {
+            "id": "site-grading",
+            "label": "Grading & Drainage",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_site_grading_ok", "title": "Condition", "comment": "Grading & Drainage was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_site_grading_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_site_grading_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Grading & Drainage requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "parking",
+            "label": "Parking & Paving",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_parking_ok", "title": "Condition", "comment": "Parking & Paving was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_parking_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_parking_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Parking & Paving requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "landscaping",
+            "label": "Landscaping",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_landscaping_ok", "title": "Condition", "comment": "Landscaping was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_landscaping_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_landscaping_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Landscaping requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "building-envelope",
+        "title": "Building Envelope",
+        "items": [
+          {
+            "id": "roof-c",
+            "label": "Roof",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_roof_c_ok", "title": "Condition", "comment": "Roof was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_roof_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_roof_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Roof requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "facade",
+            "label": "Facade / Cladding",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_facade_ok", "title": "Condition", "comment": "Facade / Cladding was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_facade_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_facade_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Facade / Cladding requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "windows-c",
+            "label": "Windows & Glazing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_windows_c_ok", "title": "Condition", "comment": "Windows & Glazing was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_windows_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_windows_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Windows & Glazing requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "structure-commercial",
+        "title": "Structure",
+        "items": [
+          {
+            "id": "foundation-c",
+            "label": "Foundation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_foundation_c_ok", "title": "Condition", "comment": "Foundation was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_foundation_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_foundation_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Foundation requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "frame-c",
+            "label": "Structural Frame",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_frame_c_ok", "title": "Condition", "comment": "Structural Frame was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_frame_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_frame_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Structural Frame requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "mep",
+        "title": "Mechanical / Electrical / Plumbing",
+        "items": [
+          {
+            "id": "hvac-c",
+            "label": "HVAC",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hvac_c_ok", "title": "Condition", "comment": "HVAC was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_hvac_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hvac_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "HVAC requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "elec-c",
+            "label": "Electrical Service",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_elec_c_ok", "title": "Condition", "comment": "Electrical Service was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_elec_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_elec_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Electrical Service requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "plumbing-c",
+            "label": "Plumbing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_plumbing_c_ok", "title": "Condition", "comment": "Plumbing was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_plumbing_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_plumbing_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Plumbing requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "fire",
+            "label": "Fire Protection",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fire_ok", "title": "Condition", "comment": "Fire Protection was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fire_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_fire_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Fire Protection requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "elevator",
+            "label": "Vertical Transportation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_elevator_ok", "title": "Condition", "comment": "Vertical Transportation was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_elevator_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_elevator_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Vertical Transportation requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "office-systems",
+        "title": "Office Systems",
+        "items": [
+          {
+            "id": "data-cabling",
+            "label": "Data Cabling",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_data_cabling_ok", "title": "Condition", "comment": "Data cabling infrastructure was inspected and appears in serviceable condition. Cable management and labeling are adequate.", "default": true },
+                { "id": "ri_data_cabling_cat6", "title": "Cat 6 or higher", "comment": "Data cabling is Cat 6 or higher rated, suitable for modern network requirements.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_data_cabling_visual", "title": "Visual scope", "comment": "Inspection limited to visible cable runs and patch panels; in-wall and plenum cabling not fully traceable.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_data_cabling_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Data cabling shows damage, poor routing, or inadequate labeling; recommend remediation by a certified low-voltage contractor.", "photos": [], "default": false },
+                { "id": "rd_data_cabling_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Data cabling presents a safety concern due to improper plenum-rated cable use or fire-stop penetrations; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "telco-room",
+            "label": "Telco Room",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_telco_room_ok", "title": "Condition", "comment": "Telecommunications room was inspected and appears in serviceable condition. Demarcation point and patch panels are organized.", "default": true },
+                { "id": "ri_telco_room_ventilated", "title": "Adequate ventilation", "comment": "Telco room has adequate ventilation to prevent equipment overheating.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_telco_room_visual", "title": "Visual scope", "comment": "Inspection limited to visible equipment and cable management; carrier-owned equipment not assessed.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_telco_room_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Telco room requires attention — poor cable management, insufficient grounding, or lack of surge protection observed.", "photos": [], "default": false },
+                { "id": "rd_telco_room_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Telco room presents a safety concern; recommend immediate evaluation for fire risk or electrical hazard.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "server-room-cooling",
+            "label": "Server Room Cooling",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_server_cooling_ok", "title": "Condition", "comment": "Server room cooling system was inspected and appears in serviceable condition. Temperature and humidity levels are within acceptable ranges.", "default": true },
+                { "id": "ri_server_cooling_redundant", "title": "Redundant cooling", "comment": "Server room is equipped with redundant cooling units providing N+1 capacity.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_server_cooling_visual", "title": "Visual scope", "comment": "Inspection limited to visible CRAC/CRAH units and ambient conditions; refrigerant levels and compressor internals not tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_server_cooling_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Server room cooling is inadequate or showing signs of failure; recommend evaluation by an HVAC specialist experienced with precision cooling.", "photos": [], "default": false },
+                { "id": "rd_server_cooling_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Server room cooling failure poses risk of equipment damage and potential fire; recommend immediate remediation.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "interior-commercial",
+        "title": "Interior",
+        "items": [
+          {
+            "id": "floors-c",
+            "label": "Floors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_floors_c_ok", "title": "Condition", "comment": "Floors was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_floors_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_floors_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Floors requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "ceilings-c",
+            "label": "Ceilings",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ceilings_c_ok", "title": "Condition", "comment": "Ceilings was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ceilings_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ceilings_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Ceilings requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "restrooms",
+            "label": "Restrooms",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_restrooms_ok", "title": "Condition", "comment": "Restrooms was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_restrooms_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_restrooms_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Restrooms requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "accessibility",
+        "title": "Accessibility (ADA)",
+        "items": [
+          {
+            "id": "ada-parking",
+            "label": "Accessible Parking",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ada_parking_ok", "title": "Condition", "comment": "Accessible Parking was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ada_parking_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ada_parking_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Accessible Parking requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "ada-entry",
+            "label": "Building Entry",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ada_entry_ok", "title": "Condition", "comment": "Building Entry was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ada_entry_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ada_entry_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Building Entry requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "summary-commercial",
+        "title": "Summary & Recommendations",
+        "items": [
+          { "id": "summary-c", "label": "Overall Assessment", "type": "text" },
+          { "id": "deferred", "label": "Deferred Maintenance", "type": "text" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/data/seed-templates/commercial-retail.json
+++ b/src/data/seed-templates/commercial-retail.json
@@ -1,0 +1,412 @@
+{
+  "id": "seed_commercial_retail_v1",
+  "name": "Retail Property Inspection",
+  "description": "Commercial retail property condition assessment — includes storefront and loading dock systems.",
+  "version": 2,
+  "schema": {
+    "schemaVersion": 2,
+    "sections": [
+      {
+        "id": "site",
+        "title": "Site",
+        "items": [
+          {
+            "id": "site-grading",
+            "label": "Grading & Drainage",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_site_grading_ok", "title": "Condition", "comment": "Grading & Drainage was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_site_grading_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_site_grading_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Grading & Drainage requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "parking",
+            "label": "Parking & Paving",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_parking_ok", "title": "Condition", "comment": "Parking & Paving was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_parking_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_parking_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Parking & Paving requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "landscaping",
+            "label": "Landscaping",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_landscaping_ok", "title": "Condition", "comment": "Landscaping was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_landscaping_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_landscaping_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Landscaping requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "building-envelope",
+        "title": "Building Envelope",
+        "items": [
+          {
+            "id": "roof-c",
+            "label": "Roof",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_roof_c_ok", "title": "Condition", "comment": "Roof was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_roof_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_roof_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Roof requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "facade",
+            "label": "Facade / Cladding",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_facade_ok", "title": "Condition", "comment": "Facade / Cladding was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_facade_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_facade_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Facade / Cladding requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "storefront",
+        "title": "Storefront",
+        "items": [
+          {
+            "id": "storefront-glass",
+            "label": "Storefront Glass",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_storefront_glass_ok", "title": "Condition", "comment": "Storefront glass and framing was inspected and appears in serviceable condition. Seals are intact with no visible fogging or cracks.", "default": true },
+                { "id": "ri_storefront_glass_tempered", "title": "Tempered glass", "comment": "Storefront glazing is tempered safety glass per code requirements.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_storefront_glass_visual", "title": "Visual scope", "comment": "Inspection limited to visible glass surfaces; thermal performance and structural glazing integrity not tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_storefront_glass_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Storefront glass shows seal failure, chips, or cracks; recommend evaluation and replacement by a glazing contractor.", "photos": [], "default": false },
+                { "id": "rd_storefront_glass_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Storefront glass presents a safety hazard due to cracking or improper glazing; recommend immediate remediation.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "signage",
+            "label": "Signage",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_signage_ok", "title": "Condition", "comment": "Exterior signage and mounting hardware was inspected and appears in serviceable condition.", "default": true },
+                { "id": "ri_signage_illuminated", "title": "Illumination functional", "comment": "Illuminated signage is operational with all lamps and transformers functioning.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_signage_visual", "title": "Visual scope", "comment": "Inspection limited to visible signage and mounting; electrical connections behind fascia not fully accessible.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_signage_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Signage shows deterioration, failed illumination, or loose mounting; recommend repair by a sign contractor.", "photos": [], "default": false },
+                { "id": "rd_signage_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Signage mounting is compromised and poses a falling hazard; recommend immediate securing or removal.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "customer-entry",
+            "label": "Customer Entry",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_customer_entry_ok", "title": "Condition", "comment": "Customer entry doors and hardware were inspected and appear in serviceable condition. Automatic closers and ADA-compliant features are operational.", "default": true },
+                { "id": "ri_customer_entry_auto", "title": "Automatic doors", "comment": "Automatic entry doors are operational with functioning sensors and safety reversals.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_customer_entry_visual", "title": "Visual scope", "comment": "Inspection limited to visible door hardware, closers, and access features.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_customer_entry_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Customer entry doors require adjustment, hardware replacement, or closer repair by a qualified door technician.", "photos": [], "default": false },
+                { "id": "rd_customer_entry_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Customer entry presents a safety concern due to malfunctioning closer, broken glass, or trip hazard; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "structure-commercial",
+        "title": "Structure",
+        "items": [
+          {
+            "id": "foundation-c",
+            "label": "Foundation",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_foundation_c_ok", "title": "Condition", "comment": "Foundation was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_foundation_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_foundation_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Foundation requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "frame-c",
+            "label": "Structural Frame",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_frame_c_ok", "title": "Condition", "comment": "Structural Frame was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_frame_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_frame_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Structural Frame requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "mep",
+        "title": "Mechanical / Electrical / Plumbing",
+        "items": [
+          {
+            "id": "hvac-c",
+            "label": "HVAC",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_hvac_c_ok", "title": "Condition", "comment": "HVAC was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_hvac_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_hvac_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "HVAC requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "elec-c",
+            "label": "Electrical Service",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_elec_c_ok", "title": "Condition", "comment": "Electrical Service was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_elec_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_elec_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Electrical Service requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "plumbing-c",
+            "label": "Plumbing",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_plumbing_c_ok", "title": "Condition", "comment": "Plumbing was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_plumbing_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_plumbing_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Plumbing requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "fire",
+            "label": "Fire Protection",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_fire_ok", "title": "Condition", "comment": "Fire Protection was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_fire_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_fire_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Fire Protection requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "loading-dock",
+        "title": "Loading Dock",
+        "items": [
+          {
+            "id": "dock-doors",
+            "label": "Dock Doors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dock_doors_ok", "title": "Condition", "comment": "Dock doors were inspected and appear in serviceable condition. Overhead doors operate smoothly with functional safety mechanisms.", "default": true },
+                { "id": "ri_dock_doors_insulated", "title": "Insulated doors", "comment": "Dock doors are insulated and equipped with perimeter weather seals to maintain interior climate.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_dock_doors_visual", "title": "Visual scope", "comment": "Inspection limited to visible door panels, tracks, and hardware; motor internals not tested.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dock_doors_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Dock doors require repair — damaged panels, worn seals, or malfunctioning opener observed; recommend service by a dock door specialist.", "photos": [], "default": false },
+                { "id": "rd_dock_doors_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Dock door presents a safety hazard due to failed safety reversal or broken cable; recommend immediate lock-out and repair.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "dock-levelers",
+            "label": "Dock Levelers",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dock_levelers_ok", "title": "Condition", "comment": "Dock levelers were inspected and appear in serviceable condition. Lip extends and retracts properly.", "default": true },
+                { "id": "ri_dock_levelers_hydraulic", "title": "Hydraulic operation", "comment": "Hydraulic dock levelers operate smoothly with no visible fluid leaks.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_dock_levelers_visual", "title": "Visual scope", "comment": "Inspection limited to surface operation; hydraulic cylinders and pit conditions below deck not fully accessible.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dock_levelers_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Dock levelers show wear, hydraulic leaks, or lip malfunction; recommend service by a loading dock equipment specialist.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "dock-lighting",
+            "label": "Dock Lighting",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_dock_lighting_ok", "title": "Condition", "comment": "Dock area lighting was inspected and appears adequate for safe loading and unloading operations.", "default": true },
+                { "id": "ri_dock_lighting_led", "title": "LED fixtures", "comment": "Dock lighting utilizes LED fixtures providing adequate lumen output for safe operations.", "default": false }
+              ],
+              "limitations": [
+                { "id": "rl_dock_lighting_visual", "title": "Visual scope", "comment": "Inspection limited to visible light fixtures and general illumination levels; lux measurements not taken.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_dock_lighting_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Dock lighting is insufficient or fixtures are damaged; recommend replacement to ensure safe loading operations.", "photos": [], "default": false },
+                { "id": "rd_dock_lighting_safety", "title": "Safety concern", "category": "safety", "location": "", "comment": "Dock area has inadequate lighting creating a safety hazard for personnel and equipment operators; recommend immediate correction.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "interior-commercial",
+        "title": "Interior",
+        "items": [
+          {
+            "id": "floors-c",
+            "label": "Floors",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_floors_c_ok", "title": "Condition", "comment": "Floors was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_floors_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_floors_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Floors requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "ceilings-c",
+            "label": "Ceilings",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_ceilings_c_ok", "title": "Condition", "comment": "Ceilings was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_ceilings_c_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_ceilings_c_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Ceilings requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          },
+          {
+            "id": "restrooms",
+            "label": "Restrooms",
+            "type": "rich",
+            "ratingOptions": ["Inspected", "Not Inspected", "Not Present", "Repair", "Safety Hazard"],
+            "tabs": {
+              "information": [
+                { "id": "ri_restrooms_ok", "title": "Condition", "comment": "Restrooms was inspected and appears in serviceable condition.", "default": true }
+              ],
+              "limitations": [
+                { "id": "rl_restrooms_visual", "title": "Visual scope", "comment": "Inspection limited to visible, accessible components at the time of inspection.", "default": false }
+              ],
+              "defects": [
+                { "id": "rd_restrooms_repair", "title": "Repair needed", "category": "recommendation", "location": "", "comment": "Restrooms requires repair or further evaluation by a qualified professional.", "photos": [], "default": false }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": "summary-commercial",
+        "title": "Summary & Recommendations",
+        "items": [
+          { "id": "summary-c", "label": "Overall Assessment", "type": "text" },
+          { "id": "deferred", "label": "Deferred Maintenance", "type": "text" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/lib/section-applicability.ts
+++ b/src/lib/section-applicability.ts
@@ -14,6 +14,7 @@ export function sectionApplies(
     section: TemplateSection,
     propertyType: string,
     subtypeId?: string | null,
+    basedOn?: string | null,
 ): boolean {
     const app = section.applicableTo;
     if (!app) return true;
@@ -29,7 +30,8 @@ export function sectionApplies(
 
     if (subtypeId && subs.includes(subtypeId)) return true;
 
-    // TODO: for org subtypes, check if basedOn is in the subs list (requires DB lookup)
+    // For org subtypes, check if their platform parent (basedOn) matches
+    if (basedOn && subs.includes(basedOn)) return true;
 
     return false;
 }
@@ -38,6 +40,7 @@ export function getApplicableSections(
     allSections: TemplateSection[],
     propertyType: string,
     subtypeId?: string | null,
+    basedOn?: string | null,
 ): TemplateSection[] {
-    return allSections.filter(s => sectionApplies(s, propertyType, subtypeId));
+    return allSections.filter(s => sectionApplies(s, propertyType, subtypeId, basedOn));
 }

--- a/src/lib/validations/admin.schema.ts
+++ b/src/lib/validations/admin.schema.ts
@@ -278,6 +278,8 @@ export const CommentResponseSchema = z.object({
 export const ListCommentsQuerySchema = z.object({
     rating: RatingBucketSchema.optional().openapi({ example: 'defect' }).describe('TODO describe rating field for the OpenInspection MCP integration'),
     section: z.string().max(64).optional().openapi({ example: 'Roof' }).describe('TODO describe section field for the OpenInspection MCP integration'),
+    sectionId: z.string().max(64).optional().openapi({ example: 'roof-general' }).describe('Filter by section ID (matches within the section_ids JSON array)'),
+    triggerCode: z.string().max(64).optional().openapi({ example: 'NI' }).describe('Filter by trigger code'),
     search: z.string().max(200).optional().describe('TODO describe search field for the OpenInspection MCP integration'),
 }).openapi('ListCommentsQuery');
 

--- a/src/lib/validations/wizard.schema.ts
+++ b/src/lib/validations/wizard.schema.ts
@@ -17,6 +17,7 @@ export const CreateInspectionFromWizardSchema = z.object({
         yearBuilt:    z.number().int().min(1700).max(2100).optional().describe('TODO describe yearBuilt field for the OpenInspection MCP integration'),
         sqft:         z.number().int().min(100).max(50_000).optional().describe('TODO describe sqft field for the OpenInspection MCP integration'),
         propertyType: z.enum(['single_family', 'condo', 'townhouse', 'multi_family', 'commercial']).optional().describe('TODO describe propertyType field for the OpenInspection MCP integration'),
+        commercialSubtype: z.enum(['office', 'retail', 'hospitality', 'industrial', 'institutional', 'mixed-use']).optional().describe('TODO describe commercialSubtype field for the OpenInspection MCP integration'),
     }).describe('TODO describe property field for the OpenInspection MCP integration'),
     services: z.array(z.string().min(1).max(64)).min(1).max(20).describe('TODO describe services field for the OpenInspection MCP integration'),
     schedule: z.object({

--- a/src/services/inspection.service.ts
+++ b/src/services/inspection.service.ts
@@ -510,6 +510,9 @@ export class InspectionService {
             const db = this.getDrizzle();
             const patch: Record<string, unknown> = {};
             if (input.property.propertyType) patch.propertyType = input.property.propertyType;
+            if (input.property.propertyType === 'commercial' && input.property.commercialSubtype) {
+                patch.commercialSubtype = input.property.commercialSubtype;
+            }
             if (input.teamMode || input.leadInspectorId || (input.helperInspectorIds?.length ?? 0) > 0) {
                 patch.teamMode           = input.teamMode;
                 patch.leadInspectorId    = input.teamMode ? (input.leadInspectorId ?? creatorUserId) : null;

--- a/src/templates/components/new-inspection-wizard.tsx
+++ b/src/templates/components/new-inspection-wizard.tsx
@@ -102,6 +102,18 @@ export function NewInspectionWizard(): JSX.Element {
                                 <option value="commercial">Commercial</option>
                             </select>
                         </label>
+                        <div x-show="property.propertyType === 'commercial'" x-cloak class="mt-3">
+                            <label class="block text-xs font-bold text-slate-600 dark:text-slate-300 mb-1">Commercial subtype</label>
+                            <select x-model="property.commercialSubtype" class="ih-input w-full">
+                                <option value="">Select subtype...</option>
+                                <option value="office">Office</option>
+                                <option value="retail">Retail</option>
+                                <option value="hospitality">Hospitality</option>
+                                <option value="industrial">Industrial</option>
+                                <option value="institutional">Institutional</option>
+                                <option value="mixed-use">Mixed-use</option>
+                            </select>
+                        </div>
                     </div>
 
                     {/* Step 2: Services */}

--- a/src/templates/pages/settings-analytics.tsx
+++ b/src/templates/pages/settings-analytics.tsx
@@ -1,0 +1,101 @@
+/**
+ * P3 post-launch — Analytics & Metrics settings page.
+ *
+ * Placeholder dashboard surfaces for inspections-per-month trend,
+ * recurring defect ranking, and team member growth. Data populated
+ * by the `analyticsAdmin()` Alpine factory when the backing API
+ * endpoints are wired up.
+ */
+import { MainLayout } from '../layouts/main-layout';
+import { PageHeader } from '../components/page-header';
+import type { BrandingConfig } from '../../types/auth';
+
+interface Props {
+    branding?: BrandingConfig | undefined;
+}
+
+export const SettingsAnalyticsPage = ({ branding }: Props): JSX.Element => (
+    <MainLayout title="Analytics & Metrics" {...(branding ? { branding } : {})}>
+        <div x-data="analyticsAdmin()" {...{ 'x-init': 'init()' }}
+             class="max-w-5xl mx-auto p-6 space-y-6">
+            <PageHeader
+                eyebrow="Settings"
+                eyebrowColor="indigo"
+                title="Analytics & Metrics"
+                meta="Inspection volume, recurring defects, and team growth."
+            />
+
+            {/* Loading skeleton */}
+            <div x-show="loading" aria-busy="true" class="space-y-4">
+                <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-6">
+                    <div class="ih-skeleton ih-skeleton--text" style="width: 40%;" />
+                    <div class="ih-skeleton ih-skeleton--text mt-3" style="width: 100%; height: 10rem;" />
+                </div>
+            </div>
+
+            <div x-show="!loading" class="space-y-6">
+                {/* Inspections per month */}
+                <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-6">
+                    <h2 class="text-sm font-bold text-slate-900 dark:text-slate-100 mb-1">Inspections per month</h2>
+                    <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">
+                        12-month rolling trend. Chart renders when data is available.
+                    </p>
+                    <div class="h-48 flex items-center justify-center border border-dashed border-slate-200 dark:border-slate-600 rounded-md">
+                        <span class="text-xs text-slate-400 dark:text-slate-500" x-text="chartPlaceholder">No data yet</span>
+                    </div>
+                </section>
+
+                {/* Recurring defects ranking */}
+                <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-6">
+                    <h2 class="text-sm font-bold text-slate-900 dark:text-slate-100 mb-1">Recurring defects</h2>
+                    <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">
+                        Most frequently flagged items across all inspections.
+                    </p>
+                    <div x-show="defects.length === 0" class="text-xs text-slate-400 dark:text-slate-500 py-4 text-center">No defect data yet</div>
+                    <table x-show="defects.length > 0" class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-slate-100 dark:border-slate-700 text-left">
+                                <th class="py-2 text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">Item</th>
+                                <th class="py-2 text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 text-right">Occurrences</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template {...{ 'x-for': 'd in defects', ':key': 'd.name' }}>
+                                <tr class="border-b border-slate-50 dark:border-slate-700/50">
+                                    <td class="py-2 text-slate-700 dark:text-slate-300" x-text="d.name" />
+                                    <td class="py-2 text-right font-mono text-slate-900 dark:text-slate-100" x-text="d.count" />
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </section>
+
+                {/* Team member growth */}
+                <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-6">
+                    <h2 class="text-sm font-bold text-slate-900 dark:text-slate-100 mb-1">Team growth</h2>
+                    <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">
+                        Active inspectors, specialists, and apprentices over time.
+                    </p>
+                    <div class="grid grid-cols-3 gap-4">
+                        <div class="text-center">
+                            <div class="text-2xl font-bold text-slate-900 dark:text-slate-100 tabular-nums" x-text="teamCounts.inspectors">0</div>
+                            <div class="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mt-1">Inspectors</div>
+                        </div>
+                        <div class="text-center">
+                            <div class="text-2xl font-bold text-slate-900 dark:text-slate-100 tabular-nums" x-text="teamCounts.specialists">0</div>
+                            <div class="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mt-1">Specialists</div>
+                        </div>
+                        <div class="text-center">
+                            <div class="text-2xl font-bold text-slate-900 dark:text-slate-100 tabular-nums" x-text="teamCounts.apprentices">0</div>
+                            <div class="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mt-1">Apprentices</div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <p class="text-xs text-rose-600 dark:text-rose-400" x-show="error" x-text="error" />
+        </div>
+        <script src="/js/auth.js" />
+        <script src="/js/settings-analytics.js" />
+    </MainLayout>
+);

--- a/src/templates/pages/settings-inspection-types.tsx
+++ b/src/templates/pages/settings-inspection-types.tsx
@@ -1,0 +1,120 @@
+import { MainLayout } from '../layouts/main-layout';
+import { PageHeader } from '../components/page-header';
+import { Modal, ModalFooter } from '../components/modal';
+import type { BrandingConfig } from '../../types/auth';
+
+interface Props { branding?: BrandingConfig; }
+
+export const SettingsInspectionTypesPage = ({ branding }: Props): JSX.Element => (
+    <MainLayout title="Settings | Inspection Types" branding={branding}>
+        <div x-data="inspectionTypesAdmin()" class="space-y-8">
+            <PageHeader
+                eyebrow="Settings · Inspection Types"
+                eyebrowColor="slate"
+                title="Inspection Types"
+            />
+
+            {/* ── Platform types ── */}
+            <section class="space-y-4">
+                <div>
+                    <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-ink-500">Platform</p>
+                    <p class="text-sm text-ink-600 mt-0.5">Standard types that ship with the platform.</p>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    <template x-for="pt in platformSubtypes" {...{ 'x-bind:key': 'pt.slug' }}>
+                        <div class="p-4 bg-white border border-surface-200 rounded-lg hover:border-blueprint-200 transition">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="flex-1 min-w-0">
+                                    <p class="font-bold text-ink-900" x-text="pt.name"></p>
+                                    <p class="text-xs text-ink-500 mt-1">
+                                        <span x-text="pt.templateCount"></span> templates &middot; <span x-text="pt.inspectionCount"></span> inspections
+                                    </p>
+                                </div>
+                                <button
+                                    x-on:click="togglePlatform(pt)"
+                                    class="text-xs font-semibold px-3 py-1 rounded-md border transition"
+                                    {...{ 'x-bind:class': "pt.enabled ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100' : 'border-surface-200 bg-surface-100 text-ink-500 hover:bg-surface-200'" }}
+                                    x-text="pt.enabled ? 'Enabled' : 'Disabled'"
+                                ></button>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </section>
+
+            {/* ── Org types ── */}
+            <section class="space-y-4">
+                <div class="flex items-end justify-between gap-3">
+                    <div>
+                        <p class="text-[10px] font-bold uppercase tracking-[0.2em] text-ink-500">Your organization</p>
+                        <p class="text-sm text-ink-600 mt-0.5">Custom types based on platform types.</p>
+                    </div>
+                    <button x-on:click="openAdd()" class="px-4 py-2 bg-blueprint-500 text-white rounded-md font-bold text-sm hover:bg-blueprint-700 active:scale-[.98] transition-all">+ Add custom subtype</button>
+                </div>
+                <div x-show="orgSubtypes.length === 0" class="text-center py-10 bg-white border border-surface-200 rounded-lg">
+                    <p class="text-ink-600 font-semibold text-sm">No custom subtypes yet.</p>
+                </div>
+                <div x-show="orgSubtypes.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    <template x-for="ot in orgSubtypes" {...{ 'x-bind:key': 'ot.id' }}>
+                        <div class="p-4 bg-white border border-surface-200 rounded-lg hover:border-blueprint-200 transition">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="flex-1 min-w-0">
+                                    <p class="font-bold text-ink-900" x-text="ot.name"></p>
+                                    <p class="text-xs text-ink-500 mt-1">
+                                        <span x-text="ot.templateCount"></span> templates &middot; <span x-text="ot.inspectionCount"></span> inspections
+                                    </p>
+                                </div>
+                                <div class="flex flex-col gap-1">
+                                    <button x-on:click="openEdit(ot)" class="text-xs text-blueprint-700 hover:underline font-semibold">Edit</button>
+                                    <button x-on:click="toggleOrg(ot)" class="text-xs font-semibold" {...{ 'x-bind:class': "ot.enabled ? 'text-ink-500 hover:underline' : 'text-emerald-700 hover:underline'" }} x-text="ot.enabled ? 'Disable' : 'Enable'"></button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </section>
+
+            {/* ── Add / edit subtype modal ── */}
+            <Modal
+                name="modalOpen"
+                titleExpr="editingId ? 'Edit custom subtype' : 'Add custom subtype'"
+                size="lg"
+                footer={
+                    <ModalFooter
+                        onCancel="modalOpen = false"
+                        onConfirm="save()"
+                        confirmDisabled="saving"
+                        confirmTextExpr="saving ? 'Saving...' : 'Save'"
+                    />
+                }
+            >
+                <div class="space-y-3">
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Name</label>
+                        <input type="text" x-model="form.name" required placeholder="e.g., Medical Office" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm" />
+                    </div>
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Based on</label>
+                        <select x-model="form.basedOn" class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm">
+                            <option value="">Select a platform type...</option>
+                            <template x-for="pt in platformSubtypes" {...{ 'x-bind:key': 'pt.slug' }}>
+                                <option {...{ 'x-bind:value': 'pt.slug' }} x-text="pt.name"></option>
+                            </template>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-bold text-ink-700 mb-1 uppercase tracking-[0.2em]">Description</label>
+                        <textarea x-model="form.description" rows={2} placeholder="Optional details..." class="w-full px-3 py-2 rounded-md border border-surface-200 focus:border-blueprint-500 focus:ring-1 focus:ring-blueprint-500 outline-none text-sm"></textarea>
+                    </div>
+                    <div x-show="duplicateWarning" class="p-3 bg-amber-50 border border-amber-200 rounded-md text-sm text-amber-800">
+                        <span x-text="duplicateWarning"></span>
+                    </div>
+                </div>
+            </Modal>
+        </div>
+
+        <script src="/js/auth.js"></script>
+        <script src="/js/toast.js"></script>
+        <script src="/js/inspection-types-admin.js"></script>
+    </MainLayout>
+);

--- a/src/templates/pages/settings-integrations-grid.tsx
+++ b/src/templates/pages/settings-integrations-grid.tsx
@@ -1,49 +1,66 @@
 /**
  * Design System 0520 subsystem E P6 — IntegrationGrid (M22).
  *
- * Mounted at /settings/integrations-grid (the existing /settings/integrations
- * is the per-integration setting page; this is the workflow-oriented
- * grid view). Renders the 6-row IntegrationsService.status snapshot
- * as cards with connect/reconnect/manage CTAs.
+ * Mounted at /settings/integrations-grid. Renders 8 integration cards
+ * in a 3-column grid with three connection states:
+ *   connected (emerald) · available (slate) · attention (amber).
+ *
+ * Alpine factory: `integrationsAdmin()` (in integrations-grid.js).
  */
 import { MainLayout } from '../layouts/main-layout';
+import { PageHeader } from '../components/page-header';
 import type { BrandingConfig } from '../../types/auth';
 
 export const IntegrationsGridPage = (
     { branding }: { branding?: BrandingConfig | undefined } = {},
 ): JSX.Element => (
     <MainLayout title="Integrations" {...(branding ? { branding } : {})}>
-        <div x-data="integrationsGrid()" {...{ 'x-init': 'init()' }}
-             class="max-w-4xl mx-auto p-6">
-            <h1 class="text-2xl font-bold mb-4">Integrations</h1>
-            <p class="text-sm text-slate-500 mb-4">
-                Connect external services to enrich your inspections,
-                send reports, and accept payments.
-            </p>
+        <div x-data="integrationsAdmin()" {...{ 'x-init': 'init()' }}
+             class="max-w-5xl mx-auto p-6 space-y-6">
+            <PageHeader
+                eyebrow="Settings"
+                eyebrowColor="indigo"
+                title="Integrations"
+                meta={<span x-text="summary"></span>}
+            />
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Loading skeleton */}
+            <div x-show="loading" aria-busy="true" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {[0, 1, 2].map(() => (
+                    <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-5 space-y-3">
+                        <div class="ih-skeleton ih-skeleton--text" style="width: 50%;" />
+                        <div class="ih-skeleton ih-skeleton--text" style="width: 80%;" />
+                        <div class="ih-skeleton ih-skeleton--text" style="width: 30%;" />
+                    </div>
+                ))}
+            </div>
+
+            {/* Integration cards */}
+            <div x-show="!loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 <template {...{ 'x-for': 'i in integrations', ':key': 'i.id' }}>
-                    <div class="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
-                        <div class="flex items-center justify-between mb-2 gap-2">
-                            <h3 class="text-base font-bold" x-text="i.name" />
-                            <span class="px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-widest"
+                    <div class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-5 flex flex-col gap-3">
+                        <div class="flex items-start justify-between gap-2">
+                            <h3 class="text-sm font-bold text-slate-900 dark:text-slate-100" x-text="i.name" />
+                            <span class="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-widest"
                                   {...{
-                                      ':class': "i.connected ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'",
-                                      'x-text':  "i.connected ? 'Connected' : 'Not configured'",
+                                      ':class': `i.state === 'connected'
+                                          ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+                                          : i.state === 'attention'
+                                              ? 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300'
+                                              : 'bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400'`,
+                                      'x-text': `i.state === 'connected' ? 'Connected' : i.state === 'attention' ? 'Attention' : 'Available'`,
                                   }} />
                         </div>
-                        <p class="text-xs text-slate-500 mb-3"
-                           x-show="i.lastSync"
-                           x-text="`Last sync: ${i.lastSync}`" />
-                        <button class="px-3 h-7 rounded-md border border-slate-200 bg-white text-xs font-bold capitalize hover:bg-slate-50"
-                                x-show="i.action"
-                                {...{ '@click': 'action(i)', 'x-text': 'i.action' }} />
+                        <p class="text-xs text-slate-500 dark:text-slate-400 leading-relaxed flex-1" x-text="i.description" />
+                        <button class="self-start px-3 h-7 rounded-md border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-xs font-bold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors capitalize"
+                                {...{ '@click': 'configure(i)', 'x-text': "i.state === 'connected' ? 'Configure' : 'Connect'" }} />
                     </div>
                 </template>
             </div>
 
-            <p class="text-xs text-rose-600 mt-4" x-show="error" x-text="error" />
+            <p class="text-xs text-rose-600 dark:text-rose-400" x-show="error" x-text="error" />
         </div>
-        <script src="/js/integrations-grid.js"></script>
+        <script src="/js/auth.js" />
+        <script src="/js/integrations-grid.js" />
     </MainLayout>
 );

--- a/tests/unit/commercial-subtypes.spec.ts
+++ b/tests/unit/commercial-subtypes.spec.ts
@@ -115,6 +115,22 @@ describe('sectionApplies', () => {
             'commercial', 'office',
         )).toBe(false);
     });
+
+    it('applies when org subtype basedOn matches a listed platform subtype', () => {
+        // An org subtype "custom-retail" is based on platform subtype "retail".
+        // The section allows "retail" — so it should apply via basedOn inheritance.
+        expect(sectionApplies(
+            makeSection({ propertyTypes: ['commercial'], commercialSubtypes: ['retail', 'hospitality'] }),
+            'commercial', 'custom-retail', 'retail',
+        )).toBe(true);
+    });
+
+    it('does not apply when neither subtypeId nor basedOn matches', () => {
+        expect(sectionApplies(
+            makeSection({ propertyTypes: ['commercial'], commercialSubtypes: ['retail'] }),
+            'commercial', 'custom-office', 'office',
+        )).toBe(false);
+    });
 });
 
 describe('getApplicableSections', () => {


### PR DESCRIPTION
## Summary

Completes Gap 16 + remaining Settings pages + Comments API.

- **Gap 16B**: Wizard subtype picker (commercial dropdown), 4 subtype seed templates (office/retail/hospitality/industrial with specialized sections)
- **Gap 16D**: Settings Inspection Types page (platform/org subtypes, add modal, duplicate warning)
- **Comments API**: sectionId + triggerCode query filters
- **section-applicability**: basedOn inheritance for org subtypes (2 new tests)
- **Settings**: integrations grid enhanced, analytics page created
- **Billing**: already comprehensive (290 lines)

## Test plan

- [x] tsc --noEmit clean
- [x] vitest 174 passed, 1281 tests, 0 failures

Generated with [Claude Code](https://claude.com/claude-code)