### PR TITLE
fix: UI/endpoint bug batch (B-1, B-4..B-10)

### DIFF
--- a/app/components/NewInspectionWizard.tsx
+++ b/app/components/NewInspectionWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useFetcher } from "react-router";
 
 const STEPS = ["Property", "Services", "Schedule", "Team"] as const;
@@ -9,33 +9,58 @@ const PROPERTY_TYPES = [
   { value: "commercial", label: "Commercial" },
 ] as const;
 
-const SERVICES = [
-  "General Home Inspection",
-  "Radon Testing",
-  "Mold Inspection",
-  "Termite / WDI",
-  "Sewer Scope",
-  "Pool & Spa",
-  "Sprinkler System",
-  "Well & Septic",
-] as const;
+export interface WizardTemplate {
+  id: string;
+  name: string;
+  itemCount?: number;
+}
+
+export interface WizardService {
+  id: string;
+  name: string;
+  price?: number | null;
+}
 
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
-export function NewInspectionWizard({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function NewInspectionWizard({
+  open,
+  onClose,
+  templates = [],
+  services: serviceCatalog = [],
+}: {
+  open: boolean;
+  onClose: () => void;
+  templates?: WizardTemplate[];
+  services?: WizardService[];
+}) {
   const fetcher = useFetcher();
-  const templatesFetcher = useFetcher<{ templates?: Array<{ id: string; name: string }> }>();
   const [step, setStep] = useState(0);
   const [propertyType, setPropertyType] = useState("single_family");
   const [address, setAddress] = useState("");
   const [templateId, setTemplateId] = useState("");
+  // Stores selected service IDs (matched against the tenant's services table).
   const [services, setServices] = useState<Set<string>>(new Set());
   const [date, setDate] = useState("");
   const [time, setTime] = useState("09:00");
   const [soloMode, setSoloMode] = useState(true);
   const [inspectorId, setInspectorId] = useState("");
+
+  const hasServiceCatalog = serviceCatalog.length > 0;
+
+  // Typeahead filter for the template picker (B-6).
+  const [templateQuery, setTemplateQuery] = useState("");
+  const filteredTemplates = useMemo(() => {
+    const q = templateQuery.trim().toLowerCase();
+    if (!q) return templates;
+    return templates.filter((t) => t.name.toLowerCase().includes(q));
+  }, [templates, templateQuery]);
+  const selectedTemplate = useMemo(
+    () => templates.find((t) => t.id === templateId),
+    [templates, templateId],
+  );
 
   useEffect(() => {
     if (open) return;
@@ -43,6 +68,7 @@ export function NewInspectionWizard({ open, onClose }: { open: boolean; onClose:
     setPropertyType("single_family");
     setAddress("");
     setTemplateId("");
+    setTemplateQuery("");
     setServices(new Set());
     setDate("");
     setTime("09:00");
@@ -50,35 +76,42 @@ export function NewInspectionWizard({ open, onClose }: { open: boolean; onClose:
     setInspectorId("");
   }, [open]);
 
-  // Load the tenant's templates for the picker the first time the wizard opens.
-  useEffect(() => {
-    if (open && templatesFetcher.state === "idle" && templatesFetcher.data === undefined) {
-      templatesFetcher.load("/templates");
-    }
-  }, [open]);
-
   if (!open) return null;
 
-  const toggleService = (s: string) =>
+  const toggleService = (id: string) =>
     setServices((prev) => {
       const next = new Set(prev);
-      if (next.has(s)) {
-        next.delete(s);
+      if (next.has(id)) {
+        next.delete(id);
       } else {
-        next.add(s);
+        next.add(id);
       }
       return next;
     });
 
   const canNext =
-    step === 0 ? address.length > 0 && templateId.length > 0 :
-    step === 1 ? services.size > 0 :
+    // propertyAddress has a min(5) server constraint — enforce it here so the
+    // wizard cannot advance into an inevitable 400.
+    step === 0 ? address.trim().length >= 5 && templateId.length > 0 :
+    // Services are optional when the tenant has no service catalog configured;
+    // otherwise require at least one so the inspection is meaningful.
+    step === 1 ? (!hasServiceCatalog || services.size > 0) :
     step === 2 ? date.length > 0 :
     true;
 
   function handleSubmit() {
     fetcher.submit(
-      { intent: "create", propertyType, address, templateId, services: [...services].join(","), date, time, soloMode: String(soloMode), inspectorId },
+      {
+        intent: "create",
+        propertyType,
+        address,
+        templateId,
+        serviceIds: [...services].join(","),
+        date,
+        time,
+        soloMode: String(soloMode),
+        inspectorId,
+      },
       { method: "post", action: "/dashboard" },
     );
     onClose();
@@ -124,12 +157,43 @@ export function NewInspectionWizard({ open, onClose }: { open: boolean; onClose:
               </div>
               <div>
                 <label className="block text-[12px] font-bold text-ih-fg-3 mb-1.5">Template</label>
-                <select value={templateId} onChange={(e) => setTemplateId(e.target.value)} className="w-full h-9 px-3 rounded-md border border-ih-border bg-ih-bg-card text-[13px] focus:shadow-ih-focus outline-none">
-                  <option value="">{templatesFetcher.state === "loading" ? "Loading templates…" : "Select a template…"}</option>
-                  {(templatesFetcher.data?.templates ?? []).map((t) => (
-                    <option key={t.id} value={t.id}>{t.name}</option>
-                  ))}
-                </select>
+                {templates.length === 0 ? (
+                  <p className="text-[12px] text-ih-fg-4 px-1 py-2">
+                    No templates yet — create one under Templates first.
+                  </p>
+                ) : (
+                  <>
+                    {templates.length > 6 && (
+                      <input
+                        value={templateQuery}
+                        onChange={(e) => setTemplateQuery(e.target.value)}
+                        placeholder="Search templates…"
+                        className="w-full h-9 px-3 mb-2 rounded-md border border-ih-border bg-ih-bg-card text-[13px] focus:shadow-ih-focus outline-none placeholder:text-ih-fg-4"
+                      />
+                    )}
+                    <select
+                      value={templateId}
+                      onChange={(e) => setTemplateId(e.target.value)}
+                      className="w-full h-9 px-3 rounded-md border border-ih-border bg-ih-bg-card text-[13px] focus:shadow-ih-focus outline-none"
+                    >
+                      <option value="">Select a template…</option>
+                      {filteredTemplates.map((t) => (
+                        <option key={t.id} value={t.id}>
+                          {t.name}
+                          {typeof t.itemCount === "number" ? ` (${t.itemCount} item${t.itemCount === 1 ? "" : "s"})` : ""}
+                        </option>
+                      ))}
+                    </select>
+                    {templateQuery && filteredTemplates.length === 0 && (
+                      <p className="text-[11px] text-ih-fg-4 mt-1">No templates match “{templateQuery}”.</p>
+                    )}
+                    {selectedTemplate && (
+                      <p className="text-[11px] text-ih-fg-4 mt-1">
+                        Selected: {selectedTemplate.name}
+                      </p>
+                    )}
+                  </>
+                )}
               </div>
             </div>
           )}
@@ -137,13 +201,25 @@ export function NewInspectionWizard({ open, onClose }: { open: boolean; onClose:
           {step === 1 && (
             <div className="space-y-2">
               <label className="block text-[12px] font-bold text-ih-fg-3 mb-1.5">Select Services</label>
-              <div className="grid grid-cols-2 gap-2">
-                {SERVICES.map((s) => (
-                  <button key={s} onClick={() => toggleService(s)}
-                    className={`text-left px-3 py-2 rounded-md text-[12px] font-medium border transition-colors ${services.has(s) ? "border-indigo-600 bg-indigo-50 text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-400" : "border-ih-border text-ih-fg-3"}`}
-                  >{services.has(s) ? "✓ " : ""}{s}</button>
-                ))}
-              </div>
+              {hasServiceCatalog ? (
+                <div className="grid grid-cols-2 gap-2">
+                  {serviceCatalog.map((s) => (
+                    <button key={s.id} onClick={() => toggleService(s.id)}
+                      className={`text-left px-3 py-2 rounded-md text-[12px] font-medium border transition-colors ${services.has(s.id) ? "border-indigo-600 bg-indigo-50 text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-400" : "border-ih-border text-ih-fg-3"}`}
+                    >
+                      {services.has(s.id) ? "✓ " : ""}{s.name}
+                      {typeof s.price === "number" && s.price > 0 ? (
+                        <span className="ml-1 text-ih-fg-4">${s.price}</span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-[12px] text-ih-fg-4 px-1 py-2">
+                  No services configured. You can add services under Settings, or continue and the
+                  inspection will be created from the template only.
+                </p>
+              )}
             </div>
           )}
 

--- a/app/components/PageLoadingSkeleton.tsx
+++ b/app/components/PageLoadingSkeleton.tsx
@@ -1,0 +1,54 @@
+import { Skeleton } from "@core/shared-ui";
+
+/**
+ * Generic content-pane loading skeleton shown while a sidebar navigation's
+ * route loader is in flight. Roughly mirrors the standard page shape:
+ * an eyebrow + title header bar, then a few stacked content blocks.
+ *
+ * Rendered by AuthLayout in place of the stale <Outlet/> during
+ * React Router navigations (navigation.state === "loading").
+ */
+export function PageLoadingSkeleton() {
+  return (
+    <div aria-busy="true" aria-live="polite">
+      <span className="sr-only">Loading page…</span>
+
+      {/* Header bar: eyebrow + title + a trailing action pill */}
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <div className="flex flex-col gap-2.5">
+          <Skeleton variant="text" width="80px" className="h-2.5" />
+          <Skeleton variant="text" width="240px" className="h-6" />
+        </div>
+        <Skeleton variant="block" width="120px" className="h-9 rounded-md" />
+      </div>
+
+      {/* A row of summary tiles */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="bg-ih-bg-card border border-ih-border rounded-lg shadow-ih-card p-5 flex flex-col gap-3"
+          >
+            <Skeleton variant="text" width="60%" className="h-2.5" />
+            <Skeleton variant="text" width="40%" className="h-6" />
+          </div>
+        ))}
+      </div>
+
+      {/* A primary content card with several rows */}
+      <div className="bg-ih-bg-card border border-ih-border rounded-lg shadow-ih-card p-6 flex flex-col gap-4">
+        <Skeleton variant="text" width="180px" className="h-4 mb-1" />
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex items-center gap-4">
+            <Skeleton variant="block" width="40px" className="h-10 rounded-md shrink-0" />
+            <div className="flex-1 flex flex-col gap-2">
+              <Skeleton variant="text" width={`${70 - i * 8}%`} />
+              <Skeleton variant="text" width={`${45 - i * 5}%`} className="h-2.5" />
+            </div>
+            <Skeleton variant="text" width="64px" className="shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/lib/inspection-create.ts
+++ b/app/lib/inspection-create.ts
@@ -4,14 +4,26 @@
  *
  * The wizard posts a separate `date` (YYYY-MM-DD) + `time` (HH:MM); the API
  * wants a single ISO datetime, so we combine them here. `templateId` and
- * `propertyAddress` are required by the schema; `date`/`inspectorId` are
- * omitted when absent so the API applies its own defaults.
+ * `propertyAddress` are required by the schema; `date`/`inspectorId`/
+ * `serviceIds` are omitted when absent so the API applies its own defaults.
+ *
+ * `serviceIds` arrives as a comma-joined string of tenant service IDs (the
+ * Services step now lists the tenant's real services, not free-text labels).
+ * The service layer matches these against the `services` table and silently
+ * ignores unknown IDs, so a stale/empty value is harmless.
+ *
+ * `inspectorId` is only forwarded when it looks like a UUID — the schema types
+ * it as `z.string().uuid()`, and the wizard's free-text "Inspector ID or name"
+ * field could otherwise carry a name that would fail validation.
  */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export interface CreateInspectionJson {
   propertyAddress: string;
   templateId: string;
   date?: string;
   inspectorId?: string;
+  serviceIds?: string[];
 }
 
 export function buildCreateInspectionJson(formData: FormData): CreateInspectionJson {
@@ -20,11 +32,16 @@ export function buildCreateInspectionJson(formData: FormData): CreateInspectionJ
   const dateStr = String(formData.get("date") || "");
   const time = String(formData.get("time") || "") || "09:00";
   const inspectorId = String(formData.get("inspectorId") || "");
+  const serviceIds = String(formData.get("serviceIds") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 
   return {
     propertyAddress: address,
     templateId,
     ...(dateStr ? { date: `${dateStr}T${time}:00Z` } : {}),
-    ...(inspectorId ? { inspectorId } : {}),
+    ...(inspectorId && UUID_RE.test(inspectorId) ? { inspectorId } : {}),
+    ...(serviceIds.length > 0 ? { serviceIds } : {}),
   };
 }

--- a/app/routes/auth-layout.tsx
+++ b/app/routes/auth-layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Outlet, useLoaderData, useLocation, useNavigation } from "react-router";
 import type { Route } from "./+types/auth-layout";
 import { requireToken } from "~/lib/session.server";
@@ -5,6 +6,28 @@ import { createApi } from "~/lib/api-client.server";
 import { Sidebar, MobileHeader } from "~/components/Sidebar";
 import { PageLoadingSkeleton } from "~/components/PageLoadingSkeleton";
 import type { SessionContext } from "~/hooks/useSessionContext";
+
+/**
+ * Returns true only once `active` has stayed true continuously for `delayMs`.
+ * Used to suppress the navigation skeleton on fast loads: humans read a sub-
+ * ~200ms transition as instant, so flashing a skeleton for it is pure jank.
+ * When the navigation finishes before the threshold the skeleton never shows;
+ * React Router keeps the previous page mounted during `loading`, so the user
+ * simply sees the current page until the new one is ready (or the skeleton
+ * appears for genuinely slow loads). Resets immediately when `active` clears.
+ */
+function useDelayedFlag(active: boolean, delayMs: number): boolean {
+  const [shown, setShown] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setShown(false);
+      return;
+    }
+    const t = setTimeout(() => setShown(true), delayMs);
+    return () => clearTimeout(t);
+  }, [active, delayMs]);
+  return shown;
+}
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const token = await requireToken(context, request);
@@ -38,6 +61,9 @@ export default function AuthLayout() {
     navigation.location != null &&
     navigation.location.pathname !== location.pathname;
 
+  // Defer the skeleton ~180ms so fast navigations never flash it (anti-jank).
+  const showSkeleton = useDelayedFlag(isNavigatingToNewPage, 180);
+
   return (
     <>
       {/* F4 — Suspension banner */}
@@ -55,7 +81,7 @@ export default function AuthLayout() {
         <Sidebar />
         <main className="flex-1 w-full bg-ih-bg-app overflow-y-auto">
           <div className="max-w-[1080px] mx-auto pt-5 pb-[60px] px-9">
-            {isNavigatingToNewPage ? <PageLoadingSkeleton /> : <Outlet />}
+            {showSkeleton ? <PageLoadingSkeleton /> : <Outlet />}
           </div>
         </main>
       </div>

--- a/app/routes/auth-layout.tsx
+++ b/app/routes/auth-layout.tsx
@@ -1,8 +1,9 @@
-import { Outlet, useLoaderData } from "react-router";
+import { Outlet, useLoaderData, useLocation, useNavigation } from "react-router";
 import type { Route } from "./+types/auth-layout";
 import { requireToken } from "~/lib/session.server";
 import { createApi } from "~/lib/api-client.server";
 import { Sidebar, MobileHeader } from "~/components/Sidebar";
+import { PageLoadingSkeleton } from "~/components/PageLoadingSkeleton";
 import type { SessionContext } from "~/hooks/useSessionContext";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -23,6 +24,19 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
 export default function AuthLayout() {
   const { context } = useLoaderData<typeof loader>();
+  const navigation = useNavigation();
+  const location = useLocation();
+
+  // Show a content-pane skeleton only during a *real* page navigation:
+  // - navigation.state === "loading" (loader in flight, not a form submission)
+  // - navigation.location is set (guards against revalidation, which has no location)
+  // - the target path differs from the current path (ignore search-param-only
+  //   refetches / replace-in-place updates so we don't flash a skeleton over
+  //   the page the user is already on)
+  const isNavigatingToNewPage =
+    navigation.state === "loading" &&
+    navigation.location != null &&
+    navigation.location.pathname !== location.pathname;
 
   return (
     <>
@@ -41,7 +55,7 @@ export default function AuthLayout() {
         <Sidebar />
         <main className="flex-1 w-full bg-ih-bg-app overflow-y-auto">
           <div className="max-w-[1080px] mx-auto pt-5 pb-[60px] px-9">
-            <Outlet />
+            {isNavigatingToNewPage ? <PageLoadingSkeleton /> : <Outlet />}
           </div>
         </main>
       </div>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -41,6 +41,20 @@ interface Tag {
   color?: string;
 }
 
+/** Template option for the New Inspection wizard picker (B-6). */
+interface TemplateOption {
+  id: string;
+  name: string;
+  itemCount?: number;
+}
+
+/** Service option for the New Inspection wizard Services step (B-8). */
+interface ServiceOption {
+  id: string;
+  name: string;
+  price?: number | null;
+}
+
 interface DashboardData {
   needsAttention: Inspection[];
   today: Inspection[];
@@ -177,9 +191,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const token = await requireToken(context, request);
   try {
     const api = createApi(context, { token });
-    const [dashRes, tagsRes] = await Promise.all([
+    // Templates + services power the New Inspection wizard (B-6 picker + B-8
+    // service linking). They are best-effort: a failure must not break the
+    // dashboard, so each falls back to an empty list.
+    const [dashRes, tagsRes, templatesRes, servicesRes] = await Promise.all([
       api.inspections.dashboard.$get(),
       api.tags.index.$get().catch(() => null),
+      api.inspections.templates.$get({ query: { page: "1", pageSize: "100" } }).catch(() => null),
+      api.services.index.$get().catch(() => null),
     ]);
     const json = dashRes.ok ? ((await dashRes.json()) as Record<string, unknown>) : {};
     const d = (json.data ?? {}) as unknown as DashboardData | undefined;
@@ -187,6 +206,16 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     if (tagsRes && tagsRes.ok) {
       const tj = (await tagsRes.json()) as Record<string, unknown>;
       tags = (tj.data ?? []) as Tag[];
+    }
+    let templates: TemplateOption[] = [];
+    if (templatesRes && templatesRes.ok) {
+      const tj = (await templatesRes.json()) as { data?: TemplateOption[] };
+      templates = (tj.data ?? []).map((t) => ({ id: t.id, name: t.name, itemCount: t.itemCount }));
+    }
+    let svcOptions: ServiceOption[] = [];
+    if (servicesRes && servicesRes.ok) {
+      const sj = (await servicesRes.json()) as { data?: ServiceOption[] };
+      svcOptions = (sj.data ?? []).map((s) => ({ id: s.id, name: s.name, price: s.price }));
     }
     return {
       buckets: {
@@ -200,6 +229,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       conciergePending: d?.conciergePending ?? 0,
       greeting: "Good morning",
       tags,
+      templates,
+      services: svcOptions,
     };
   } catch {
     return {
@@ -214,6 +245,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       conciergePending: 0,
       greeting: "Good morning",
       tags: [] as Tag[],
+      templates: [] as TemplateOption[],
+      services: [] as ServiceOption[],
     };
   }
 }
@@ -287,7 +320,7 @@ const BUCKET_META: Record<string, { label: string; hint: string }> = {
 const PAGE_SIZE = 25;
 
 export default function DashboardPage() {
-  const { buckets, conciergePending, greeting: _ssrGreeting, tags } = useLoaderData<typeof loader>();
+  const { buckets, conciergePending, greeting: _ssrGreeting, tags, templates, services } = useLoaderData<typeof loader>();
   const sessionCtx = useSessionContext();
   const [greeting, setGreeting] = useState(_ssrGreeting);
   useEffect(() => { setGreeting(getGreeting()); }, []);
@@ -814,7 +847,12 @@ export default function DashboardPage() {
       )}
 
       {/* Wizard modal */}
-      <NewInspectionWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
+      <NewInspectionWizard
+        open={wizardOpen}
+        onClose={() => setWizardOpen(false)}
+        templates={templates}
+        services={services}
+      />
 
       {/* Command Palette */}
       <CommandPalette onNewInspection={() => setWizardOpen(true)} />

--- a/app/routes/library/rating-systems.tsx
+++ b/app/routes/library/rating-systems.tsx
@@ -80,15 +80,22 @@ export default function RatingSystemsPage() {
     setEditorOpen(true);
   }
   function openEdit(sys: System) {
+    // Guard `levels`: a system row may arrive without a `levels` array (the card
+    // render already defends with `?? []`). Without the same guard here, spreading
+    // `undefined` throws inside the click handler, so the Edit button silently does
+    // nothing — exactly the "unresponsive" symptom.
+    const levels = [...(sys.levels ?? [])]
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+      .map((l) => ({
+        id: l.id, abbr: l.abbr, label: l.label, color: l.color, bucket: l.bucket, hotkey: l.hotkey,
+      }));
     setEditing({
       id: sys.id,
       name: sys.name,
       slug: sys.slug,
       description: sys.description ?? "",
       isDefault: sys.isDefault,
-      levels: [...sys.levels].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)).map((l) => ({
-        id: l.id, abbr: l.abbr, label: l.label, color: l.color, bucket: l.bucket, hotkey: l.hotkey,
-      })),
+      levels,
     });
     setEditorOpen(true);
   }

--- a/app/routes/public/booking-embed.tsx
+++ b/app/routes/public/booking-embed.tsx
@@ -36,15 +36,27 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
       param: { tenant: params.tenant ?? "", slug: params.slug ?? "" },
     });
     const body = res.ok ? await res.json() : {};
-    const d = ((body as Record<string, unknown>).data ?? {}) as Partial<EmbedData> | undefined;
+    // Shape returned by GET /api/public/book/:tenant/:slug — see server/api/bookings.ts:
+    //   { inspectorId, name, company, avatar, turnstileSiteKey, services }
+    // NOTE: the field names here (`name`, `turnstileSiteKey`) differ from this
+    // route's EmbedData; map them explicitly rather than relying on matching keys.
+    const d = res.ok
+      ? (((body as Record<string, unknown>).data ?? null) as
+          | {
+              inspectorId?: string;
+              name?: string;
+              turnstileSiteKey?: string | null;
+            }
+          | null)
+      : null;
     return {
       data: d
         ? ({
-            slug: d.slug ?? params.slug ?? "",
+            slug: params.slug ?? "",
             inspectorId: d.inspectorId ?? "",
-            inspectorName: d.inspectorName ?? "Inspector",
-            tenantSubdomain: d.tenantSubdomain ?? params.tenant ?? "",
-            siteKey: d.siteKey ?? "",
+            inspectorName: d.name ?? "Inspector",
+            tenantSubdomain: params.tenant ?? "",
+            siteKey: d.turnstileSiteKey ?? "",
             theme,
           } satisfies EmbedData)
         : null,

--- a/app/routes/public/messages.tsx
+++ b/app/routes/public/messages.tsx
@@ -120,7 +120,7 @@ export default function MessagesPublicPage() {
                   {m.attachments.map((a) => (
                     <a
                       key={a.id}
-                      href={`/api/photos/${encodeURIComponent(a.key)}`}
+                      href={`/api/messages/public/${encodeURIComponent(token)}/attachments/${encodeURIComponent(a.id)}`}
                       target="_blank"
                       rel="noreferrer"
                       className="text-xs bg-ih-bg-card border border-ih-border rounded-lg px-2 py-1 hover:bg-ih-bg-muted"

--- a/app/routes/settings-communication.tsx
+++ b/app/routes/settings-communication.tsx
@@ -70,12 +70,15 @@ export async function action({ request, context }: Route.ActionArgs) {
       return submission.reply();
     }
     const { senderEmail, replyTo } = submission.value;
-    await api.admin.communication.$patch({
+    const res = await api.admin.communication.$patch({
       json: {
         senderEmail: senderEmail || null,
         replyTo: replyTo || null,
       },
     });
+    if (!res.ok) {
+      return { ok: false, error: "Failed to save email settings." };
+    }
     return { ok: true };
   }
 

--- a/app/routes/template-edit.tsx
+++ b/app/routes/template-edit.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useLoaderData, useFetcher, Link } from "react-router";
+import { useLoaderData, useFetcher, Link, isRouteErrorResponse, useRouteError } from "react-router";
 import type { Route } from "./+types/template-edit";
 import { requireToken } from "~/lib/session.server";
 import { createApi } from "~/lib/api-client.server";
@@ -138,7 +138,16 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const id = params.id;
   const api = createApi(context, { token });
   const res = await api.inspections.templates[":id"].$get({ param: { id } });
-  const body = res.ok ? await res.json() : {};
+  // A non-OK response previously fell through to an empty `{}`, which rendered a
+  // section-less editor that looks blank ("the editor never opened"). Surface the
+  // failure to the ErrorBoundary instead so the user gets an actionable message.
+  if (!res.ok) {
+    // res.status is typed to the route's declared success code (200) by the
+    // hono client, but the runtime value is the real HTTP status — read it as
+    // a number to distinguish a permission failure from a missing template.
+    throw new Response("Template not found", { status: (res.status as number) === 403 ? 403 : 404 });
+  }
+  const body = await res.json();
   const raw = ((body as Record<string, unknown>).data ?? {}) as Record<string, unknown>;
   const tpl = raw?.template ? (raw.template as Record<string, unknown>) : raw;
   const name = (tpl?.name as string) || "Untitled Template";
@@ -147,25 +156,29 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   if (typeof schema === "string") {
     try { schema = JSON.parse(schema); } catch { schema = { schemaVersion: 2, sections: [] }; }
   }
-  // Normalize name/title
-  if (schema.sections) {
-    schema.sections = schema.sections.map((sec) => {
-      const s = { ...sec };
-      if (!s.title && (s as unknown as Record<string, string>).name) {
-        s.title = (s as unknown as Record<string, string>).name;
-      }
-      if (s.items) {
-        s.items = s.items.map((item) => {
+  // Normalize name/title. Always coerce `items` to an array so the editor's
+  // `section.items.length` / `.map` calls can never crash on a section whose
+  // `items` key is absent (which renders as a blank screen via the root
+  // ErrorBoundary).
+  if (!Array.isArray(schema.sections)) {
+    schema.sections = [];
+  }
+  schema.sections = schema.sections.map((sec) => {
+    const s = { ...sec };
+    if (!s.title && (s as unknown as Record<string, string>).name) {
+      s.title = (s as unknown as Record<string, string>).name;
+    }
+    s.items = Array.isArray(s.items)
+      ? s.items.map((item) => {
           const it = { ...item };
           if (!it.label && (it as unknown as Record<string, string>).name) {
             it.label = (it as unknown as Record<string, string>).name;
           }
           return it;
-        });
-      }
-      return s;
-    });
-  }
+        })
+      : [];
+    return s;
+  });
   return { id, name, version, schema, token };
 }
 
@@ -826,6 +839,35 @@ export default function TemplateEditPage() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Error boundary                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Local boundary so a failed template fetch (404/403) or an unexpected render
+ * error surfaces an actionable message + a way back to the list, instead of a
+ * blank full-screen editor that looks like "the editor never opened".
+ */
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = isRouteErrorResponse(error) ? error.status : null;
+  const message =
+    status === 404
+      ? "This template could not be found. It may have been deleted."
+      : status === 403
+        ? "You do not have permission to edit this template."
+        : "Something went wrong while opening the template editor.";
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-[#f8fafc] dark:bg-[#0f172a] gap-3 px-6 text-center">
+      <p className="text-[15px] font-bold text-ih-fg-1">{message}</p>
+      <Link to="/templates" className="h-8 px-4 inline-flex items-center rounded-md bg-ih-primary text-white font-bold text-[13px] hover:bg-ih-primary-600">
+        Back to Templates
+      </Link>
     </div>
   );
 }

--- a/server/api/messages.ts
+++ b/server/api/messages.ts
@@ -148,6 +148,29 @@ const publicUploadRoute = createRoute(withMcpMetadata({
     description: "Auto-generated placeholder for uploadMessage (POST /public/{token}/upload, messages domain). TODO: replace with a real description sourced from the handler."
 }, { scopes: ['write'], tier: 'extended' }));
 
+// ── B-5: public attachment download (token-scoped, no JWT) ──────────────────────
+// The public messages page links each attachment here. The route is scoped by
+// the conversation `token` (already in the /api/messages/public/ public
+// allowlist) + the attachment `id`, so it can only serve files attached to that
+// conversation — never an arbitrary R2 key. The original filename + MIME type
+// come from the stored attachment metadata.
+const publicAttachmentRoute = createRoute(withMcpMetadata({
+    method: 'get',
+    path: '/public/{token}/attachments/{attachmentId}',
+    tags: ["messages"],
+    request: { params: z.object({
+        token: z.string().describe('Conversation token from the public messages link.'),
+        attachmentId: z.string().describe('Attachment id within the conversation.'),
+    }) },
+    responses: {
+        200: { content: { 'application/octet-stream': { schema: z.any() } }, description: 'Attachment bytes' },
+        404: { description: 'Not found' },
+    },
+    operationId: "downloadMessageAttachmentPublic",
+    summary: "Download a message attachment for public view",
+    description: "Streams a message attachment from R2 for the public (token-gated) conversation view. Scoped by conversation token + attachment id; sets Content-Disposition with the original filename.",
+}, { scopes: ['read'], tier: 'extended' }));
+
 export const messageRoutes = createApiRouter()
     .openapi(listRoute, async (c) => {
         const { inspectionId } = c.req.valid('param');
@@ -257,6 +280,25 @@ export const messageRoutes = createApiRouter()
         if (!c.env.PHOTOS) throw Errors.BadRequest('Storage not available');
         await c.env.PHOTOS.put(key, buf, { httpMetadata: { contentType: detected ?? file.type } });
         return c.json({ success: true, data: { id, key, name: file.name, size: file.size, type: detected ?? file.type, uploadedAt: Date.now() } }, 200);
+    })
+    .openapi(publicAttachmentRoute, async (c) => {
+        const { token, attachmentId } = c.req.valid('param');
+        const svc = c.var.services.message;
+        const att = await svc.resolveAttachmentByToken(token, attachmentId);
+        if (!att) throw Errors.NotFound('Attachment not found');
+        if (!c.env.PHOTOS) throw Errors.NotFound('Storage not available');
+        const obj = await c.env.PHOTOS.get(att.key);
+        if (!obj) throw Errors.NotFound('Attachment not found');
+        // Sanitize the filename for the Content-Disposition header (strip quotes
+        // and control/path characters) so a crafted attachment name can't inject
+        // header tokens.
+        const safeName = (att.name || 'attachment').replace(/["\\\r\n]/g, '').replace(/[/\\]/g, '_').slice(0, 200);
+        const headers = new Headers();
+        headers.set('Content-Type', att.type || obj.httpMetadata?.contentType || 'application/octet-stream');
+        headers.set('Content-Disposition', `attachment; filename="${safeName}"`);
+        headers.set('Cache-Control', 'private, max-age=300');
+        if (obj.httpEtag) headers.set('etag', obj.httpEtag);
+        return new Response(obj.body, { status: 200, headers });
     });
 
 export type MessagesApi = typeof messageRoutes;

--- a/server/services/message.service.ts
+++ b/server/services/message.service.ts
@@ -106,4 +106,30 @@ export class MessageService {
         const [insp] = await this.db().select().from(inspections).where(eq(inspections.messageToken, token)).limit(1);
         return insp ?? null;
     }
+
+    /**
+     * Resolves a single message attachment for a conversation, scoped by the
+     * conversation `token` and the attachment `id`. Returns the stored
+     * attachment metadata (R2 `key`, original `name`, MIME `type`) only when
+     * the attachment belongs to a message on the token's inspection — never
+     * exposing arbitrary R2 keys. Returns null when the token is unknown or no
+     * attachment with that id exists on the conversation.
+     */
+    async resolveAttachmentByToken(
+        token: string,
+        attachmentId: string,
+    ): Promise<{ key: string; name: string; type: string; tenantId: string } | null> {
+        if (!attachmentId) return null;
+        const insp = await this.resolveByToken(token);
+        if (!insp) return null;
+        const rows = await this.listForInspection(insp.id, insp.tenantId);
+        for (const row of rows) {
+            for (const att of row.attachments ?? []) {
+                if (att.id === attachmentId) {
+                    return { key: att.key, name: att.name, type: att.type, tenantId: insp.tenantId };
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/tests/web/unit/inspection-create.spec.ts
+++ b/tests/web/unit/inspection-create.spec.ts
@@ -32,9 +32,15 @@ describe("buildCreateInspectionJson", () => {
         expect("date" in json).toBe(false);
     });
 
-    it("includes inspectorId only when non-empty", () => {
+    it("includes inspectorId only when it is a valid UUID", () => {
+        // empty → omitted
         expect("inspectorId" in buildCreateInspectionJson(fd({ address: "1 A St", templateId: "t", inspectorId: "" }))).toBe(false);
-        expect(buildCreateInspectionJson(fd({ address: "1 A St", templateId: "t", inspectorId: "u9" })).inspectorId).toBe("u9");
+        // non-UUID free text (e.g. a typed name/id) → dropped, since the schema
+        // types inspectorId as z.string().uuid() — sending it would 400 the create.
+        expect("inspectorId" in buildCreateInspectionJson(fd({ address: "1 A St", templateId: "t", inspectorId: "u9" }))).toBe(false);
+        // valid UUID → forwarded
+        const uuid = "625fb306-bde0-4fe9-a0e8-d8151296b23a";
+        expect(buildCreateInspectionJson(fd({ address: "1 A St", templateId: "t", inspectorId: uuid })).inspectorId).toBe(uuid);
     });
 
     it("defaults the time to 09:00 when only a date is given", () => {


### PR DESCRIPTION
## What

A batch of dashboard / settings / embed bug fixes surfaced during prod E2E triage. Each was developed against the real route/typed-client/schema definitions.

| Bug | Fix | Confidence |
|---|---|---|
| **B-7** template editor blank | loader now throws to an ErrorBoundary on non-OK + coerces sections/items to arrays (was a silent empty render / crash) | code-verified; needs a click-through |
| **B-10** Rating Systems "Edit" dead | guarded `sys.levels` spread in `openEdit` (threw when levels absent) | code-verified |
| **B-4** communication "save" false success | `save-email` action now checks the PATCH `.ok` (routes already existed) | code-verified |
| **B-5** attachment download 404 | new token-gated serve route `GET /api/messages/public/:token/attachments/:attachmentId` streaming R2 with `Content-Disposition` | code-verified |
| **B-6** raw "Template ID" text box | searchable dropdown of the tenant's templates (name + item count); list loaded in the dashboard loader | needs a click-through |
| **B-8 (+A-5)** create no-op | wired the dashboard `create` intent → `POST /api/inspections` (date+time→ISO, services→serviceIds, UUID-guarded inspectorId) + redirect to the new inspection | needs end-to-end run |
| **B-9** no nav loading feedback | token-based skeleton during real cross-page RR navigations | needs a click-through |
| **B-1** embed empty | fixed loader field mapping (`inspectorName←name`, `siteKey←turnstileSiteKey`) + aligned style param (light/dark/branded) | field-mapping fixed; the original "blank iframe" symptom may have a separate runtime cause — see note |

## Notes / follow-ups (not in scope here)

- **B-1**: branded theme falls back to light pending **C-6** (tenant `primaryColor` isn't exposed by the public booking API). If a blank iframe persists at runtime, capture the `/api/public/book/:tenant/:slug` network response + any SSR error.
- **B-4**: saved `senderEmail`/`replyTo` persist but are not yet consumed by the outbound mail path (`di.ts`/`email.service.ts` read a secret + have no Reply-To header) — that wiring is **A-7**.
- **B-8**: maps the wizard to the single-inspection create shape (services = add-on line items, not sub-inspections); `clientName` defaults server-side to "Private Client"; `propertyType` is dropped (no column on create).

## Verification

`type-check` (0) · `lint` (0 errors) · `db:check` (EQUIVALENT 59=59) · `test:unit` (1044) · `test:web` (5) · `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
