### PR TITLE
refactor(tenant): rename tenants.subdomain → slug

### DIFF
--- a/app/components/CommandPalette.tsx
+++ b/app/components/CommandPalette.tsx
@@ -139,7 +139,7 @@ export function CommandPalette({ onNewInspection }: { onNewInspection?: () => vo
     const actions: PaletteItem[] = [];
     const slug = sessionCtx?.branding?.currentUserSlug;
     const host = sessionCtx?.branding?.bookingHost;
-    const tenant = sessionCtx?.branding?.tenantSubdomain;
+    const tenant = sessionCtx?.branding?.tenantSlug;
     if (slug && host && tenant) {
       const bookingUrl = `https://${host}/book/${tenant}/${slug}`;
       actions.push({

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -237,7 +237,7 @@ export function Sidebar() {
   const siteName = ctx?.branding?.siteName || "OpenInspection";
   const logoUrl = ctx?.branding?.logoUrl || "/logo.svg";
   const userName = ctx?.user?.name || "Inspector";
-  const userSubline = ctx?.branding?.tenantSubdomain || "openinspection.dev";
+  const userSubline = ctx?.branding?.tenantSlug || "openinspection.dev";
   const userInitials = ctx?.user?.initials || "OI";
   const showSwitchWorkspace = ctx?.branding?.isSaas && ctx?.branding?.portalBaseUrl;
 

--- a/app/components/agent/AgentCommandPalette.tsx
+++ b/app/components/agent/AgentCommandPalette.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 export interface AgentCommandPaletteInspector {
   name: string | null;
   slug: string | null;
-  tenantSubdomain: string;
+  tenantSlug: string;
 }
 
 interface AgentCommandPaletteProps {
@@ -40,9 +40,9 @@ export function AgentCommandPalette({ inspectors, agentSlug, bookingHost }: Agen
     const ref = agentSlug ? `?ref=${encodeURIComponent(agentSlug)}` : "";
     for (const insp of inspectors) {
       if (!insp.slug) continue;
-      const url = `https://${bookingHost}/book/${insp.tenantSubdomain}/${insp.slug}${ref}`;
+      const url = `https://${bookingHost}/book/${insp.tenantSlug}/${insp.slug}${ref}`;
       const displayName = insp.name?.trim() || insp.slug;
-      list.push({ id: `copy-${insp.tenantSubdomain}-${insp.slug}`, group: "Actions", label: `Copy booking link — ${displayName}`, hint: "copy", action: "copy", payload: url });
+      list.push({ id: `copy-${insp.tenantSlug}-${insp.slug}`, group: "Actions", label: `Copy booking link — ${displayName}`, hint: "copy", action: "copy", payload: url });
     }
     return list;
   }, [inspectors, agentSlug, bookingHost]);

--- a/app/hooks/useSessionContext.ts
+++ b/app/hooks/useSessionContext.ts
@@ -13,7 +13,7 @@ export interface SessionContext {
     reportTheme: string;
     isSaas: boolean;
     portalBaseUrl: string | null;
-    tenantSubdomain: string | null;
+    tenantSlug: string | null;
     tenantStatus: string;
     currentUserSlug: string | null;
     bookingHost: string | null;

--- a/app/routes/agent/inspectors.tsx
+++ b/app/routes/agent/inspectors.tsx
@@ -12,7 +12,7 @@ interface Inspector {
   inspectorSlug: string | null;
   inspectorPhotoUrl: string | null;
   tenantName: string;
-  tenantSubdomain: string;
+  tenantSlug: string;
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -86,7 +86,7 @@ export default function AgentInspectorsPage() {
               {row.inspectorSlug ? (
                 <button
                   onClick={() => {
-                    const url = `https://${row.tenantSubdomain}.inspectorhub.io/book/${row.inspectorSlug}`;
+                    const url = `https://${row.tenantSlug}.inspectorhub.io/book/${row.inspectorSlug}`;
                     navigator.clipboard.writeText(url);
                   }}
                   className="w-full h-9 rounded-md bg-ih-primary text-white font-bold text-[13px] hover:bg-ih-primary-600 transition-colors uppercase tracking-wide mt-auto"

--- a/app/routes/public/agreement-sign.tsx
+++ b/app/routes/public/agreement-sign.tsx
@@ -20,7 +20,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
  try {
  const api = createApi(context);
  // The public agreement fetch lives on the bookings router (GET
- // /api/public/agreements/:token); tenant resolves from the subdomain server-side.
+ // /api/public/agreements/:token); tenant resolves from the slug server-side.
  const res = await api.bookings.agreements[":token"].$get({
  param: { token: params.token ?? "" },
  });

--- a/app/routes/public/booking-embed.tsx
+++ b/app/routes/public/booking-embed.tsx
@@ -15,7 +15,7 @@ interface EmbedData {
   slug: string;
   inspectorId: string;
   inspectorName: string;
-  tenantSubdomain: string;
+  tenantSlug: string;
   siteKey: string;
   theme: "light" | "dark" | "branded";
 }
@@ -55,7 +55,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
             slug: params.slug ?? "",
             inspectorId: d.inspectorId ?? "",
             inspectorName: d.name ?? "Inspector",
-            tenantSubdomain: params.tenant ?? "",
+            tenantSlug: params.tenant ?? "",
             siteKey: d.turnstileSiteKey ?? "",
             theme,
           } satisfies EmbedData)

--- a/app/routes/settings-booking.tsx
+++ b/app/routes/settings-booking.tsx
@@ -77,7 +77,7 @@ export default function SettingsBookingPage() {
   const data = useLoaderData<typeof loader>();
   const ctx = useSessionContext();
 
-  const tenant = ctx?.branding?.tenantSubdomain;
+  const tenant = ctx?.branding?.tenantSlug;
   const slug = ctx?.branding?.currentUserSlug;
 
   return (

--- a/app/routes/settings-profile.tsx
+++ b/app/routes/settings-profile.tsx
@@ -93,7 +93,7 @@ export default function SettingsProfilePage() {
   const actionData = useActionData<typeof action>();
   const [bioLen, setBioLen] = useState((profile.bio ?? "").length);
   const ctx = useSessionContext();
-  const tenant = ctx?.branding?.tenantSubdomain;
+  const tenant = ctx?.branding?.tenantSlug;
 
   // Conform owns the main profile form (default intent). The save-signature
   // intent is handled by a separate useFetcher below, so guard against feeding

--- a/migrations/0005_rename_tenant_subdomain_to_slug.sql
+++ b/migrations/0005_rename_tenant_subdomain_to_slug.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `tenants` RENAME COLUMN `subdomain` TO `slug`;--> statement-breakpoint
+DROP INDEX `tenants_subdomain_unique`;--> statement-breakpoint
+CREATE UNIQUE INDEX `tenants_slug_unique` ON `tenants` (`slug`);

--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -1465,7 +1465,7 @@ export const adminRoutes = createApiRouter()
             ...(body.clientName !== undefined ? { clientName: body.clientName } : {}),
             ...(body.inspectionId !== undefined ? { inspectionId: body.inspectionId } : {}),
         });
-        const tenantSlug = c.get('requestedSubdomain') ?? '';
+        const tenantSlug = c.get('requestedTenantSlug') ?? '';
         const signUrl = agreementSignUrl(getBookingHost(c), tenantSlug, request.token);
 
         // Spec 5H D-patch — fetch the agreement HTML at send-time to compute its

--- a/server/api/agent.ts
+++ b/server/api/agent.ts
@@ -215,7 +215,7 @@ const AgentInspectorRowSchema = z.object({
     inspectorSlug:     z.string().nullable().describe('Inspector public profile slug.'),
     inspectorPhotoUrl: z.string().nullable().describe('Inspector avatar URL.'),
     tenantName:        z.string().describe('Inspecting company name.'),
-    tenantSubdomain:   z.string().describe('Tenant subdomain for the booking link.'),
+    tenantSlug:   z.string().describe('Tenant slug for the booking link.'),
 });
 const inspectorsRoute = createRoute(withMcpMetadata({
     method: 'get',
@@ -229,7 +229,7 @@ const inspectorsRoute = createRoute(withMcpMetadata({
     },
     security: [{ bearerAuth: [] }],
     operationId: "listAgentInspectors",
-    description: "Lists every inspecting team the signed-in agent has an active link with, with the public profile slug + subdomain needed to build shareable booking links for clients.",
+    description: "Lists every inspecting team the signed-in agent has an active link with, with the public profile slug + slug needed to build shareable booking links for clients.",
 }, { scopes: ['agent'], tier: 'extended' }));
 
 export const agentRoutes = createApiRouter()

--- a/server/api/agreements-render.ts
+++ b/server/api/agreements-render.ts
@@ -45,9 +45,9 @@ export async function agreementRenderHandler(
   if (!reqRow || reqRow.status !== 'signed' || !reqRow.signatureBase64) {
     return new Response('Not Found', { status: 404 });
   }
-  const tenant = await db.select({ subdomain: schema.tenants.subdomain })
+  const tenant = await db.select({ slug: schema.tenants.slug })
     .from(schema.tenants).where(eq(schema.tenants.id, reqRow.tenantId)).get();
-  if (!tenant || tenant.subdomain !== tenantSlug) {
+  if (!tenant || tenant.slug !== tenantSlug) {
     return new Response('Not Found', { status: 404 });
   }
   const agreement = await db.select().from(schema.agreements)

--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -674,12 +674,12 @@ export const coreAuthRoutes = createApiRouter()
         // 3. Initialize Workspace
         const passwordHash = await c.var.services.auth.hashPassword(body.password);
         const tenantId = c.env.SINGLE_TENANT_ID || '00000000-0000-0000-0000-000000000000';
-        const subdomain = body.companyName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        const slug = body.companyName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
         await c.var.services.admin.updateTenantStatus({
             id: tenantId,
             name: body.companyName,
-            subdomain,
+            slug,
             status: 'active',
             adminEmail: body.email,
             adminPasswordHash: passwordHash,

--- a/server/api/bookings.ts
+++ b/server/api/bookings.ts
@@ -277,7 +277,7 @@ const publicGeocodeRoute = createRoute(withMcpMetadata({
 
 export const bookingsRoutes = createApiRouter()
     .openapi(listInspectorsRoute, async (c) => {
-        const tenantId = c.get('tenantId') || c.get('requestedSubdomain');
+        const tenantId = c.get('tenantId') || c.get('requestedTenantSlug');
         if (!tenantId) throw Errors.Forbidden('Tenant context missing.');
 
         const service = c.var.services.booking;
@@ -285,7 +285,7 @@ export const bookingsRoutes = createApiRouter()
         return c.json({ success: true, data: inspectors }, 200);
     })
     .openapi(listPublicServicesRoute, async (c) => {
-        const tenantId = c.get('tenantId') || c.get('requestedSubdomain');
+        const tenantId = c.get('tenantId') || c.get('requestedTenantSlug');
         if (!tenantId) throw Errors.Forbidden('Tenant context missing.');
         const db = drizzle(c.env.DB);
         const rows = await db.select({
@@ -315,7 +315,7 @@ export const bookingsRoutes = createApiRouter()
         }, 200);
     })
     .openapi(getAvailabilityRoute, async (c) => {
-        const tenantId = c.get('tenantId') || c.get('requestedSubdomain');
+        const tenantId = c.get('tenantId') || c.get('requestedTenantSlug');
         if (!tenantId) throw Errors.Forbidden('Tenant context missing.');
 
         const { inspectorId } = c.req.valid('param');
@@ -332,7 +332,7 @@ export const bookingsRoutes = createApiRouter()
         await checkRateLimit(c, 'book');
 
         const body = c.req.valid('json');
-        const tenantId = c.get('tenantId') || c.get('requestedSubdomain');
+        const tenantId = c.get('tenantId') || c.get('requestedTenantSlug');
         if (!tenantId) throw Errors.Forbidden('Tenant context missing.');
 
         const service = c.var.services.booking;
@@ -668,7 +668,7 @@ export const bookingsRoutes = createApiRouter()
         // + Certificate of Completion + appends 'workflow.complete' to audit chain).
         // Fire-and-forget: client doesn't wait. Workflow has its own retry policy.
         if (request && c.env.SIGN_COMPLETION_WORKFLOW) {
-            const tenantSlug = c.get('requestedSubdomain') ?? '';
+            const tenantSlug = c.get('requestedTenantSlug') ?? '';
             c.executionCtx.waitUntil((async () => {
                 try {
                     await c.env.SIGN_COMPLETION_WORKFLOW!.create({
@@ -870,9 +870,9 @@ export const bookingsRoutes = createApiRouter()
         const { tenant, slug } = c.req.param();
         const db = drizzle(c.env.DB);
 
-        // Resolve tenant by subdomain
+        // Resolve tenant by slug
         const tenantRow = await db.select({ id: tenants.id, name: tenants.name })
-            .from(tenants).where(eq(tenants.subdomain, tenant)).get();
+            .from(tenants).where(eq(tenants.slug, tenant)).get();
         if (!tenantRow) return c.json({ success: false, error: { code: 'not_found', message: 'Tenant not found' } }, 404);
 
         // Find inspector by slug within tenant

--- a/server/api/concierge.ts
+++ b/server/api/concierge.ts
@@ -147,7 +147,7 @@ export const conciergeRoutes = createApiRouter()
                         view.inspection.tenantId,
                         view.inspection.id,
                     );
-                    redirect = agreementSignPath(view.inspection.tenantSubdomain, agr.token);
+                    redirect = agreementSignPath(view.inspection.tenantSlug, agr.token);
                 } catch (err) {
                     // No template configured — surface a generic thank-you page.
                     logger.warn('concierge.findOrCreate.failed', {
@@ -155,12 +155,12 @@ export const conciergeRoutes = createApiRouter()
                         inspectionId: view.inspection.id,
                         error: err instanceof Error ? err.message : String(err),
                     });
-                    redirect = `/report/${view.inspection.tenantSubdomain}/${view.inspection.id}`;
+                    redirect = `/report/${view.inspection.tenantSlug}/${view.inspection.id}`;
                 }
             } else {
                 // Optimistically redirect to the report viewer; the gate will lock
                 // it down if the inspection is still pending.
-                redirect = `/report/${view.inspection.tenantSubdomain}/${view.inspection.id}`;
+                redirect = `/report/${view.inspection.tenantSlug}/${view.inspection.id}`;
             }
         }
 

--- a/server/api/inspections.ts
+++ b/server/api/inspections.ts
@@ -80,8 +80,8 @@ async function resolveSignatureInspector(
             slug:            users.slug,
         }).from(users).where(and(eq(users.id, inspectorId), eq(users.tenantId, tenantId))).get();
         if (!row) return undefined;
-        const tenantSubdomain = c.get('requestedSubdomain') ?? null;
-        return { ...row, tenantSubdomain };
+        const tenantSlug = c.get('requestedTenantSlug') ?? null;
+        return { ...row, tenantSlug };
     } catch (err) {
         logger.error('[email-signature] inspector lookup failed', { inspectorId }, err instanceof Error ? err : undefined);
         return undefined;
@@ -2178,7 +2178,7 @@ export const inspectionsRoutes = createApiRouter()
         await db.update(inspectionTable).set({ status: 'completed' }).where(and(eq(inspectionTable.id, id), eq(inspectionTable.tenantId, tenantId)));
 
         if (inspection.clientEmail) {
-            const tenantSlug = c.get('requestedSubdomain') ?? '';
+            const tenantSlug = c.get('requestedTenantSlug') ?? '';
             const reportUrl = buildReportUrl(getBookingHost(c), tenantSlug, id);
             const clientEmail = inspection.clientEmail;
             const address = inspection.propertyAddress as string;
@@ -2233,7 +2233,7 @@ export const inspectionsRoutes = createApiRouter()
             throw Errors.BadRequest('No recipient email — set inspection.clientEmail or pass toEmail.');
         }
 
-        const tenantSlug = c.get('requestedSubdomain') ?? '';
+        const tenantSlug = c.get('requestedTenantSlug') ?? '';
         const reportUrl = buildReportUrl(getBookingHost(c), tenantSlug, id);
         const address = inspection.propertyAddress as string;
 
@@ -2375,7 +2375,7 @@ export const inspectionsRoutes = createApiRouter()
         // remains the universal fallback.
         const reportPdf = c.var.services.reportPdf;
         if (await reportPdf.isPipelineEnabled(tenantId)) {
-            const tenantSlug = c.get('requestedSubdomain') ?? '';
+            const tenantSlug = c.get('requestedTenantSlug') ?? '';
             const reportUrl = buildReportUrl(getBookingHost(c), tenantSlug, id);
             const sourceVersion = Date.now();
             const renderBoth = async () => {
@@ -2422,7 +2422,7 @@ export const inspectionsRoutes = createApiRouter()
         if (!(await reportPdf.isPipelineEnabled(tenantId))) {
             throw Errors.Forbidden('PDF pipeline is disabled for this workspace. Enable it in Settings → Reports.');
         }
-        const tenantSlug = c.get('requestedSubdomain') ?? '';
+        const tenantSlug = c.get('requestedTenantSlug') ?? '';
         const reportUrl = buildReportUrl(getBookingHost(c), tenantSlug, id);
         const sourceVersion = Date.now();
 
@@ -2512,7 +2512,7 @@ export const inspectionsRoutes = createApiRouter()
         const tenantId = c.get('tenantId') as string;
         const { id } = c.req.valid('param');
         const token = await c.var.services.inspection.generateAgentViewToken(tenantId, id);
-        const tenantSlug = c.get('requestedSubdomain') ?? '';
+        const tenantSlug = c.get('requestedTenantSlug') ?? '';
         const url = `${buildReportUrl(getBookingHost(c), tenantSlug, id)}?view=agent&token=${token}`;
         return c.json({ success: true, data: { token, url } });
     })
@@ -2557,7 +2557,7 @@ export const inspectionsRoutes = createApiRouter()
         }
 
         const token = await c.var.services.inspection.generateAgentViewToken(tenantId, id);
-        const tenantSlug = c.get('requestedSubdomain') ?? '';
+        const tenantSlug = c.get('requestedTenantSlug') ?? '';
         const url = `${buildReportUrl(getBookingHost(c), tenantSlug, id)}?view=agent&token=${token}`;
 
         // Sprint B-4c — append the inspector's signature so the receiving agent

--- a/server/api/public-report.ts
+++ b/server/api/public-report.ts
@@ -22,7 +22,7 @@ const reportRoute = createRoute(withMcpMetadata({
     summary: 'Public token-gated inspection report data',
     request: {
         params: z.object({
-            tenant: z.string().describe('Tenant subdomain (display only; tenant is resolved from the token).'),
+            tenant: z.string().describe('Tenant slug (display only; tenant is resolved from the token).'),
             id: z.string().describe('Inspection id.'),
         }),
         query: z.object({ token: z.string().optional().describe('Persistent portal access token.') }),
@@ -36,7 +36,7 @@ const reportRoute = createRoute(withMcpMetadata({
 }, { scopes: [], tier: 'extended' }));
 
 // Public inspector marketing profile (by slug). Tenant resolves from the
-// subdomain (no token — public page); returns whitelisted public fields only.
+// slug (no token — public page); returns whitelisted public fields only.
 const PublicInspectorProfileSchema = z.object({
     profile: z.object({
         name: z.string().nullable(),
@@ -60,7 +60,7 @@ const inspectorRoute = createRoute(withMcpMetadata({
     tags: ['public'],
     summary: 'Public inspector marketing profile',
     request: { params: z.object({
-        tenant: z.string().describe('Tenant subdomain that scopes the inspector lookup.'),
+        tenant: z.string().describe('Tenant slug that scopes the inspector lookup.'),
         slug: z.string().describe('Public inspector profile slug.'),
     }) },
     responses: {
@@ -68,11 +68,11 @@ const inspectorRoute = createRoute(withMcpMetadata({
         404: { description: 'Tenant or inspector not found' },
     },
     operationId: 'getPublicInspectorProfile',
-    description: 'Public, no-login inspector profile resolved by tenant subdomain + slug. Returns only public marketing fields (name/bio/photo/serviceAreas) + bookable services — never email/phone/license/ids.',
+    description: 'Public, no-login inspector profile resolved by tenant slug + slug. Returns only public marketing fields (name/bio/photo/serviceAreas) + bookable services — never email/phone/license/ids.',
 }, { scopes: [], tier: 'extended' }));
 
 // Public invoice for the report-gate "Pay invoice" CTA (by inspection id;
-// tenant resolves from subdomain). The id is unguessable; tenant-scoped query.
+// tenant resolves from slug). The id is unguessable; tenant-scoped query.
 const PublicInvoiceSchema = z.object({
     id: z.string(),
     amountCents: z.number(),
@@ -92,7 +92,7 @@ const invoiceRoute = createRoute(withMcpMetadata({
         404: { description: 'Tenant not resolved' },
     },
     operationId: 'getPublicInvoice',
-    description: 'Public, no-login invoice for an inspection (the unguessable id is the key). Tenant resolved from subdomain; tenant-scoped query.',
+    description: 'Public, no-login invoice for an inspection (the unguessable id is the key). Tenant resolved from slug; tenant-scoped query.',
 }, { scopes: [], tier: 'extended' }));
 
 // Public Stripe PaymentIntent mint for the invoice pay-panel (bring-your-own-keys:
@@ -118,7 +118,7 @@ const payIntentRoute = createRoute(withMcpMetadata({
         503: { description: 'Stripe is not configured for this tenant, or the charge could not be started' },
     },
     operationId: 'createPublicPayIntent',
-    description: "Mints a Stripe PaymentIntent for the inspection's invoice using the tenant's own Stripe keys. Public — the unguessable inspection id is the key; tenant resolved from subdomain.",
+    description: "Mints a Stripe PaymentIntent for the inspection's invoice using the tenant's own Stripe keys. Public — the unguessable inspection id is the key; tenant resolved from slug.",
 }, { scopes: [], tier: 'extended' }));
 
 // Public live-observer view (③-A.4). Gated by an OBSERVER-link token (distinct
@@ -154,7 +154,7 @@ const observeRoute = createRoute(withMcpMetadata({
 }, { scopes: [], tier: 'extended' }));
 
 // Public report-gate (③-A.2). The "report blocked, here's why + CTA" page,
-// resolved by tenant subdomain + id (no token — pre-report). Returns only
+// resolved by tenant slug + id (no token — pre-report). Returns only
 // non-sensitive gate fields (reason + branding + inspector contact + amount).
 const ReportGateResponseSchema = z.object({
     reason: z.enum(['payment', 'agreement']),
@@ -179,7 +179,7 @@ const reportGateRoute = createRoute(withMcpMetadata({
     summary: 'Public report-gate status (why the report is blocked + CTA)',
     request: {
         params: z.object({
-            tenant: z.string().describe('Tenant subdomain (display + CTA-URL building; tenant is resolved from the subdomain).'),
+            tenant: z.string().describe('Tenant slug (display + CTA-URL building; tenant is resolved from the slug).'),
             id: z.string().describe('Inspection id.'),
         }),
     },
@@ -188,7 +188,7 @@ const reportGateRoute = createRoute(withMcpMetadata({
         404: { description: 'Tenant not resolved' },
     },
     operationId: 'getPublicReportGate',
-    description: 'Public, no-login report-gate status resolved by tenant subdomain + inspection id. Returns the outstanding gate (agreement before payment) with branding, inspector contact, and amount due — or null when the report is not gated.',
+    description: 'Public, no-login report-gate status resolved by tenant slug + inspection id. Returns the outstanding gate (agreement before payment) with branding, inspector contact, and amount due — or null when the report is not gated.',
 }, { scopes: [], tier: 'extended' }));
 
 // Public e-sign verifier (Spec 5H P2, court-friendly). Reuses the raw siblings'

--- a/server/api/public-share.ts
+++ b/server/api/public-share.ts
@@ -59,7 +59,7 @@ export const publicShareRoutes = createApiRouter()
 
         const token = await c.var.services.inspection.generateAgentViewToken(tenantId, id);
         const baseUrl = c.env.APP_BASE_URL || `https://${c.req.header('host') ?? ''}`;
-        const tenantSlug = c.get('requestedSubdomain') ?? '';
+        const tenantSlug = c.get('requestedTenantSlug') ?? '';
         const url = `${baseUrl}/report/${tenantSlug}/${id}?view=agent&token=${token}`;
         logger.info('Public share-token minted', { inspectionId: id, tenantId });
         return sendSuccess(c, { token, url });

--- a/server/api/public-slug.ts
+++ b/server/api/public-slug.ts
@@ -11,7 +11,7 @@ import { withMcpMetadata } from "../lib/route-metadata-standards";
  * Booking #7 Sprint A — public slug-availability endpoint.
  *
  * Mounted at `/api/public/check/slug` inside the `/api/public/*` JWT
- * allowlist. tenantId resolves from subdomain via `tenantRouter`; an
+ * allowlist. tenantId resolves from slug via `tenantRouter`; an
  * unresolved tenant returns `{ available:false, reason:'invalid' }` so the
  * client can surface a friendly message instead of a 5xx.
  *

--- a/server/api/repair-requests.ts
+++ b/server/api/repair-requests.ts
@@ -8,7 +8,7 @@
  * (or to a contractor). Same gates as `/r/:id/repair-request`:
  *   - Tenant must opt in via tenant_configs.enable_customer_repair_export
  *   - Inspection's payment + agreement requirements must be satisfied
- *   - Tenant resolved from subdomain (or single-tenant default in standalone)
+ *   - Tenant resolved from slug (or single-tenant default in standalone)
  *
  * Audit log: writes 'repair_request.exported' on success.
  *
@@ -66,7 +66,7 @@ const sendEmailRoute = createRoute(withMcpMetadata({
 
 // C-10 ③-D — GET /api/public/repair-request/:id — the data the public
 // repair-request page renders (property + defects + estimates + prefill email).
-// Tenant resolved from subdomain; the unguessable inspection id is the key.
+// Tenant resolved from slug; the unguessable inspection id is the key.
 const RepairDefectSchema = z.object({
     sectionId:           z.string().describe('Report section id.'),
     sectionTitle:        z.string().describe('Report section title.'),
@@ -104,7 +104,7 @@ const getRepairRequestRoute = createRoute(withMcpMetadata({
         404: { description: 'Tenant not resolved' },
     },
     operationId: "getPublicRepairRequest",
-    description: "Public, no-login repair-request page data (property + flattened defect list + estimates) for an inspection, resolved by tenant subdomain + the unguessable inspection id.",
+    description: "Public, no-login repair-request page data (property + flattened defect list + estimates) for an inspection, resolved by tenant slug + the unguessable inspection id.",
 }, { scopes: [], tier: 'extended' }));
 
 export const repairRequestRoutes = createApiRouter()

--- a/server/api/session-context.ts
+++ b/server/api/session-context.ts
@@ -79,7 +79,7 @@ export const sessionContextRoutes = createApiRouter()
                     reportTheme: branding?.reportTheme || 'modern',
                     isSaas: branding?.isSaas || false,
                     portalBaseUrl: branding?.portalBaseUrl || null,
-                    tenantSubdomain: branding?.tenantSubdomain || null,
+                    tenantSlug: branding?.tenantSlug || null,
                     tenantStatus: branding?.tenantStatus || 'active',
                     currentUserSlug: branding?.currentUserSlug || null,
                     bookingHost: branding?.bookingHost || null,

--- a/server/api/stripe-webhook.ts
+++ b/server/api/stripe-webhook.ts
@@ -8,10 +8,10 @@ import { extractSettledPayment } from '../lib/stripe-helpers';
  * index.ts `isPublic`); authenticity is proven by the `stripe-signature`
  * HMAC verified against the tenant's OWN webhook signing secret.
  *
- * Per-tenant routing: the tenant is resolved from the request subdomain by
+ * Per-tenant routing: the tenant is resolved from the request slug by
  * tenantRouter, and integration-secrets middleware loads THAT tenant's
  * STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET into c.env. So each inspector
- * points their Stripe dashboard webhook at their own subdomain and we verify
+ * points their Stripe dashboard webhook at their own slug and we verify
  * with their own secret.
  */
 const api = new Hono<HonoConfig>();

--- a/server/api/well-known.ts
+++ b/server/api/well-known.ts
@@ -19,7 +19,7 @@ wellKnownRoutes.get('/openinspection/tenant-keys/:slug', async (c) => {
     const db = drizzle(c.env.DB, { schema });
     const tenant = await db.select({ id: schema.tenants.id })
         .from(schema.tenants)
-        .where(eq(schema.tenants.subdomain, slug))
+        .where(eq(schema.tenants.slug, slug))
         .get();
     if (!tenant) return c.json({ error: 'tenant not found' }, 404);
     const signing = new SigningKeyService(c.env.DB, c.env.KEY_ENCRYPTION_SECRET || c.env.JWT_SECRET);

--- a/server/features/tenant-routing/index.ts
+++ b/server/features/tenant-routing/index.ts
@@ -15,11 +15,11 @@ import { resolveByPathParam } from './resolve-by-path-param';
  *
  * Path-param resolution runs first regardless of mode, so public
  * routes like `/book/:tenant/:slug` work uniformly across all
- * deploys. Subdomain-based resolution was retired with the
+ * deploys. DNS/host-based tenant resolution was retired with the
  * silo-deconvergence plan (2026-05-29) — silo + shared now share
- * the same path/JWT lookup; vanity subdomains, if any, are bound
- * by ops at the Cloudflare DNS + Worker-route layer and the tenant
- * row is identified by path or JWT inside the Worker either way.
+ * the same path/JWT lookup; the tenant row is always identified by
+ * the path slug or the JWT claim inside the Worker, never by the
+ * request's hostname.
  *
  * The 503 fallthrough fires ONLY in standalone mode when the fixed
  * tenant resolver failed AND the path isn't on the bypass list. In
@@ -70,7 +70,7 @@ export const tenantRouter: MiddlewareHandler<HonoConfig> = async (c, next) => {
                 logger.info('[TenantRouter] Tenant resolution failed', {
                     path,
                     tenantId: c.get('tenantId'),
-                    subdomain: c.get('requestedSubdomain'),
+                    slug: c.get('requestedTenantSlug'),
                 });
                 return c.text('Tenant not found or system not initialized.', 503);
             }

--- a/server/features/tenant-routing/resolve-by-fixed-tenant.ts
+++ b/server/features/tenant-routing/resolve-by-fixed-tenant.ts
@@ -6,7 +6,7 @@ import type { HonoConfig } from '../../types/hono';
 
 /**
  * Standalone path: fixed tenant id from profile, with KV cache
- * for the row metadata (subdomain / tier / status).
+ * for the row metadata (slug / tier / status).
  */
 export async function resolveByFixedTenant(c: Context<HonoConfig>, tenantId: string): Promise<void> {
     c.set('tenantId', tenantId);
@@ -32,7 +32,7 @@ export async function resolveByFixedTenant(c: Context<HonoConfig>, tenantId: str
 
     if (cachedTenant) {
         const t = cachedTenant as Record<string, unknown>;
-        c.set('requestedSubdomain', t.subdomain as string);
+        c.set('requestedTenantSlug', t.slug as string);
         c.set('tenantTier', (t.tier as string) || 'free');
         c.set('tenantStatus', (t.status as string) || 'active');
     }

--- a/server/features/tenant-routing/resolve-by-path-param.ts
+++ b/server/features/tenant-routing/resolve-by-path-param.ts
@@ -7,14 +7,14 @@ import type { HonoConfig } from '../../types/hono';
 /**
  * Path-param resolution: pulls the tenant slug from the URL's first
  * non-prefix segment for known public routes, then resolves via KV/D1
- * the same way subdomain resolution does.
+ * the same way slug resolution does.
  *
  * Pattern: /<prefix>/<tenant>/...
  *   prefix ∈ {book, embed/book, inspector, report, sign,
  *             agreements/sign, m2m/agreement-render}
  *
  * Returns true if a tenant was extracted + resolved; false otherwise
- * (caller should then try subdomain → fixed → leave-unset).
+ * (caller should then try slug → fixed → leave-unset).
  */
 const PUBLIC_PREFIXES = [
     '/book/',
@@ -43,7 +43,7 @@ export async function resolveByPathParam(c: Context<HonoConfig>, path: string): 
     if (!cachedTenant) {
         try {
             const db = drizzle(c.env.DB);
-            const tenantMatch = await db.select().from(tenants).where(eq(tenants.subdomain, tenantSlug)).get();
+            const tenantMatch = await db.select().from(tenants).where(eq(tenants.slug, tenantSlug)).get();
             if (tenantMatch) {
                 cachedTenant = tenantMatch;
                 if (c.env.TENANT_CACHE && c.executionCtx) {
@@ -61,7 +61,7 @@ export async function resolveByPathParam(c: Context<HonoConfig>, path: string): 
     const tenantId = cached.id as string;
     c.set('tenantId', tenantId);
     c.set('resolvedTenantId', tenantId);
-    c.set('requestedSubdomain', cached.subdomain as string);
+    c.set('requestedTenantSlug', cached.slug as string);
     c.set('tenantTier', (cached.tier as string) || 'free');
     c.set('tenantStatus', (cached.status as string) || 'active');
     return true;

--- a/server/index.ts
+++ b/server/index.ts
@@ -343,7 +343,7 @@ app.use('*', async (c, next) => {
     }
 
     // --- Tenant Isolation Guard (Fail-Fast) ---
-    // In SaaS mode, strictly verify that the token's tenant matches the requested subdomain's tenant.
+    // In SaaS mode, strictly verify that the token's tenant matches the requested slug's tenant.
     if (c.var.profile.mode === 'saas') {
         const tokenTenantId = c.get('tenantId');
         const resolvedTenantId = c.get('resolvedTenantId');
@@ -566,7 +566,7 @@ app.get('/inspector/:tenant/:slug/calendar.ics', async (c) => {
     // Tenant slug from path must match what tenant-router resolved.
     // The middleware only sets resolvedTenantId on a successful match,
     // so an unresolved path tenant manifests as a 404 here.
-    if (!tenantId || c.get('requestedSubdomain') !== tenantSlugFromPath) {
+    if (!tenantId || c.get('requestedTenantSlug') !== tenantSlugFromPath) {
         return c.text('Not found', 404);
     }
     const ics = await c.var.services.ics.busyFeedForInspector(tenantId, slug);
@@ -597,7 +597,7 @@ app.get('/agreements/sign', (c) => c.redirect('/not-found?from=agreement-sign', 
 // / never created), redirects to the friendly not-found page so the
 // customer at least sees branded copy instead of the bare 404.
 //
-// Public — no JWT required. tenantId resolves from the subdomain via
+// Public — no JWT required. tenantId resolves from the slug via
 // tenantRouter middleware (`resolvedTenantId`), the same way the public
 // `/report/:id` viewer is scoped.
 app.get('/sign/:tenant/:id', async (c) => {
@@ -609,7 +609,7 @@ app.get('/sign/:tenant/:id', async (c) => {
     // so an unresolved path tenant manifests as a 404 here. Use the
     // friendly not-found page to match the rest of this handler's
     // failure modes (token miss / no live request).
-    if (!tenantId || c.get('requestedSubdomain') !== tenantSlugFromPath) {
+    if (!tenantId || c.get('requestedTenantSlug') !== tenantSlugFromPath) {
         return c.redirect('/not-found?from=agreement-sign', 302);
     }
 
@@ -646,7 +646,7 @@ app.get('/api/public/verify/:envelopeId/document', async (c) => {
     const envelopeId = c.req.param('envelopeId') as string;
     const data = await loadVerifyData(c, envelopeId);
     if (!data) return c.text('Not found', 404);
-    return c.redirect(agreementSignPath(data.tenantSubdomain, data.reqRow.token), 302);
+    return c.redirect(agreementSignPath(data.tenantSlug, data.reqRow.token), 302);
 });
 
 app.get('/api/public/verify-by-token/:token', async (c) => {

--- a/server/lib/auth/agent-tenant.ts
+++ b/server/lib/auth/agent-tenant.ts
@@ -11,7 +11,7 @@ import type { HonoConfig } from '../../types/hono';
  * Agent JWTs intentionally carry no `tenantId` claim because a single agent can
  * be linked to multiple tenants (multi-to-multi via `agent_tenant_links`). Each
  * agent-scoped handler must therefore explicitly resolve the tenant from the
- * request (typically `?tenant=<subdomain>` or a path segment) and confirm that
+ * request (typically `?tenant=<slug>` or a path segment) and confirm that
  * the agent has an active link to it.
  *
  * Throws:

--- a/server/lib/db/schema/tenant.ts
+++ b/server/lib/db/schema/tenant.ts
@@ -4,7 +4,7 @@ import { sql } from 'drizzle-orm';
 export const tenants = sqliteTable('tenants', {
     id: text('id').primaryKey(),
     name: text('name').notNull(),
-    subdomain: text('subdomain').unique().notNull(),
+    slug: text('slug').unique().notNull(),
     tier: text('tier').notNull().default('free'),
     stripeConnectAccountId: text('stripe_connect_account_id'),
     status: text('status').notNull().default('pending'),

--- a/server/lib/inspector-signature.ts
+++ b/server/lib/inspector-signature.ts
@@ -18,8 +18,8 @@ export interface SignatureUser {
     phone?: string | null;
     licenseNumber?: string | null;
     slug?: string | null;
-    /** Tenant subdomain — required for path-tenant booking URLs (`/book/<tenant>/<slug>`). */
-    tenantSubdomain?: string | null;
+    /** Tenant slug — required for path-tenant booking URLs (`/book/<tenant>/<slug>`). */
+    tenantSlug?: string | null;
 }
 
 export interface SignatureOutput {
@@ -52,8 +52,8 @@ export function inspectorSignature(user: SignatureUser, host: string): Signature
     const email     = user.email         ? escapeHtml(user.email)         : null;
     const phoneRaw  = user.phone         ? escapeHtml(user.phone)         : null;
     const phoneE164 = phoneTel(user.phone ?? null);
-    const link      = (user.slug && user.tenantSubdomain)
-        ? `https://${host}/book/${escapeHtml(user.tenantSubdomain)}/${escapeHtml(user.slug)}`
+    const link      = (user.slug && user.tenantSlug)
+        ? `https://${host}/book/${escapeHtml(user.tenantSlug)}/${escapeHtml(user.slug)}`
         : null;
 
     const htmlLines: string[] = [];
@@ -75,8 +75,8 @@ export function inspectorSignature(user: SignatureUser, host: string): Signature
         if (user.email) cb.push(user.email);
         textLines.push(cb.join(' · '));
     }
-    if (user.slug && user.tenantSubdomain) {
-        textLines.push(`Book again: https://${host}/book/${user.tenantSubdomain}/${user.slug}`);
+    if (user.slug && user.tenantSlug) {
+        textLines.push(`Book again: https://${host}/book/${user.tenantSlug}/${user.slug}`);
     }
     const text = textLines.join('\n');
 

--- a/server/lib/integration.ts
+++ b/server/lib/integration.ts
@@ -4,7 +4,7 @@
  */
 export interface TenantUpdateParams {
     id?: string;
-    subdomain: string;
+    slug: string;
     status: string;
     tier?: 'free' | 'pro' | 'enterprise';
     name?: string;
@@ -27,5 +27,5 @@ export interface IntegrationProvider {
     /**
      * Called when a tenant connects their Stripe account.
      */
-    handleStripeConnect?(subdomain: string, accountId: string): Promise<void>;
+    handleStripeConnect?(slug: string, accountId: string): Promise<void>;
 }

--- a/server/lib/integration/standalone.ts
+++ b/server/lib/integration/standalone.ts
@@ -182,16 +182,16 @@ export class StandaloneProvider implements IntegrationProvider {
 
     async handleTenantUpdate(params: TenantUpdateParams): Promise<void> {
         const db = this.getDrizzle();
-        const { id, subdomain, status, tier, name, deploymentMode, maxUsers, adminEmail, adminPasswordHash, adminName } = params;
+        const { id, slug, status, tier, name, deploymentMode, maxUsers, adminEmail, adminPasswordHash, adminName } = params;
 
         let tenantId = id || crypto.randomUUID();
-        const existingTenant = await db.select().from(tenants).where(eq(tenants.subdomain, subdomain)).get();
+        const existingTenant = await db.select().from(tenants).where(eq(tenants.slug, slug)).get();
 
         if (!existingTenant) {
             await db.insert(tenants).values({
                 id: tenantId,
-                name: name || subdomain,
-                subdomain,
+                name: name || slug,
+                slug,
                 tier: tier || 'free',
                 status: (adminEmail ? 'active' : status) || 'pending',
                 deploymentMode: deploymentMode || 'silo',
@@ -208,7 +208,7 @@ export class StandaloneProvider implements IntegrationProvider {
             if (name) update.name = name;
             if (maxUsers != null) update.maxUsers = maxUsers;
 
-            await db.update(tenants).set(update).where(eq(tenants.subdomain, subdomain));
+            await db.update(tenants).set(update).where(eq(tenants.slug, slug));
         }
 
         // Handle Admin User creation/sync
@@ -265,11 +265,11 @@ export class StandaloneProvider implements IntegrationProvider {
             }
         }
 
-        if (this.kv) await this.kv.delete(`tenant:${subdomain}`);
+        if (this.kv) await this.kv.delete(`tenant:${slug}`);
     }
 
-    async handleStripeConnect(subdomain: string, accountId: string): Promise<void> {
+    async handleStripeConnect(slug: string, accountId: string): Promise<void> {
         const db = this.getDrizzle();
-        await db.update(tenants).set({ stripeConnectAccountId: accountId }).where(eq(tenants.subdomain, subdomain));
+        await db.update(tenants).set({ stripeConnectAccountId: accountId }).where(eq(tenants.slug, slug));
     }
 }

--- a/server/lib/middleware/inspector-palette.ts
+++ b/server/lib/middleware/inspector-palette.ts
@@ -36,7 +36,7 @@ export const inspectorPaletteMiddleware: MiddlewareHandler<HonoConfig> = async (
             ...branding,
             currentUserSlug: row?.slug ?? null,
             bookingHost:     getBookingHost(c),
-            tenantSubdomain: c.get('requestedSubdomain') ?? null,
+            tenantSlug: c.get('requestedTenantSlug') ?? null,
         };
         c.set('branding', enriched);
     } catch (e) {

--- a/server/lib/validations/admin.schema.ts
+++ b/server/lib/validations/admin.schema.ts
@@ -76,7 +76,7 @@ export const AgreementSchema = z.object({
  */
 export const TenantStatusSchema = z.object({
     id: z.string().uuid().optional().openapi({ example: '550e8400-e29b-41d4-a716-446655440000' }).describe('TODO describe id field for the OpenInspection MCP integration'),
-    subdomain: z.string().min(1).openapi({ example: 'acme' }).describe('TODO describe subdomain field for the OpenInspection MCP integration'),
+    slug: z.string().min(1).openapi({ example: 'acme' }).describe('TODO describe slug field for the OpenInspection MCP integration'),
     status: z.string().min(1).openapi({ example: 'active' }).describe('TODO describe status field for the OpenInspection MCP integration'),
     tier: z.string().optional().openapi({ example: 'pro' }).describe('TODO describe tier field for the OpenInspection MCP integration'),
     name: z.string().optional().openapi({ example: 'Acme Corp' }).describe('TODO describe name field for the OpenInspection MCP integration'),
@@ -98,13 +98,13 @@ export const SiloUpdateSchema = z.object({
  * Validation schema for Stripe Connect updates (M2M).
  */
 export const StripeConnectSchema = z.object({
-    subdomain: z.string().min(1).openapi({ example: 'acme' }).describe('TODO describe subdomain field for the OpenInspection MCP integration'),
+    slug: z.string().min(1).openapi({ example: 'acme' }).describe('TODO describe slug field for the OpenInspection MCP integration'),
     stripeConnectAccountId: z.string().min(1).openapi({ example: 'acct_12345' }).describe('TODO describe stripeConnectAccountId field for the OpenInspection MCP integration'),
 }).openapi('StripeConnect');
 
 /**
- * Body schema for PATCH /api/integration/tenants/:subdomain (M2M).
- * subdomain comes from URL param, not body.
+ * Body schema for PATCH /api/integration/tenants/:slug (M2M).
+ * slug comes from URL param, not body.
  */
 export const TenantStatusBodySchema = z.object({
     id: z.string().uuid().optional().describe('TODO describe id field for the OpenInspection MCP integration'),
@@ -119,7 +119,7 @@ export const TenantStatusBodySchema = z.object({
 });
 
 /**
- * Body schema for POST /api/integration/tenants/:subdomain/stripe-connect (M2M).
+ * Body schema for POST /api/integration/tenants/:slug/stripe-connect (M2M).
  */
 export const StripeConnectBodySchema = z.object({
     accountId: z.string().min(1).describe('TODO describe accountId field for the OpenInspection MCP integration'),

--- a/server/lib/verify-data.ts
+++ b/server/lib/verify-data.ts
@@ -21,10 +21,10 @@ export async function loadVerifyData(c: Context<HonoConfig>, envelopeId: string)
         .all();
     const verify = await c.var.services.auditLog.verifyChain(reqRow.tenantId, envelopeId);
     const pubKey = await c.var.services.signingKey.getPublicKey(reqRow.tenantId);
-    const tenantRow = await db.select({ subdomain: schema.tenants.subdomain })
+    const tenantRow = await db.select({ slug: schema.tenants.slug })
         .from(schema.tenants)
         .where(eq(schema.tenants.id, reqRow.tenantId))
         .get();
-    const tenantSubdomain = tenantRow?.subdomain ?? '';
-    return { reqRow, agreement, auditRows, verify, pubKey, tenantSubdomain };
+    const tenantSlug = tenantRow?.slug ?? '';
+    return { reqRow, agreement, auditRows, verify, pubKey, tenantSlug };
 }

--- a/server/portal/integration.routes.ts
+++ b/server/portal/integration.routes.ts
@@ -8,11 +8,11 @@ import { requireServiceBinding } from './service-binding-guard';
 const api = new Hono<HonoConfig>();
 
 /**
- * PATCH /api/integration/tenants/:subdomain
+ * PATCH /api/integration/tenants/:slug
  * Triggered by Portal when tenant information changes.
  */
-api.patch('/tenants/:subdomain', requireServiceBinding, async (c) => {
-    const subdomain = c.req.param('subdomain');
+api.patch('/tenants/:slug', requireServiceBinding, async (c) => {
+    const slug = c.req.param('slug');
     const parsed = TenantStatusBodySchema.safeParse(await c.req.json());
     if (!parsed.success) {
         return c.json({ success: false, error: { message: 'Invalid input' } }, 400);
@@ -23,7 +23,7 @@ api.patch('/tenants/:subdomain', requireServiceBinding, async (c) => {
     try {
         await adminService.handleTenantUpdate({
             ...parsed.data,
-            subdomain,
+            slug,
         } as TenantUpdateParams);
 
         return c.json({ success: true });
@@ -34,11 +34,11 @@ api.patch('/tenants/:subdomain', requireServiceBinding, async (c) => {
 });
 
 /**
- * POST /api/integration/tenants/:subdomain/stripe-connect
+ * POST /api/integration/tenants/:slug/stripe-connect
  * Triggered by Portal when Stripe Connect is completed.
  */
-api.post('/tenants/:subdomain/stripe-connect', requireServiceBinding, async (c) => {
-    const subdomain = c.req.param('subdomain');
+api.post('/tenants/:slug/stripe-connect', requireServiceBinding, async (c) => {
+    const slug = c.req.param('slug');
     const parsed = StripeConnectBodySchema.safeParse(await c.req.json());
     if (!parsed.success) {
         return c.json({ success: false, error: { message: 'Invalid input' } }, 400);
@@ -47,7 +47,7 @@ api.post('/tenants/:subdomain/stripe-connect', requireServiceBinding, async (c) 
     const adminService = c.var.services.admin;
 
     try {
-        await adminService.updateStripeConnect(subdomain as string, parsed.data.accountId);
+        await adminService.updateStripeConnect(slug as string, parsed.data.accountId);
         return c.json({ success: true });
     } catch (error: unknown) {
         logger.error('Failed to handle stripe connect', {}, error instanceof Error ? error : undefined);
@@ -56,16 +56,16 @@ api.post('/tenants/:subdomain/stripe-connect', requireServiceBinding, async (c) 
 });
 
 /**
- * POST /api/integration/tenants/:subdomain/data-export
+ * POST /api/integration/tenants/:slug/data-export
  * Triggered by Portal during offboarding workflow. Returns ZIP stream.
  */
-api.post('/tenants/:subdomain/data-export', requireServiceBinding, async (c) => {
-    const subdomain = c.req.param('subdomain');
+api.post('/tenants/:slug/data-export', requireServiceBinding, async (c) => {
+    const slug = c.req.param('slug');
     const { drizzle } = await import('drizzle-orm/d1');
     const { eq } = await import('drizzle-orm');
     const { tenants } = await import('../lib/db/schema');
     const d = drizzle(c.env.DB);
-    const t = await d.select({ id: tenants.id }).from(tenants).where(eq(tenants.subdomain, subdomain as string)).get();
+    const t = await d.select({ id: tenants.id }).from(tenants).where(eq(tenants.slug, slug as string)).get();
     if (!t) return c.json({ success: false, error: { message: 'Tenant not found' } }, 404);
 
     const { DataExportService } = await import('../services/data-export.service');
@@ -77,27 +77,27 @@ api.post('/tenants/:subdomain/data-export', requireServiceBinding, async (c) => 
         return new Response(blob, {
             headers: {
                 'content-type':        'application/zip',
-                'content-disposition': `attachment; filename="export-${subdomain}.zip"`,
+                'content-disposition': `attachment; filename="export-${slug}.zip"`,
                 'x-export-manifest':   JSON.stringify(manifest),
             },
         });
     } catch (error: unknown) {
-        logger.error('Data export failed', { subdomain }, error instanceof Error ? error : undefined);
+        logger.error('Data export failed', { slug }, error instanceof Error ? error : undefined);
         return c.json({ success: false, error: { message: 'Export failed' } }, 500);
     }
 });
 
 /**
- * POST /api/integration/tenants/:subdomain/purge
+ * POST /api/integration/tenants/:slug/purge
  * Triggered by Portal at end of offboarding grace period. Cascade-deletes all tenant data.
  */
-api.post('/tenants/:subdomain/purge', requireServiceBinding, async (c) => {
-    const subdomain = c.req.param('subdomain');
+api.post('/tenants/:slug/purge', requireServiceBinding, async (c) => {
+    const slug = c.req.param('slug');
     const { drizzle } = await import('drizzle-orm/d1');
     const { eq } = await import('drizzle-orm');
     const { tenants } = await import('../lib/db/schema');
     const d = drizzle(c.env.DB);
-    const t = await d.select({ id: tenants.id }).from(tenants).where(eq(tenants.subdomain, subdomain as string)).get();
+    const t = await d.select({ id: tenants.id }).from(tenants).where(eq(tenants.slug, slug as string)).get();
     if (!t) return c.json({ success: false, error: { message: 'Tenant not found' } }, 404);
 
     const { TenantPurgeService } = await import('../services/tenant-purge.service');
@@ -106,7 +106,7 @@ api.post('/tenants/:subdomain/purge', requireServiceBinding, async (c) => {
         const result = await svc.purge(t.id as string);
         return c.json({ success: true, data: result });
     } catch (error: unknown) {
-        logger.error('Tenant purge failed', { subdomain }, error instanceof Error ? error : undefined);
+        logger.error('Tenant purge failed', { slug }, error instanceof Error ? error : undefined);
         return c.json({ success: false, error: { message: 'Purge failed' } }, 500);
     }
 });

--- a/server/portal/portal.provider.ts
+++ b/server/portal/portal.provider.ts
@@ -17,20 +17,20 @@ export class PortalProvider implements IntegrationProvider {
 
     async handleTenantUpdate(params: TenantUpdateParams): Promise<void> {
         const db = this.getDrizzle();
-        const { id, subdomain, status, tier, name, maxUsers, adminEmail, adminPasswordHash } = params;
+        const { id, slug, status, tier, name, maxUsers, adminEmail, adminPasswordHash } = params;
 
         // Upsert tenant
         const existingTenant = await db.select()
             .from(tenants)
-            .where(eq(tenants.subdomain, subdomain))
+            .where(eq(tenants.slug, slug))
             .get();
 
         if (!existingTenant) {
             const newTenantId = id || crypto.randomUUID();
             await db.insert(tenants).values({
                 id: newTenantId,
-                subdomain,
-                name: name || subdomain,
+                slug,
+                name: name || slug,
                 status: (status as 'active' | 'suspended' | 'trial') || 'active',
                 tier: (tier as 'free' | 'pro' | 'enterprise') || 'free',
                 ...(maxUsers != null ? { maxUsers } : {}),
@@ -51,7 +51,7 @@ export class PortalProvider implements IntegrationProvider {
                     name: name || existingTenant.name,
                     ...(maxUsers != null ? { maxUsers } : {}),
                 })
-                .where(eq(tenants.subdomain, subdomain));
+                .where(eq(tenants.slug, slug));
         }
 
         // Handle Admin Sync if provided
@@ -89,18 +89,18 @@ export class PortalProvider implements IntegrationProvider {
         // Clear cache if KV exists
         if (this.kv) {
             // Standardized key matched with tenant-router.ts
-            await this.kv.delete(`tenant:${subdomain}`);
+            await this.kv.delete(`tenant:${slug}`);
         }
     }
 
-    async handleStripeConnect(subdomain: string, accountId: string): Promise<void> {
+    async handleStripeConnect(slug: string, accountId: string): Promise<void> {
         const db = this.getDrizzle();
         await db.update(tenants)
             .set({ stripeConnectAccountId: accountId })
-            .where(eq(tenants.subdomain, subdomain));
+            .where(eq(tenants.slug, slug));
 
         if (this.kv) {
-            await this.kv.delete(`tenant:${subdomain}`);
+            await this.kv.delete(`tenant:${slug}`);
         }
     }
 

--- a/server/services/admin.service.ts
+++ b/server/services/admin.service.ts
@@ -168,11 +168,11 @@ export class AdminService {
     /**
      * Connects a Stripe account for the tenant.
      */
-    async updateStripeConnect(subdomain: string, accountId: string) {
+    async updateStripeConnect(slug: string, accountId: string) {
         if (!this.integration?.handleStripeConnect) {
             throw new Error('IntegrationProvider not configured or does not support Stripe Connect');
         }
-        await this.integration.handleStripeConnect(subdomain, accountId);
+        await this.integration.handleStripeConnect(slug, accountId);
     }
 
     /**

--- a/server/services/agent.service.ts
+++ b/server/services/agent.service.ts
@@ -18,7 +18,7 @@ export interface AgentReferralRow {
     id: string;
     tenantId: string;
     tenantName: string;
-    tenantSubdomain: string;
+    tenantSlug: string;
     propertyAddress: string;
     clientName: string | null;
     date: string;
@@ -30,7 +30,7 @@ export interface AgentReferralRow {
 export interface AgentInspectorRow {
     tenantId: string;
     tenantName: string;
-    tenantSubdomain: string;
+    tenantSlug: string;
     contactId: string | null;
     inspectorName: string | null;
     inspectorPhotoUrl: string | null;
@@ -445,7 +445,7 @@ export class AgentService {
                 id:              inspections.id,
                 tenantId:        inspections.tenantId,
                 tenantName:      tenants.name,
-                tenantSubdomain: tenants.subdomain,
+                tenantSlug: tenants.slug,
                 propertyAddress: inspections.propertyAddress,
                 clientName:      inspections.clientName,
                 date:            inspections.date,
@@ -500,7 +500,7 @@ export class AgentService {
             id:              r.id,
             tenantId:        r.tenantId,
             tenantName:      r.tenantName,
-            tenantSubdomain: r.tenantSubdomain,
+            tenantSlug: r.tenantSlug,
             propertyAddress: r.propertyAddress,
             clientName:      r.clientName ?? null,
             date:            r.date,
@@ -592,7 +592,7 @@ export class AgentService {
             .select({
                 tenantId:          agentTenantLinks.tenantId,
                 tenantName:        tenants.name,
-                tenantSubdomain:   tenants.subdomain,
+                tenantSlug:   tenants.slug,
                 contactId:         agentTenantLinks.inspectorContactId,
                 inspectorName:     users.name,
                 inspectorPhotoUrl: users.photoUrl,
@@ -611,7 +611,7 @@ export class AgentService {
         return rows.map((r) => ({
             tenantId:          r.tenantId,
             tenantName:        r.tenantName,
-            tenantSubdomain:   r.tenantSubdomain,
+            tenantSlug:   r.tenantSlug,
             contactId:         r.contactId ?? null,
             inspectorName:     r.inspectorName ?? null,
             inspectorPhotoUrl: r.inspectorPhotoUrl ?? null,

--- a/server/services/automation.service.ts
+++ b/server/services/automation.service.ts
@@ -229,7 +229,7 @@ export class AutomationService {
                     property_address: inspection.propertyAddress,
                     scheduled_date:   inspection.date,
                     inspector_name:   '',
-                    report_url:       reportUrl(appHost, tenant.subdomain, inspection.id),
+                    report_url:       reportUrl(appHost, tenant.slug, inspection.id),
                     invoice_url:      `${appBaseUrl}/invoices`,
                     payment_url:      `${appBaseUrl}/invoices`,
                     company_name:     appName,

--- a/server/services/concierge.service.ts
+++ b/server/services/concierge.service.ts
@@ -53,7 +53,7 @@ export interface ConciergeTokenView {
     inspection: {
         id: string;
         tenantId: string;
-        tenantSubdomain: string;
+        tenantSlug: string;
         propertyAddress: string;
         date: string;
         clientName: string | null;
@@ -368,11 +368,11 @@ export class ConciergeService {
         if (!insp) return null;
 
         const tenantRow = await db
-            .select({ subdomain: tenants.subdomain })
+            .select({ slug: tenants.slug })
             .from(tenants)
             .where(eq(tenants.id, insp.tenantId))
             .get();
-        const tenantSubdomain = tenantRow?.subdomain ?? '';
+        const tenantSlug = tenantRow?.slug ?? '';
 
         let inspector: ConciergeTokenView['inspector'] = null;
         if (insp.inspectorId) {
@@ -395,7 +395,7 @@ export class ConciergeService {
             inspection: {
                 id: insp.id,
                 tenantId: insp.tenantId,
-                tenantSubdomain,
+                tenantSlug,
                 propertyAddress: insp.propertyAddress,
                 date: insp.date,
                 clientName: insp.clientName ?? null,

--- a/server/services/inspection.service.ts
+++ b/server/services/inspection.service.ts
@@ -2462,9 +2462,9 @@ export class InspectionService {
             }
         }
 
-        const tenantRow = await db.select({ subdomain: tenants.subdomain })
+        const tenantRow = await db.select({ slug: tenants.slug })
             .from(tenants).where(eq(tenants.id, tenantId)).get();
-        const tenantSlug = tenantRow?.subdomain ?? '';
+        const tenantSlug = tenantRow?.slug ?? '';
         return {
             reportUrl: `/report/${tenantSlug}/${inspectionId}`,
             status: 'delivered',

--- a/server/services/tenant-purge.service.ts
+++ b/server/services/tenant-purge.service.ts
@@ -30,13 +30,13 @@ export class TenantPurgeService {
         const d = drizzle(this.db);
 
         // 1. Collect KV keys before tables deleted
-        const t = await d.select({ subdomain: tenants.subdomain }).from(tenants).where(eq(tenants.id, tenantId)).get();
+        const t = await d.select({ slug: tenants.slug }).from(tenants).where(eq(tenants.id, tenantId)).get();
         const userIds = (await d.select({ id: users.id }).from(users).where(eq(users.tenantId, tenantId)).all())
             .map(u => u.id as string);
         const kvKeys: string[] = [];
-        if (t?.subdomain) {
-            kvKeys.push(`tenant:${t.subdomain}`);
-            kvKeys.push(`setup_code:${t.subdomain}`);
+        if (t?.slug) {
+            kvKeys.push(`tenant:${t.slug}`);
+            kvKeys.push(`setup_code:${t.slug}`);
         }
         userIds.forEach(uid => kvKeys.push(`pwchanged:${uid}`));
 

--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -32,9 +32,9 @@ export interface BrandingConfig {
     /** Sprint B-1 — host portion of the booking URL (e.g. "acme.inspectorhub.io").
      *  Used by the ⌘K palette action and any other slug-aware UI. */
     bookingHost?: string | undefined;
-    /** PR 2 — tenant subdomain (path segment). Needed for path-tenant booking
+    /** PR 2 — tenant slug (path segment). Needed for path-tenant booking
      *  URLs (`<host>/book/<tenant>/<slug>`). Populated by inspectorPaletteMiddleware. */
-    tenantSubdomain?: string | null | undefined;
+    tenantSlug?: string | null | undefined;
     /** SaaS mode flag — true when this worker runs as `APP_MODE=saas`.
      *  Plumbed via brandingMiddleware so layouts can render the "Switch
      *  workspace" affordance (the only way for a multi-workspace identity
@@ -65,7 +65,7 @@ export interface AuthVariables {
     // Mirrors `user.sub` but lets agent-only handlers stay narrowly typed
     // without re-deriving from the broader User payload.
     agentUserId?: string;
-    requestedSubdomain?: string;
+    requestedTenantSlug?: string;
     tenantTier?: string;
     tenantStatus?: string;
     branding?: BrandingConfig;

--- a/server/workflows/sign-completion-workflow.ts
+++ b/server/workflows/sign-completion-workflow.ts
@@ -12,7 +12,7 @@ import * as schema from '../lib/db/schema';
 export interface SignCompletionParams {
     requestId: string;
     tenantId: string;
-    tenantSlug: string;       // tenant subdomain, required for /m2m/agreement-render/<tenant>/<token>
+    tenantSlug: string;       // tenant slug, required for /m2m/agreement-render/<tenant>/<token>
     token: string;            // public agreement-request token (used for /m2m/* render routes)
 }
 

--- a/tests/backup-restore-seed.spec.ts
+++ b/tests/backup-restore-seed.spec.ts
@@ -11,7 +11,7 @@ test.describe('Seeding Data for Backup Validation', () => {
         const setupRes = await request.post(`${BASE}/setup`, {
             data: {
                 companyName: 'Backup Restore Test Corp',
-                subdomain: 'br-test',
+                slug: 'br-test',
                 email: 'admin@example.com',
                 password: 'Testpassword!123',
             },

--- a/tests/core.integration.spec.ts
+++ b/tests/core.integration.spec.ts
@@ -74,7 +74,7 @@ async function resetAndBootstrap(request: import('@playwright/test').APIRequestC
     const setupRes = await request.post(`${BASE_URL}/setup`, {
         data: {
             companyName: 'Integration Test Co',
-            subdomain: 'integration',
+            slug: 'integration',
             email: 'admin@integration.test',
             password: 'TestPass123!',
         },

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -29,7 +29,7 @@ test.beforeAll(async ({ request }) => {
   const res = await request.post(`${BASE}/setup`, {
     data: {
       companyName: 'Test Workspace',
-      subdomain: 'dev',
+      slug: 'dev',
       email: 'admin@example.com',
       password: 'testpassword123',
     },
@@ -385,7 +385,7 @@ test('GET /setup renders HTML (form or redirect to dashboard)', async ({ request
 
 test('POST /setup rejects missing fields', async ({ request }) => {
   const res = await request.post(`${BASE}/setup`, {
-    data: { companyName: 'Acme', subdomain: 'acme' }, // missing email + password
+    data: { companyName: 'Acme', slug: 'acme' }, // missing email + password
     headers: { 'Content-Type': 'application/json' },
   });
   expect(res.status()).toBe(400);
@@ -393,11 +393,11 @@ test('POST /setup rejects missing fields', async ({ request }) => {
   expect(body).toHaveProperty('error');
 });
 
-test('POST /setup rejects invalid subdomain characters', async ({ request }) => {
+test('POST /setup rejects invalid slug characters', async ({ request }) => {
   const res = await request.post(`${BASE}/setup`, {
     data: {
       companyName: 'Acme',
-      subdomain: 'INVALID SPACES!',
+      slug: 'INVALID SPACES!',
       email: 'admin@example.com',
       password: 'password123',
     },
@@ -405,7 +405,7 @@ test('POST /setup rejects invalid subdomain characters', async ({ request }) => 
   });
   expect(res.status()).toBe(400);
   const body = await res.json();
-  expect(body.error).toContain('Subdomain');
+  expect(body.error).toContain('Slug');
 });
 
 test('POST /setup returns 409 when setup is already complete', async ({ request }) => {
@@ -413,7 +413,7 @@ test('POST /setup returns 409 when setup is already complete', async ({ request 
   const res = await request.post(`${BASE}/setup`, {
     data: {
       companyName: 'Acme',
-      subdomain: 'acme',
+      slug: 'acme',
       email: 'admin2@example.com',
       password: 'password123',
     },
@@ -1026,7 +1026,7 @@ test('POST /api/admin/silo rejects missing tenantId with correct secret', async 
 
 test('POST /api/admin/connect rejects request with no Authorization header', async ({ request }) => {
   const res = await request.post(`${BASE}/api/admin/connect`, {
-    data: { subdomain: 'test', stripeConnectAccountId: 'acct_123' },
+    data: { slug: 'test', stripeConnectAccountId: 'acct_123' },
     headers: { 'Content-Type': 'application/json' },
   });
   expect(res.status()).toBe(401);
@@ -1034,7 +1034,7 @@ test('POST /api/admin/connect rejects request with no Authorization header', asy
 
 test('POST /api/admin/connect rejects request with wrong secret', async ({ request }) => {
   const res = await request.post(`${BASE}/api/admin/connect`, {
-    data: { subdomain: 'test', stripeConnectAccountId: 'acct_123' },
+    data: { slug: 'test', stripeConnectAccountId: 'acct_123' },
     headers: { 'Content-Type': 'application/json', Authorization: 'Bearer wrong-secret' },
   });
   expect(res.status()).toBe(401);
@@ -1042,7 +1042,7 @@ test('POST /api/admin/connect rejects request with wrong secret', async ({ reque
 
 test('POST /api/admin/connect rejects missing fields with correct secret', async ({ request }) => {
   const res = await request.post(`${BASE}/api/admin/connect`, {
-    data: { subdomain: 'test' }, // missing stripeConnectAccountId
+    data: { slug: 'test' }, // missing stripeConnectAccountId
     headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
   });
   expect(res.status()).toBe(400);
@@ -1563,7 +1563,7 @@ test.describe('agent referral booking end-to-end', () => {
     if (!agentUserId) return;
 
     // Create an inspection with referredByAgentId via the authenticated API so both
-    // use the same real tenantId (the public /book API uses 'dev' subdomain as tenantId
+    // use the same real tenantId (the public /book API uses 'dev' slug as tenantId
     // in local dev, which would mismatch the JWT-scoped tenantId in my-reports).
     const tmplRes = await request.get(`${BASE}/api/inspections/templates`, {
       headers: { Authorization: `Bearer ${setupToken}` },
@@ -1627,7 +1627,7 @@ test.describe('agent referral booking end-to-end', () => {
 
   test('POST /api/public/book with agentId param is accepted (dev tenant skips Turnstile)', async ({ request }) => {
     // Verifies the agentId field is accepted without error in the public booking payload.
-    // Note: in dev mode tenantId is the subdomain string 'dev'; agent lookups use the
+    // Note: in dev mode tenantId is the slug string 'dev'; agent lookups use the
     // real UUID from JWT, so cross-checking ownership requires authenticated endpoint (above).
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
@@ -1659,7 +1659,7 @@ test.describe('agent referral booking end-to-end', () => {
 
 test('POST /api/admin/tenant-status rejects missing Authorization', async ({ request }) => {
   const res = await request.post(`${BASE}/api/admin/tenant-status`, {
-    data: { subdomain: 'dev', status: 'active' },
+    data: { slug: 'dev', status: 'active' },
     headers: { 'Content-Type': 'application/json' },
   });
   expect(res.status()).toBe(401);
@@ -1667,13 +1667,13 @@ test('POST /api/admin/tenant-status rejects missing Authorization', async ({ req
 
 test('POST /api/admin/tenant-status rejects wrong secret', async ({ request }) => {
   const res = await request.post(`${BASE}/api/admin/tenant-status`, {
-    data: { subdomain: 'dev', status: 'active' },
+    data: { slug: 'dev', status: 'active' },
     headers: { 'Content-Type': 'application/json', Authorization: 'Bearer wrong-secret' },
   });
   expect(res.status()).toBe(401);
 });
 
-test('POST /api/admin/tenant-status rejects missing subdomain', async ({ request }) => {
+test('POST /api/admin/tenant-status rejects missing slug', async ({ request }) => {
   const res = await request.post(`${BASE}/api/admin/tenant-status`, {
     data: { status: 'active' },
     headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
@@ -1689,7 +1689,7 @@ test.describe('tenant tier/status lifecycle (M2M)', () => {
 
     // Promote to pro tier
     const res = await request.post(`${BASE}/api/admin/tenant-status`, {
-      data: { subdomain: 'dev', status: 'active', tier: 'pro' },
+      data: { slug: 'dev', status: 'active', tier: 'pro' },
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
     });
     expect(res.status()).toBe(200);
@@ -1698,7 +1698,7 @@ test.describe('tenant tier/status lifecycle (M2M)', () => {
 
     // Restore to free/active so subsequent tests are unaffected
     await request.post(`${BASE}/api/admin/tenant-status`, {
-      data: { subdomain: 'dev', status: 'active', tier: 'free' },
+      data: { slug: 'dev', status: 'active', tier: 'free' },
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
     });
   });
@@ -1708,7 +1708,7 @@ test.describe('tenant tier/status lifecycle (M2M)', () => {
 
     // Set status only �?tier should remain as-is
     const res = await request.post(`${BASE}/api/admin/tenant-status`, {
-      data: { subdomain: 'dev', status: 'active' }, // no tier field
+      data: { slug: 'dev', status: 'active' }, // no tier field
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
     });
     expect(res.status()).toBe(200);
@@ -1717,20 +1717,20 @@ test.describe('tenant tier/status lifecycle (M2M)', () => {
   });
 
   // NOTE: The requireActiveSubscription 402 path cannot be exercised via localhost E2E tests
-  // because all requests fall back to the 'dev' subdomain which always bypasses enforcement.
+  // because all requests fall back to the 'dev' slug which always bypasses enforcement.
   // The 402 path is covered by the unit-level middleware logic and integration with real tenant
-  // subdomains in production. The M2M endpoint that drives state changes is tested above.
+  // slugs in production. The M2M endpoint that drives state changes is tested above.
   test('requireActiveSubscription: GET requests bypass enforcement even in past_due context', async ({ request }) => {
     test.skip(!setupToken, 'Skipping: requires fresh DB');
 
-    // The dev subdomain bypasses tier guard. We verify that read endpoints remain accessible
+    // The dev slug bypasses tier guard. We verify that read endpoints remain accessible
     // regardless �?this documents the read-only access guarantee.
     await request.post(`${BASE}/api/admin/tenant-status`, {
-      data: { subdomain: 'dev', status: 'past_due' },
+      data: { slug: 'dev', status: 'past_due' },
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
     });
 
-    // GET requests should succeed regardless (dev subdomain bypass)
+    // GET requests should succeed regardless (dev slug bypass)
     const getRes = await request.get(`${BASE}/api/inspections`, {
       headers: { Authorization: `Bearer ${setupToken}` },
     });
@@ -1738,7 +1738,7 @@ test.describe('tenant tier/status lifecycle (M2M)', () => {
 
     // Restore
     await request.post(`${BASE}/api/admin/tenant-status`, {
-      data: { subdomain: 'dev', status: 'active', tier: 'free' },
+      data: { slug: 'dev', status: 'active', tier: 'free' },
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer fallback_secret_for_local_dev' },
     });
   });

--- a/tests/integration-sync.integration.spec.ts
+++ b/tests/integration-sync.integration.spec.ts
@@ -3,13 +3,13 @@ import { test, expect } from '@playwright/test';
 const BASE_URL = 'http://localhost:8789';
 
 test.describe('Core Integration API (Service Binding)', () => {
-    test('PATCH /api/integration/tenants/:subdomain syncs tenant and admin user', async ({ request }) => {
-        const subdomain = `sync-test-${Date.now()}`;
-        const adminEmail = `admin@${subdomain}.test`;
+    test('PATCH /api/integration/tenants/:slug syncs tenant and admin user', async ({ request }) => {
+        const slug = `sync-test-${Date.now()}`;
+        const adminEmail = `admin@${slug}.test`;
         const adminPasswordHash = 'fake-hash-123';
 
         const payload = {
-            subdomain,
+            slug,
             status: 'active',
             tier: 'pro',
             name: 'Sync Test Corp',
@@ -18,7 +18,7 @@ test.describe('Core Integration API (Service Binding)', () => {
             adminPasswordHash
         };
 
-        const res = await request.patch(`${BASE_URL}/api/integration/tenants/${subdomain}`, {
+        const res = await request.patch(`${BASE_URL}/api/integration/tenants/${slug}`, {
             headers: {
                 'cf-worker': 'portal-api',
                 'Content-Type': 'application/json',
@@ -40,11 +40,11 @@ test.describe('Core Integration API (Service Binding)', () => {
         expect(loginText).toContain('Invalid credentials');
     });
 
-    test('PATCH /api/integration/tenants/:subdomain rejects requests without cf-worker header', async ({ request }) => {
-        const subdomain = 'no-binding-test';
-        const payload = { subdomain, status: 'active' };
+    test('PATCH /api/integration/tenants/:slug rejects requests without cf-worker header', async ({ request }) => {
+        const slug = 'no-binding-test';
+        const payload = { slug, status: 'active' };
 
-        const res = await request.patch(`${BASE_URL}/api/integration/tenants/${subdomain}`, {
+        const res = await request.patch(`${BASE_URL}/api/integration/tenants/${slug}`, {
             headers: {
                 'Content-Type': 'application/json',
             },

--- a/tests/seed-fixtures.ts
+++ b/tests/seed-fixtures.ts
@@ -48,9 +48,9 @@ export function seedFixtures(appDir: string): void {
     const now = new Date().toISOString();
 
     // Two tenants so the IdentitySwitcher (E P4) has somewhere to land.
-    d1(`INSERT OR REPLACE INTO tenants (id, name, subdomain, status, deployment_mode, tier, max_users, created_at)
+    d1(`INSERT OR REPLACE INTO tenants (id, name, slug, status, deployment_mode, tier, max_users, created_at)
         VALUES ('${TENANT_A_ID}', 'Seed Tenant A', 'seed-a', 'active', 'shared', 'free', 5, '${now}')`, cwd);
-    d1(`INSERT OR REPLACE INTO tenants (id, name, subdomain, status, deployment_mode, tier, max_users, created_at)
+    d1(`INSERT OR REPLACE INTO tenants (id, name, slug, status, deployment_mode, tier, max_users, created_at)
         VALUES ('${TENANT_B_ID}', 'Seed Tenant B', 'seed-b', 'active', 'shared', 'free', 5, '${now}')`, cwd);
 
     // Tenant A users.
@@ -69,7 +69,7 @@ export function seedFixtures(appDir: string): void {
                 '${MENTOR_EMAIL}', '${SEED_PASSWORD_HASH}', 'Seed Mentor', 'inspector', '${now}')`, cwd);
 
     // Seat-quota / at-cap admin for the over-quota E2E.
-    d1(`INSERT OR REPLACE INTO tenants (id, name, subdomain, status, deployment_mode, tier, max_users, created_at)
+    d1(`INSERT OR REPLACE INTO tenants (id, name, slug, status, deployment_mode, tier, max_users, created_at)
         VALUES ('00000000-0000-0000-0000-000000000cc1', 'Seed Full Tenant', 'seed-full',
                 'active', 'shared', 'free', 1, '${now}')`, cwd);
     d1(`INSERT OR REPLACE INTO users (id, tenant_id, email, password_hash, name, role, created_at)

--- a/tests/unit/account-export-delete.spec.ts
+++ b/tests/unit/account-export-delete.spec.ts
@@ -30,8 +30,8 @@ describe('exportAccount', () => {
         testDb = fix.db;
         await setupSchema(fix.sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT,   name: 'T1', subdomain: 't1', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: TENANT_B, name: 'T2', subdomain: 't2', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT,   name: 'T1', slug: 't1', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_B, name: 'T2', slug: 't2', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.users).values({
             id: USER_ID, tenantId: TENANT, email: 'a@x.com', passwordHash: 'x', role: 'admin', createdAt: new Date(),
@@ -88,7 +88,7 @@ describe('softDeleteAccount', () => {
         testDb = fix.db;
         await setupSchema(fix.sqlite);
         await testDb.insert(schema.tenants).values({
-            id: TENANT, name: 'T1', subdomain: 't1', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+            id: TENANT, name: 'T1', slug: 't1', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.users).values({
             id: USER_ID, tenantId: TENANT, email: 'a@x.com', passwordHash: 'x', role: 'admin', createdAt: new Date(),

--- a/tests/unit/admin.service.spec.ts
+++ b/tests/unit/admin.service.spec.ts
@@ -33,7 +33,7 @@ describe('AdminService', () => {
         await testDb.insert(tenants).values({
             id: 't1',
             name: 'Test Tenant',
-            subdomain: 'test',
+            slug: 'test',
             createdAt: new Date(),
         });
 

--- a/tests/unit/agent-auto-link.spec.ts
+++ b/tests/unit/agent-auto-link.spec.ts
@@ -22,9 +22,9 @@ describe('AgentService.autoLinkSameEmail — A1', () => {
         await setupSchema(fixture.sqlite);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT_A, name: 'A', subdomain: 'aco', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: TENANT_B, name: 'B', subdomain: 'bco', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: TENANT_C, name: 'C', subdomain: 'cco', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_A, name: 'A', slug: 'aco', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_B, name: 'B', slug: 'bco', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_C, name: 'C', slug: 'cco', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
 
         (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(testDb);

--- a/tests/unit/agent-routes-c10.spec.ts
+++ b/tests/unit/agent-routes-c10.spec.ts
@@ -45,7 +45,7 @@ describe('agent C-10 routes', () => {
 
     it('GET /api/agent/inspectors returns listInspectors data, called with userId', async () => {
         const listInspectors = vi.fn().mockResolvedValue([
-            { inspectorName: 'Pat', inspectorSlug: 'pat', inspectorPhotoUrl: null, tenantName: 'Acme', tenantSubdomain: 'acme' },
+            { inspectorName: 'Pat', inspectorSlug: 'pat', inspectorPhotoUrl: null, tenantName: 'Acme', tenantSlug: 'acme' },
         ]);
         const res = await agentApp({ agent: { listInspectors } }).request('/api/agent/inspectors');
         expect(res.status).toBe(200);

--- a/tests/unit/agent-service-invite.spec.ts
+++ b/tests/unit/agent-service-invite.spec.ts
@@ -24,7 +24,7 @@ describe('AgentService.invite — A1', () => {
         await testDb.insert(schema.tenants).values({
             id: TENANT,
             name: 'Acme Inspections',
-            subdomain: 'acme',
+            slug: 'acme',
             status: 'active',
             deploymentMode: 'shared',
             tier: 'free',
@@ -92,7 +92,7 @@ describe('AgentService.invite — A1', () => {
         const TENANT_B = '00000000-0000-0000-0000-000000000002';
         const INSPECTOR_B = '00000000-0000-0000-0000-000000000011';
         await testDb.insert(schema.tenants).values({
-            id: TENANT_B, name: 'Bob Co', subdomain: 'bobco', status: 'active',
+            id: TENANT_B, name: 'Bob Co', slug: 'bobco', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.users).values({

--- a/tests/unit/agent-service-listings.spec.ts
+++ b/tests/unit/agent-service-listings.spec.ts
@@ -26,8 +26,8 @@ describe('AgentService.listReferrals — A2', () => {
         await setupSchema(fixture.sqlite);
 
         await testDb.insert(schema.tenants).values([
-            { id: T1, name: 'Acme Inspections', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: T2, name: 'BobsInsp', subdomain: 'bobs', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: T1, name: 'Acme Inspections', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: T2, name: 'BobsInsp', slug: 'bobs', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
 
         await testDb.insert(schema.users).values([
@@ -121,8 +121,8 @@ describe('AgentService.listInspectors — A2', () => {
         await setupSchema(fixture.sqlite);
 
         await testDb.insert(schema.tenants).values([
-            { id: T1, name: 'Acme Inspections', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: T2, name: 'BobsInsp', subdomain: 'bobs', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: T1, name: 'Acme Inspections', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: T2, name: 'BobsInsp', slug: 'bobs', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
 
         await testDb.insert(schema.users).values([
@@ -168,19 +168,19 @@ describe('AgentService.listInspectors — A2', () => {
         expect(rows[0]?.tenantId).toBe(T2);
     });
 
-    it('exposes inspector slug + photo + name + tenant subdomain', async () => {
+    it('exposes inspector slug + photo + name + tenant slug', async () => {
         const rows = await svc.listInspectors(AGENT_USER);
         const acme = rows.find((r) => r.tenantId === T1);
         expect(acme?.inspectorSlug).toBe('mike');
         expect(acme?.inspectorPhotoUrl).toBe('https://r2/me.jpg');
         expect(acme?.inspectorName).toBe('Mike');
-        expect(acme?.tenantSubdomain).toBe('acme');
+        expect(acme?.tenantSlug).toBe('acme');
     });
 
     it('falls back to null inspector fields when invitedByUserId missing', async () => {
         // Add a link with no invitedByUserId (auto-link path).
         await testDb.insert(schema.tenants).values({
-            id: 'T3', name: 'NoInspector', subdomain: 'no', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+            id: 'T3', name: 'NoInspector', slug: 'no', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.agentTenantLinks).values({
             id: 'l3', agentUserId: AGENT_USER, tenantId: 'T3', status: 'active', createdAt: new Date(),
@@ -203,7 +203,7 @@ describe('AgentService.revokeLink — A2', () => {
         await setupSchema(fixture.sqlite);
 
         await testDb.insert(schema.tenants).values({
-            id: T1, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+            id: T1, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.users).values({
             id: AGENT_USER, tenantId: null, email: 'jane@realty.com', role: 'agent', name: 'Jane', createdAt: new Date(), passwordHash: 'h',

--- a/tests/unit/agent-tables-schema.spec.ts
+++ b/tests/unit/agent-tables-schema.spec.ts
@@ -29,7 +29,7 @@ describe('agent tables schema — A1', () => {
 
     it('agent_tenant_links table accepts a row + enforces unique (agent_user_id, tenant_id)', () => {
         // Seed a tenant + user so the FK references resolve.
-        sqlite.prepare(`INSERT INTO tenants (id, name, subdomain, tier, status, max_users, deployment_mode, created_at) VALUES (?,?,?,?,?,?,?,?)`).run(
+        sqlite.prepare(`INSERT INTO tenants (id, name, slug, tier, status, max_users, deployment_mode, created_at) VALUES (?,?,?,?,?,?,?,?)`).run(
             't1', 'Acme', 'acme', 'free', 'active', 5, 'shared', Date.now(),
         );
         sqlite.prepare(`INSERT INTO users (id, tenant_id, email, password_hash, role, created_at) VALUES (?, NULL, ?, ?, 'agent', ?)`).run(
@@ -44,7 +44,7 @@ describe('agent tables schema — A1', () => {
     });
 
     it('agent_invites table accepts a row + agent_tenant_links enforces tenant_id FK', () => {
-        sqlite.prepare(`INSERT INTO tenants (id, name, subdomain, tier, status, max_users, deployment_mode, created_at) VALUES (?,?,?,?,?,?,?,?)`).run(
+        sqlite.prepare(`INSERT INTO tenants (id, name, slug, tier, status, max_users, deployment_mode, created_at) VALUES (?,?,?,?,?,?,?,?)`).run(
             't1', 'Acme', 'acme', 'free', 'active', 5, 'shared', Date.now(),
         );
         sqlite.prepare(`INSERT INTO users (id, tenant_id, email, password_hash, role, created_at) VALUES (?, ?, ?, ?, 'inspector', ?)`).run(

--- a/tests/unit/agreement.service.spec.ts
+++ b/tests/unit/agreement.service.spec.ts
@@ -14,7 +14,7 @@ const AGR_ID   = '00000000-0000-0000-0000-000000000020';
 
 async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
         { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() },

--- a/tests/unit/agreements-render.spec.ts
+++ b/tests/unit/agreements-render.spec.ts
@@ -20,7 +20,7 @@ describe('agreement-render handler', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT_A, name: 'A', subdomain: 'acme', status: 'active',
+      id: TENANT_A, name: 'A', slug: 'acme', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.agreements).values({
@@ -119,7 +119,7 @@ describe('cert-render handler', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT_A, name: 'A', subdomain: 'acme', status: 'active',
+      id: TENANT_A, name: 'A', slug: 'acme', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.agreements).values({

--- a/tests/unit/api/admin-seed-starter-content.spec.ts
+++ b/tests/unit/api/admin-seed-starter-content.spec.ts
@@ -60,7 +60,7 @@ describe('POST /api/admin/seed-starter-content', () => {
         await testDb.insert(schema.tenants).values({
             id:        tenantId,
             name:      'Test Tenant',
-            subdomain: 'test',
+            slug: 'test',
             createdAt: new Date(),
         });
     });

--- a/tests/unit/apprentice-service.spec.ts
+++ b/tests/unit/apprentice-service.spec.ts
@@ -15,7 +15,7 @@ const ORPHAN       = '44444444-4444-4444-4444-444444444444';
 
 async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active',
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     // Mentor first (apprentice references mentor_id).

--- a/tests/unit/audit-inspector-slug.spec.ts
+++ b/tests/unit/audit-inspector-slug.spec.ts
@@ -21,7 +21,7 @@ describe('writeAuditLogWithSlug — Sprint B-3', () => {
         sqlite = fixture.sqlite;
         await setupSchema(sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.users).values([
             { id: USER, tenantId: TENANT, email: 'mike@test.com', name: 'Mike', role: 'inspector', slug: 'mike', createdAt: new Date(), passwordHash: 'x' },

--- a/tests/unit/auth.service.spec.ts
+++ b/tests/unit/auth.service.spec.ts
@@ -34,7 +34,7 @@ describe('AuthService', () => {
         await testDb.insert(tenants).values({
             id: 't1',
             name: 'Test Tenant',
-            subdomain: 'test',
+            slug: 'test',
             createdAt: new Date(),
         });
         

--- a/tests/unit/auto-sign-publish.spec.ts
+++ b/tests/unit/auto-sign-publish.spec.ts
@@ -30,7 +30,7 @@ describe('InspectionService.publishInspection auto-sign behavior', () => {
         db = fixture.db;
         await setupSchema(fixture.sqlite);
         await db.insert(schema.tenants).values({
-            id: TENANT, name: 'A', subdomain: 's', status: 'active',
+            id: TENANT, name: 'A', slug: 's', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await db.insert(schema.users).values({

--- a/tests/unit/automation.service.spec.ts
+++ b/tests/unit/automation.service.spec.ts
@@ -14,7 +14,7 @@ const AGR    = '00000000-0000-0000-0000-000000000020';
 
 async function seedFor(testDb: BetterSQLite3Database<typeof schema>, agreementRequired: boolean) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT, name: 'T', subdomain: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
         { id: INSP, tenantId: TENANT, propertyAddress: '1 St', clientName: 'J', clientEmail: 'j@t.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired, paymentRequired: false, createdAt: new Date() },

--- a/tests/unit/branding-block-policy.spec.ts
+++ b/tests/unit/branding-block-policy.spec.ts
@@ -43,7 +43,7 @@ describe('BrandingService — Round-2 #10 persistence', () => {
         await testDb.insert(schema.tenants).values({
             id: TENANT,
             name: 'Acme',
-            subdomain: 'acme',
+            slug: 'acme',
             status: 'active',
             deploymentMode: 'shared',
             tier: 'free',

--- a/tests/unit/comments.spec.ts
+++ b/tests/unit/comments.spec.ts
@@ -29,7 +29,7 @@ describe('comments table — rating bucket + section', () => {
         await testDb.insert(tenants).values({
             id: 't1',
             name: 'Test Tenant',
-            subdomain: 'test',
+            slug: 'test',
             createdAt: new Date(),
         });
     });
@@ -112,7 +112,7 @@ describe('comments table — rating bucket + section', () => {
         await testDb.insert(tenants).values({
             id: 't2',
             name: 'Other Tenant',
-            subdomain: 'other',
+            slug: 'other',
             createdAt: new Date(),
         });
         await testDb.insert(comments).values([

--- a/tests/unit/concierge-public-flow.spec.ts
+++ b/tests/unit/concierge-public-flow.spec.ts
@@ -33,7 +33,7 @@ describe('concierge public flow', () => {
         await db.insert(tenants).values({
             id: 't-1',
             name: 'Acme Inspections',
-            subdomain: 'acme',
+            slug: 'acme',
             tier: 'free',
             status: 'active',
             maxUsers: 3,

--- a/tests/unit/concierge-schema.spec.ts
+++ b/tests/unit/concierge-schema.spec.ts
@@ -43,7 +43,7 @@ describe('concierge schema — A3', () => {
         await fixture.db.insert(schema.tenants).values({
             id: TENANT,
             name: 'A3 Test Co',
-            subdomain: 'a3test',
+            slug: 'a3test',
             status: 'active',
             deploymentMode: 'shared',
             tier: 'free',

--- a/tests/unit/concierge-service.spec.ts
+++ b/tests/unit/concierge-service.spec.ts
@@ -21,7 +21,7 @@ interface SeedOpts { reviewRequired?: boolean; agentLinkStatus?: 'active' | 'pen
 async function seedFixture(testDb: BetterSQLite3Database<typeof schema>, opts: SeedOpts = {}) {
     const { reviewRequired = false, agentLinkStatus = 'active' } = opts;
     await testDb.insert(schema.tenants).values({
-        id: T1, name: 'Acme', subdomain: T1_SUB, status: 'active',
+        id: T1, name: 'Acme', slug: T1_SUB, status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.tenantConfigs).values({

--- a/tests/unit/contact.service.spec.ts
+++ b/tests/unit/contact.service.spec.ts
@@ -23,8 +23,8 @@ describe('ContactService.listContacts inspectionCount', () => {
         await setupSchema(fixture.sqlite);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.contacts).values([
             { id: CLIENT_JANE, tenantId: TENANT_A, type: 'client', name: 'Jane', email: 'jane@test.com', createdAt: new Date() },

--- a/tests/unit/contacts-import.spec.ts
+++ b/tests/unit/contacts-import.spec.ts
@@ -62,7 +62,7 @@ describe('importContacts', () => {
         await testDb.insert(schema.tenants).values({
             id: TENANT_ID,
             name: 'Test Tenant',
-            subdomain: 'test',
+            slug: 'test',
             status: 'active',
             deploymentMode: 'shared',
             tier: 'free',

--- a/tests/unit/email-signature-integration.spec.ts
+++ b/tests/unit/email-signature-integration.spec.ts
@@ -7,7 +7,7 @@ const STUB_INSPECTOR = {
     phone: '(303) 555-0142',
     licenseNumber: 'TX-INSP-9001',
     slug: 'mike',
-    tenantSubdomain: 'acme',
+    tenantSlug: 'acme',
 };
 
 const HOST = 'app.inspectorhub.io';

--- a/tests/unit/estimate-range.spec.ts
+++ b/tests/unit/estimate-range.spec.ts
@@ -51,7 +51,7 @@ const TEMPLATE_SCHEMA = {
 
 async function seedFixture(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.templates).values({
         id: TEMPLATE_ID, tenantId: TENANT, name: 'Standard', schema: TEMPLATE_SCHEMA, version: 1, createdAt: new Date(),

--- a/tests/unit/event.service.spec.ts
+++ b/tests/unit/event.service.spec.ts
@@ -22,7 +22,7 @@ describe('EventService', () => {
         (mockDrizzle as any).mockReturnValue(testDb);
         svc = new EventService({} as D1Database);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
     });
 
@@ -45,7 +45,7 @@ describe('EventService', () => {
 
         it('respects tenant scoping — seeds only for given tenant', async () => {
             await testDb.insert(schema.tenants).values([
-                { id: 'other', name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+                { id: 'other', name: 'Other', slug: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
             ]);
             await svc.bulkSeed(TENANT);
             const otherTypes = await svc.listEventTypes('other');

--- a/tests/unit/evidence-download.spec.ts
+++ b/tests/unit/evidence-download.spec.ts
@@ -19,7 +19,7 @@ describe('downloadAgreementPdf', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT_A, name: 'A', subdomain: 'acme', status: 'active',
+      id: TENANT_A, name: 'A', slug: 'acme', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.agreements).values({
@@ -80,7 +80,7 @@ describe('downloadCertPdf', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT_A, name: 'A', subdomain: 'acme', status: 'active',
+      id: TENANT_A, name: 'A', slug: 'acme', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.agreements).values({
@@ -126,7 +126,7 @@ describe('downloadEvidenceZip', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT_A, name: 'A', subdomain: 'acme', status: 'active',
+      id: TENANT_A, name: 'A', slug: 'acme', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.agreements).values({

--- a/tests/unit/guest-invite-info.spec.ts
+++ b/tests/unit/guest-invite-info.spec.ts
@@ -24,7 +24,7 @@ describe('GuestInviteService.getInviteInfo — ③-B', () => {
         await setupSchema(sqlite);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);
-        await testDb.insert(tenants).values({ id: 't1', name: 'Acme Inspections', subdomain: 'acme', createdAt: new Date() });
+        await testDb.insert(tenants).values({ id: 't1', name: 'Acme Inspections', slug: 'acme', createdAt: new Date() });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         svc = new GuestInviteService({} as any);
     });

--- a/tests/unit/guest-invite-service.spec.ts
+++ b/tests/unit/guest-invite-service.spec.ts
@@ -20,7 +20,7 @@ const TENANT = '00000000-0000-0000-0000-000000000099';
 
 async function seedTenant(testDb: BetterSQLite3Database<typeof schema>, maxUsers = 5) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active',
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     // Core tenants table doesn't carry max_users (that lives on the portal

--- a/tests/unit/ics-busy-feed.spec.ts
+++ b/tests/unit/ics-busy-feed.spec.ts
@@ -22,7 +22,7 @@ describe('IcsService.busyFeedForInspector — Sprint C-2', () => {
         await setupSchema(sqlite);
 
         await testDb.insert(schema.tenants).values([{
-            id: TENANT, name: 'A', subdomain: 'a', status: 'active',
+            id: TENANT, name: 'A', slug: 'a', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         }]);
         await testDb.insert(schema.users).values([{
@@ -81,7 +81,7 @@ describe('IcsService.busyFeedForInspector — Sprint C-2', () => {
     it('enforces tenant scope', async () => {
         const OTHER = '00000000-0000-0000-0000-000000000099';
         await testDb.insert(schema.tenants).values({
-            id: OTHER, name: 'O', subdomain: 'o', status: 'active',
+            id: OTHER, name: 'O', slug: 'o', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         const ics = await svc.busyFeedForInspector(OTHER, 'mike');

--- a/tests/unit/identity-service.spec.ts
+++ b/tests/unit/identity-service.spec.ts
@@ -36,8 +36,8 @@ const STRANGER   = 'cccccccc-cccc-cccc-cccc-cccccccccce0';
 
 async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'Acme A', subdomain: 'acme-a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'Acme B', subdomain: 'acme-b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'Acme A', slug: 'acme-a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'Acme B', slug: 'acme-b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.users).values([
         { id: PRIMARY,  tenantId: TENANT_A, email: 'u@a.test', passwordHash: 'x', role: 'admin',     createdAt: new Date() },

--- a/tests/unit/import-history.service.spec.ts
+++ b/tests/unit/import-history.service.spec.ts
@@ -44,8 +44,8 @@ describe('ImportHistoryService', () => {
         testDb = setup.db;
         await setupSchema(setup.sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'T', subdomain: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: OTHER_TENANT, name: 'O', subdomain: 'o', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: OTHER_TENANT, name: 'O', slug: 'o', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);

--- a/tests/unit/inspection-create-policy.spec.ts
+++ b/tests/unit/inspection-create-policy.spec.ts
@@ -36,7 +36,7 @@ describe('InspectionService.createInspection — Round-2 #10 policy inheritance'
         await testDb.insert(schema.tenants).values({
             id: TENANT,
             name: 'Acme',
-            subdomain: 'acme',
+            slug: 'acme',
             status: 'active',
             deploymentMode: 'shared',
             tier: 'free',

--- a/tests/unit/inspection-people-card.spec.ts
+++ b/tests/unit/inspection-people-card.spec.ts
@@ -22,7 +22,7 @@ describe('Round-2 F3 — InspectionService.getPeopleCard', () => {
         svc = new InspectionService({} as D1Database);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
     });
 
@@ -101,7 +101,7 @@ describe('Round-2 F3 — InspectionService.getPeopleCard', () => {
     it('throws NotFound for cross-tenant access', async () => {
         const OTHER = '00000000-0000-0000-0000-0000000000ff';
         await testDb.insert(schema.tenants).values({
-            id: OTHER, name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+            id: OTHER, name: 'Other', slug: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.inspections).values({
             id: 'insp-other', tenantId: OTHER,

--- a/tests/unit/inspection-recipients.spec.ts
+++ b/tests/unit/inspection-recipients.spec.ts
@@ -22,7 +22,7 @@ describe('Round-2 F1 — InspectionService.getRecipientList', () => {
         svc = new InspectionService({} as D1Database);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
     });
 
@@ -130,7 +130,7 @@ describe('Round-2 F1 — InspectionService.getRecipientList', () => {
     it('throws NotFound for an inspection in another tenant', async () => {
         const OTHER = '00000000-0000-0000-0000-0000000000ff';
         await testDb.insert(schema.tenants).values({
-            id: OTHER, name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+            id: OTHER, name: 'Other', slug: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.inspections).values({
             id: 'insp-other', tenantId: OTHER,

--- a/tests/unit/inspection-request.service.spec.ts
+++ b/tests/unit/inspection-request.service.spec.ts
@@ -33,8 +33,8 @@ describe('InspectionRequestService (Sprint 2 S2-2)', () => {
 
         // Seed tenants + templates so create() can validate ownership.
         await testDb.insert(schema.tenants).values([
-            { id: TENANT,  name: 'Acme', subdomain: 'acme',  status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: TENANT2, name: 'Beta', subdomain: 'beta',  status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT,  name: 'Acme', slug: 'acme',  status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT2, name: 'Beta', slug: 'beta',  status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.templates).values([
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/inspection-results-batch.spec.ts
+++ b/tests/unit/inspection-results-batch.spec.ts
@@ -26,7 +26,7 @@ describe('applyResultsBatch', () => {
         await setupSchema(sqlite);
 
         await db.insert(tenants).values({
-            id: 't-1', name: 'Test', subdomain: 'test', createdAt: new Date(),
+            id: 't-1', name: 'Test', slug: 'test', createdAt: new Date(),
         } as any);
         await db.insert(inspections).values({
             id: 'i-1',

--- a/tests/unit/inspection-service.spec.ts
+++ b/tests/unit/inspection-service.spec.ts
@@ -49,7 +49,7 @@ describe('InspectionService.getDashboardBuckets (Spec 3A)', () => {
         svc = new InspectionService({} as D1Database);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
     });
 

--- a/tests/unit/inspector-pre-sign.spec.ts
+++ b/tests/unit/inspector-pre-sign.spec.ts
@@ -21,7 +21,7 @@ describe('applyInspectorPreSign', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT, name: 'A', subdomain: 's', status: 'active',
+      id: TENANT, name: 'A', slug: 's', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.users).values({

--- a/tests/unit/inspector-signature.spec.ts
+++ b/tests/unit/inspector-signature.spec.ts
@@ -7,7 +7,7 @@ const FULL_USER = {
     phone: '(303) 555-0142',
     licenseNumber: 'TX-INSP-9001',
     slug: 'mike',
-    tenantSubdomain: 'acme',
+    tenantSlug: 'acme',
 } as const;
 
 const HOST = 'app.inspectorhub.io';

--- a/tests/unit/iter2-bug10-public-invoice.spec.ts
+++ b/tests/unit/iter2-bug10-public-invoice.spec.ts
@@ -14,8 +14,8 @@ const INSP_B   = '00000000-0000-0000-0000-000000000011';
 
 async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
         { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },

--- a/tests/unit/iter2-bug9-sign-redirect.spec.ts
+++ b/tests/unit/iter2-bug9-sign-redirect.spec.ts
@@ -15,8 +15,8 @@ const AGR_ID   = '00000000-0000-0000-0000-000000000020';
 
 async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
         { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },

--- a/tests/unit/library-replace.spec.ts
+++ b/tests/unit/library-replace.spec.ts
@@ -45,7 +45,7 @@ describe('MarketplaceService.updateLibraryImport — replace mode (S2-7)', () =>
         testDb = setup.db;
         await setupSchema(setup.sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'T', subdomain: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);
@@ -247,7 +247,7 @@ describe('MarketplaceService.updateLibraryImport — replace mode (S2-7)', () =>
     it('does not delete other tenants comments under replace', async () => {
         const otherTenant = '00000000-0000-0000-0000-000000000002';
         await testDb.insert(schema.tenants).values({
-            id: otherTenant, name: 'O', subdomain: 'o',
+            id: otherTenant, name: 'O', slug: 'o',
             status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         const libraryId = await seedLibrary({ semver: '2.0.0', entries: [{ text: 'X' }] });

--- a/tests/unit/marketplace.service.spec.ts
+++ b/tests/unit/marketplace.service.spec.ts
@@ -20,7 +20,7 @@ describe('MarketplaceService.importTemplate (Spec 1 fix verification)', () => {
         testDb = setup.db;
         await setupSchema(setup.sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'T', subdomain: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);

--- a/tests/unit/media-center.spec.ts
+++ b/tests/unit/media-center.spec.ts
@@ -45,7 +45,7 @@ describe.skip('InspectionService — Media Center (Round-2 backlog #9)', () => {
         r2Mock.delete.mockClear();
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
 
         // Inspection with a frozen template snapshot so getMediaCenter can

--- a/tests/unit/message.service.spec.ts
+++ b/tests/unit/message.service.spec.ts
@@ -18,7 +18,7 @@ describe('MessageService', () => {
         await setupSchema(setup.sqlite);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);
-        await testDb.insert(tenants).values({ id: 't1', name: 'T', subdomain: 't1', createdAt: new Date() });
+        await testDb.insert(tenants).values({ id: 't1', name: 'T', slug: 't1', createdAt: new Date() });
         await testDb.insert(inspections).values({
             id: 'i1', tenantId: 't1', propertyAddress: '1 Main', date: '2026-05-01',
             createdAt: new Date(), price: 0,

--- a/tests/unit/notification.service.spec.ts
+++ b/tests/unit/notification.service.spec.ts
@@ -14,8 +14,8 @@ const USER_2   = '00000000-0000-0000-0000-0000000000a2';
 
 async function seedTenantAndUsers(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.users).values([
         { id: USER_1, tenantId: TENANT_A, email: 'u1@a.com', name: 'U1', passwordHash: 'x', role: 'admin', createdAt: new Date() },

--- a/tests/unit/observer-link-service.spec.ts
+++ b/tests/unit/observer-link-service.spec.ts
@@ -12,7 +12,7 @@ const INSPECTION = '11111111-1111-1111-1111-111111111111';
 
 async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active',
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.inspections).values({

--- a/tests/unit/property-facts.spec.ts
+++ b/tests/unit/property-facts.spec.ts
@@ -36,8 +36,8 @@ describe('InspectionService.updatePropertyFacts (G1)', () => {
         svc = new InspectionService({} as D1Database);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT_A, name: 'Acme',   subdomain: 'acme',   status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: TENANT_B, name: 'Globex', subdomain: 'globex', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_A, name: 'Acme',   slug: 'acme',   status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT_B, name: 'Globex', slug: 'globex', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.inspections).values([
             { id: 'insp-A', tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'A', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },

--- a/tests/unit/public-report-endpoint.spec.ts
+++ b/tests/unit/public-report-endpoint.spec.ts
@@ -114,7 +114,7 @@ describe('GET /api/public/observe/inspections/:id — ③-A.4', () => {
 /**
  * C-10 ③-A.2 — GET /api/public/report-gate/:tenant/:id
  * Public "report blocked, here's why + CTA" page. tenantId resolves from the
- * subdomain (middleware), never the URL :tenant. No token (pre-report).
+ * slug (middleware), never the URL :tenant. No token (pre-report).
  */
 describe('GET /api/public/report-gate/:tenant/:id — ③-A.2', () => {
     function buildApp(
@@ -137,7 +137,7 @@ describe('GET /api/public/report-gate/:tenant/:id — ③-A.2', () => {
         return { app, getReportGate };
     }
 
-    it('404 when the tenant subdomain does not resolve', async () => {
+    it('404 when the tenant slug does not resolve', async () => {
         const { app } = buildApp(null);
         const res = await app.request('/api/public/report-gate/acme/insp1');
         expect(res.status).toBe(404);

--- a/tests/unit/rating-system.spec.ts
+++ b/tests/unit/rating-system.spec.ts
@@ -26,8 +26,8 @@ const TENANT_B = '00000000-0000-0000-0000-000000000002';
 
 async function seedTenants(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
 }
 

--- a/tests/unit/recommendation.service.spec.ts
+++ b/tests/unit/recommendation.service.spec.ts
@@ -13,8 +13,8 @@ const USER_1   = '00000000-0000-0000-0000-0000000000a1';
 
 async function seedBaseRows(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
 }
 

--- a/tests/unit/repair-list.service.spec.ts
+++ b/tests/unit/repair-list.service.spec.ts
@@ -73,7 +73,7 @@ const TEMPLATE_SCHEMA = {
 
 async function seedFixture(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.templates).values({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/repair-request-get.spec.ts
+++ b/tests/unit/repair-request-get.spec.ts
@@ -5,8 +5,8 @@ import type { HonoConfig } from '../../server/types/hono';
 
 /**
  * C-10 ③-D — GET /api/public/repair-request/:id
- * Public (subdomain-resolved tenant, unguessable id) repair-request page data.
- * tenantId comes from the resolved subdomain, never the URL. Thin wrapper over
+ * Public (slug-resolved tenant, unguessable id) repair-request page data.
+ * tenantId comes from the resolved slug, never the URL. Thin wrapper over
  * inspection.getRepairRequestData.
  */
 describe('GET /api/public/repair-request/:id — ③-D', () => {
@@ -21,7 +21,7 @@ describe('GET /api/public/repair-request/:id — ③-D', () => {
         return app;
     }
 
-    it('404 when the tenant subdomain does not resolve', async () => {
+    it('404 when the tenant slug does not resolve', async () => {
         const res = await buildApp(null, vi.fn()).request('/api/public/repair-request/i1');
         expect(res.status).toBe(404);
     });

--- a/tests/unit/report-pdf.service.spec.ts
+++ b/tests/unit/report-pdf.service.spec.ts
@@ -17,7 +17,7 @@ const INSP_1   = '00000000-0000-0000-0000-0000000000b1';
 
 async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT_A, name: 'A', subdomain: 'a', status: 'active',
+        id: TENANT_A, name: 'A', slug: 'a', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
 }

--- a/tests/unit/report-version-service.spec.ts
+++ b/tests/unit/report-version-service.spec.ts
@@ -12,7 +12,7 @@ const INSPECTION = '11111111-1111-1111-1111-111111111111';
 
 async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active',
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.inspections).values({

--- a/tests/unit/save-default-signature.spec.ts
+++ b/tests/unit/save-default-signature.spec.ts
@@ -19,7 +19,7 @@ describe('saveUserDefaultSignature', () => {
     db = fixture.db;
     await setupSchema(fixture.sqlite);
     await db.insert(schema.tenants).values({
-      id: TENANT, name: 'A', subdomain: 's', status: 'active',
+      id: TENANT, name: 'A', slug: 's', status: 'active',
       deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await db.insert(schema.users).values({

--- a/tests/unit/seat-quota.spec.ts
+++ b/tests/unit/seat-quota.spec.ts
@@ -45,7 +45,7 @@ describe('getSeatUsage', () => {
         await testDb.insert(tenants).values({
             id,
             name: `Tenant ${id}`,
-            subdomain: id,
+            slug: id,
             maxUsers,
             createdAt: new Date(),
         });

--- a/tests/unit/section-disclaimer-render.spec.ts
+++ b/tests/unit/section-disclaimer-render.spec.ts
@@ -54,7 +54,7 @@ describe('Track E2 — section disclaimer + alwaysPageBreak surfacing', () => {
         svc = new InspectionService({} as D1Database);
 
         await testDb.insert(schema.tenants).values({
-            id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(schema.templates).values({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/starter-content.service.spec.ts
+++ b/tests/unit/starter-content.service.spec.ts
@@ -35,7 +35,7 @@ describe('seedStarterContent', () => {
         await testDb.insert(schema.tenants).values({
             id:        tenantId,
             name:      'Test Tenant',
-            subdomain: 'test',
+            slug: 'test',
             createdAt: new Date(),
         });
     });

--- a/tests/unit/tag.service.spec.ts
+++ b/tests/unit/tag.service.spec.ts
@@ -28,8 +28,8 @@ const ITEM_2 = 'item_2';
 
 async function seedTenants(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values([
-        { id: TENANT_A, name: 'A', subdomain: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-        { id: TENANT_B, name: 'B', subdomain: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
 }
 

--- a/tests/unit/team-invite.service.spec.ts
+++ b/tests/unit/team-invite.service.spec.ts
@@ -19,7 +19,7 @@ const MENTOR = '11111111-1111-1111-1111-1111111111c1';
 
 async function seedTenant(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme-c1', status: 'active',
+        id: TENANT, name: 'Acme', slug: 'acme-c1', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.users).values({

--- a/tests/unit/template-migration.service.spec.ts
+++ b/tests/unit/template-migration.service.spec.ts
@@ -75,8 +75,8 @@ describe('TemplateMigrationService', () => {
         testDb = setup.db;
         await setupSchema(setup.sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'T', subdomain: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: OTHER_TENANT, name: 'O', subdomain: 'o', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: OTHER_TENANT, name: 'O', slug: 'o', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);

--- a/tests/unit/template.service.spec.ts
+++ b/tests/unit/template.service.spec.ts
@@ -19,7 +19,7 @@ describe('Spec 5B — TemplateService + v2 schema round-trip', () => {
         testDb = setup.db;
         await setupSchema(setup.sqlite);
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'T', subdomain: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);

--- a/tests/unit/tenant-routing-path-param.spec.ts
+++ b/tests/unit/tenant-routing-path-param.spec.ts
@@ -13,7 +13,7 @@ function makeApp(profile = SAAS_PROFILE) {
 
 describe('tenant-routing — path-param resolution', () => {
     it('extracts tenant from /book/:tenant/:slug path', async () => {
-        const fakeTenant = { id: 'tenant-uuid', subdomain: 'acme', tier: 'pro', status: 'active' };
+        const fakeTenant = { id: 'tenant-uuid', slug: 'acme', tier: 'pro', status: 'active' };
         const env: Partial<HonoConfig['Bindings']> = {
             DB: { } as never,
             TENANT_CACHE: { get: vi.fn().mockResolvedValue(fakeTenant), put: vi.fn() } as never,
@@ -25,9 +25,9 @@ describe('tenant-routing — path-param resolution', () => {
         expect(capturedTenantId).toBe('tenant-uuid');
     });
 
-    it('path-param wins over subdomain', async () => {
-        const aTenant = { id: 'tenant-a', subdomain: 'acme', tier: 'pro', status: 'active' };
-        const bTenant = { id: 'tenant-b', subdomain: 'bravo', tier: 'pro', status: 'active' };
+    it('path-param wins over slug', async () => {
+        const aTenant = { id: 'tenant-a', slug: 'acme', tier: 'pro', status: 'active' };
+        const bTenant = { id: 'tenant-b', slug: 'bravo', tier: 'pro', status: 'active' };
         const get = vi.fn((key: string) => Promise.resolve(key.endsWith('acme') ? aTenant : bTenant));
         const env: Partial<HonoConfig['Bindings']> = { DB: {} as never, TENANT_CACHE: { get, put: vi.fn() } as never };
         const app = makeApp();

--- a/tests/unit/tenant-routing.spec.ts
+++ b/tests/unit/tenant-routing.spec.ts
@@ -84,8 +84,8 @@ describe('tenant-routing — saas mode', () => {
         // unresolved" describe with a positive path-param happy path —
         // the path-param resolver runs before the profile branch, so
         // /book/<slug>/<inspector> correctly populates tenantId in saas
-        // mode without needing any subdomain magic.
-        const fakeTenant = { id: 'tenant-uuid', subdomain: 'acme', tier: 'pro', status: 'active' };
+        // mode without needing any slug magic.
+        const fakeTenant = { id: 'tenant-uuid', slug: 'acme', tier: 'pro', status: 'active' };
         const { app, env } = makeApp(
             {
                 DB: {} as never,
@@ -103,7 +103,7 @@ describe('tenant-routing — saas mode', () => {
     });
 
     it('leaves tenantId unset on a non-public path so JWT middleware downstream can fill it', async () => {
-        // Section F rewrite. Replaces the old "silo subdomain" describe.
+        // Section F rewrite. Replaces the old "silo slug" describe.
         // In saas mode, tenantRouter's job for non-public paths is to do
         // nothing — JWT middleware downstream owns tenantId. We confirm
         // that contract: tenantId is undefined when the handler runs and

--- a/tests/unit/unit-service.spec.ts
+++ b/tests/unit/unit-service.spec.ts
@@ -18,7 +18,7 @@ const INSPECTION = '11111111-1111-1111-1111-111111111111';
 
 async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.tenants).values({
-        id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active',
+        id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
         deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
     });
     await testDb.insert(schema.inspections).values({

--- a/tests/unit/user-service-profile.spec.ts
+++ b/tests/unit/user-service-profile.spec.ts
@@ -23,7 +23,7 @@ describe('UserService.getProfileBySlug — Sprint C-1', () => {
         await setupSchema(sqlite);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.users).values([
             {
@@ -87,7 +87,7 @@ describe('UserService.getProfileBySlug — Sprint C-1', () => {
 
     it('enforces tenant scope (different tenant cannot read profile)', async () => {
         const OTHER_TENANT = '00000000-0000-0000-0000-000000000099';
-        await testDb.insert(schema.tenants).values({ id: OTHER_TENANT, name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() });
+        await testDb.insert(schema.tenants).values({ id: OTHER_TENANT, name: 'Other', slug: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() });
         const profile = await svc.getProfileBySlug(OTHER_TENANT, 'mike');
         expect(profile).toBeNull();
     });

--- a/tests/unit/user-service-slug.spec.ts
+++ b/tests/unit/user-service-slug.spec.ts
@@ -30,8 +30,8 @@ describe('UserService — slug', () => {
         (mockDrizzle as any).mockReturnValue(testDb);
 
         await testDb.insert(schema.tenants).values([
-            { id: TENANT, name: 'Acme', subdomain: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
-            { id: OTHER_TENANT, name: 'Other', subdomain: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+            { id: OTHER_TENANT, name: 'Other', slug: 'other', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
 
         svc = new UserService({} as unknown as D1Database);

--- a/tests/unit/users-nullable-tenant-schema.spec.ts
+++ b/tests/unit/users-nullable-tenant-schema.spec.ts
@@ -22,7 +22,7 @@ describe('users schema — A1', () => {
         // human can now hold one users row per tenant in core's shared D1,
         // matching the per-identity / per-membership model on the portal side.
         const row1 = sqlite.prepare(
-            `INSERT INTO tenants (id, name, subdomain, tier, status, max_users, deployment_mode, created_at)
+            `INSERT INTO tenants (id, name, slug, tier, status, max_users, deployment_mode, created_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         );
         row1.run('t-a', 'A', 'aco', 'free', 'active', 5, 'shared', Date.now());

--- a/tests/unit/widget.service.spec.ts
+++ b/tests/unit/widget.service.spec.ts
@@ -25,7 +25,7 @@ describe('WidgetService.isOriginAllowed', () => {
         svc = new WidgetService({} as any);
 
         await testDb.insert(tenants).values({
-            id: TENANT_ID, name: 'T', subdomain: 't', status: 'active',
+            id: TENANT_ID, name: 'T', slug: 't', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await testDb.insert(tenantConfigs).values({
@@ -39,7 +39,7 @@ describe('WidgetService.isOriginAllowed', () => {
         expect(await svc.isOriginAllowed(TENANT_ID, 'https://acme.com')).toBe(true);
     });
 
-    it('returns true for wildcard subdomain match', async () => {
+    it('returns true for wildcard slug match', async () => {
         expect(await svc.isOriginAllowed(TENANT_ID, 'https://shop.acme-staging.com')).toBe(true);
         expect(await svc.isOriginAllowed(TENANT_ID, 'https://api.acme-staging.com')).toBe(true);
     });
@@ -57,7 +57,7 @@ describe('WidgetService.isOriginAllowed', () => {
         const svc2 = new WidgetService({} as any);
         const otherTenant = '00000000-0000-0000-0000-000000000002';
         await setup2.db.insert(tenants).values({
-            id: otherTenant, name: 'T2', subdomain: 't2', status: 'active',
+            id: otherTenant, name: 'T2', slug: 't2', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
         await setup2.db.insert(tenantConfigs).values({ tenantId: otherTenant, updatedAt: new Date() });
@@ -87,7 +87,7 @@ describe('WidgetService.recordEvent', () => {
         const svc = new WidgetService({} as any);
 
         await setup.db.insert(tenants).values({
-            id: TENANT_ID, name: 'T', subdomain: 't', status: 'active',
+            id: TENANT_ID, name: 'T', slug: 't', status: 'active',
             deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
         });
 


### PR DESCRIPTION
## Summary

Rename `tenants.subdomain` → `tenants.slug` and all related symbols. The `subdomain` naming was a misnomer: **no deploy mode resolves a tenant by DNS subdomain** — standalone uses `SINGLE_TENANT_ID`, saas uses the JWT claim, and public routes (`/book`, `/embed`, `/inspector`, `/r`) resolve by the **path slug** (`resolve-by-path-param` does `eq(tenants.subdomain, …)`). The value has always been the public tenant slug.

## Changes
- **Schema**: `tenants.subdomain` → `slug` + migration `0005` (`ALTER TABLE … RENAME COLUMN`, so existing rows keep their value; unique index → `tenants_slug_unique`).
- **Symbols**: `tenantSubdomain` → `tenantSlug` (branding), `requestedSubdomain` → `requestedTenantSlug` (context var), `:subdomain` route params → `:slug`, M2M `TenantStatus`/`StripeConnect` schema field → `slug`.
- **Vanity removed**: dropped the retired-vanity-subdomain note from `tenant-routing` (vanity custom domains aren't used); reworded the comment to "DNS/host-based resolution retired".

## Wire-compatible
The M2M PATCH body (`TenantStatusBodySchema`) never carried `subdomain` — the slug travels via the **URL path value** (unchanged), and any extra body key is stripped by zod. So the portal↔core integration is unaffected and this ships independently.

## Validation
`type-check` 0/0 · `db:check` EQUIVALENT · `test:unit` 1044/0 · `test:web` 5/5 · `lint` 0 errors · `build` OK · migration verified on local D1 (data preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
