### PR TITLE
fix: sidebar FOUC + page header consistency + merge create buttons

### DIFF
--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -333,6 +333,8 @@ textarea {
         transition: width var(--ih-dur-slow) var(--ih-ease-out);
     }
     .ih-sidebar.is-collapsed { width: var(--ih-sidebar-collapsed-w); }
+    html[data-sidebar-collapsed="1"] .ih-sidebar { width: var(--ih-sidebar-collapsed-w); }
+    html[data-sidebar-collapsed="1"] .ih-sidebar [x-show="!sbc"] { display: none !important; }
 
     .ih-btn {
         display: inline-flex;

--- a/src/templates/pages/contacts.tsx
+++ b/src/templates/pages/contacts.tsx
@@ -11,7 +11,7 @@ export const ContactsPage = ({ branding }: { branding?: BrandingConfig | undefin
                 <div x-data="contactsMeta">
                     <PageHeader
                         eyebrow="CONTACTS"
-                        eyebrowColor="slate"
+                        eyebrowColor="indigo"
                         title="Contacts"
                         meta={<span x-text="metaText"></span>}
                         actions={

--- a/src/templates/pages/dashboard.tsx
+++ b/src/templates/pages/dashboard.tsx
@@ -93,28 +93,13 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                                 </button>
                                 <button
                                     type="button"
-                                    onclick="showCreateModal()"
+                                    onclick="window.dispatchEvent(new CustomEvent('open-new-inspection-wizard'))"
                                     class="h-8 px-4 rounded-md bg-indigo-600 text-white font-bold text-[13px] hover:bg-indigo-700 active:scale-95 transition-all inline-flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                                 >
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
                                     </svg>
                                     New Inspection
-                                </button>
-                                {/* Design System 0520 subsystem B phase 5 — discoverable
-                                    wizard launcher. Coexists with the legacy quick-create
-                                    button above; wizard offers the 4-step flow with
-                                    team-mode + service picker + scheduled time + duration. */}
-                                <button
-                                    type="button"
-                                    onclick="window.dispatchEvent(new CustomEvent('open-new-inspection-wizard'))"
-                                    class="h-8 px-3 rounded-md ring-1 ring-indigo-300 text-indigo-700 text-[13px] font-semibold hover:bg-indigo-50 inline-flex items-center gap-1.5"
-                                    title="Open 4-step wizard"
-                                >
-                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"></path>
-                                    </svg>
-                                    Wizard
                                 </button>
                             </>
                         }
@@ -174,13 +159,6 @@ export const DashboardPage = ({ branding, seatUsage, billingPortalUrl }: Dashboa
                                     style="display: none;"
                                 ></p>
                             ) : null}
-                            {/* Portfolio defect chips — only when bucket has at least one defect.
-                                ih-pill canonical class lives in input.css. */}
-                            <div class="mt-3 flex items-center gap-1 flex-wrap" x-show={`agg('${stat.target}').safety + agg('${stat.target}').recommendation + agg('${stat.target}').maintenance > 0`}>
-                                <span x-show={`agg('${stat.target}').safety > 0`} class="ih-pill ih-pill--defect" title="Safety defects" x-text={`'\u{1F534} ' + agg('${stat.target}').safety`}></span>
-                                <span x-show={`agg('${stat.target}').recommendation > 0`} class="ih-pill ih-pill--monitor" title="Recommendations" x-text={`'\u{1F7E1} ' + agg('${stat.target}').recommendation`}></span>
-                                <span x-show={`agg('${stat.target}').maintenance > 0`} class="ih-pill ih-pill--info" title="Maintenance items" x-text={`'\u{1F535} ' + agg('${stat.target}').maintenance`}></span>
-                            </div>
                         </button>
                     ))}
                 </div>

--- a/src/templates/pages/settings.tsx
+++ b/src/templates/pages/settings.tsx
@@ -2,6 +2,7 @@ import { MainLayout } from '../layouts/main-layout';
 import { BrandingConfig } from '../../types/auth';
 import { BUILD } from '../../generated/version';
 import { SETTINGS_GROUPS } from '../components/settings-layout';
+import { PageHeader } from '../components/page-header';
 
 /**
  * Hub page at `/settings` — shows the 6 group cards (Profile / Workspace / Catalog /
@@ -26,10 +27,11 @@ export const SettingsPage = ({ branding }: { branding?: BrandingConfig | undefin
                     </div>
 
                     {/* Header */}
-                    <header class="space-y-2">
-                        <span class="inline-flex items-center rounded-md bg-blueprint-100 px-2.5 py-1 text-[10px] font-bold text-blueprint-700 uppercase tracking-[0.2em]">Settings</span>
-                        <h1 class="text-3xl font-bold tracking-tight text-ink-900 dark:text-slate-100">Settings</h1>
-                    </header>
+                    <PageHeader
+                        eyebrow="SETTINGS"
+                        eyebrowColor="slate"
+                        title="Settings"
+                    />
 
                     {/* Group cards */}
                     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary

- **Sidebar FOUC fix**: CSS rules for html[data-sidebar-collapsed] prevent jitter before Alpine hydrates
- **Dashboard**: removed defect chips from stat cards, merged New Inspection + Wizard into one button
- **Contacts**: eyebrowColor slate -> indigo (main workflow page)
- **Settings**: manual h1 replaced with canonical PageHeader

174 tests pass, 1281 total.

Generated with [Claude Code](https://claude.com/claude-code)