### PR TITLE
fix(deps): bump hono to 4.12.24 and uuid to 11.1.1 (Dependabot #8-12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "drizzle-orm": "^0.45.2",
         "exceljs": "^4.4.0",
         "fflate": "^0.8.3",
-        "hono": "^4.12.18",
+        "hono": "^4.12.21",
         "isbot": "^5.1.0",
         "node-diff3": "^3.1.2",
         "otpauth": "^9.5.1",
@@ -6391,9 +6391,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.24",
+      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.24.tgz",
+      "integrity": "sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -10027,12 +10027,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "drizzle-orm": "^0.45.2",
     "exceljs": "^4.4.0",
     "fflate": "^0.8.3",
-    "hono": "^4.12.18",
+    "hono": "^4.12.21",
     "isbot": "^5.1.0",
     "node-diff3": "^3.1.2",
     "otpauth": "^9.5.1",
@@ -137,7 +137,8 @@
     "wrangler": "^4.95.0"
   },
   "overrides": {
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "uuid": "^11.1.1"
   },
   "optionalDependencies": {
     "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",


### PR DESCRIPTION
Fixes 5 open Dependabot alerts.

## Changes
- \hono\: \^4.12.18\ → \^4.12.21\ (resolved to 4.12.24)
- \uuid\: \^8.3.0\ → \^11.1.1\ via \overrides\ (transitive dep of exceljs)

## CVEs addressed
| Alert | Package | Severity | Summary |
|-------|---------|----------|---------|
| #8 | hono | medium | JWT middleware accepts any Authorization scheme |
| #9 | hono | medium | IP Restriction bypass for non-canonical IPv6 |
| #10 | hono | medium | app.mount() incorrect routing for percent-encoded paths |
| #11 | hono | medium | Cookie helper Set-Cookie injection via sameSite/priority |
| #12 | uuid | medium | Missing buffer bounds check in v3/v5/v6 when buf is provided |

## Testing
All 1620 unit tests pass.