### PR TITLE
core: service-binding M2M auth, SSO/logout session fixes, single R2 bucket, agreement sanitization, self-host docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## What it is
 
-A complete home inspection software stack: inspector dashboard, public booking widget, mobile field form, professional HTML reports with e-signatures, AI assistance, multi-tenant routing, and PWA offline support — all running on Cloudflare's edge.
+A complete home inspection software stack: inspector dashboard, public booking widget, mobile field form, professional HTML reports with e-signatures, AI assistance, and PWA offline support — all running on Cloudflare's edge, self-hosted on a single Worker.
 
 ### Architecture
 
@@ -45,17 +45,17 @@ A complete home inspection software stack: inspector dashboard, public booking w
 - "Share with buyer" link generation
 - Recommendations export
 
-### Multi-tenant
-- Subdomain routing
-- Branded UI per tenant
-- Tenant-scoped D1 data isolation
+### Self-host friendly
+- Runs **standalone** (single-tenant) by default — one fixed tenant holds all your data, no subdomains to manage
+- Branded UI (logo, colors) configurable in Settings
+- Tenant-scoped D1 data isolation baked into every table
 
 ## Why OpenInspection
 
 - **Free to run**: Cloudflare Workers Free tier covers a solo inspector's full year. Pay only for a domain (~$10).
 - **Yours**: fork it, change templates, add integrations. No vendor lock-in.
 - **Fast**: edge-deployed, < 100 ms response times globally
-- **Compliant**: PBKDF2-SHA256 password hashing, hash-chained Ed25519 audit log on e-signatures (ESIGN Act + UETA), server-rendered PDF + Certificate of Completion via Browser Run, offline-verifiable evidence pack, multi-tenant data isolation
+- **Compliant**: PBKDF2-SHA256 password hashing, hash-chained Ed25519 audit log on e-signatures (ESIGN Act + UETA), server-rendered PDF + Certificate of Completion via Browser Run, offline-verifiable evidence pack, tenant-scoped data isolation
 - **Modern**: React Router v7 + React 18 + Hono API + Drizzle + Tailwind v4 — small surface, easy to read
 
 ## Quick start

--- a/app/components/SanitizedHtml.tsx
+++ b/app/components/SanitizedHtml.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Renders agreement rich-text HTML with a client-side DOMPurify pass as
+ * defense-in-depth on top of the server-side `sanitizeAgreementHtml()` that
+ * already runs at write time.
+ *
+ * DOMPurify needs a DOM, which Cloudflare Workers SSR does not have, so it is
+ * imported and applied only in the browser (and in the Browser Run headless
+ * renderer used to produce signed PDFs). SSR emits the already server-sanitized
+ * `html` so the first paint — and any no-JS PDF fallback — stays safe; the
+ * effect then re-sanitizes with a real HTML parser once mounted.
+ *
+ * The allow-list mirrors the Quill editor toolbar and the server sanitizer:
+ * basic formatting, two heading levels, lists, and `class` (for `ql-indent-N`).
+ */
+const ALLOWED_TAGS = ["p", "strong", "em", "u", "b", "i", "h2", "h3", "ol", "ul", "li", "br", "span"];
+const ALLOWED_ATTR = ["class"];
+
+export function SanitizedHtml({ html, className }: { html: string; className?: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void import("dompurify").then(({ default: DOMPurify }) => {
+      if (cancelled || !ref.current) return;
+      ref.current.innerHTML = DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [html]);
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      // Server-sanitized at write time (sanitizeAgreementHtml); DOMPurify re-sanitizes on mount.
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -190,7 +190,7 @@ function MobileDrawer({ open, onClose }: { open: boolean; onClose: () => void })
           </div>
           <a href="/logout" className="w-full flex items-center gap-3 px-3 py-2 rounded-[6px] text-ih-bad-fg hover:bg-ih-bad-bg transition-all font-medium text-[13px]">
             <svg className={IC} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
-            <span>Sign Out</span>
+            <span>Log Out</span>
           </a>
         </div>
       </div>
@@ -355,10 +355,10 @@ export function Sidebar() {
         <a
           href="/logout"
           className={`flex items-center gap-2.5 px-[10px] py-[7px] rounded-[6px] text-[13px] font-medium text-ih-fg-2 hover:bg-ih-bad-bg hover:text-ih-bad-fg transition-all ${collapsed ? "justify-center" : ""}`}
-          title={collapsed ? "Sign out" : undefined}
+          title={collapsed ? "Log out" : undefined}
         >
           <svg className={IC} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
-          {!collapsed && <span>Sign Out</span>}
+          {!collapsed && <span>Log Out</span>}
         </a>
       </div>
     </aside>

--- a/app/components/agent/AgentCommandPalette.tsx
+++ b/app/components/agent/AgentCommandPalette.tsx
@@ -35,7 +35,7 @@ export function AgentCommandPalette({ inspectors, agentSlug, bookingHost }: Agen
       { id: "page-dashboard", group: "Pages", label: "Dashboard", hint: "G then D", href: "/agent-dashboard" },
       { id: "page-inspectors", group: "Pages", label: "Inspectors", hint: "G then I", href: "/agent-inspectors" },
       { id: "page-settings", group: "Pages", label: "Settings", hint: "G then S", href: "/agent-settings/profile" },
-      { id: "action-signout", group: "Actions", label: "Sign out", hint: "log out", action: "signout" },
+      { id: "action-signout", group: "Actions", label: "Log out", hint: "log out", action: "signout" },
     ];
     const ref = agentSlug ? `?ref=${encodeURIComponent(agentSlug)}` : "";
     for (const insp of inspectors) {

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -39,9 +39,30 @@ export async function getSession(context: AppLoadContext, request: Request) {
   return getStorage(context).getSession(request.headers.get("Cookie"));
 }
 
+/** Read a single raw cookie value from the request's Cookie header. */
+function readRawCookie(request: Request, name: string): string | null {
+  const header = request.headers.get("Cookie");
+  if (!header) return null;
+  for (const part of header.split(/;\s*/)) {
+    const eq = part.indexOf("=");
+    if (eq > 0 && part.slice(0, eq) === name) {
+      return decodeURIComponent(part.slice(eq + 1));
+    }
+  }
+  return null;
+}
+
 export async function getToken(context: AppLoadContext, request: Request): Promise<string | null> {
   const session = await getSession(context, request);
-  return session.get("token") || null;
+  const fromSession = session.get("token");
+  if (fromSession) return fromSession;
+  // Fallback: the SSO handoff consume (GET /sso, server/api/auth.ts) sets the
+  // JWT only in the raw `__Host-inspector_token` cookie and never writes the
+  // React Router `__session` cookie that createUserSession sets on local form
+  // login. Without this fallback, loaders' requireToken() bounce every SSO
+  // arrival to /login even though the session is valid. Both cookies carry the
+  // same JWT; the value is used purely as the bearer token for createApi().
+  return readRawCookie(request, "__Host-inspector_token");
 }
 
 export async function requireToken(context: AppLoadContext, request: Request): Promise<string> {

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -87,9 +87,15 @@ export async function createSessionWithToken(
 
 export async function destroyUserSession(context: AppLoadContext, request: Request) {
   const session = await getSession(context, request);
-  return redirect("/login", {
-    headers: {
-      "Set-Cookie": await getStorage(context).destroySession(session),
-    },
-  });
+  const headers = new Headers();
+  headers.append("Set-Cookie", await getStorage(context).destroySession(session));
+  // Also expire the raw JWT cookie the API sets (and that getToken() falls back
+  // to). Without this, logout would clear only the RR `__session` cookie and the
+  // getToken fallback would keep the user authenticated via __Host-inspector_token.
+  // __Host- prefix requires Secure + Path=/ + no Domain.
+  headers.append(
+    "Set-Cookie",
+    "__Host-inspector_token=; Path=/; Secure; HttpOnly; SameSite=Strict; Max-Age=0",
+  );
+  return redirect("/login", { headers });
 }

--- a/app/routes/agent-layout.tsx
+++ b/app/routes/agent-layout.tsx
@@ -49,7 +49,7 @@ export default function AgentLayout() {
               href="/logout"
               className="px-3 py-1.5 rounded-md text-[13px] font-medium text-slate-600 hover:bg-red-50 hover:text-red-600 dark:text-slate-400 dark:hover:bg-red-900/20 dark:hover:text-red-400 transition-colors ml-2"
             >
-              Sign out
+              Log out
             </a>
           </nav>
         </div>

--- a/app/routes/agent/signup.tsx
+++ b/app/routes/agent/signup.tsx
@@ -36,7 +36,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   if (!res.ok || !(json as Record<string, unknown>).success) {
     const err = json.error as Record<string, string> | undefined;
     if (err?.code === "conflict") {
-      return submission.reply({ formErrors: ["That email is already registered. Sign in instead."] });
+      return submission.reply({ formErrors: ["That email is already registered. Log in instead."] });
     }
     return submission.reply({ formErrors: [err?.message || "Could not create account"] });
   }
@@ -230,7 +230,7 @@ export default function AgentSignupPage() {
               to="/login"
               className="text-ih-primary font-medium hover:underline"
             >
-              Sign in
+              Log in
             </Link>
           </p>
         </div>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -7,7 +7,7 @@ import { createApi } from "~/lib/api-client.server";
 import { loginSchema } from "~/lib/forms/auth.schema";
 
 export function meta() {
-  return [{ title: "Sign In - OpenInspection" }];
+  return [{ title: "Log In - OpenInspection" }];
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -88,7 +88,7 @@ export default function LoginPage() {
         </div>
 
         <h1 className="text-2xl font-bold text-ih-fg-1 mb-2">
-          Sign in to your workspace
+          Log in to your workspace
         </h1>
         <p className="text-sm text-ih-fg-3 mb-6">
           Enter your credentials to access inspections, reports, and team tools.
@@ -144,7 +144,7 @@ export default function LoginPage() {
             disabled={isSubmitting}
             className="w-full py-2.5 rounded-lg bg-ih-primary text-white font-bold text-sm hover:bg-ih-primary-600 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? "Signing in…" : "Sign In"}
+            {isSubmitting ? "Logging in…" : "Log In"}
           </button>
         </Form>
       </div>

--- a/app/routes/public/agreement-printable.tsx
+++ b/app/routes/public/agreement-printable.tsx
@@ -1,5 +1,6 @@
 import { useLoaderData } from "react-router";
 import type { Route } from "./+types/agreement-printable";
+import { SanitizedHtml } from "~/components/SanitizedHtml";
 
 export function meta() {
   return [{ title: "Signed Agreement - OpenInspection" }];
@@ -77,9 +78,9 @@ export default function AgreementPrintablePage() {
       </div>
 
       {/* Agreement body */}
-      <div
+      <SanitizedHtml
         className="text-[13px] leading-[1.7] [&_p]:mb-3 [&_strong]:font-semibold [&_ol]:pl-6 [&_ul]:pl-6 [&_ol]:mb-3 [&_ul]:mb-3"
-        dangerouslySetInnerHTML={{ __html: agreement.bodyHtml }}
+        html={agreement.bodyHtml}
       />
 
       {/* Signature block */}

--- a/app/routes/public/agreement-sign.tsx
+++ b/app/routes/public/agreement-sign.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useLoaderData } from "react-router";
 import type { Route } from "./+types/agreement-sign";
 import { createApi } from "~/lib/api-client.server";
+import { SanitizedHtml } from "~/components/SanitizedHtml";
 
 export function meta() {
  return [{ title: "Sign Agreement - OpenInspection" }];
@@ -205,9 +206,9 @@ export default function AgreementSignPage() {
 
  {/* Agreement content */}
  <div className="px-6 py-6 sm:px-10 sm:py-8 border-b border-slate-100 dark:border-slate-700 max-h-96 overflow-y-auto">
- <div
+ <SanitizedHtml
  className="prose prose-sm dark:prose-invert max-w-none text-ih-fg-3 leading-relaxed"
- dangerouslySetInnerHTML={{ __html: agreement.body }}
+ html={agreement.body}
  />
  </div>
 

--- a/app/routes/settings-security.tsx
+++ b/app/routes/settings-security.tsx
@@ -201,7 +201,7 @@ export default function SettingsSecurityPage() {
             <div>
               <p className="font-bold text-ih-fg-1 text-[13px]">Two-factor authentication</p>
               <p className="text-[11px] text-ih-fg-3">
-                {user.totpEnabled ? "Enabled. Required at every sign in." : "Not enabled."}
+                {user.totpEnabled ? "Enabled. Required at every log in." : "Not enabled."}
               </p>
               {user.totpEnabled && user.recoveryCodesRemaining != null && (
                 <p className="text-[11px] text-ih-fg-3 mt-1">{user.recoveryCodesRemaining} recovery codes remaining</p>

--- a/docs/developers/01_architecture.md
+++ b/docs/developers/01_architecture.md
@@ -1,6 +1,8 @@
 # Architecture
 
-OpenInspection is a multi-tenant home inspection app deployed as a single Cloudflare Worker (the cloudflare/react-router-hono-fullstack-template shape): a Hono entry that mounts the full API in-process and delegates page routes to React Router v7 SSR. This doc covers the high-level architecture for self-hosters, contributors, and reviewers.
+OpenInspection is a home inspection app deployed as a single Cloudflare Worker (the cloudflare/react-router-hono-fullstack-template shape): a Hono entry that mounts the full API in-process and delegates page routes to React Router v7 SSR. This doc covers the high-level architecture for self-hosters, contributors, and reviewers.
+
+> Self-hosted instances run **standalone** (single-tenant) — the default in `wrangler.jsonc`. The engine is tenant-aware under the hood (every table carries `tenant_id`), but you don't manage tenants or subdomains; one fixed tenant holds all your data.
 
 ## Stack at a glance
 
@@ -24,7 +26,7 @@ OpenInspection is a multi-tenant home inspection app deployed as a single Cloudf
 
 ## Single-Worker Architecture
 
-OpenInspection runs as ONE Cloudflare Worker. `workers/app.ts` is a Hono app that is the worker entry: it mounts the full API (`src/`) for API-owned paths and delegates everything else (page routes) to the React Router v7 SSR handler.
+OpenInspection runs as ONE Cloudflare Worker. `workers/app.ts` is a Hono app that is the worker entry: it mounts the full API (`server/`) for API-owned paths and delegates everything else (page routes) to the React Router v7 SSR handler.
 
 ```
                     ┌──────────────────────────────────────────┐
@@ -34,7 +36,7 @@ OpenInspection runs as ONE Cloudflare Worker. `workers/app.ts` is a Hono app tha
                     │  ┌──────────────────┐  ┌────────────────┐ │
                     │  │ /api/*, /status, │  │ everything else│ │
                     │  │ /sign/*, … →     │  │ → React Router │ │
-                    │  │ API app (src/)   │  │ v7 SSR (app/)  │ │
+                    │  │ API app (server/)│  │ v7 SSR (app/)  │ │
                     │  │ in-process       │◄─┤ in-process     │ │
                     │  │ Hono+Drizzle+D1  │  │ API_WORKER     │ │
                     │  └──────────────────┘  └────────────────┘ │
@@ -44,7 +46,7 @@ OpenInspection runs as ONE Cloudflare Worker. `workers/app.ts` is a Hono app tha
 ```
 
 - **`workers/app.ts`** — a Hono app is the worker entry. It routes API-owned paths (`/api/*`, `/status`, `/m2m/*`, `/photos/*`, `/.well-known/*`, `/doc`, `/sso`, `/sign/*`, ICS/observe feeds) to the API app and sends everything else to the React Router v7 SSR handler. It injects an in-process `API_WORKER` self-binding so React Router loaders/actions call the API app DIRECTLY (no network hop, no second worker, no Service Binding between workers).
-- **`src/`** — Hono + Drizzle + D1. Handles all business logic, authentication, and data access. Exposes a typed JSON API.
+- **`server/`** — Hono + Drizzle + D1. Handles all business logic, authentication, and data access. Exposes a typed JSON API.
 - **`app/`** — React Router v7 + React 18 + Tailwind v4. Server-side renders the React UI on the edge.
 - **Shared UI** (`packages/shared-ui/`) — Design System 0523 token-based React components (Button, Pill, Card, etc.).
 - **API Types** (`packages/api-types/`) — Re-exports the Hono app type so the web layer's `hono/client` gets full end-to-end type safety.
@@ -65,7 +67,7 @@ The web layer uses a **Token Relay BFF** pattern: the React Router v7 server hol
 apps/core/
 ├── workers/
 │   └── app.ts                     # Single-worker entry: Hono mounts API in-process + delegates pages to RR SSR
-├── src/                           # API (Hono + Drizzle + D1)
+├── server/                        # API (Hono + Drizzle + D1)
 │   ├── index.ts                   # Hono app entry, middleware order, route registration
 │   ├── api/                       # Route handlers (one file per resource)
 │   │   ├── auth.ts                # /api/auth/{login,register,reset-password,...}
@@ -74,8 +76,8 @@ apps/core/
 │   │   ├── booking.ts             # /public/* (no auth) + /api/book
 │   │   └── ...
 │   ├── services/                  # Business logic, DB queries (Drizzle)
-│   ├── features/                  # Feature-scoped modules (per-strategy splits)
-│   │   └── tenant-routing/        # Tenant resolution: path-param → subdomain → fixed
+│   ├── features/                  # Feature-scoped modules
+│   │   └── tenant-routing/        # Tenant resolution (standalone pins one fixed tenant)
 │   ├── lib/
 │   │   ├── middleware/            # Hono middleware (auth, RBAC, branding, DI)
 │   │   ├── db/                    # Drizzle schema + utils
@@ -83,7 +85,8 @@ apps/core/
 │   │   ├── errors.ts              # AppError + ErrorCode + Errors factory
 │   │   ├── logger.ts              # Structured JSON logger (use this, not console)
 │   │   └── ics.ts                 # iCalendar string builder
-│   └── workflows/                 # Cloudflare Workflow durable steps
+│   ├── workflows/                 # Cloudflare Workflow durable steps (e-sign completion)
+│   └── portal/                    # SaaS-only portal integration (unused in standalone)
 ├── app/                           # Web (React Router v7 + React 18 + Tailwind v4)
 │   ├── root.tsx                   # React Router v7 root layout
 │   ├── routes.ts                  # Route configuration
@@ -133,7 +136,7 @@ Cloudflare edge → single Worker (workers/app.ts) → Hono routes API-owned pat
 Hono middleware stack (in order):
    1. CSP / security headers
    2. Branding resolver (KV → D1 fallback)
-   3. Tenant router (subdomain → tenant ID)
+   3. Tenant router (standalone: pins the one fixed tenant)
    4. JWT auth (skip on /api/auth, /api/public, /api/setup)
    5. Bot protection (Turnstile + threat score)
    6. Tier guard (subscription check, no-op in standalone)
@@ -148,19 +151,17 @@ Service queries D1 (Drizzle) / R2 / KV / external API
 Response via sendSuccess() / sendError() (canonical envelope)
 ```
 
-## Multi-tenancy model
+## Tenancy model
 
-Every D1 table includes `tenant_id` (NOT NULL). Three deployment modes:
+Every D1 table includes `tenant_id` (NOT NULL) so the data model is tenant-aware, but a
+self-hosted instance runs **standalone**: `SINGLE_TENANT_ID` pins all data to one fixed
+tenant. You never manage tenants or subdomains. Tenant resolution lives in
+`server/features/tenant-routing/`; in standalone the `tenantRouter` middleware simply pins
+the request to `profile.fixedTenantId` (`resolve-by-fixed-tenant.ts`).
 
-- **Standalone** (default for self-hosters): single tenant. `SINGLE_TENANT_ID` env var pins all data to one tenant. The tenant subdomain is irrelevant.
-- **Shared SaaS**: one Worker, many tenants, each on a subdomain (`acme.app.com`, `xyz.app.com`).
-- **Silo SaaS**: per-tenant dedicated D1 (provisioned via Cloudflare API).
-
-Tenant resolution lives in `src/features/tenant-routing/` (entry point `index.ts`, with per-strategy resolvers in sibling files). The `tenantRouter` middleware tries three strategies in order:
-
-1. **Path-param resolution** (`resolve-by-path-param.ts`) — matches URL patterns like `/book/:tenant/:slug` first so public routes work uniformly across all deploy modes
-2. **Subdomain resolution** (`resolve-by-subdomain.ts`) — silo / shared SaaS: extracts the subdomain from the `Host` header, looks up the tenant via KV (5-minute TTL) with D1 fallback, then writes the result back to KV
-3. **Fixed-tenant fallback** (`resolve-by-fixed-tenant.ts`) — standalone: pins the request to `profile.fixedTenantId`
+> The same engine also powers a multi-tenant SaaS (subdomain/silo routing, portal SSO, billing
+> tiers) when `APP_MODE=saas`. Those modes are out of scope for self-hosting and not documented
+> here.
 
 ## Authentication
 
@@ -240,12 +241,12 @@ The DI proxy in `server/lib/middleware/di.ts` lazy-instantiates each service on 
 ## Storage
 
 - **D1**: structured data (tenants, users, inspections, templates, comments, agreements, audit logs, ...)
-- **R2**: blobs (photos, logos, future PDFs). Bucket bindings: `PHOTOS`. Photos accessed via signed URL or pass-through endpoint.
+- **R2**: blobs. Bucket bindings: `PHOTOS` (field photos, logos) and `REPORTS` (pre-rendered report + e-sign PDFs). Accessed via signed URL or a Worker pass-through endpoint.
 - **KV**: short-lived signed tokens (agent share, password reset, magic link), tenant config cache, rate-limit counters.
 
 ## Background work
 
-- **Onboarding workflow** (`server/workflows/onboarding-workflow.ts`): provision DNS → activate tenant → sync to core → send welcome email. Cloudflare Workflow guarantees retries and persistence across Worker restarts.
+- **Sign-completion workflow** (`server/workflows/`): renders the signed PDF + Certificate of Completion, assembles the evidence pack, and emails the client — see [E-signature](#e-signature-spec-5h). Cloudflare Workflow guarantees retries and persistence across Worker restarts.
 - **Cron triggers**: notification reminder sweeps (hourly), report-ready automations.
 
 ## Cost model (Cloudflare Free tier)

--- a/docs/developers/02_deploy.md
+++ b/docs/developers/02_deploy.md
@@ -8,7 +8,7 @@ This guide covers self-hosted production deploys — what every adopter does to 
 
 OpenInspection deploys as a single Cloudflare Worker (the cloudflare/react-router-hono-fullstack-template shape):
 
-- **`workers/app.ts`** — a Hono entry that mounts the full API (`src/`, Hono + Drizzle + D1) in-process for API-owned paths and delegates all other (page) routes to React Router v7 SSR (`app/`, React 18 + Tailwind v4).
+- **`workers/app.ts`** — a Hono entry that mounts the full API (`server/`, Hono + Drizzle + D1) in-process for API-owned paths and delegates all other (page) routes to React Router v7 SSR (`app/`, React 18 + Tailwind v4).
 - React Router loaders/actions call the API DIRECTLY through an injected in-process `API_WORKER` self-binding — no network hop, no second worker, no Service Binding between workers.
 
 One deployable; `npm run deploy` builds and ships it.
@@ -57,11 +57,10 @@ Set them via `wrangler secret put SECRET_NAME` or through the Cloudflare dashboa
 ```bash
 npm install
 npm run setup:cloudflare   # provisions D1/KV/R2 + writes real IDs to wrangler.local.jsonc
-npm run deploy             # standalone: build + wrangler deploy (uses wrangler.local.jsonc)
-# npm run deploy:saas      # saas: uses the gitignored wrangler.saas.jsonc
+npm run deploy             # build + wrangler deploy (uses wrangler.local.jsonc)
 ```
 
-`npm run deploy` runs `react-router build` (bundling `src/` API + `app/` SSR into one worker) then `wrangler deploy` against the built `build/server/wrangler.json`. The build bakes whichever wrangler config wins (`WRANGLER_CONFIG` env > `wrangler.local.jsonc` > committed `wrangler.jsonc`). Apply remote D1 migrations with `npm run db:migrate:remote`.
+`npm run deploy` runs `react-router build` (bundling `server/` API + `app/` SSR into one worker) then `wrangler deploy` against the built `build/server/wrangler.json`. The build bakes whichever wrangler config wins (`WRANGLER_CONFIG` env > `wrangler.local.jsonc` > committed `wrangler.jsonc`). Apply remote D1 migrations with `npm run db:migrate:remote`.
 
 > **One-click**: the committed `wrangler.jsonc` carries placeholder IDs; the README's *Deploy to Cloudflare* button provisions resources and injects real IDs automatically — no manual `setup:cloudflare` needed for that path.
 
@@ -74,7 +73,7 @@ That bootstraps your first admin account.
 
 ### How the single worker is wired
 
-The Worker entry at `workers/app.ts` is a Hono app. It routes API-owned paths (`/api/*`, `/status`, `/sign/*`, …) to the API app (`src/`) in-process, and sends every other path to React Router via `createRequestHandler` with `import("virtual:react-router/server-build")`, passing `{ cloudflare: { env, ctx } }` as the `AppLoadContext`. Before delegating to SSR it injects an in-process `API_WORKER` self-binding so React Router loaders/actions call the API app directly — no network hop, no second worker. `@cloudflare/vite-plugin` integrates the React Router SSR build with wrangler, so the standard `wrangler deploy` pipeline ships everything.
+The Worker entry at `workers/app.ts` is a Hono app. It routes API-owned paths (`/api/*`, `/status`, `/sign/*`, …) to the API app (`server/`) in-process, and sends every other path to React Router via `createRequestHandler` with `import("virtual:react-router/server-build")`, passing `{ cloudflare: { env, ctx } }` as the `AppLoadContext`. Before delegating to SSR it injects an in-process `API_WORKER` self-binding so React Router loaders/actions call the API app directly — no network hop, no second worker. `@cloudflare/vite-plugin` integrates the React Router SSR build with wrangler, so the standard `wrangler deploy` pipeline ships everything.
 
 ### Local development
 

--- a/docs/developers/03_api_reference.md
+++ b/docs/developers/03_api_reference.md
@@ -702,26 +702,8 @@ Returns `404` if the agreement does not exist or does not belong to the caller's
 
 ---
 
-#### `POST /api/admin/tenant-status` *(machine-to-machine)*
-Sync a tenant's billing tier and status. Called by the portal after every Stripe subscription event. Invalidates the tenant's KV cache entry so the updated record is applied on the next request.
-
-**Auth:** `Authorization: Bearer {JWT_SECRET}` (shared secret, not a user JWT)
-
-**Request body:**
-```json
-{ "subdomain": "smith", "status": "active", "tier": "pro" }
-```
-
-- `subdomain` (required) — identifies the tenant
-- `status` (required) — one of `pending`, `trialing`, `active`, `past_due`, `suspended`
-- `tier` (optional) — one of `free`, `pro`, `enterprise`; omit to leave tier unchanged
-
-**Response:**
-```json
-{ "success": true }
-```
-
-Returns `404` if no tenant matches the given subdomain.
+> Portal ↔ core machine-to-machine endpoints (e.g. `POST /api/admin/tenant-status`,
+> `POST /api/admin/silo`) are SaaS-only and not used by a standalone self-hosted deploy.
 
 ---
 

--- a/docs/developers/05_testing.md
+++ b/docs/developers/05_testing.md
@@ -81,8 +81,6 @@ npx playwright test --config playwright.api.config.ts
 | Agent Referral Booking | Create inspection with `referredByAgentId`, verify in `my-reports` and leaderboard |
 | Agent CRM | `GET /api/agent/my-reports` (agent-scoped), `GET /api/agent/leaderboard` (admin-scoped) |
 | Google Calendar | Auth enforcement on connect/disconnect/sync |
-| Admin M2M Endpoints | `POST /api/admin/silo`, `POST /api/admin/connect` auth + field validation |
-| Tenant Tier/Status (M2M) | `POST /api/admin/tenant-status` auth + validation + tier/status update lifecycle |
 | AI Comment Assist | Auth enforcement; 500 without `GEMINI_API_KEY` |
 
 ## Key Flows
@@ -108,13 +106,6 @@ npx playwright test --config playwright.api.config.ts
 3. Admin calls `GET /api/agent/leaderboard` — referral counts grouped by agent
 4. Public booking via `POST /public/book` with `agentId` body field also stores the referral
    (Note: dev-mode tenantId is the subdomain string `'dev'`, not the UUID — verified separately via authenticated endpoint)
-
-### Tenant Tier/Status Sync
-
-1. Portal sends `POST /api/admin/tenant-status` with `Authorization: Bearer {JWT_SECRET}`
-2. Core updates D1 and deletes the `tenant:{subdomain}` KV cache entry
-3. Next request reads fresh tenant record from D1 (no stale cache)
-4. The `dev` subdomain always bypasses tier enforcement — GET requests remain accessible regardless of status
 
 ### Password Change Flow
 

--- a/docs/developers/07_route_metadata.md
+++ b/docs/developers/07_route_metadata.md
@@ -2,7 +2,7 @@
 
 Every `createRoute()` call under `server/api/` must declare metadata used by the
 MCP server + Skill generator. The vitest gate at
-`src/__tests__/route-metadata.test.ts` enforces this on CI; missing or
+`tests/unit/route-metadata.spec.ts` enforces this on CI; missing or
 malformed metadata fails the build.
 
 This document codifies the standard. See the design spec at

--- a/docs/developers/08_kv_cache.md
+++ b/docs/developers/08_kv_cache.md
@@ -2,43 +2,39 @@
 
 `TENANT_CACHE` is a Cloudflare KV namespace used to avoid repeated D1 queries on hot paths.
 
-## Tenant Routing Cache (`tenant:{subdomain}`)
+## Tenant resolution cache (`global_tenant:{tenantId}`)
 
-Every request needs to know which tenant it belongs to. Without caching, that's a D1 query on every request.
+Every request needs to know which tenant it belongs to. In a standalone (self-hosted)
+deploy there is exactly one tenant — pinned by `SINGLE_TENANT_ID` — so the fixed-tenant
+resolver caches that profile under `global_tenant:{tenantId}` instead of hitting D1 on every
+request.
 
-KV reads are served from the nearest edge location — effectively zero latency. A 1-hour TTL balances freshness with efficiency. When tenant state changes (e.g., Stripe webhook activates/suspends), the cache is explicitly invalidated.
-
-### Cache invalidation
-
-`POST /api/admin/tenant-status` (called by portal after Stripe events) deletes the KV key:
-
-```typescript
-await c.env.TENANT_CACHE.delete(`tenant:${subdomain}`);
-```
+KV reads are served from the nearest edge location — effectively zero latency. A 1-hour TTL
+balances freshness with efficiency.
 
 ### Data stored
 
 ```
-Key:   "tenant:john"
-Value: { "id": "uuid", "subdomain": "john", "tier": "pro", "status": "active" }
+Key:   "global_tenant:00000000-0000-0000-0000-000000000000"
+Value: { "id": "uuid", "tier": "...", "status": "active", ... }
 TTL:   3600 seconds (1 hour)
 ```
 
 Written non-blocking via `c.executionCtx.waitUntil()`.
 
-## All KV Key Patterns
+## All KV Key Patterns (standalone)
 
 | Key pattern | Written by | Read by | TTL |
 |---|---|---|---|
-| `tenant:{subdomain}` | Tenant router on cache miss | Tenant router (every request) | 3600s |
-| `global_tenant:{tenantId}` | Fixed-tenant resolver (standalone mode) | Fixed-tenant resolver | 3600s |
-| `silo:{tenantId}` | `POST /api/admin/silo` (portal m2m) | Silo middleware | None |
+| `global_tenant:{tenantId}` | Fixed-tenant resolver | Fixed-tenant resolver (every request) | 3600s |
 | `pwchanged:{userId}` | Password change/reset handlers | Auth middleware (JWT validation) | None |
 | `setup_verification_code` | Setup wizard | Setup endpoint | 3600s |
-| `sso:{code}` | Portal SSO handoff | `GET /sso?code=` | Short |
 | `qbo_oauth_state:{state}` | QBO OAuth initiation | QBO OAuth callback | 600s |
 | `google_token:{tenantId}:{userId}` | Google Calendar OAuth | Calendar API calls | 3500s |
 | `places:{hash}` | Google Places proxy | Address autocomplete | 3600s |
+
+> SaaS mode adds subdomain/silo routing keys (`tenant:{subdomain}`, `silo:{tenantId}`,
+> `sso:{code}`); those are not used by a standalone deploy.
 
 ## Why Not Alternatives?
 

--- a/docs/developers/10_rotate_secrets.md
+++ b/docs/developers/10_rotate_secrets.md
@@ -4,9 +4,8 @@ OpenInspection's auth surface has one rotating secret:
 
 1. **JWT signing keys** — ES256 keypairs in a multi-version keyring (`JWT_PRIVATE_KEY_V<N>` / `JWT_PUBLIC_KEY_V<N>` + `JWT_CURRENT_KID`).
 
-> **Note:** M2M authentication between core and portal previously used HMAC shared secrets (`PORTAL_M2M_SECRET_V<N>`). This has been replaced by Cloudflare Service Bindings — no shared secrets, no rotation needed. See `src/portal/README.md`.
-
-The JWT keyring supports zero-downtime overlap rotation. Operators run one script; users do not notice.
+The JWT keyring supports zero-downtime overlap rotation. You run one script and redeploy the
+single Worker; users do not notice.
 
 ## When to rotate
 
@@ -26,24 +25,20 @@ There is no business reason to rotate on a fixed cron — these aren't access to
 ```bash
 cd apps/core
 
-# 1. Mint a new keypair, push to all 5 worker targets, bump JWT_CURRENT_KID
+# 1. Mint a new keypair, push the secrets to the Worker, bump JWT_CURRENT_KID
 npm run rotate:jwt
 
-# 2. Redeploy both workers so they pick up the new env var bindings
-npm run deploy            # api + web, standalone env (= deploy:standalone)
-npm run deploy:saas       # api + web, saas env
-cd ../portal && npm run deploy
-cd ../portal && npm run deploy:saas
+# 2. Redeploy so the Worker picks up the new env var bindings
+npm run deploy
 
 # 3. Wait at least the maximum JWT TTL since rotation
 #    (default ~24h; check your auth.ts setExpirationTime() value)
 
 # 4. Prune the previous kid
-cd ../core
 node scripts/rotate-jwt-keys.js --prune-old-kid=v<old>
 ```
 
-What happens during the overlap window: workers hold BOTH `v<old>` and `v<new>` keypairs. New tokens are signed with `v<new>` (the current kid). Existing tokens signed with `v<old>` still verify because `v<old>` is still in the keyring. Once max-TTL elapses, no in-flight tokens reference `v<old>` anymore, so it's safe to prune.
+What happens during the overlap window: the Worker holds BOTH `v<old>` and `v<new>` keypairs. New tokens are signed with `v<new>` (the current kid). Existing tokens signed with `v<old>` still verify because `v<old>` is still in the keyring. Once max-TTL elapses, no in-flight tokens reference `v<old>` anymore, so it's safe to prune.
 
 ### Dry-run preview
 
@@ -61,7 +56,10 @@ On a fresh deploy with no keys provisioned, run the rotation script once. The "n
 npm run rotate:jwt    # mints JWT_PRIVATE_KEY_V1 + JWT_PUBLIC_KEY_V1 + sets JWT_CURRENT_KID=v1
 ```
 
-Then deploy both workers. They start with v1 immediately.
+Then deploy the Worker. It starts with v1 immediately.
+
+> Note: `npm run deploy` already runs `jwt:ensure`, so a brand-new deploy provisions V1
+> automatically. Run `rotate:jwt` manually only when you want to roll to a new version.
 
 ## Emergency rotation (active compromise)
 
@@ -72,8 +70,7 @@ Skip the overlap window — accept the user impact:
 npm run rotate:jwt
 
 # 2. Deploy immediately
-cd ../portal && npm run deploy
-cd ../core && npm run deploy && npm run deploy:saas
+npm run deploy
 
 # 3. Prune the old kid right away (no waiting)
 node scripts/rotate-jwt-keys.js --prune-old-kid=v<old>
@@ -86,29 +83,25 @@ Users with existing JWTs get 401 on their next request and re-login. Containment
 After deploying with new secrets:
 
 ```bash
-# Per worker target, confirm new env vars are populated
-npx wrangler secret list                              # standalone
-npx wrangler secret list -c wrangler.saas.toml        # saas
-cd ../portal && npx wrangler secret list              # portal
+# Confirm the new env vars are populated on the Worker
+npx wrangler secret list
 
-# Each should now show JWT_PRIVATE_KEY_V<NEW>, JWT_PUBLIC_KEY_V<NEW>,
+# It should now show JWT_PRIVATE_KEY_V<NEW>, JWT_PUBLIC_KEY_V<NEW>,
 # JWT_CURRENT_KID = v<NEW>
 ```
 
-Functional check:
-
-1. Hit `/login` on a deployed worker, log in. Cookie set. Visit a protected route → 200.
-2. Trigger a portal→core call (e.g. provision a test tenant via portal console → OnboardingWorkflow calls core via Service Binding). Verify the call returns 2xx.
+Functional check: hit `/login` on the deployed Worker, log in (cookie set), then visit a
+protected route → 200. Old tokens signed with the pruned kid get 401 and re-login.
 
 ## Failure recovery
 
-### "wrangler secret put failed mid-rotation on one of 5 targets"
+### "wrangler secret put failed mid-rotation"
 
-Re-run the rotation script. It's idempotent — same target gets pushed the same value. If the failure was network/timeout, retry is safe.
+Re-run the rotation script. It's idempotent — the target gets pushed the same value. If the failure was network/timeout, retry is safe.
 
 ### "JWT_CURRENT_KID set but private key missing"
 
-`buildKeyring()` throws on startup. Worker returns 5xx on every request. Push the missing var:
+`buildKeyring()` throws on startup. The Worker returns 5xx on every request. Push the missing var:
 
 ```bash
 npx wrangler secret put JWT_PRIVATE_KEY_V<N>  # from .dev.vars or a fresh keypair if .dev.vars was lost
@@ -116,18 +109,11 @@ npx wrangler secret put JWT_PRIVATE_KEY_V<N>  # from .dev.vars or a fresh keypai
 
 ### "Pruned a kid too early; still-valid tokens in flight"
 
-Re-mint and re-push the same kid:
-
-```bash
-# Get the PEMs from your local .dev.vars (if still there) or generate fresh
-# Push them under the same V<N> name to restore the keyring
-```
-
-Users hit by the gap re-login; the gap is bounded by how long ago you pruned.
+Re-mint and re-push the same kid under the same `V<N>` name to restore the keyring. Users hit by the gap re-login; the gap is bounded by how long ago you pruned.
 
 ### "Wrangler login expired during rotation"
 
-Run `wrangler logout && wrangler login` to refresh OAuth token. Re-run the rotation script — it picks up where it left off (idempotent).
+Run `wrangler logout && wrangler login` to refresh the OAuth token. Re-run the rotation script — it picks up where it left off (idempotent).
 
 ## What's NOT in scope
 
@@ -141,4 +127,4 @@ Run `wrangler logout && wrangler login` to refresh OAuth token. Re-run the rotat
 |---|---|
 | `npm run rotate:jwt` | New ES256 keypair → push V<N+1> → bump JWT_CURRENT_KID |
 | `node scripts/rotate-jwt-keys.js --dry-run` | Preview without pushing |
-| `node scripts/rotate-jwt-keys.js --prune-old-kid=v1` | Remove V1 from all targets |
+| `node scripts/rotate-jwt-keys.js --prune-old-kid=v1` | Remove V1 |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ After deploying (see [`developers/02_deploy.md`](developers/02_deploy.md)), visi
 
 ```
 workers/app.ts        Single-worker entry: Hono mounts API in-process + delegates pages to RR SSR
-src/                  Hono API (business logic, D1, R2)
+server/               Hono API (business logic, D1, R2)
 app/                  React Router v7 web UI (React SSR on CF Workers)
 packages/shared-ui/   Design System 0523 components (Button, Card, Pill, etc.)
 packages/api-types/   Hono app type re-export for end-to-end type safety
@@ -72,7 +72,7 @@ npm run dev                    # build-based; http://localhost:8788 (serves API 
 | Command | Purpose |
 |---|---|
 | `npm run dev` | Build + run the single worker locally (port 8788) |
-| `npm run build` | `react-router build` — bundle `src/` API + `app/` SSR into one worker |
+| `npm run build` | `react-router build` — bundle `server/` API + `app/` SSR into one worker |
 | `npm run db:migrate` | Apply D1 migrations locally |
 | `npm run db:generate` | Generate a forward migration from schema changes |
 | `npm run deploy` | Build + `wrangler deploy` (single worker) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@conform-to/zod": "^1.19.3",
         "@react-router/cloudflare": "^7.6.0",
         "dexie": "^4.0.10",
+        "dompurify": "^3.4.7",
         "drizzle-orm": "^0.45.2",
         "fflate": "^0.8.3",
         "hono": "^4.12.18",
@@ -1481,9 +1482,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1562,9 +1563,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2954,6 +2955,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
@@ -3643,9 +3651,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4405,6 +4413,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/drizzle-kit": {
       "version": "0.31.10",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
@@ -5032,9 +5049,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5113,9 +5130,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
   },
   "cloudflare": {
     "label": "OpenInspection",
-    "products": ["Workers"],
-    "categories": ["starter"],
+    "products": [
+      "Workers"
+    ],
+    "categories": [
+      "starter"
+    ],
     "docs_url": "https://github.com/InspectorHub/OpenInspection#readme",
     "publish": true
   },
@@ -55,6 +59,7 @@
     "@conform-to/zod": "^1.19.3",
     "@react-router/cloudflare": "^7.6.0",
     "dexie": "^4.0.10",
+    "dompurify": "^3.4.7",
     "drizzle-orm": "^0.45.2",
     "fflate": "^0.8.3",
     "hono": "^4.12.18",

--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -1939,7 +1939,7 @@ export const adminRoutes = createApiRouter()
             401: { description: 'Unauthorized' },
         },
     }, { scopes: [], tier: 'excluded' }), async (c) => {
-        if (!isServiceBindingCall(c)) {
+        if (!(await isServiceBindingCall(c))) {
             throw Errors.Unauthorized();
         }
 
@@ -2052,7 +2052,7 @@ export const adminRoutes = createApiRouter()
             404: { description: 'Tenant not found' },
         },
     }, { scopes: [], tier: 'excluded' }), async (c) => {
-        if (!isServiceBindingCall(c)) {
+        if (!(await isServiceBindingCall(c))) {
             throw Errors.Unauthorized();
         }
 
@@ -2092,7 +2092,7 @@ export const adminRoutes = createApiRouter()
             404: { description: 'Tenant not found' },
         },
     }, { scopes: [], tier: 'excluded' }), async (c) => {
-        if (!isServiceBindingCall(c)) {
+        if (!(await isServiceBindingCall(c))) {
             throw Errors.Unauthorized();
         }
 

--- a/server/api/evidence.ts
+++ b/server/api/evidence.ts
@@ -17,7 +17,7 @@ export async function downloadAgreementPdf(
     envelopeId: string,
     tenantId: string,
 ): Promise<Response> {
-    if (!r2) return new Response('REPORTS bucket not configured', { status: 500 });
+    if (!r2) return new Response('Storage bucket not configured', { status: 500 });
     const db = drizzle(d1, { schema });
     const row = await db.select().from(schema.agreementRequests)
         .where(eq(schema.agreementRequests.id, envelopeId)).get();
@@ -43,7 +43,7 @@ export async function downloadCertPdf(
     envelopeId: string,
     tenantId: string,
 ): Promise<Response> {
-    if (!r2) return new Response('REPORTS bucket not configured', { status: 500 });
+    if (!r2) return new Response('Storage bucket not configured', { status: 500 });
     const db = drizzle(d1, { schema });
     const row = await db.select().from(schema.agreementRequests)
         .where(eq(schema.agreementRequests.id, envelopeId)).get();
@@ -69,7 +69,7 @@ export async function downloadEvidenceZip(
     envelopeId: string,
     tenantId: string,
 ): Promise<Response> {
-    if (!r2) return new Response('REPORTS bucket not configured', { status: 500 });
+    if (!r2) return new Response('Storage bucket not configured', { status: 500 });
     const db = drizzle(d1, { schema });
     const row = await db.select().from(schema.agreementRequests)
         .where(eq(schema.agreementRequests.id, envelopeId)).get();
@@ -138,17 +138,17 @@ export const evidenceRoutes = createApiRouter()
     .openapi(downloadAgreementRoute, async (c) => {
         const { id } = c.req.valid('param');
         const tenantId = c.get('tenantId') as string;
-        return downloadAgreementPdf(c.env.DB, c.env.REPORTS, id, tenantId);
+        return downloadAgreementPdf(c.env.DB, c.env.PHOTOS, id, tenantId);
     })
     .openapi(downloadCertRoute, async (c) => {
         const { id } = c.req.valid('param');
         const tenantId = c.get('tenantId') as string;
-        return downloadCertPdf(c.env.DB, c.env.REPORTS, id, tenantId);
+        return downloadCertPdf(c.env.DB, c.env.PHOTOS, id, tenantId);
     })
     .openapi(downloadEvidenceRoute, async (c) => {
         const { id } = c.req.valid('param');
         const tenantId = c.get('tenantId') as string;
-        return downloadEvidenceZip(c.env.DB, c.env.REPORTS, id, tenantId);
+        return downloadEvidenceZip(c.env.DB, c.env.PHOTOS, id, tenantId);
     });
 
 export type EvidenceApi = typeof evidenceRoutes;

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,6 @@ import { verifyJwt } from './lib/jwt-keyring';
 import { classifyJwtPayload } from './lib/auth/jwt-claims';
 import { drizzle } from 'drizzle-orm/d1';
 import { and, eq, asc } from 'drizzle-orm';
-import { users } from './lib/db/schema';
 import * as schema from './lib/db/schema';
 
 import { brandingMiddleware } from './lib/middleware/branding';

--- a/server/lib/m2m-auth.ts
+++ b/server/lib/m2m-auth.ts
@@ -1,0 +1,129 @@
+/**
+ * M2M (worker-to-worker) request authentication for the portal ↔ core
+ * Service Bindings.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Cloudflare does NOT inject any identifying header (there is no `cf-worker`)
+ * on a direct Service-Binding `.fetch()` call. Those `cf-*` headers are added
+ * by Cloudflare's public edge for internet-facing requests; a binding call
+ * never crosses that edge, so the receiver sees no such header. The previous
+ * "auth is implicit via the cf-worker header" assumption therefore failed
+ * closed (403) on every binding call once SaaS went live. See the integration
+ * routes in apps/core (`requireServiceBinding`) and apps/portal
+ * (`/api/integration/from-core`).
+ *
+ * HOW IT WORKS
+ * ------------
+ * Both apps MUST already hold the IDENTICAL ES256 keyring private key
+ * (`JWT_PRIVATE_KEY_V<N>`) — that is a hard requirement for portal-issued JWTs
+ * to be verifiable by core and vice-versa. We derive a DEDICATED HMAC key from
+ * that shared private-key PEM via HKDF (domain-separated with a fixed label),
+ * so there is zero extra configuration and the M2M trust root is automatically
+ * the same one the JWT flow already proves is shared. We never reuse the raw
+ * signing key directly — HKDF domain separation yields an independent key, and
+ * knowing the derived HMAC key reveals nothing about the EC private key.
+ *
+ * HEADER FORMAT
+ * -------------
+ *   x-portal-m2m: <unixSeconds>.<hmacSha256Hex>
+ * where hmac = HMAC-SHA256(derivedKey, "<unixSeconds>"). Verification enforces
+ * a ±MAX_SKEW_SECONDS window to bound replay (binding traffic never touches the
+ * public wire, so the only exposure is the integration routes' public hostname,
+ * which an attacker cannot sign for without the shared keyring).
+ *
+ * Keep this file byte-for-byte identical in apps/portal and apps/core.
+ */
+
+export const M2M_HEADER = 'x-portal-m2m';
+const HKDF_INFO = 'inspectorhub-portal-core-m2m-v1';
+const MAX_SKEW_SECONDS = 300;
+const enc = new TextEncoder();
+
+/** Strip a PEM envelope to its raw DER bytes (HKDF input keying material). */
+function pemBodyBuf(pem: string): ArrayBuffer {
+    const b64 = pem
+        .replace(/-----BEGIN [A-Z ]+-----/, '')
+        .replace(/-----END [A-Z ]+-----/, '')
+        .replace(/\s+/g, '');
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out.buffer;
+}
+
+/**
+ * Collect every provisioned `JWT_PRIVATE_KEY_V<N>` PEM, current kid first.
+ * Verification tries each so the handshake survives a rotation window in which
+ * the two apps briefly disagree on `JWT_CURRENT_KID`.
+ */
+function privateKeyPems(env: Record<string, string | undefined>): string[] {
+    const pems: string[] = [];
+    const seen = new Set<string>();
+    const push = (pem?: string) => {
+        if (pem && !seen.has(pem)) { seen.add(pem); pems.push(pem); }
+    };
+    const current = env['JWT_CURRENT_KID'];
+    if (current) push(env[`JWT_PRIVATE_KEY_V${current.replace(/^v/i, '')}`]);
+    for (const k of Object.keys(env)) {
+        if (/^JWT_PRIVATE_KEY_V\d+$/.test(k)) push(env[k]);
+    }
+    return pems;
+}
+
+async function deriveHmacKey(privatePem: string): Promise<CryptoKey> {
+    const ikm = await crypto.subtle.importKey('raw', pemBodyBuf(privatePem), 'HKDF', false, ['deriveKey']);
+    return crypto.subtle.deriveKey(
+        { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: enc.encode(HKDF_INFO) },
+        ikm,
+        { name: 'HMAC', hash: 'SHA-256', length: 256 },
+        false,
+        ['sign'],
+    );
+}
+
+function toHex(buf: ArrayBuffer): string {
+    const b = new Uint8Array(buf);
+    let s = '';
+    for (let i = 0; i < b.length; i++) s += (b[i] as number).toString(16).padStart(2, '0');
+    return s;
+}
+
+/** Constant-time string compare (equal-length hex strings). */
+function timingSafeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let r = 0;
+    for (let i = 0; i < a.length; i++) r |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return r === 0;
+}
+
+/** Build the `x-portal-m2m` header value for an outbound binding call. */
+export async function signM2mHeader(env: Record<string, string | undefined>): Promise<string> {
+    const pems = privateKeyPems(env);
+    if (pems.length === 0) throw new Error('M2M: no JWT_PRIVATE_KEY_V<N> in env');
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const key = await deriveHmacKey(pems[0] as string);
+    const mac = await crypto.subtle.sign('HMAC', key, enc.encode(ts));
+    return `${ts}.${toHex(mac)}`;
+}
+
+/** Verify an inbound `x-portal-m2m` header. True iff signature valid + in-window. */
+export async function verifyM2mHeader(
+    env: Record<string, string | undefined>,
+    headerValue: string | undefined | null,
+): Promise<boolean> {
+    if (!headerValue) return false;
+    const dot = headerValue.indexOf('.');
+    if (dot <= 0) return false;
+    const ts = headerValue.slice(0, dot);
+    const mac = headerValue.slice(dot + 1);
+    const tsNum = Number(ts);
+    if (!Number.isFinite(tsNum)) return false;
+    if (Math.abs(Math.floor(Date.now() / 1000) - tsNum) > MAX_SKEW_SECONDS) return false;
+    for (const pem of privateKeyPems(env)) {
+        const key = await deriveHmacKey(pem);
+        const expected = toHex(await crypto.subtle.sign('HMAC', key, enc.encode(ts)));
+        if (timingSafeEqual(expected, mac)) return true;
+    }
+    return false;
+}

--- a/server/lib/middleware/di.ts
+++ b/server/lib/middleware/di.ts
@@ -193,7 +193,7 @@ export async function diMiddleware(c: Context<HonoConfig>, next: Next) {
                     target.templateSeed = new TemplateSeedService(c.env.DB);
                     break;
                 case 'reportPdf':
-                    target.reportPdf = new ReportPdfService(c.env.DB, c.env.BROWSER, c.env.REPORTS);
+                    target.reportPdf = new ReportPdfService(c.env.DB, c.env.BROWSER, c.env.PHOTOS);
                     break;
                 case 'templateMigration':
                     target.templateMigration = new TemplateMigrationService(c.env.DB, c.get('tenantId'));

--- a/server/portal/outbox.service.ts
+++ b/server/portal/outbox.service.ts
@@ -127,6 +127,7 @@ export class OutboxService {
 export async function flushOutboxOnce(
     db: D1Database,
     portalService: Fetcher,
+    m2mHeader: string,
     limit = 50,
 ): Promise<{ posted: number; pending: number; failed: number }> {
     const svc = new OutboxService(db);
@@ -148,6 +149,7 @@ export async function flushOutboxOnce(
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    'x-portal-m2m': m2mHeader,
                 },
                 body,
             });

--- a/server/portal/service-binding-guard.ts
+++ b/server/portal/service-binding-guard.ts
@@ -1,13 +1,29 @@
 import type { Context } from 'hono';
 import type { HonoConfig } from '../types/hono';
+import { M2M_HEADER, verifyM2mHeader } from '../lib/m2m-auth';
 
+/**
+ * Gate for portal→core integration endpoints.
+ *
+ * Auth is the `x-portal-m2m` HMAC header (see lib/m2m-auth.ts), NOT the
+ * non-existent `cf-worker` header — Cloudflare injects no identifying header on
+ * direct Service-Binding `.fetch()` calls, so the old cf-worker check failed
+ * closed (403) on every binding call in production.
+ */
 export async function requireServiceBinding(c: Context<HonoConfig>, next: () => Promise<void>) {
-    if (!c.req.header('cf-worker')) {
+    const ok = await verifyM2mHeader(
+        c.env as unknown as Record<string, string | undefined>,
+        c.req.header(M2M_HEADER),
+    );
+    if (!ok) {
         return c.json({ success: false, error: { message: 'Forbidden' } }, 403);
     }
     return next();
 }
 
-export function isServiceBindingCall(c: Context<HonoConfig>): boolean {
-    return !!c.req.header('cf-worker');
+export async function isServiceBindingCall(c: Context<HonoConfig>): Promise<boolean> {
+    return verifyM2mHeader(
+        c.env as unknown as Record<string, string | undefined>,
+        c.req.header(M2M_HEADER),
+    );
 }

--- a/server/scheduled.ts
+++ b/server/scheduled.ts
@@ -124,7 +124,9 @@ export async function scheduled(
     // 4. Drain user-sync outbox to portal (no-op for standalone)
     if (env.PORTAL_SERVICE) {
         try {
-            await flushOutboxOnce(env.DB, env.PORTAL_SERVICE, 50);
+            const { signM2mHeader } = await import('./lib/m2m-auth');
+            const m2m = await signM2mHeader(env as unknown as Record<string, string | undefined>);
+            await flushOutboxOnce(env.DB, env.PORTAL_SERVICE, m2m, 50);
         } catch (err) {
             logger.error('[cron:outbox] flush threw', {}, err instanceof Error ? err : undefined);
         }

--- a/server/services/report-pdf.service.ts
+++ b/server/services/report-pdf.service.ts
@@ -82,7 +82,7 @@ export class ReportPdfService {
         opts: { reportUrl: string; sourceVersion: number },
     ): Promise<ReportPdf> {
         if (!this.browser) throw Errors.BadRequest('PDF rendering unavailable: BROWSER binding not configured');
-        if (!this.r2) throw Errors.BadRequest('PDF storage unavailable: REPORTS bucket binding not configured');
+        if (!this.r2) throw Errors.BadRequest('PDF storage unavailable: storage bucket binding not configured');
 
         // type=summary appends &summary=1 so the report template can render
         // a condensed view (defects + safety only). Implementation wired in
@@ -92,7 +92,7 @@ export class ReportPdfService {
             : opts.reportUrl;
 
         const pdfBuffer = await generatePdfFromUrl(this.browser, renderUrl);
-        const r2Key = `${tenantId}/${inspectionId}/${type}.pdf`;
+        const r2Key = `${tenantId}/${inspectionId}/reports/${type}.pdf`;
         await this.r2.put(r2Key, pdfBuffer);
 
         const now = Date.now();
@@ -141,7 +141,7 @@ export class ReportPdfService {
      * if the D1 row says status='ready', but guard anyway).
      */
     async streamPdf(record: ReportPdf): Promise<R2ObjectBody | null> {
-        if (!this.r2) throw Errors.BadRequest('PDF storage unavailable: REPORTS bucket binding not configured');
+        if (!this.r2) throw Errors.BadRequest('PDF storage unavailable: storage bucket binding not configured');
         if (record.status !== 'ready') {
             throw Errors.BadRequest(`PDF not ready (status=${record.status})`);
         }

--- a/server/types/hono.ts
+++ b/server/types/hono.ts
@@ -83,7 +83,6 @@ export interface AppEnv {
 
     // Report PDF storage (Spec 5A) — pre-rendered Summary + Full Report PDFs.
     // Optional during local dev so the worker boots without the binding.
-    REPORTS?: R2Bucket;
 
     // Spec 5H P1 — async sign-completion pipeline (signed.pdf + cert.pdf + audit append)
     SIGN_COMPLETION_WORKFLOW?: Workflow;

--- a/server/workflows/sign-completion-workflow.ts
+++ b/server/workflows/sign-completion-workflow.ts
@@ -76,7 +76,7 @@ export class SignCompletionWorkflow extends WorkflowEntrypoint<AppEnv, SignCompl
         // Step 3 — assemble evidence.zip (best-effort; gracefully tolerated)
         const evidenceZipMeta = await step.do('build-evidence-pack', async () => {
             try {
-                if (!env.REPORTS) return null;
+                if (!env.PHOTOS) return null;
                 const signing = new SigningKeyService(env.DB, env.KEY_ENCRYPTION_SECRET || env.JWT_SECRET);
                 const pubKey = await signing.getPublicKey(tenantId);
                 if (!pubKey) return null;
@@ -104,7 +104,7 @@ export class SignCompletionWorkflow extends WorkflowEntrypoint<AppEnv, SignCompl
                     })),
                 };
                 const zipBuf = await buildEvidencePack({
-                    r2: env.REPORTS,
+                    r2: env.PHOTOS,
                     auditTrailJson: JSON.stringify(auditPayload, null, 2),
                     publicKeyPem: pubKey.pem,
                     tenantId,
@@ -114,7 +114,7 @@ export class SignCompletionWorkflow extends WorkflowEntrypoint<AppEnv, SignCompl
                 const bytes = new Uint8Array(zipBuf);
                 const hashBuf = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as unknown as ArrayBuffer));
                 const sha256 = Array.from(hashBuf).map((b) => b.toString(16).padStart(2, '0')).join('');
-                await env.REPORTS.put(r2Key, bytes, {
+                await env.PHOTOS.put(r2Key, bytes, {
                     httpMetadata: { contentType: 'application/zip' },
                     customMetadata: { sha256 },
                 });
@@ -148,14 +148,14 @@ export class SignCompletionWorkflow extends WorkflowEntrypoint<AppEnv, SignCompl
             try {
                 if (!evidenceZipMeta || !signedPdfMeta) return;
                 if (!env.RESEND_API_KEY) return;
-                if (!env.REPORTS) return;
+                if (!env.PHOTOS) return;
                 const db = drizzle(env.DB, { schema });
                 const req = await db.select().from(schema.agreementRequests)
                     .where(eq(schema.agreementRequests.id, requestId)).get();
                 if (!req) return;
                 const [signedObj, evidenceObj] = await Promise.all([
-                    env.REPORTS.get(signedPdfMeta.r2Key),
-                    env.REPORTS.get(evidenceZipMeta.r2Key),
+                    env.PHOTOS.get(signedPdfMeta.r2Key),
+                    env.PHOTOS.get(evidenceZipMeta.r2Key),
                 ]);
                 if (!signedObj || !evidenceObj) return;
                 const signedBytes = new Uint8Array(await new Response(signedObj.body).arrayBuffer());
@@ -189,7 +189,7 @@ export class SignCompletionWorkflow extends WorkflowEntrypoint<AppEnv, SignCompl
  * Browser Run does not reliably forward custom headers).
  */
 async function renderPdfToR2(env: AppEnv, opts: { renderUrl: string; r2Key: string }): Promise<{ r2Key: string; sha256: string; sizeBytes: number }> {
-    if (!env.REPORTS) throw new Error('REPORTS R2 bucket not configured');
+    if (!env.PHOTOS) throw new Error('storage R2 bucket not configured');
     if (!env.BROWSER) throw new Error('BROWSER binding not configured');
 
     console.info('[sign-workflow] BR quickAction("pdf")', { renderUrl: opts.renderUrl });
@@ -203,7 +203,7 @@ async function renderPdfToR2(env: AppEnv, opts: { renderUrl: string; r2Key: stri
     const bytes = new Uint8Array(pdfBuffer);
     const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as unknown as ArrayBuffer));
     const sha256 = Array.from(hash).map((b) => b.toString(16).padStart(2, '0')).join('');
-    await env.REPORTS.put(opts.r2Key, bytes, {
+    await env.PHOTOS.put(opts.r2Key, bytes, {
         httpMetadata: { contentType: 'application/pdf' },
         customMetadata: { sha256 },
     });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,8 +32,7 @@
     { "binding": "TENANT_CACHE", "id": "00000000000000000000000000000000" }
   ],
   "r2_buckets": [
-    { "binding": "PHOTOS", "bucket_name": "openinspection-photos" },
-    { "binding": "REPORTS", "bucket_name": "openinspection-reports" }
+    { "binding": "PHOTOS", "bucket_name": "openinspection-photos" }
   ],
   "browser": { "binding": "BROWSER" },
   "workflows": [


### PR DESCRIPTION
Batches several core-engine improvements developed on the fork.

- **fix(saas): service-binding M2M auth + SSO session pickup** — Cloudflare injects no `cf-worker` header on a direct Service-Binding `.fetch()`, so the implicit-auth guard rejected every binding call (403). Replace with an `x-portal-m2m` HMAC derived via HKDF from the shared ES256 keyring (no extra secret, ±300s replay window, rotation-safe); verify in `requireServiceBinding`/`isServiceBindingCall`; sign the outbox flush. Also: the `/sso` consume sets only `__Host-inspector_token`, so `getToken()` now falls back to that raw cookie — dashboard loaders previously bounced every SSO arrival to `/login`. Plus a "Sign in/out" → "Log in/out" wording pass.
- **fix(saas): logout clears `__Host-inspector_token`** — `destroyUserSession` cleared only the React Router `__session` cookie; with the new getToken fallback that left users signed in. Expire the raw JWT cookie on logout too.
- **refactor(storage): single R2 bucket** — consolidate PHOTOS + REPORTS into one bucket with path-based separation (`<tenant>/<inspection>/photos|reports`) for simpler permissioning.
- **fix(security): sanitize agreement HTML** — DOMPurify on agreement render + brace-expansion patch.
- **docs: refocus on single-tenant self-hosting** after the single-worker flatten.

## Test plan
- [x] `npm run build` passes
- [x] SaaS SSO handoff verified end-to-end on live (handoff 200 → `/sso` 302 → dashboard renders)
- [x] logout clears the session (dashboard bounces to `/login`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)