### PR TITLE
ci: stamp version before type-check + harden seed script (fix verify + CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # server/generated/version.ts is git-ignored and produced by the build;
+      # type-check imports it, so stamp it before type-check on a fresh checkout.
+      - name: Generate version stamp
+        run: npm run gen-version
+
       - name: Type-check (react-router typegen + tsc app + api)
         run: npm run type-check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
         "lightningcss-linux-x64-gnu": "1.32.0"
       }
     },
@@ -2160,6 +2161,22 @@
       "integrity": "sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.0-rc.15",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "esbuild": "^0.25.0"
   },
   "optionalDependencies": {
+    "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
     "lightningcss-linux-x64-gnu": "1.32.0"
   },
   "engines": {

--- a/scripts/seed-test-user.mjs
+++ b/scripts/seed-test-user.mjs
@@ -11,7 +11,7 @@
  * Uses the same PBKDF2-SHA256 (100k iters, 16-byte salt, `pbkdf2:salt:hash`)
  * format as server/lib/password.ts, and the standalone SINGLE_TENANT_ID.
  */
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
@@ -21,6 +21,9 @@ const TENANT_ID = process.env.SINGLE_TENANT_ID || "5b0d0e5c-7d2a-4d9e-9c1f-1e2c3
 const CONFIG = process.env.WRANGLER_CONFIG || "wrangler.jsonc";
 
 const toHex = (b) => Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+// Escape single quotes for safe interpolation into the SQL string literals below
+// (values originate from env vars — defends against SQL injection).
+const sq = (s) => String(s).replace(/'/g, "''");
 
 async function hashPassword(password) {
   const salt = crypto.getRandomValues(new Uint8Array(16));
@@ -35,17 +38,23 @@ const userId = "test-admin-0000-0000-0000-000000000001";
 
 const sql = [
   // Tenant (standalone single tenant) — created once, ignored thereafter.
-  `INSERT OR IGNORE INTO tenants (id, name, subdomain, created_at) VALUES ('${TENANT_ID}', 'Test Tenant', 'test', ${now});`,
+  `INSERT OR IGNORE INTO tenants (id, name, subdomain, created_at) VALUES ('${sq(TENANT_ID)}', 'Test Tenant', 'test', ${now});`,
   // Owner user — delete+insert so the password resets to a known value each run.
-  `DELETE FROM users WHERE email = '${EMAIL}';`,
-  `INSERT INTO users (id, tenant_id, email, password_hash, role, created_at) VALUES ('${userId}', '${TENANT_ID}', '${EMAIL}', '${pw}', 'owner', ${now});`,
+  `DELETE FROM users WHERE email = '${sq(EMAIL)}';`,
+  `INSERT INTO users (id, tenant_id, email, password_hash, role, created_at) VALUES ('${userId}', '${sq(TENANT_ID)}', '${sq(EMAIL)}', '${pw}', 'owner', ${now});`,
 ].join("\n");
 
 const sqlFile = join(process.cwd(), ".seed-test-user.tmp.sql");
 writeFileSync(sqlFile, sql, "utf8");
 try {
-  execSync(`npx wrangler d1 execute DB --local -c ${CONFIG} --file ${sqlFile}`, { stdio: ["ignore", "ignore", "inherit"] });
-  console.log(`✓ seeded test account: ${EMAIL} / ${PASSWORD} (tenant ${TENANT_ID})`);
+  // execFileSync with an argv array (no shell) — env-derived CONFIG can't inject
+  // shell metacharacters. npx is npx.cmd on Windows.
+  const npx = process.platform === "win32" ? "npx.cmd" : "npx";
+  execFileSync(npx, ["wrangler", "d1", "execute", "DB", "--local", "-c", CONFIG, "--file", sqlFile], {
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  // Do not log the password (clear-text logging of sensitive data).
+  console.log(`✓ seeded test account: ${EMAIL} (tenant ${TENANT_ID})`);
 } finally {
   rmSync(sqlFile, { force: true });
 }


### PR DESCRIPTION
Fixes the `verify` CI failure on `main` and the two CodeQL alerts.

- **verify failure:** `type-check` imports `server/generated/version.ts`, which is git-ignored and only produced by the build — so on a fresh CI checkout it's missing (`TS2307: Cannot find module './generated/version'`). Adds a `npm run gen-version` step before type-check.
- **CodeQL (scripts/seed-test-user.mjs):** `execFileSync` with an argv array instead of a shell string built from `$WRANGLER_CONFIG` (shell-command-injection-from-environment); stop logging the password (clear-text logging); escape single quotes in env-derived SQL values (sql-injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)