### PR TITLE
Split inspection lifecycle status from report status + report review workflow

### DIFF
--- a/app/lib/hub-blocks.ts
+++ b/app/lib/hub-blocks.ts
@@ -11,6 +11,8 @@
  * Intl.NumberFormat usage in routes/invoices.tsx.)
  */
 
+import { INSPECTION_STATUS, INSPECTION_STATUS_LABELS, isReportPublished } from '~/lib/status';
+
 /** Pill tone union — kept in sync with packages/shared-ui/src/Pill.tsx. */
 export type PillTone =
     | 'sat'
@@ -46,6 +48,7 @@ export interface BlockStates {
 export interface HubPayload {
     inspection: {
         status: string;
+        reportStatus: string;
         paymentRequired: boolean;
         agreementRequired: boolean;
     };
@@ -130,33 +133,31 @@ function deriveInvoice(hub: HubPayload): BlockState {
     }
 }
 
-/**
- * Report pill. Pre-completion statuses are all "in progress"; once completed
- * the publish-readiness gate decides ready-vs-blocked; delivered/published is
- * the terminal "published" state.
- */
-function deriveReport(hub: HubPayload): BlockState {
-    const { status } = hub.inspection;
+/** Inspection lifecycle pill (appointment axis). */
+export function deriveInspectionPill(status: string): BlockState {
+    const label = INSPECTION_STATUS_LABELS[status as keyof typeof INSPECTION_STATUS_LABELS] ?? status;
     switch (status) {
-        case 'draft':
-        case 'scheduled':
-        case 'confirmed':
-        case 'in_progress':
-            return { tone: 'neutral', label: 'In progress' };
-        case 'completed':
-            return hub.publishReadiness.ready
-                ? { tone: 'monitor', label: 'Ready to publish' }
-                : { tone: 'warning', label: `${hub.publishReadiness.blockingCount} blocker(s)` };
-        case 'delivered':
-        case 'published':
-            return { tone: 'sat', label: 'Published' };
-        case 'signed':
-            return { tone: 'info', label: 'Signed' };
-        case 'cancelled':
-            return { tone: 'defect', label: 'Cancelled' };
-        default:
-            return { tone: 'neutral', label: 'In progress' };
+        case 'requested':  return { tone: 'ni',      label };
+        case 'scheduled':  return { tone: 'info',    label };
+        case 'confirmed':  return { tone: 'info',    label };
+        case 'completed':  return { tone: 'sat',     label };
+        case 'cancelled':  return { tone: 'gen',     label };
+        default:           return { tone: 'neutral', label };
     }
+}
+
+/** Report deliverable pill (report axis). */
+export function deriveReportPill(reportStatus: string): BlockState {
+    switch (reportStatus) {
+        case 'in_progress': return { tone: 'neutral', label: 'In Progress' };
+        case 'submitted':   return { tone: 'warning', label: 'Submitted' };
+        case 'published':   return { tone: 'sat',     label: 'Published' };
+        default:            return { tone: 'neutral', label: 'In Progress' };
+    }
+}
+
+function deriveReport(hub: HubPayload): BlockState {
+    return deriveReportPill(hub.inspection.reportStatus);
 }
 
 /** Collapse the hub payload into the three action-block status pills. */
@@ -173,34 +174,18 @@ export function deriveBlockStates(hub: HubPayload): BlockStates {
 /* ------------------------------------------------------------------ */
 
 /**
- * Statuses where the report is already shipped to the client — no publish CTA.
- * `delivered` is the only LIVE inspection status here (the lifecycle enum is
- * `draft | completed | delivered`; publishInspection transitions to
- * `delivered`). `published` / `signed` are retained DEFENSIVELY, mirroring the
- * dashboard's `matchesWorkflow` published-tab matching — they are not produced
- * as inspection.status today but cost nothing to tolerate if that changes.
- */
-const PUBLISHED_STATUSES = new Set(['delivered', 'published', 'signed']);
-
-/**
- * Task 9 (Issue #111) — whether the hub Report card should offer an ACTIVE
- * "Publish report" button. True only when the inspection is `completed` (the
- * only status from which publishing is legitimate) AND publish-ready AND not
- * already shipped. The `completed` gate excludes cancelled / draft / in_progress
- * regardless of readiness, so a stale `ready` flag can never offer a Publish CTA
- * for a cancelled inspection. A non-ready completed report shows the disabled
- * button + a blockers hint; an already-shipped report shows read-only state +
- * the header View link.
+ * Whether the hub Report card should offer an active "Publish report" button.
+ * True only when the inspection is `completed` AND the report is not already
+ * published. The `completed` gate excludes cancelled / requested / in-progress
+ * regardless of report status.
  */
 export function canPublish(hub: HubPayload): boolean {
-    if (PUBLISHED_STATUSES.has(hub.inspection.status)) return false;
-    if (hub.inspection.status !== 'completed') return false;
-    return hub.publishReadiness.ready;
+    return hub.inspection.status === INSPECTION_STATUS.COMPLETED && !isReportPublished(hub.inspection.reportStatus);
 }
 
 /** Whether the report has already been shipped to the client (read-only state). */
 export function isReportShipped(hub: HubPayload): boolean {
-    return PUBLISHED_STATUSES.has(hub.inspection.status);
+    return isReportPublished(hub.inspection.reportStatus);
 }
 
 /* ------------------------------------------------------------------ */

--- a/app/lib/status.ts
+++ b/app/lib/status.ts
@@ -1,0 +1,18 @@
+// Re-export everything from both server status modules for app-side use.
+// No bare status string literals in app code — import from here.
+export {
+  INSPECTION_STATUSES,
+  INSPECTION_STATUS,
+  INSPECTION_STATUS_LABELS,
+  type InspectionStatus,
+  isInspectionStatus,
+} from '../../server/lib/status/inspection-status';
+
+export {
+  REPORT_STATUSES,
+  REPORT_STATUS,
+  REPORT_STATUS_LABELS,
+  type ReportStatus,
+  isReportStatus,
+  isReportPublished,
+} from '../../server/lib/status/report-status';

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -99,9 +99,8 @@ export default [
     // requireToken() can redirect to /login when unauthenticated.
     route("resources/schedule-conflicts", "routes/resources/schedule-conflicts.ts"),
     route("dashboard", "routes/dashboard.tsx"),
-    // Inspections nav points here; same component as the dashboard list view.
-    // Explicit id avoids a duplicate-route-id collision with the dashboard route.
-    route("inspections", "routes/dashboard.tsx", { id: "inspections-list" }),
+    // Inspections list — dedicated route using the new inspections.tsx component.
+    route("inspections", "routes/inspections.tsx"),
     route("calendar", "routes/calendar.tsx"),
     route("contacts", "routes/contacts.tsx"),
     // IA-18 (#111) — contact detail (record + inspection history + stats).

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -12,6 +12,7 @@ import { SeatBanner } from "~/components/SeatBanner";
 import { useSessionContext } from "~/hooks/useSessionContext";
 import { formatInspectionDateTime } from "~/lib/format-date";
 import { computeOnboardingSteps } from "~/lib/onboarding-progress";
+import { INSPECTION_STATUS, REPORT_STATUS, isReportPublished } from "~/lib/status";
 import { PageHeader, TabStrip, Pill, Card, EmptyState, Button, Icon } from "@core/shared-ui";
 
 export function meta() {
@@ -30,6 +31,7 @@ interface Inspection {
   clientName: string | null;
   clientEmail?: string | null;
   status: string;
+  reportStatus?: string;
   confirmedAt?: string | null;
   price?: number | null;
   paymentStatus?: string | null;
@@ -138,8 +140,8 @@ function startOfWeek(d: Date) {
 function matchesFilter(insp: Inspection, filter: FilterId, now: Date): boolean {
   if (filter === "all") return true;
   const status = (insp.status || "").toLowerCase();
-  if (filter === "unconfirmed") return status === "scheduled" || status === "draft";
-  if (filter === "in_progress") return status === "in_progress";
+  if (filter === "unconfirmed") return status === INSPECTION_STATUS.SCHEDULED || status === INSPECTION_STATUS.REQUESTED;
+  if (filter === "in_progress") return status === INSPECTION_STATUS.COMPLETED && !isReportPublished(insp.reportStatus);
   if (!insp.date) return false;
   const date = new Date(insp.date);
   if (isNaN(date.getTime())) return false;
@@ -167,7 +169,8 @@ function matchesFilter(insp: Inspection, filter: FilterId, now: Date): boolean {
 const TABS = [
   { key: "all", label: "All" },
   { key: "active", label: "Active" },
-  { key: "drafts", label: "Drafts" },
+  { key: "requested", label: "Requested" },
+  { key: "to_review", label: "To Review" },
   { key: "awaiting_payment", label: "Awaiting payment" },
   { key: "published", label: "Published" },
   { key: "cancelled", label: "Cancelled" },
@@ -175,38 +178,51 @@ const TABS = [
 
 type TabKey = (typeof TABS)[number]["key"];
 
-export function matchesWorkflow(i: Inspection, tab: TabKey): boolean {
+/**
+ * Pure tab matching function for both inspection lifecycle and report axes.
+ * Exported for unit testing.
+ */
+export function tabMatches(
+  tab: string,
+  i: { status: string; reportStatus?: string; paymentStatus?: string | null },
+): boolean {
   if (tab === "all") return true;
   switch (tab) {
-    case "active": return ["scheduled", "in_progress", "draft", "confirmed"].includes(i.status);
-    case "drafts": return i.status === "draft";
-    case "awaiting_payment": return (i.status === "delivered" || i.status === "published") && i.paymentStatus !== "paid";
-    // #111: Published absorbs the retired /reports list — all report-ready statuses.
-    case "published": return ["completed", "delivered", "published", "signed"].includes(i.status);
-    case "cancelled": return i.status === "cancelled";
+    case "active": return (
+        i.status === INSPECTION_STATUS.REQUESTED ||
+        i.status === INSPECTION_STATUS.SCHEDULED ||
+        i.status === INSPECTION_STATUS.CONFIRMED
+      );
+    case "requested": return i.status === INSPECTION_STATUS.REQUESTED;
+    case "to_review": return i.reportStatus === REPORT_STATUS.SUBMITTED;
+    case "published": return isReportPublished(i.reportStatus);
+    case "awaiting_payment": return isReportPublished(i.reportStatus) && i.paymentStatus !== "paid";
+    case "cancelled": return i.status === INSPECTION_STATUS.CANCELLED;
     default: return true;
   }
+}
+
+/** @deprecated Use tabMatches instead. Kept for backward compat. */
+export function matchesWorkflow(i: Inspection, tab: TabKey): boolean {
+  return tabMatches(tab, i);
 }
 
 /* ------------------------------------------------------------------ */
 /*  Report-state badge (Published tab)                                 */
 /* ------------------------------------------------------------------ */
 
-// #111: the Published tab shows a report-state Pill. Mapping copied verbatim
-// from the now-retired reports.tsx (STATUS_TONE + statusLabel) so the
-// report-oriented list keeps its semantics after the page is deleted.
-const REPORT_STATE_TONE: Record<string, "monitor" | "sat" | "info"> = {
-  completed: "monitor",
-  delivered: "sat",
+// Report-state pill for the Published/to_review tabs (uses reportStatus axis).
+const REPORT_STATE_TONE: Record<string, "monitor" | "sat" | "warning"> = {
+  in_progress: "monitor",
+  submitted: "warning",
   published: "sat",
-  signed: "info",
 };
 
-function reportStateLabel(s: string): string {
-  if (s === "completed") return "Ready";
-  if (s === "delivered" || s === "published") return "Delivered";
-  if (s === "signed") return "Signed";
-  return s;
+function reportStateLabel(reportStatus: string): string {
+  if (reportStatus === "in_progress") return "In Progress";
+  if (reportStatus === "submitted") return "Submitted";
+  if (reportStatus === "published") return "Published";
+  return reportStatus;
 }
 
 /* ------------------------------------------------------------------ */
@@ -382,7 +398,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   }
   if (intent === "status") {
     const id = formData.get("id") as string;
-    const status = formData.get("status") as "draft" | "completed" | "delivered";
+    const status = formData.get("status") as "requested" | "scheduled" | "confirmed" | "completed" | "cancelled";
     const res = await api.inspections[":id"].$patch({
       param: { id },
       json: { status },
@@ -621,7 +637,7 @@ export default function DashboardPage() {
   /* ---- Stats ---- */
   const counts = useMemo(() => ({
     upcoming: new Set([...buckets.today, ...buckets.thisWeek, ...buckets.later].map((i) => i.id)).size,
-    inProgress: allInspections.filter((i) => i.status === "in_progress").length,
+    inProgress: allInspections.filter((i) => i.status === INSPECTION_STATUS.COMPLETED && !isReportPublished(i.reportStatus)).length,
     needsAttention: buckets.needsAttention.length,
     recent: buckets.recentReports.length,
   }), [buckets, allInspections]);
@@ -723,14 +739,12 @@ export default function DashboardPage() {
     ? Object.values(filteredBuckets).flat().length
     : filteredInspections.length;
 
-  /* ---- Status → Pill tone mapping ---- */
+  /* ---- Status → Pill tone mapping (inspection lifecycle axis) ---- */
   const statusTone: Record<string, "ni" | "info" | "monitor" | "sat" | "gen"> = {
-    draft: "ni",
+    requested: "ni",
     scheduled: "info",
     confirmed: "info",
-    in_progress: "monitor",
-    delivered: "sat",
-    published: "sat",
+    completed: "sat",
     cancelled: "gen",
   };
 
@@ -744,7 +758,7 @@ export default function DashboardPage() {
   function InspectionRow({ insp, reportView = false }: { insp: Inspection; reportView?: boolean }) {
     const isSelected = selectedIds.has(insp.id);
     const showReportLink =
-      reportView && tenantSlug && (insp.status === "delivered" || insp.status === "published");
+      reportView && tenantSlug && isReportPublished(insp.reportStatus);
     return (
       <div className="flex items-center gap-2 px-4 py-3 hover:bg-ih-bg-muted transition-colors group">
         <input
@@ -787,10 +801,10 @@ export default function DashboardPage() {
                 {insp.status.replace(/_/g, " ")}
               </Pill>
             )}
-            {/* #111: report-state badge (Published tab only) */}
-            {reportView && REPORT_STATE_TONE[insp.status] && (
-              <Pill tone={REPORT_STATE_TONE[insp.status]}>
-                {reportStateLabel(insp.status)}
+            {/* report-state badge (Published/to_review tabs) */}
+            {reportView && insp.reportStatus && REPORT_STATE_TONE[insp.reportStatus] && (
+              <Pill tone={REPORT_STATE_TONE[insp.reportStatus]}>
+                {reportStateLabel(insp.reportStatus)}
               </Pill>
             )}
             {isColumnVisible("defectChips") && insp.defectStats && (
@@ -845,12 +859,10 @@ export default function DashboardPage() {
             onClick={(e) => e.stopPropagation()}
             className="h-6 px-1 rounded text-[10px] font-bold bg-ih-bg-muted text-ih-fg-3 border-0 outline-none cursor-pointer"
           >
-            <option value="draft">Draft</option>
+            <option value="requested">Requested</option>
             <option value="scheduled">Scheduled</option>
             <option value="confirmed">Confirmed</option>
-            <option value="in_progress">In Progress</option>
-            <option value="delivered">Delivered</option>
-            <option value="published">Published</option>
+            <option value="completed">Completed</option>
             <option value="cancelled">Cancelled</option>
           </select>
         </div>
@@ -1051,7 +1063,7 @@ export default function DashboardPage() {
                 {!collapsed && (
                   <div className="divide-y divide-ih-border">
                     {items.map((insp) => (
-                      <InspectionRow key={insp.id} insp={insp} reportView={activeTab === "published"} />
+                      <InspectionRow key={insp.id} insp={insp} reportView={activeTab === "published" || activeTab === "to_review"} />
                     ))}
                   </div>
                 )}
@@ -1075,7 +1087,7 @@ export default function DashboardPage() {
               </div>
               <div className="divide-y divide-ih-border">
                 {!isSearching && displayList.map((insp) => (
-                  <InspectionRow key={insp.id} insp={insp} reportView={activeTab === "published"} />
+                  <InspectionRow key={insp.id} insp={insp} reportView={activeTab === "published" || activeTab === "to_review"} />
                 ))}
               </div>
               {isSearching && (

--- a/app/routes/inspection-hub.tsx
+++ b/app/routes/inspection-hub.tsx
@@ -4,7 +4,7 @@ import type { Route } from "./+types/inspection-hub";
 import { requireToken } from "~/lib/session.server";
 import { createApi } from "~/lib/api-client.server";
 import { formatInspectionDateTime } from "~/lib/format-date";
-import { deriveBlockStates, formatCents, canPublish, isReportShipped, type HubPayload } from "~/lib/hub-blocks";
+import { deriveBlockStates, formatCents, isReportShipped, type HubPayload } from "~/lib/hub-blocks";
 import { INSPECTION_STATUS, REPORT_STATUS, isReportPublished } from "~/lib/status";
 import { getEffectivePriceCents } from "~/lib/effective-price";
 import { PageHeader, Card, Pill, Button, EmptyState } from "@core/shared-ui";
@@ -463,7 +463,6 @@ export default function InspectionHubPage() {
 
   // Report card affordance: active publish CTA vs read-only-shipped.
   const reportPublished = isReportShipped(hub);
-  const publishReady = canPublish(hub);
 
   // Report action matrix — what buttons to show in the Report card.
   const reportActionList = reportActions(

--- a/app/routes/inspection-hub.tsx
+++ b/app/routes/inspection-hub.tsx
@@ -5,6 +5,7 @@ import { requireToken } from "~/lib/session.server";
 import { createApi } from "~/lib/api-client.server";
 import { formatInspectionDateTime } from "~/lib/format-date";
 import { deriveBlockStates, formatCents, canPublish, isReportShipped, type HubPayload } from "~/lib/hub-blocks";
+import { INSPECTION_STATUS, REPORT_STATUS, isReportPublished } from "~/lib/status";
 import { getEffectivePriceCents } from "~/lib/effective-price";
 import { PageHeader, Card, Pill, Button, EmptyState } from "@core/shared-ui";
 
@@ -39,6 +40,7 @@ interface HubData extends HubPayload {
     referredByAgentId: string | null;
     sellingAgentId: string | null;
     createdAt: string | null;
+    // reportStatus is inherited from HubPayload["inspection"] but listed here for clarity
   };
   tenantSlug: string;
   people: {
@@ -92,11 +94,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const hub = ((body as Record<string, unknown>).data ?? {}) as unknown as HubData;
 
   // #119 Task 6 — re-inspection candidates for the "Create re-inspection" modal.
-  // Only meaningful off a PUBLISHED baseline, so we fetch them only then (the
-  // endpoint returns [] for unpublished anyway). Best-effort: a failure degrades
-  // to an empty list and the action gates publication server-side.
+  // Only meaningful off a PUBLISHED baseline (reportStatus=published), so we
+  // fetch them only then. Best-effort: a failure degrades to an empty list.
   let reinspectCandidates: ReinspectCandidate[] = [];
-  if (hub.inspection?.status === "published" || hub.inspection?.status === "delivered") {
+  if (isReportPublished(hub.inspection?.reportStatus)) {
     const candRes = await api.inspections[":id"]["reinspect-candidates"]
       .$get({ param: { id } })
       .catch(() => null);
@@ -114,7 +115,26 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       ? (((await consentRes.json()) as { data?: { consent?: "granted" | "revoked" | "none" } }).data?.consent ?? "none")
       : "none";
 
-  return { hub, smsConsent, reinspectCandidates };
+  // Capability: whether the current user can publish reports (owner/manager/inspector).
+  // Best-effort: falls back to false (inspector will see submit-only flow).
+  let canPublishCap = false;
+  try {
+    const meGet = (api as unknown as { auth?: { me?: { $get?: (args?: unknown) => Promise<Response> } } })
+      ?.auth?.me?.$get;
+    if (meGet) {
+      const meRes = await meGet().catch(() => null);
+      if (meRes && meRes.ok) {
+        const meBody = (await meRes.json().catch(() => ({}))) as { data?: { user?: { role?: string } } };
+        const role = meBody.data?.user?.role ?? 'inspector';
+        const publishRoles = new Set(['owner', 'manager', 'inspector']);
+        canPublishCap = publishRoles.has(role);
+      }
+    }
+  } catch {
+    // Best-effort: fail open on cap check (canPublishCap stays false)
+  }
+
+  return { hub, smsConsent, reinspectCandidates, canPublishCap };
 }
 
 /* ------------------------------------------------------------------ */
@@ -207,6 +227,54 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     return { ok: true, intent: "publish" as const, error: undefined };
   }
 
+  if (intent === "submit") {
+    const submitApi = api.inspections[":id"] as unknown as {
+      submit: { $post: (args: { param: { id: string } }) => Promise<Response> };
+    };
+    const res = await submitApi.submit.$post({ param: { id } });
+    if (!res.ok) {
+      const err = (await res.json().catch(() => null)) as { error?: { message?: string } } | null;
+      return {
+        ok: false,
+        intent: "submit" as const,
+        error: err?.error?.message ?? "Could not submit the report. Please try again.",
+      };
+    }
+    return { ok: true, intent: "submit" as const, error: undefined };
+  }
+
+  if (intent === "return") {
+    const returnApi = api.inspections[":id"] as unknown as {
+      return: { $post: (args: { param: { id: string } }) => Promise<Response> };
+    };
+    const res = await returnApi.return.$post({ param: { id } });
+    if (!res.ok) {
+      const err = (await res.json().catch(() => null)) as { error?: { message?: string } } | null;
+      return {
+        ok: false,
+        intent: "return" as const,
+        error: err?.error?.message ?? "Could not return the report. Please try again.",
+      };
+    }
+    return { ok: true, intent: "return" as const, error: undefined };
+  }
+
+  if (intent === "unpublish") {
+    const unpublishApi = api.inspections[":id"] as unknown as {
+      unpublish: { $post: (args: { param: { id: string } }) => Promise<Response> };
+    };
+    const res = await unpublishApi.unpublish.$post({ param: { id } });
+    if (!res.ok) {
+      const err = (await res.json().catch(() => null)) as { error?: { message?: string } } | null;
+      return {
+        ok: false,
+        intent: "unpublish" as const,
+        error: err?.error?.message ?? "Could not unpublish the report. Please try again.",
+      };
+    }
+    return { ok: true, intent: "unpublish" as const, error: undefined };
+  }
+
   if (intent === "create-reinspection") {
     // #119 Task 6 — carry the checked baseline items forward into a new
     // re-inspection. The form submits one `selectedItemIds` value per checked
@@ -261,11 +329,32 @@ function humanizeStatus(status: string): string {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Report action matrix (pure — testable)                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Derive which report action buttons to render given the current user's
+ * capabilities, the report status, and the inspection lifecycle status.
+ * Returns an ordered array of action identifiers for the Report card.
+ */
+export function reportActions(
+  caps: { publish: boolean },
+  reportStatus: string,
+  inspectionStatus: string,
+): Array<'submit' | 'publish' | 'return' | 'unpublish'> {
+  if (inspectionStatus !== INSPECTION_STATUS.COMPLETED) return [];
+  if (reportStatus === REPORT_STATUS.PUBLISHED) return caps.publish ? ['unpublish'] : [];
+  if (reportStatus === REPORT_STATUS.SUBMITTED) return caps.publish ? ['publish', 'return'] : [];
+  // in_progress (or unknown)
+  return caps.publish ? ['publish'] : ['submit'];
+}
+
+/* ------------------------------------------------------------------ */
 /*  Page component                                                     */
 /* ------------------------------------------------------------------ */
 
 export default function InspectionHubPage() {
-  const { hub, smsConsent, reinspectCandidates } = useLoaderData<typeof loader>();
+  const { hub, smsConsent, reinspectCandidates, canPublishCap } = useLoaderData<typeof loader>();
   const { inspection, people, services, tenantSlug } = hub;
   const blocks = deriveBlockStates(hub);
   const navigate = useNavigate();
@@ -336,6 +425,14 @@ export default function InspectionHubPage() {
     }
   }, [publishModalOpen, publish.state, publish.data]);
 
+  // Submit / return / unpublish — dedicated fetchers (B-17: never share).
+  const submitReport = useFetcher<typeof action>();
+  const returnReport = useFetcher<typeof action>();
+  const unpublishReport = useFetcher<typeof action>();
+  const submittingReport = submitReport.state !== "idle";
+  const returningReport = returnReport.state !== "idle";
+  const unpublishingReport = unpublishReport.state !== "idle";
+
   // Create-re-inspection modal — its own dedicated fetcher (B-17). On success
   // the action returns the new inspection id; navigate to its hub (mirrors the
   // app's create-then-navigate flow). Only published baselines can re-inspect.
@@ -362,13 +459,18 @@ export default function InspectionHubPage() {
   }, [createReinspection.state, createReinspection.data, navigate]);
 
   // "View report" only makes sense once the report is shipped to the client.
-  const reportShipped =
-    inspection.status === "delivered" || inspection.status === "published";
+  const reportShipped = isReportPublished(inspection.reportStatus);
 
-  // Report card affordance (Task 9): active publish CTA vs disabled-with-blockers
-  // vs read-only-shipped.
+  // Report card affordance: active publish CTA vs read-only-shipped.
   const reportPublished = isReportShipped(hub);
   const publishReady = canPublish(hub);
+
+  // Report action matrix — what buttons to show in the Report card.
+  const reportActionList = reportActions(
+    { publish: canPublishCap },
+    inspection.reportStatus,
+    inspection.status,
+  );
 
   const servicesTotalCents = services.reduce((sum, s) => sum + s.priceCents, 0);
   const allAgents = [...people.buyerAgents, ...people.listingAgents];
@@ -631,7 +733,7 @@ export default function InspectionHubPage() {
               <p className="text-[12px] text-ih-fg-3 mb-3">
                 Report delivered to the client.
               </p>
-              {reportPublished && (
+              <div className="flex items-center gap-2 flex-wrap">
                 <Button
                   variant="secondary"
                   size="sm"
@@ -639,41 +741,79 @@ export default function InspectionHubPage() {
                 >
                   Create re-inspection
                 </Button>
+                {reportActionList.includes('unpublish') && (
+                  <unpublishReport.Form method="post">
+                    <input type="hidden" name="intent" value="unpublish" />
+                    <button
+                      type="submit"
+                      disabled={unpublishingReport}
+                      className="px-3 py-1.5 rounded-md border border-ih-border text-[12px] font-bold text-ih-fg-2 hover:bg-ih-bg-muted disabled:opacity-60"
+                    >
+                      {unpublishingReport ? "Unpublishing…" : "Unpublish"}
+                    </button>
+                  </unpublishReport.Form>
+                )}
+              </div>
+            </>
+          ) : reportActionList.length > 0 ? (
+            <>
+              {inspection.reportStatus === 'submitted' && (
+                <p className="text-[12px] text-ih-fg-3 mb-3">
+                  Report submitted for review.
+                </p>
               )}
-            </>
-          ) : publishReady ? (
-            <>
-              <p className="text-[12px] text-ih-fg-3 mb-3">
-                All required fields are complete.
-              </p>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setPublishModalOpen(true)}
-              >
-                Publish report
-              </Button>
-            </>
-          ) : !hub.publishReadiness.ready ? (
-            <>
-              <p className="text-[12px] text-ih-fg-3 mb-3">
-                {hub.publishReadiness.blockingCount} blocker(s) to resolve before publishing
-              </p>
-              <div className="flex items-center gap-3">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  disabled
-                  title="Resolve blockers first"
-                >
-                  Publish report
-                </Button>
-                <Link
-                  to={`/inspections/${inspection.id}/edit`}
-                  className="text-[12px] font-bold text-ih-primary hover:underline"
-                >
-                  Resolve in editor
-                </Link>
+              {inspection.reportStatus === 'in_progress' && hub.publishReadiness.ready && (
+                <p className="text-[12px] text-ih-fg-3 mb-3">
+                  All required fields are complete.
+                </p>
+              )}
+              {inspection.reportStatus === 'in_progress' && !hub.publishReadiness.ready && hub.publishReadiness.blockingCount > 0 && (
+                <p className="text-[12px] text-ih-fg-3 mb-3">
+                  {hub.publishReadiness.blockingCount} blocker(s) to resolve before publishing.
+                </p>
+              )}
+              <div className="flex items-center gap-2 flex-wrap">
+                {reportActionList.includes('publish') && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setPublishModalOpen(true)}
+                  >
+                    Publish report
+                  </Button>
+                )}
+                {reportActionList.includes('submit') && (
+                  <submitReport.Form method="post">
+                    <input type="hidden" name="intent" value="submit" />
+                    <button
+                      type="submit"
+                      disabled={submittingReport}
+                      className="px-3 py-1.5 rounded-md bg-ih-primary text-ih-fg-inverse text-[12px] font-bold hover:bg-ih-primary-600 disabled:opacity-60"
+                    >
+                      {submittingReport ? "Submitting…" : "Submit for review"}
+                    </button>
+                  </submitReport.Form>
+                )}
+                {reportActionList.includes('return') && (
+                  <returnReport.Form method="post">
+                    <input type="hidden" name="intent" value="return" />
+                    <button
+                      type="submit"
+                      disabled={returningReport}
+                      className="px-3 py-1.5 rounded-md border border-ih-border text-[12px] font-bold text-ih-fg-2 hover:bg-ih-bg-muted disabled:opacity-60"
+                    >
+                      {returningReport ? "Returning…" : "Return to inspector"}
+                    </button>
+                  </returnReport.Form>
+                )}
+                {inspection.reportStatus === 'in_progress' && !hub.publishReadiness.ready && hub.publishReadiness.blockingCount > 0 && (
+                  <Link
+                    to={`/inspections/${inspection.id}/edit`}
+                    className="text-[12px] font-bold text-ih-primary hover:underline"
+                  >
+                    Resolve in editor
+                  </Link>
+                )}
               </div>
             </>
           ) : (

--- a/app/routes/inspections.tsx
+++ b/app/routes/inspections.tsx
@@ -1,0 +1,135 @@
+import { useLoaderData, Link } from 'react-router';
+import { requireToken } from '~/lib/session.server';
+import { createApi } from '~/lib/api-client.server';
+import { INSPECTION_STATUSES, INSPECTION_STATUS_LABELS, isReportPublished } from '~/lib/status';
+import { deriveInspectionPill, deriveReportPill } from '~/lib/hub-blocks';
+import { PageHeader, Card, Pill, EmptyState } from '@core/shared-ui';
+import { formatInspectionDateTime } from '~/lib/format-date';
+
+export function meta() {
+  return [{ title: 'Inspections - OpenInspection' }];
+}
+
+// Row type — matches what dashboard buckets return (both axes now present)
+interface InspectionRow {
+  id: string;
+  date: string | null;
+  address?: string | null;
+  propertyAddress?: string | null;
+  clientName: string | null;
+  status: string;
+  reportStatus?: string;
+}
+
+/** Group rows by inspection lifecycle status, in canonical order, non-empty only. */
+export function groupByInspectionStatus<T extends { status: string }>(
+  rows: T[]
+): Array<{ status: string; label: string; items: T[] }> {
+  const map = new Map<string, T[]>();
+  for (const status of INSPECTION_STATUSES) map.set(status, []);
+  for (const row of rows) {
+    const bucket = map.get(row.status);
+    if (bucket) bucket.push(row);
+    // unknown statuses are silently dropped
+  }
+  return Array.from(map.entries())
+    .filter(([, items]) => items.length > 0)
+    .map(([status, items]) => ({
+      status,
+      label: INSPECTION_STATUS_LABELS[status as keyof typeof INSPECTION_STATUS_LABELS] ?? status,
+      items,
+    }));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function loader({ request, context }: { request: Request; context: any }) {
+  const token = await requireToken(context, request);
+  const api = createApi(context, { token });
+  const res = await api.inspections.dashboard.$get().catch(() => null);
+  let inspections: InspectionRow[] = [];
+  if (res && res.ok) {
+    const body = (await res.json() as unknown) as { data?: Record<string, unknown[]> };
+    const d = body.data ?? {};
+    const seen = new Set<string>();
+    for (const items of Object.values(d)) {
+      if (!Array.isArray(items)) continue;
+      for (const i of items as InspectionRow[]) {
+        if (i && i.id && !seen.has(i.id)) {
+          seen.add(i.id);
+          inspections.push(i);
+        }
+      }
+    }
+  }
+  return { inspections };
+}
+
+export default function InspectionsPage() {
+  const { inspections } = useLoaderData<typeof loader>();
+  const groups = groupByInspectionStatus(inspections);
+
+  return (
+    <div className="max-w-[1080px] mx-auto pt-5 pb-[60px] px-9 space-y-[18px]">
+      <PageHeader
+        eyebrow="INSPECTIONS"
+        eyebrowColor="indigo"
+        title="All Inspections"
+        meta={<>{inspections.length} total</>}
+      />
+
+      {groups.length === 0 ? (
+        <Card>
+          <EmptyState title="No inspections" description="No inspections yet." />
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <Card key={group.status} className="overflow-hidden">
+              <div className="px-4 py-3 border-b border-ih-border flex items-center gap-3">
+                <Pill tone={deriveInspectionPill(group.status).tone}>
+                  {group.label}
+                </Pill>
+                <span className="text-[11px] text-ih-fg-4">{group.items.length}</span>
+              </div>
+              <div className="divide-y divide-ih-border">
+                {group.items.map((insp) => (
+                  <Link
+                    key={insp.id}
+                    to={`/inspections/${insp.id}`}
+                    className="flex items-center justify-between px-4 py-3 hover:bg-ih-bg-muted transition-colors"
+                  >
+                    <div>
+                      <p className="text-[13px] font-medium text-ih-fg-1">
+                        {insp.address || insp.propertyAddress || 'No address'}
+                      </p>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        {insp.clientName && (
+                          <span className="text-[11px] text-ih-fg-3">{insp.clientName}</span>
+                        )}
+                        {insp.date && (
+                          <span className="text-[11px] text-ih-fg-3">
+                            &middot; {formatInspectionDateTime(insp.date)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0 ml-4">
+                      <Pill tone={deriveInspectionPill(insp.status).tone}>
+                        {INSPECTION_STATUS_LABELS[insp.status as keyof typeof INSPECTION_STATUS_LABELS] ?? insp.status}
+                      </Pill>
+                      {insp.reportStatus && (
+                        <Pill tone={deriveReportPill(insp.reportStatus).tone}>
+                          {deriveReportPill(insp.reportStatus).label}
+                        </Pill>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/routes/inspections.tsx
+++ b/app/routes/inspections.tsx
@@ -1,7 +1,7 @@
 import { useLoaderData, Link } from 'react-router';
 import { requireToken } from '~/lib/session.server';
 import { createApi } from '~/lib/api-client.server';
-import { INSPECTION_STATUSES, INSPECTION_STATUS_LABELS, isReportPublished } from '~/lib/status';
+import { INSPECTION_STATUSES, INSPECTION_STATUS_LABELS } from '~/lib/status';
 import { deriveInspectionPill, deriveReportPill } from '~/lib/hub-blocks';
 import { PageHeader, Card, Pill, EmptyState } from '@core/shared-ui';
 import { formatInspectionDateTime } from '~/lib/format-date';
@@ -46,7 +46,7 @@ export async function loader({ request, context }: { request: Request; context: 
   const token = await requireToken(context, request);
   const api = createApi(context, { token });
   const res = await api.inspections.dashboard.$get().catch(() => null);
-  let inspections: InspectionRow[] = [];
+  const inspections: InspectionRow[] = [];
   if (res && res.ok) {
     const body = (await res.json() as unknown) as { data?: Record<string, unknown[]> };
     const d = body.data ?? {};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,28 @@ export default tseslint.config(
                     selector: "Literal[value=/^(owner|admin|manager|inspector|agent)$/]:not(CallExpression[callee.name='requireRole'] > Literal)",
                     message: 'Use ROLES / Role from server/lib/auth/roles.ts — no bare role string literals.',
                 },
+                // Status taxonomy guard — inspection status literals must derive from
+                // INSPECTION_STATUS / REPORT_STATUS in server/lib/status/*.ts.
+                // Narrowly targets only the values that are unambiguous in this codebase:
+                //   'requested'  — only an InspectionStatus value (lifecycle axis)
+                //   'submitted'  — only a ReportStatus value (report deliverable axis)
+                // Values NOT banned because they collide with other enums:
+                //   'draft'      — invoice status ('draft'|'sent'|'paid'|'partial')
+                //   'published'  — sync outbox status + automation trigger names
+                //   'completed'  — could be used in other enums
+                //   'cancelled'  — broad usage
+                //   'scheduled'  — booking/concierge status
+                //   'confirmed'  — booking/concierge status
+                //   'in_progress' — collision: inspection_requests table status +
+                //                   dashboard filter tab IDs + report-status
+                // All legit uses of 'requested' and 'submitted' live in files already
+                // covered by the override block below (server/lib/**, server/api/**,
+                // server/services/**, app/**), so this guard only fires on NEW code
+                // outside those zones — keeping it forward-looking with zero current noise.
+                {
+                    selector: "Literal[value=/^(requested|submitted)$/]",
+                    message: 'Use INSPECTION_STATUS / REPORT_STATUS from server/lib/status/* — no bare status literals.',
+                },
             ],
         },
     },

--- a/migrations/0007_status_split.sql
+++ b/migrations/0007_status_split.sql
@@ -1,0 +1,13 @@
+-- Additive only. The `status` enum change is type-layer (SQLite does not enforce
+-- enums) and the `status` DB-level default is intentionally left unchanged to
+-- AVOID a full table rebuild — `inspections` is FK-referenced and D1 cannot
+-- rebuild FK-referenced tables on remote (no PRAGMA foreign_keys=OFF outside a
+-- transaction). The resulting `status` default drift in `db:check` is accepted
+-- (same class as the pre-existing users.role default drift; db:check is not a
+-- deploy gate). New rows get 'requested' via the drizzle schema default.
+ALTER TABLE `inspections` ADD COLUMN `report_status` text DEFAULT 'in_progress' NOT NULL;--> statement-breakpoint
+-- Backfill report axis from the old conflated status.
+UPDATE inspections SET report_status = 'published' WHERE status IN ('delivered', 'published');--> statement-breakpoint
+-- Remap lifecycle axis to the 5-value set.
+UPDATE inspections SET status = 'completed' WHERE status IN ('delivered', 'published', 'in_progress');--> statement-breakpoint
+UPDATE inspections SET status = 'requested' WHERE status = 'draft';

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,0 +1,7825 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9546b0d6-971d-41c8-b4bb-59084a81a9f0",
+  "prevId": "6cfce7ec-f25e-418f-ab33-35dd1e338f47",
+  "tables": {
+    "agreement_requests": {
+      "name": "agreement_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "signature_base64": {
+          "name": "signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_signature_base64": {
+          "name": "inspector_signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_signed_at": {
+          "name": "inspector_signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_user_id": {
+          "name": "inspector_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_policy": {
+          "name": "completion_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agreement_requests_token_unique": {
+          "name": "agreement_requests_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_agreement_requests_verify_token": {
+          "name": "idx_agreement_requests_verify_token",
+          "columns": [
+            "verification_token"
+          ],
+          "isUnique": true
+        },
+        "idx_agreement_requests_tenant": {
+          "name": "idx_agreement_requests_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agreement_requests_inspection": {
+          "name": "idx_agreement_requests_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agreement_requests_token_hash": {
+          "name": "idx_agreement_requests_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agreement_requests_tenant_id_tenants_id_fk": {
+          "name": "agreement_requests_tenant_id_tenants_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agreement_requests_inspection_id_inspections_id_fk": {
+          "name": "agreement_requests_inspection_id_inspections_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agreement_requests_agreement_id_agreements_id_fk": {
+          "name": "agreement_requests_agreement_id_agreements_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "agreements",
+          "columnsFrom": [
+            "agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agreement_requests_inspector_user_id_users_id_fk": {
+          "name": "agreement_requests_inspector_user_id_users_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agreement_signers": {
+      "name": "agreement_signers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'client'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "signature_base64": {
+          "name": "signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "on_behalf_of": {
+          "name": "on_behalf_of",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "on_behalf_disclaimer": {
+          "name": "on_behalf_disclaimer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminded_at": {
+          "name": "last_reminded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agreement_signers_tenant_request": {
+          "name": "idx_agreement_signers_tenant_request",
+          "columns": [
+            "tenant_id",
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agreement_signers_request_email": {
+          "name": "idx_agreement_signers_request_email",
+          "columns": [
+            "request_id",
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_agreement_signers_token_hash": {
+          "name": "idx_agreement_signers_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agreements": {
+      "name": "agreements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agreements_tenant": {
+          "name": "idx_agreements_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agreements_tenant_id_tenants_id_fk": {
+          "name": "agreements_tenant_id_tenants_id_fk",
+          "tableFrom": "agreements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_logs": {
+      "name": "automation_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "send_at": {
+          "name": "send_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_automation_logs_pending": {
+          "name": "idx_automation_logs_pending",
+          "columns": [
+            "tenant_id",
+            "status",
+            "send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_automation_logs_insp": {
+          "name": "idx_automation_logs_insp",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "uq_automation_logs_event": {
+          "name": "uq_automation_logs_event",
+          "columns": [
+            "automation_id",
+            "inspection_id",
+            "event_id"
+          ],
+          "isUnique": true,
+          "where": "event_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "automation_logs_tenant_id_tenants_id_fk": {
+          "name": "automation_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "automation_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_minutes": {
+          "name": "delay_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_template": {
+          "name": "body_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channels": {
+          "name": "channels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"email\"]'"
+        },
+        "sms_body": {
+          "name": "sms_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_automations_tenant": {
+          "name": "idx_automations_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_tenant_id_tenants_id_fk": {
+          "name": "automations_tenant_id_tenants_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "availability": {
+      "name": "availability",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_availability_inspector": {
+          "name": "idx_availability_inspector",
+          "columns": [
+            "inspector_id"
+          ],
+          "isUnique": false
+        },
+        "idx_availability_window_unique": {
+          "name": "idx_availability_window_unique",
+          "columns": [
+            "inspector_id",
+            "day_of_week",
+            "start_time"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "availability_tenant_id_tenants_id_fk": {
+          "name": "availability_tenant_id_tenants_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_inspector_id_users_id_fk": {
+          "name": "availability_inspector_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "availability_overrides": {
+      "name": "availability_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_avail_overrides_insp": {
+          "name": "idx_avail_overrides_insp",
+          "columns": [
+            "inspector_id"
+          ],
+          "isUnique": false
+        },
+        "idx_avail_overrides_block_unique": {
+          "name": "idx_avail_overrides_block_unique",
+          "columns": [
+            "inspector_id",
+            "date"
+          ],
+          "isUnique": true,
+          "where": "is_available = 0"
+        }
+      },
+      "foreignKeys": {
+        "availability_overrides_tenant_id_tenants_id_fk": {
+          "name": "availability_overrides_tenant_id_tenants_id_fk",
+          "tableFrom": "availability_overrides",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_overrides_inspector_id_users_id_fk": {
+          "name": "availability_overrides_inspector_id_users_id_fk",
+          "tableFrom": "availability_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_usage": {
+      "name": "comment_usage",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_comment_usage_user_last_used": {
+          "name": "idx_comment_usage_user_last_used",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_usage_comment_id_comments_id_fk": {
+          "name": "comment_usage_comment_id_comments_id_fk",
+          "tableFrom": "comment_usage",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_usage_tenant_id_user_id_comment_id_pk": {
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "comment_id"
+          ],
+          "name": "comment_usage_tenant_id_user_id_comment_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating_bucket": {
+          "name": "rating_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_ids": {
+          "name": "section_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_labels": {
+          "name": "item_labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_code": {
+          "name": "trigger_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_keywords": {
+          "name": "search_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_label": {
+          "name": "item_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_summary": {
+          "name": "repair_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_min_cents": {
+          "name": "estimate_min_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_max_cents": {
+          "name": "estimate_max_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recommended_contractor_type_id": {
+          "name": "recommended_contractor_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_comments_tenant": {
+          "name": "idx_comments_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_comments_rating_bucket": {
+          "name": "idx_comments_rating_bucket",
+          "columns": [
+            "tenant_id",
+            "rating_bucket"
+          ],
+          "isUnique": false
+        },
+        "idx_comments_library_id": {
+          "name": "idx_comments_library_id",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_tenant_id_tenants_id_fk": {
+          "name": "comments_tenant_id_tenants_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "commercial_subtypes": {
+      "name": "commercial_subtypes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_commercial_subtypes_tenant_name": {
+          "name": "idx_commercial_subtypes_tenant_name",
+          "columns": [
+            "tenant_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "commercial_subtypes_tenant_id_tenants_id_fk": {
+          "name": "commercial_subtypes_tenant_id_tenants_id_fk",
+          "tableFrom": "commercial_subtypes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "concierge_confirm_tokens": {
+      "name": "concierge_confirm_tokens",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_concierge_tokens_expiry": {
+          "name": "idx_concierge_tokens_expiry",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_concierge_confirm_token_hash": {
+          "name": "idx_concierge_confirm_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "concierge_confirm_tokens_inspection_id_inspections_id_fk": {
+          "name": "concierge_confirm_tokens_inspection_id_inspections_id_fk",
+          "tableFrom": "concierge_confirm_tokens",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'client'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contacts_type": {
+          "name": "idx_contacts_type",
+          "columns": [
+            "tenant_id",
+            "type"
+          ],
+          "isUnique": false
+        },
+        "idx_contacts_tenant": {
+          "name": "idx_contacts_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "uq_contacts_tenant_email": {
+          "name": "uq_contacts_tenant_email",
+          "columns": [
+            "tenant_id",
+            "email"
+          ],
+          "isUnique": true,
+          "where": "email IS NOT NULL AND archived_at IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "contacts_tenant_id_tenants_id_fk": {
+          "name": "contacts_tenant_id_tenants_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contractor_types": {
+      "name": "contractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contractor_types_tenant": {
+          "name": "idx_contractor_types_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "customer_messages": {
+      "name": "customer_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_role": {
+          "name": "from_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_msg_inspection": {
+          "name": "idx_msg_inspection",
+          "columns": [
+            "inspection_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_msg_unread": {
+          "name": "idx_msg_unread",
+          "columns": [
+            "tenant_id",
+            "inspection_id",
+            "from_role"
+          ],
+          "isUnique": false,
+          "where": "\"customer_messages\".\"read_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "customer_messages_tenant_id_tenants_id_fk": {
+          "name": "customer_messages_tenant_id_tenants_id_fk",
+          "tableFrom": "customer_messages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_messages_inspection_id_inspections_id_fk": {
+          "name": "customer_messages_inspection_id_inspections_id_fk",
+          "tableFrom": "customer_messages",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discount_codes": {
+      "name": "discount_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discount_codes_tenant": {
+          "name": "idx_discount_codes_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "discount_codes_code_tenant": {
+          "name": "discount_codes_code_tenant",
+          "columns": [
+            "upper(code)",
+            "tenant_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "discount_codes_tenant_id_tenants_id_fk": {
+          "name": "discount_codes_tenant_id_tenants_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "erasure_log": {
+      "name": "erasure_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_basis": {
+          "name": "identity_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decisions_json": {
+          "name": "decisions_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retained_count": {
+          "name": "retained_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "anonymized_count": {
+          "name": "anonymized_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deleted_count": {
+          "name": "deleted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_note": {
+          "name": "response_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_erasure_log_tenant": {
+          "name": "idx_erasure_log_tenant",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "esign_audit_logs": {
+      "name": "esign_audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prev_hash": {
+          "name": "prev_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_fingerprint": {
+          "name": "key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_esign_audit_logs_request": {
+          "name": "idx_esign_audit_logs_request",
+          "columns": [
+            "tenant_id",
+            "request_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_esign_audit_logs_event_dedup": {
+          "name": "idx_esign_audit_logs_event_dedup",
+          "columns": [
+            "tenant_id",
+            "request_id",
+            "event"
+          ],
+          "isUnique": true,
+          "where": "event NOT LIKE 'signer.%'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_types": {
+      "name": "event_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_duration_min": {
+          "name": "default_duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "default_price_cents": {
+          "name": "default_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#6366f1'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_types_tenant_slug_idx": {
+          "name": "event_types_tenant_slug_idx",
+          "columns": [
+            "tenant_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "event_types_tenant_id_tenants_id_fk": {
+          "name": "event_types_tenant_id_tenants_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_access_tokens": {
+      "name": "inspection_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'client'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_iat_token": {
+          "name": "idx_iat_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_iat_inspection": {
+          "name": "idx_iat_inspection",
+          "columns": [
+            "tenant_id",
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_iat_recipient": {
+          "name": "idx_iat_recipient",
+          "columns": [
+            "inspection_id",
+            "recipient_email"
+          ],
+          "isUnique": true
+        },
+        "idx_iat_token_hash": {
+          "name": "idx_iat_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_access_tokens_tenant_id_tenants_id_fk": {
+          "name": "inspection_access_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_access_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_agreements": {
+      "name": "inspection_agreements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signature_base64": {
+          "name": "signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_insp_agreements_tenant": {
+          "name": "idx_insp_agreements_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_insp_agreements_insp": {
+          "name": "idx_insp_agreements_insp",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_agreements_tenant_id_tenants_id_fk": {
+          "name": "inspection_agreements_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_agreements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_agreements_inspection_id_inspections_id_fk": {
+          "name": "inspection_agreements_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_agreements",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_conflicts": {
+      "name": "inspection_conflicts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base": {
+          "name": "base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local": {
+          "name": "local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_conflicts_inspection": {
+          "name": "idx_inspection_conflicts_inspection",
+          "columns": [
+            "inspection_id",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_events": {
+      "name": "inspection_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results_received_at": {
+          "name": "results_received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gcal_event_id": {
+          "name": "gcal_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inspection_events_scheduled_idx": {
+          "name": "inspection_events_scheduled_idx",
+          "columns": [
+            "tenant_id",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "inspection_events_inspection_idx": {
+          "name": "inspection_events_inspection_idx",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_events_tenant_id_tenants_id_fk": {
+          "name": "inspection_events_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_events_inspection_id_inspections_id_fk": {
+          "name": "inspection_events_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspection_events_event_type_id_event_types_id_fk": {
+          "name": "inspection_events_event_type_id_event_types_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_events_inspector_id_users_id_fk": {
+          "name": "inspection_events_inspector_id_users_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_inspectors": {
+      "name": "inspection_inspectors",
+      "columns": {
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lead'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_insp_inspectors_tenant_user": {
+          "name": "idx_insp_inspectors_tenant_user",
+          "columns": [
+            "tenant_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_insp_inspectors_user": {
+          "name": "idx_insp_inspectors_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inspection_inspectors_inspection_id_user_id_pk": {
+          "columns": [
+            "inspection_id",
+            "user_id"
+          ],
+          "name": "inspection_inspectors_inspection_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_item_tag_links": {
+      "name": "inspection_item_tag_links",
+      "columns": {
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tag_links_tenant": {
+          "name": "idx_tag_links_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tag_links_tag": {
+          "name": "idx_tag_links_tag",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tag_links_inspection_item": {
+          "name": "idx_tag_links_inspection_item",
+          "columns": [
+            "inspection_id",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inspection_item_tag_links_inspection_id_item_id_tag_id_pk": {
+          "columns": [
+            "inspection_id",
+            "item_id",
+            "tag_id"
+          ],
+          "name": "inspection_item_tag_links_inspection_id_item_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_media_pool": {
+      "name": "inspection_media_pool",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_pool_tenant": {
+          "name": "idx_media_pool_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_media_pool_inspection": {
+          "name": "idx_media_pool_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_requests": {
+      "name": "inspection_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_phone": {
+          "name": "client_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_address": {
+          "name": "property_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_city": {
+          "name": "property_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_state": {
+          "name": "property_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_zip": {
+          "name": "property_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unpaid'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_requests_tenant": {
+          "name": "idx_inspection_requests_tenant",
+          "columns": [
+            "tenant_id",
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_inspection_requests_email": {
+          "name": "idx_inspection_requests_email",
+          "columns": [
+            "tenant_id",
+            "client_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_requests_tenant_id_tenants_id_fk": {
+          "name": "inspection_requests_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_requests",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_results": {
+      "name": "inspection_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_system_id": {
+          "name": "rating_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating_system_snapshot": {
+          "name": "rating_system_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_results_tenant": {
+          "name": "idx_results_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_results_inspection": {
+          "name": "idx_results_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "uq_results_inspection": {
+          "name": "uq_results_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_results_tenant_id_tenants_id_fk": {
+          "name": "inspection_results_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_results",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_results_inspection_id_inspections_id_fk": {
+          "name": "inspection_results_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_results",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_services": {
+      "name": "inspection_services",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_override_cents": {
+          "name": "price_override_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_snapshot": {
+          "name": "name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_snapshot_cents": {
+          "name": "price_snapshot_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_insp_services_tenant": {
+          "name": "idx_insp_services_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_insp_services_insp": {
+          "name": "idx_insp_services_insp",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_services_tenant_id_tenants_id_fk": {
+          "name": "inspection_services_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_services",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_services_inspection_id_inspections_id_fk": {
+          "name": "inspection_services_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_services",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspection_services_service_id_services_id_fk": {
+          "name": "inspection_services_service_id_services_id_fk",
+          "tableFrom": "inspection_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_units": {
+      "name": "inspection_units",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_unit_id": {
+          "name": "parent_unit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unit'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "inspection_units_tenant_inspection_idx": {
+          "name": "inspection_units_tenant_inspection_idx",
+          "columns": [
+            "tenant_id",
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "inspection_units_parent_idx": {
+          "name": "inspection_units_parent_idx",
+          "columns": [
+            "parent_unit_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspections": {
+      "name": "inspections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_address": {
+          "name": "property_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_place_id": {
+          "name": "address_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_county": {
+          "name": "address_county",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_lat": {
+          "name": "address_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_lng": {
+          "name": "address_lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_geocoded_at": {
+          "name": "address_geocoded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_contact_id": {
+          "name": "client_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_phone": {
+          "name": "client_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'requested'"
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unpaid'"
+        },
+        "referred_by_agent_id": {
+          "name": "referred_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_notes": {
+          "name": "cancel_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_required": {
+          "name": "payment_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "agreement_required": {
+          "name": "agreement_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_sign_on_publish": {
+          "name": "auto_sign_on_publish",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "discount_code_id": {
+          "name": "discount_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount_cents": {
+          "name": "discount_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "closing_date": {
+          "name": "closing_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sqft": {
+          "name": "sqft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "foundation_type": {
+          "name": "foundation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_facts": {
+          "name": "property_facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_photo_id": {
+          "name": "cover_photo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_crop": {
+          "name": "cover_crop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image_key": {
+          "name": "cover_image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_subtype": {
+          "name": "commercial_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "county": {
+          "name": "county",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selling_agent_id": {
+          "name": "selling_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_automations": {
+          "name": "disable_automations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "message_token": {
+          "name": "message_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_snapshot": {
+          "name": "template_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_snapshot_version": {
+          "name": "template_snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "report_theme_override": {
+          "name": "report_theme_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_defect_fields_override": {
+          "name": "require_defect_fields_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concierge_status": {
+          "name": "concierge_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_mode": {
+          "name": "team_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "lead_inspector_id": {
+          "name": "lead_inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "helper_inspector_ids": {
+          "name": "helper_inspector_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "data_version": {
+          "name": "data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "source_inspection_id": {
+          "name": "source_inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_inspection_id": {
+          "name": "root_inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reinspection_round": {
+          "name": "reinspection_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspections_msg_token": {
+          "name": "idx_inspections_msg_token",
+          "columns": [
+            "message_token"
+          ],
+          "isUnique": true
+        },
+        "idx_inspections_tenant": {
+          "name": "idx_inspections_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_request": {
+          "name": "idx_inspections_request",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_inspector": {
+          "name": "idx_inspections_inspector",
+          "columns": [
+            "inspector_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_agent": {
+          "name": "idx_inspections_agent",
+          "columns": [
+            "referred_by_agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_tenant_status": {
+          "name": "idx_inspections_tenant_status",
+          "columns": [
+            "tenant_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_tenant_date": {
+          "name": "idx_inspections_tenant_date",
+          "columns": [
+            "tenant_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_tenant_client_email": {
+          "name": "idx_inspections_tenant_client_email",
+          "columns": [
+            "tenant_id",
+            "client_email"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_inspector_date": {
+          "name": "idx_inspections_inspector_date",
+          "columns": [
+            "inspector_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_root": {
+          "name": "idx_inspections_root",
+          "columns": [
+            "root_inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspections_tenant_id_tenants_id_fk": {
+          "name": "inspections_tenant_id_tenants_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_inspector_id_users_id_fk": {
+          "name": "inspections_inspector_id_users_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_template_id_templates_id_fk": {
+          "name": "inspections_template_id_templates_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_discount_code_id_discount_codes_id_fk": {
+          "name": "inspections_discount_code_id_discount_codes_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "discount_codes",
+          "columnsFrom": [
+            "discount_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_selling_agent_id_contacts_id_fk": {
+          "name": "inspections_selling_agent_id_contacts_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "selling_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_request_id_inspection_requests_id_fk": {
+          "name": "inspections_request_id_inspection_requests_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "inspection_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "line_items": {
+          "name": "line_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "partial_paid_at": {
+          "name": "partial_paid_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qbo_sync_status": {
+          "name": "qbo_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_invoices_tenant": {
+          "name": "idx_invoices_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_inspection": {
+          "name": "idx_invoices_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_contact": {
+          "name": "idx_invoices_contact",
+          "columns": [
+            "tenant_id",
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invoices_tenant_id_tenants_id_fk": {
+          "name": "invoices_tenant_id_tenants_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_inspection_id_inspections_id_fk": {
+          "name": "invoices_inspection_id_inspections_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_contact_id_contacts_id_fk": {
+          "name": "invoices_contact_id_contacts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "marketplace_libraries": {
+      "name": "marketplace_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "semver": {
+          "name": "semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_marketplace_libraries_kind_featured": {
+          "name": "idx_marketplace_libraries_kind_featured",
+          "columns": [
+            "kind",
+            "featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "marketplace_templates": {
+      "name": "marketplace_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "semver": {
+          "name": "semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "observer_links": {
+      "name": "observer_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "observer_links_token_unique": {
+          "name": "observer_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "observer_links_inspection_idx": {
+          "name": "observer_links_inspection_idx",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_observer_links_token_hash": {
+          "name": "idx_observer_links_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "qbo_connections": {
+      "name": "qbo_connections",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_enabled": {
+          "name": "sync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "default_item_id": {
+          "name": "default_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "qbo_entity_map": {
+      "name": "qbo_entity_map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_type": {
+          "name": "oi_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_id": {
+          "name": "oi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qbo_type": {
+          "name": "qbo_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qbo_id": {
+          "name": "qbo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qbo_sync_token": {
+          "name": "qbo_sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_qbo_entity_map_qbo": {
+          "name": "idx_qbo_entity_map_qbo",
+          "columns": [
+            "tenant_id",
+            "qbo_type",
+            "qbo_id"
+          ],
+          "isUnique": true
+        },
+        "idx_qbo_entity_map_oi": {
+          "name": "idx_qbo_entity_map_oi",
+          "columns": [
+            "tenant_id",
+            "oi_type",
+            "oi_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "qbo_sync_errors": {
+      "name": "qbo_sync_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_type": {
+          "name": "oi_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_id": {
+          "name": "oi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rating_systems": {
+      "name": "rating_systems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "levels": {
+          "name": "levels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rating_systems_tenant_slug": {
+          "name": "idx_rating_systems_tenant_slug",
+          "columns": [
+            "tenant_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_rating_systems_tenant": {
+          "name": "idx_rating_systems_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rating_systems_tenant_id_tenants_id_fk": {
+          "name": "rating_systems_tenant_id_tenants_id_fk",
+          "tableFrom": "rating_systems",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_pdfs": {
+      "name": "report_pdfs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rendered_at": {
+          "name": "rendered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_report_pdfs_inspection_type": {
+          "name": "uq_report_pdfs_inspection_type",
+          "columns": [
+            "inspection_id",
+            "type",
+            "version_number"
+          ],
+          "isUnique": true
+        },
+        "idx_report_pdfs_tenant": {
+          "name": "idx_report_pdfs_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_report_pdfs_status": {
+          "name": "idx_report_pdfs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_report_pdfs_content_hash": {
+          "name": "idx_report_pdfs_content_hash",
+          "columns": [
+            "inspection_id",
+            "type",
+            "content_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "report_pdfs_tenant_id_tenants_id_fk": {
+          "name": "report_pdfs_tenant_id_tenants_id_fk",
+          "tableFrom": "report_pdfs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_versions": {
+      "name": "report_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prev_hash": {
+          "name": "prev_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_fingerprint": {
+          "name": "key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_amendment": {
+          "name": "is_amendment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "report_versions_inspection_idx": {
+          "name": "report_versions_inspection_idx",
+          "columns": [
+            "inspection_id",
+            "version_number"
+          ],
+          "isUnique": false
+        },
+        "report_versions_inspection_version_unique": {
+          "name": "report_versions_inspection_version_unique",
+          "columns": [
+            "inspection_id",
+            "version_number"
+          ],
+          "isUnique": true
+        },
+        "idx_report_versions_verify_token": {
+          "name": "idx_report_versions_verify_token",
+          "columns": [
+            "verification_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_inspectors": {
+      "name": "service_inspectors",
+      "columns": {
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_service_inspectors_tenant": {
+          "name": "idx_service_inspectors_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "service_inspectors_service_id_user_id_pk": {
+          "columns": [
+            "service_id",
+            "user_id"
+          ],
+          "name": "service_inspectors_service_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_services_tenant": {
+          "name": "idx_services_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "services_tenant_id_tenants_id_fk": {
+          "name": "services_tenant_id_tenants_id_fk",
+          "tableFrom": "services",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_template_id_templates_id_fk": {
+          "name": "services_template_id_templates_id_fk",
+          "tableFrom": "services",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_agreement_id_agreements_id_fk": {
+          "name": "services_agreement_id_agreements_id_fk",
+          "tableFrom": "services",
+          "tableTo": "agreements",
+          "columnsFrom": [
+            "agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "signing_keys": {
+      "name": "signing_keys",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_enc": {
+          "name": "private_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_iv": {
+          "name": "private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Ed25519'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signing_keys_tenant_id_tenants_id_fk": {
+          "name": "signing_keys_tenant_id_tenants_id_fk",
+          "tableFrom": "signing_keys",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sms_consent_log": {
+      "name": "sms_consent_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_type": {
+          "name": "recipient_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_via": {
+          "name": "captured_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sms_consent_contact": {
+          "name": "idx_sms_consent_contact",
+          "columns": [
+            "tenant_id",
+            "contact_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sms_disclosure_versions": {
+      "name": "sms_disclosure_versions",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_tenant_name": {
+          "name": "idx_tags_tenant_name",
+          "columns": [
+            "tenant_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_tags_tenant": {
+          "name": "idx_tags_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "templates": {
+      "name": "templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_system_id": {
+          "name": "rating_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_subtype": {
+          "name": "commercial_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_templates_tenant": {
+          "name": "idx_templates_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_templates_rating_system": {
+          "name": "idx_templates_rating_system",
+          "columns": [
+            "rating_system_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "templates_tenant_id_tenants_id_fk": {
+          "name": "templates_tenant_id_tenants_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_library_imports": {
+      "name": "tenant_library_imports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_semver": {
+          "name": "imported_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_tenant_library_import": {
+          "name": "uq_tenant_library_import",
+          "columns": [
+            "tenant_id",
+            "library_id"
+          ],
+          "isUnique": true
+        },
+        "idx_tenant_library_imports_tenant": {
+          "name": "idx_tenant_library_imports_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_marketplace_import_history": {
+      "name": "tenant_marketplace_import_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_version": {
+          "name": "target_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rows_affected": {
+          "name": "rows_affected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_marketplace_history_tenant": {
+          "name": "idx_marketplace_history_tenant",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_marketplace_history_template": {
+          "name": "idx_marketplace_history_template",
+          "columns": [
+            "template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_marketplace_history_library": {
+          "name": "idx_marketplace_history_library",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_marketplace_imports": {
+      "name": "tenant_marketplace_imports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_template_id": {
+          "name": "marketplace_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_semver": {
+          "name": "imported_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_template_id": {
+          "name": "local_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mkt_imports_tmpl": {
+          "name": "idx_mkt_imports_tmpl",
+          "columns": [
+            "marketplace_template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mkt_imports_tenant": {
+          "name": "idx_mkt_imports_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tenant_marketplace_imports_marketplace_template_id_marketplace_templates_id_fk": {
+          "name": "tenant_marketplace_imports_marketplace_template_id_marketplace_templates_id_fk",
+          "tableFrom": "tenant_marketplace_imports",
+          "tableTo": "marketplace_templates",
+          "columnsFrom": [
+            "marketplace_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tenant_marketplace_imports_local_template_id_templates_id_fk": {
+          "name": "tenant_marketplace_imports_local_template_id_templates_id_fk",
+          "tableFrom": "tenant_marketplace_imports",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "local_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_counters": {
+      "name": "usage_counters",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_usage_counters_tenant": {
+          "name": "idx_usage_counters_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_counters_tenant_id_metric_period_key_pk": {
+          "columns": [
+            "tenant_id",
+            "metric",
+            "period_key"
+          ],
+          "name": "usage_counters_tenant_id_metric_period_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_identity_links": {
+      "name": "user_identity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_user_id": {
+          "name": "primary_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_tenant_id": {
+          "name": "linked_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_role": {
+          "name": "linked_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_display_name": {
+          "name": "linked_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "user_identity_links_primary_idx": {
+          "name": "user_identity_links_primary_idx",
+          "columns": [
+            "primary_user_id"
+          ],
+          "isUnique": false
+        },
+        "user_identity_links_primary_linked_unique": {
+          "name": "user_identity_links_primary_linked_unique",
+          "columns": [
+            "primary_user_id",
+            "linked_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_invites": {
+      "name": "agent_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_contact_id": {
+          "name": "inspector_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_invites_email": {
+          "name": "idx_agent_invites_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_invites_tenant": {
+          "name": "idx_agent_invites_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_invites_expiration": {
+          "name": "idx_agent_invites_expiration",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_invites_tenant_id_tenants_id_fk": {
+          "name": "agent_invites_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_invites",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_invites_invited_by_user_id_users_id_fk": {
+          "name": "agent_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "agent_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_tenant_links": {
+      "name": "agent_tenant_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_user_id": {
+          "name": "agent_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_contact_id": {
+          "name": "inspector_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_tenant_unique": {
+          "name": "idx_agent_tenant_unique",
+          "columns": [
+            "agent_user_id",
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "idx_agent_tenant_by_tenant": {
+          "name": "idx_agent_tenant_by_tenant",
+          "columns": [
+            "tenant_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_tenant_by_agent": {
+          "name": "idx_agent_tenant_by_agent",
+          "columns": [
+            "agent_user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_tenant_links_agent_user_id_users_id_fk": {
+          "name": "agent_tenant_links_agent_user_id_users_id_fk",
+          "tableFrom": "agent_tenant_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "agent_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_tenant_links_tenant_id_tenants_id_fk": {
+          "name": "agent_tenant_links_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tenant_links",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_slug": {
+          "name": "inspector_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_tenant_created": {
+          "name": "idx_audit_tenant_created",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_entity": {
+          "name": "idx_audit_entity",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_tenant_id_tenants_id_fk": {
+          "name": "audit_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_templates": {
+      "name": "email_templates",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_templates_tenant_id_tenants_id_fk": {
+          "name": "email_templates_tenant_id_tenants_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_templates_tenant_id_trigger_pk": {
+          "columns": [
+            "tenant_id",
+            "trigger"
+          ],
+          "name": "email_templates_tenant_id_trigger_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_tenant_user_created": {
+          "name": "idx_notifications_tenant_user_created",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_notifications_tenant_user_unread": {
+          "name": "idx_notifications_tenant_user_unread",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_tenant_id_tenants_id_fk": {
+          "name": "notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "parked_cmd_events": {
+      "name": "parked_cmd_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_parked_cmd_events_received_at": {
+          "name": "idx_parked_cmd_events_received_at",
+          "columns": [
+            "received_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_cmd_events": {
+      "name": "processed_cmd_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cmd_type": {
+          "name": "cmd_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slug_reservations": {
+      "name": "slug_reservations",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_outbox": {
+      "name": "sync_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_tried_at": {
+          "name": "last_tried_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sync_outbox_status_created": {
+          "name": "idx_sync_outbox_status_created",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_configs": {
+      "name": "tenant_configs",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_mode": {
+          "name": "email_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'platform'"
+        },
+        "sms_mode": {
+          "name": "sms_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'platform'"
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_inspector_from_name": {
+          "name": "use_inspector_from_name",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "point_of_contact": {
+          "name": "point_of_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'company'"
+        },
+        "billing_url": {
+          "name": "billing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "company_phone": {
+          "name": "company_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "integration_config": {
+          "name": "integration_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dek_enc": {
+          "name": "dek_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ics_token": {
+          "name": "ics_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "widget_allowed_origins": {
+          "name": "widget_allowed_origins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_theme": {
+          "name": "report_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'modern'"
+        },
+        "attention_thresholds": {
+          "name": "attention_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"agreement_unsigned_h\":72,\"invoice_overdue_h\":72,\"report_unpublished_h\":72}'"
+        },
+        "inspection_prefs": {
+          "name": "inspection_prefs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_estimates": {
+          "name": "show_estimates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_repair_list": {
+          "name": "enable_repair_list",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_customer_repair_export": {
+          "name": "enable_customer_repair_export",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "block_unpaid": {
+          "name": "block_unpaid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "block_unsigned_agreement": {
+          "name": "block_unsigned_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "custom_referral_sources": {
+          "name": "custom_referral_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dashboard_column_prefs": {
+          "name": "dashboard_column_prefs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concierge_review_required": {
+          "name": "concierge_review_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_inspector_choice": {
+          "name": "allow_inspector_choice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_pdf_pipeline": {
+          "name": "enable_pdf_pipeline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "team_mode_default": {
+          "name": "team_mode_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "apprentice_review_required": {
+          "name": "apprentice_review_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guest_invites_enabled": {
+          "name": "guest_invites_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_defect_fields": {
+          "name": "require_defect_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "agreement_retention_years": {
+          "name": "agreement_retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "reinspection_statuses": {
+          "name": "reinspection_statuses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_configs_tenant_id_tenants_id_fk": {
+          "name": "tenant_configs_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_configs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_destruction_records": {
+      "name": "tenant_destruction_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_slug": {
+          "name": "tenant_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rows_deleted": {
+          "name": "rows_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_objects": {
+          "name": "r2_objects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_bytes": {
+          "name": "r2_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kv_keys": {
+          "name": "kv_keys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_destruction_tenant": {
+          "name": "idx_destruction_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_destruction_destroyed_at": {
+          "name": "idx_destruction_destroyed_at",
+          "columns": [
+            "destroyed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_invites": {
+      "name": "tenant_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inspector'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_section_ids": {
+          "name": "assigned_section_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_overrides": {
+          "name": "permission_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_invites_tenant": {
+          "name": "idx_invites_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "uq_tenant_invites_pending_email": {
+          "name": "uq_tenant_invites_pending_email",
+          "columns": [
+            "tenant_id",
+            "email"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'"
+        }
+      },
+      "foreignKeys": {
+        "tenant_invites_tenant_id_tenants_id_fk": {
+          "name": "tenant_invites_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_invites",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenants": {
+      "name": "tenants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "stripe_connect_account_id": {
+          "name": "stripe_connect_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "max_users": {
+          "name": "max_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "deployment_mode": {
+          "name": "deployment_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "nachi_number": {
+          "name": "nachi_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_cmd_seq": {
+          "name": "applied_cmd_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "applied_cred_seq": {
+          "name": "applied_cred_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_signature_base64": {
+          "name": "default_signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signature_enabled": {
+          "name": "signature_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_areas": {
+          "name": "service_areas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manager'"
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_calendar_id": {
+          "name": "google_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_state": {
+          "name": "onboarding_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "totp_recovery_codes": {
+          "name": "totp_recovery_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_verified_at": {
+          "name": "totp_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_on_referral": {
+          "name": "notify_on_referral",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_on_report": {
+          "name": "notify_on_report",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_on_paid": {
+          "name": "notify_on_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_section_ids": {
+          "name": "assigned_section_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terms_accepted": {
+          "name": "terms_accepted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_overrides": {
+          "name": "permission_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "users_tenant_email_unique": {
+          "name": "users_tenant_email_unique",
+          "columns": [
+            "tenant_id",
+            "email"
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL"
+        },
+        "idx_users_tenant": {
+          "name": "idx_users_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_users_slug_per_tenant": {
+          "name": "idx_users_slug_per_tenant",
+          "columns": [
+            "tenant_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "discount_codes_code_tenant": {
+        "columns": {
+          "upper(code)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,48 +1,55 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1781346338558,
-      "tag": "0000_baseline",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1781358469141,
-      "tag": "0001_living_the_fury",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "6",
-      "when": 1781395951852,
-      "tag": "0002_classy_ben_grimm",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "6",
-      "when": 1781414719428,
-      "tag": "0004_report_pdf_content_hash",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "6",
-      "when": 1781428433108,
-      "tag": "0005_email_identity_and_signature",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "6",
-      "when": 1781445762726,
-      "tag": "0006_bent_gamma_corps",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1781346338558,
+			"tag": "0000_baseline",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1781358469141,
+			"tag": "0001_living_the_fury",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1781395951852,
+			"tag": "0002_classy_ben_grimm",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1781414719428,
+			"tag": "0004_report_pdf_content_hash",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1781428433108,
+			"tag": "0005_email_identity_and_signature",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1781445762726,
+			"tag": "0006_bent_gamma_corps",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "6",
+			"when": 1781483714892,
+			"tag": "0007_status_split",
+			"breakpoints": true
+		}
+	]
 }

--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -47,6 +47,7 @@ import { templates, agreements as agreementTable, agreements as agreementsTable,
 import { commentUsage } from '../lib/db/schema/inspection';
 import { withMcpMetadata } from "../lib/route-metadata-standards";
 import { syncInspectionAssignmentsBatch } from '../lib/db/assignment-links';
+import { INSPECTION_STATUS } from '../lib/status/inspection-status';
 import type { Context } from 'hono';
 import type { HonoConfig } from '../types/hono';
 
@@ -1421,7 +1422,7 @@ export const adminRoutes = createApiRouter()
         interface InspectionImport {
             id: string; propertyAddress: string; inspectorId?: string; clientName?: string;
             clientEmail?: string; templateId?: string; date?: string;
-            status?: 'draft' | 'scheduled' | 'confirmed' | 'in_progress' | 'completed' | 'delivered' | 'published' | 'cancelled';
+            status?: 'requested' | 'scheduled' | 'confirmed' | 'completed' | 'cancelled';
             paymentStatus?: 'unpaid' | 'partial' | 'paid'; price?: number; createdAt?: string
         }
         interface ResultImport { id: string; inspectionId: string; data: unknown; lastSyncedAt?: string }
@@ -1452,7 +1453,7 @@ export const adminRoutes = createApiRouter()
                 id: ins.id, tenantId, propertyAddress: ins.propertyAddress,
                 inspectorId: ins.inspectorId || null, clientName: ins.clientName || null,
                 clientEmail: ins.clientEmail || null, templateId: ins.templateId || null,
-                date: ins.date || new Date().toISOString(), status: ins.status || 'draft',
+                date: ins.date || new Date().toISOString(), status: ins.status || INSPECTION_STATUS.REQUESTED,
                 paymentStatus: ins.paymentStatus || 'unpaid', price: ins.price || 0,
                 createdAt: ins.createdAt ? new Date(ins.createdAt) : new Date(),
             }).onConflictDoNothing().run();

--- a/server/api/bookings.ts
+++ b/server/api/bookings.ts
@@ -18,6 +18,7 @@ import {
 import { withMcpMetadata } from "../lib/route-metadata-standards";
 import { syncInspectionAssignments } from '../lib/db/assignment-links';
 import { runEnvelopeCompletionPipeline } from '../lib/sign-effects';
+import { INSPECTION_STATUS } from '../lib/status/inspection-status';
 
 /**
  * GET /api/public/inspectors
@@ -664,7 +665,7 @@ export const bookingsRoutes = createApiRouter()
                 // bare `body.date` never marked the slot busy, so even
                 // sequential double-booking succeeded.
                 date: startIso,
-                status: 'draft',
+                status: INSPECTION_STATUS.REQUESTED,
                 paymentStatus: 'unpaid',
                 price: 0,
                 requestId: createdRequestId,

--- a/server/api/inspections-pdf-helpers.ts
+++ b/server/api/inspections-pdf-helpers.ts
@@ -1,12 +1,14 @@
 /**
- * Resolve the immutable archive version for a report download. Published/delivered
+ * Resolve the immutable archive version for a report download. Published
  * reports serve the latest published report_versions snapshot (rendered once,
  * cached forever — the #120 archive). Drafts (and any pre-publish status) return
  * null → the download renders on-demand keyed by the live dataVersion instead.
  */
+import { isReportPublished, type ReportStatus } from '../lib/status/report-status';
+
 export function resolveArchiveVersion(
-    status: string, versionsDesc: { versionNumber: number }[],
+    reportStatus: ReportStatus, versionsDesc: { versionNumber: number }[],
 ): number | null {
-    if (status === 'published' || status === 'delivered') return versionsDesc[0]?.versionNumber ?? null;
+    if (isReportPublished(reportStatus)) return versionsDesc[0]?.versionNumber ?? null;
     return null;
 }

--- a/server/api/inspections.ts
+++ b/server/api/inspections.ts
@@ -2606,7 +2606,7 @@ export const inspectionsRoutes = createApiRouter()
                 try {
                     const contentHash = await c.var.services.inspection.getReportContentHash(id, tenantId);
                     const versions = await c.var.services.reportVersion.list(tenantId, id);
-                    const versionNumber = resolveArchiveVersion(inspection.status, versions);
+                    const versionNumber = resolveArchiveVersion(inspection.reportStatus, versions);
                     const record = await c.var.services.reportPdf.getOrRender(id, tenantId, 'full', { reportUrl: renderUrl, contentHash, versionNumber });
                     const obj = await c.var.services.reportPdf.streamPdf(record);
                     if (!obj) throw new Error('PDF unavailable');
@@ -2670,7 +2670,7 @@ export const inspectionsRoutes = createApiRouter()
             // is unchanged, avoiding a redundant Browser Rendering call.
             const contentHash = await c.var.services.inspection.getReportContentHash(id, tenantId);
             const versions = await c.var.services.reportVersion.list(tenantId, id);
-            const versionNumber = resolveArchiveVersion(inspection.status, versions);
+            const versionNumber = resolveArchiveVersion(inspection.reportStatus, versions);
             const record = await c.var.services.reportPdf.getOrRender(id, tenantId, 'full', { reportUrl: renderUrl, contentHash, versionNumber });
             const obj = await c.var.services.reportPdf.streamPdf(record);
             if (!obj) throw new Error('PDF unavailable');
@@ -3047,8 +3047,8 @@ export const inspectionsRoutes = createApiRouter()
         // Tenant isolation: getInspection throws NotFound if cross-tenant.
         const { inspection } = await c.var.services.inspection.getInspection(id, tenantId);
         const versions = await c.var.services.reportVersion.list(tenantId, id);
-        // Published/delivered → immutable archive version (#120). Drafts → null → keyed on dataVersion.
-        const versionNumber = resolveArchiveVersion(inspection.status, versions);
+        // Published → immutable archive version (#120). Drafts → null → keyed on dataVersion.
+        const versionNumber = resolveArchiveVersion(inspection.reportStatus, versions);
         const tenantSlug = await resolveTenantSlug(c, tenantId);
         const reportUrl = await buildRenderReportUrl(getBookingHost(c), tenantSlug, id, c.env.JWT_SECRET);
         const contentHash = await c.var.services.inspection.getReportContentHash(id, tenantId);

--- a/server/api/inspections.ts
+++ b/server/api/inspections.ts
@@ -1495,7 +1495,7 @@ const publishRoute = createRoute(withMcpMetadata({
         200: {
             content: {
                 'application/json': {
-                    schema: createApiResponseSchema(z.object({ reportUrl: z.string().describe('TODO describe reportUrl field for the OpenInspection MCP integration'), status: z.string().describe('TODO describe status field for the OpenInspection MCP integration') })),
+                    schema: createApiResponseSchema(z.object({ reportUrl: z.string().describe('TODO describe reportUrl field for the OpenInspection MCP integration'), reportStatus: z.string().describe('TODO describe reportStatus field for the OpenInspection MCP integration') })),
                 },
             },
             description: 'Published',

--- a/server/api/inspections.ts
+++ b/server/api/inspections.ts
@@ -1470,6 +1470,83 @@ const sendAgreementRequestRoute = createRoute(withMcpMetadata({
 
 
 /**
+ * POST /api/inspections/:id/submit
+ * Submits a completed report for review (in_progress → submitted).
+ * Does NOT require the `publish` capability — any inspector/manager/owner can submit.
+ */
+const submitReportRoute = createRoute(withMcpMetadata({
+    method: 'post',
+    path: '/{id}/submit',
+    tags: ['inspections'],
+    summary: 'Submit report for review',
+    middleware: [requireRole('owner', 'manager', 'inspector')] as const,
+    request: {
+        params: z.object({ id: z.string().describe('Inspection id') }),
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: createApiResponseSchema(z.object({ reportStatus: z.string() })) } },
+            description: 'Report submitted for review',
+        },
+        400: { description: 'Invalid precondition (e.g. report already submitted, inspection not completed)' },
+    },
+    operationId: 'submitReport',
+    description: 'Transitions reportStatus from in_progress → submitted. Requires inspection.status === completed.',
+}, { scopes: ['write'], tier: 'extended' }));
+
+/**
+ * POST /api/inspections/:id/return
+ * Returns a submitted report to the inspector for revision (submitted → in_progress).
+ * Requires the `publish` capability (owner/manager by default; inspector only if not overridden).
+ */
+const returnReportRoute = createRoute(withMcpMetadata({
+    method: 'post',
+    path: '/{id}/return',
+    tags: ['inspections'],
+    summary: 'Return submitted report to inspector for revision',
+    middleware: [requireRole('owner', 'manager', 'inspector'), requireCapability('publish')] as const,
+    request: {
+        params: z.object({ id: z.string().describe('Inspection id') }),
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: createApiResponseSchema(z.object({ reportStatus: z.string() })) } },
+            description: 'Report returned to inspector',
+        },
+        400: { description: 'Invalid precondition (report is not in submitted state)' },
+        403: { description: 'Missing publish capability' },
+    },
+    operationId: 'returnReport',
+    description: 'Transitions reportStatus from submitted → in_progress. Requires publish capability.',
+}, { scopes: ['write'], tier: 'extended' }));
+
+/**
+ * POST /api/inspections/:id/unpublish
+ * Unpublishes a published report, reverting it to in_progress (published → in_progress).
+ * Requires the `publish` capability.
+ */
+const unpublishReportRoute = createRoute(withMcpMetadata({
+    method: 'post',
+    path: '/{id}/unpublish',
+    tags: ['inspections'],
+    summary: 'Unpublish a published report',
+    middleware: [requireRole('owner', 'manager', 'inspector'), requireCapability('publish')] as const,
+    request: {
+        params: z.object({ id: z.string().describe('Inspection id') }),
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: createApiResponseSchema(z.object({ reportStatus: z.string() })) } },
+            description: 'Report unpublished',
+        },
+        400: { description: 'Invalid precondition (report is not published)' },
+        403: { description: 'Missing publish capability' },
+    },
+    operationId: 'unpublishReport',
+    description: 'Transitions reportStatus from published → in_progress. Requires publish capability.',
+}, { scopes: ['write'], tier: 'extended' }));
+
+/**
  * POST /api/inspections/:id/publish
  */
 const publishRoute = createRoute(withMcpMetadata({
@@ -2956,6 +3033,36 @@ export const inspectionsRoutes = createApiRouter()
         const { id } = c.req.valid('param');
         const candidates = await c.var.services.inspection.getReinspectCandidates(tenantId, id);
         return c.json({ success: true, data: { candidates } }, 200);
+    })
+    .openapi(submitReportRoute, async (c) => {
+        const tenantId = c.get('tenantId') as string;
+        const { id } = c.req.valid('param');
+        try {
+            await c.var.services.inspection.submitReport(id, tenantId);
+            return c.json({ success: true as const, data: { reportStatus: 'submitted' } }, 200);
+        } catch (err) {
+            return c.json({ success: false as const, error: { code: 'BAD_REQUEST', message: err instanceof Error ? err.message : 'Failed to submit report' } }, 400);
+        }
+    })
+    .openapi(returnReportRoute, async (c) => {
+        const tenantId = c.get('tenantId') as string;
+        const { id } = c.req.valid('param');
+        try {
+            await c.var.services.inspection.returnReport(id, tenantId);
+            return c.json({ success: true as const, data: { reportStatus: 'in_progress' } }, 200);
+        } catch (err) {
+            return c.json({ success: false as const, error: { code: 'BAD_REQUEST', message: err instanceof Error ? err.message : 'Failed to return report' } }, 400);
+        }
+    })
+    .openapi(unpublishReportRoute, async (c) => {
+        const tenantId = c.get('tenantId') as string;
+        const { id } = c.req.valid('param');
+        try {
+            await c.var.services.inspection.unpublishReport(id, tenantId);
+            return c.json({ success: true as const, data: { reportStatus: 'in_progress' } }, 200);
+        } catch (err) {
+            return c.json({ success: false as const, error: { code: 'BAD_REQUEST', message: err instanceof Error ? err.message : 'Failed to unpublish report' } }, 400);
+        }
     })
     .openapi(createRoute(withMcpMetadata({
         method: 'post', path: '/{id}/pdf/refresh',

--- a/server/api/public-report.ts
+++ b/server/api/public-report.ts
@@ -625,13 +625,13 @@ export const publicReportRoutes = createApiRouter()
 
         const db = drizzle(c.env.DB);
         const insp = await db
-            .select({ status: inspections.status, dataVersion: inspections.dataVersion })
+            .select({ status: inspections.status, reportStatus: inspections.reportStatus, dataVersion: inspections.dataVersion })
             .from(inspections)
             .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
             .get();
         if (!insp) return c.notFound();
         const versions = await c.var.services.reportVersion.list(tenantId, id);
-        const versionNumber = resolveArchiveVersion(insp.status, versions);
+        const versionNumber = resolveArchiveVersion(insp.reportStatus, versions);
         const reportUrl = await buildRenderReportUrl(getBookingHost(c), tenant, id, c.env.JWT_SECRET);
         const contentHash = await c.var.services.inspection.getReportContentHash(id, tenantId);
         const record = await c.var.services.reportPdf.getOrRender(id, tenantId, reportType, {

--- a/server/api/public-share.ts
+++ b/server/api/public-share.ts
@@ -15,6 +15,7 @@ import { drizzle } from 'drizzle-orm/d1';
 import { eq, and } from 'drizzle-orm';
 import { inspections } from '../lib/db/schema';
 import { Errors } from '../lib/errors';
+import { isReportPublished } from '../lib/status/report-status';
 import { logger } from '../lib/logger';
 import { sendSuccess } from '../lib/response';
 import { withMcpMetadata } from "../lib/route-metadata-standards";
@@ -49,11 +50,12 @@ export const publicShareRoutes = createApiRouter()
         const db = drizzle(c.env.DB);
         const insp = await db.select({
             status: inspections.status,
+            reportStatus: inspections.reportStatus,
         }).from(inspections)
             .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
             .get();
         if (!insp) throw Errors.NotFound('Inspection not found');
-        if (insp.status !== 'delivered') {
+        if (!isReportPublished(insp.reportStatus)) {
             throw Errors.Forbidden('Report has not been published yet');
         }
 

--- a/server/lib/calendar-event-style.ts
+++ b/server/lib/calendar-event-style.ts
@@ -14,6 +14,8 @@
  * we render an inspection on a calendar surface.
  */
 
+import { INSPECTION_STATUS } from './status/inspection-status';
+
 export interface CalendarEventStyle {
     /** Hex fill color FullCalendar applies to the event chip. */
     color: string;
@@ -35,7 +37,7 @@ export interface CalendarEventStyle {
  */
 export function getCalendarEventStyle(status: string | null | undefined): CalendarEventStyle {
     const s = (status ?? '').toLowerCase();
-    if (s === 'draft') {
+    if (s === INSPECTION_STATUS.REQUESTED) {
         return {
             // Sprint 1 design tokens — slate-400 reads as "tentative" against
             // the indigo "confirmed" chips without introducing a new hue.

--- a/server/lib/db/schema/inspection.ts
+++ b/server/lib/db/schema/inspection.ts
@@ -2,6 +2,8 @@ import { sqliteTable, text, integer, real, uniqueIndex, index, primaryKey } from
 import { sql } from 'drizzle-orm';
 import { tenants, users } from './tenant';
 import { contacts } from './contact';
+import { INSPECTION_STATUSES } from '../../status/inspection-status';
+import { REPORT_STATUSES } from '../../status/report-status';
 
 // Sprint 2 S2-1 — tenant-scoped rating systems library. The level list
 // itself is stored as JSON because it is never queried independently and
@@ -66,7 +68,8 @@ export const inspections = sqliteTable('inspections', {
     clientPhone:         text('client_phone'),
     templateId:          text('template_id').references(() => templates.id),
     date:                text('date').notNull(),
-    status:              text('status', { enum: ['draft','scheduled','confirmed','in_progress','completed','delivered','published','cancelled'] }).notNull().default('draft'),
+    status:              text('status', { enum: [...INSPECTION_STATUSES] }).notNull().default('requested'),
+    reportStatus:        text('report_status', { enum: [...REPORT_STATUSES] }).notNull().default('in_progress'),
     paymentStatus:       text('payment_status', { enum: ['unpaid','partial','paid'] }).notNull().default('unpaid'),
     referredByAgentId:   text('referred_by_agent_id'),   // Buyer's Agent — unkeyed TEXT (backward compat)
     // P-4 authority chain: denormalized cache only — never reconcile back from invoice

--- a/server/lib/status/inspection-status.ts
+++ b/server/lib/status/inspection-status.ts
@@ -1,0 +1,30 @@
+/**
+ * Single source of truth for the INSPECTION (appointment/event) lifecycle axis.
+ * Mirrors server/lib/auth/roles.ts. Every consumer (drizzle enum, Zod enum,
+ * UI labels, filters) MUST derive from these — no bare status string literals.
+ */
+export const INSPECTION_STATUSES = [
+  'requested', 'scheduled', 'confirmed', 'completed', 'cancelled',
+] as const;
+
+export type InspectionStatus = typeof INSPECTION_STATUSES[number];
+
+export const INSPECTION_STATUS = {
+  REQUESTED: 'requested',
+  SCHEDULED: 'scheduled',
+  CONFIRMED: 'confirmed',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+} as const satisfies Record<string, InspectionStatus>;
+
+export const INSPECTION_STATUS_LABELS: Record<InspectionStatus, string> = {
+  requested: 'Requested',
+  scheduled: 'Scheduled',
+  confirmed: 'Confirmed',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+};
+
+export function isInspectionStatus(value: unknown): value is InspectionStatus {
+  return typeof value === 'string' && (INSPECTION_STATUSES as readonly string[]).includes(value);
+}

--- a/server/lib/status/report-status.ts
+++ b/server/lib/status/report-status.ts
@@ -1,0 +1,28 @@
+/**
+ * Single source of truth for the REPORT (deliverable) axis. Independent of the
+ * inspection lifecycle axis. Mirrors server/lib/auth/roles.ts. No bare literals.
+ */
+export const REPORT_STATUSES = ['in_progress', 'submitted', 'published'] as const;
+
+export type ReportStatus = typeof REPORT_STATUSES[number];
+
+export const REPORT_STATUS = {
+  IN_PROGRESS: 'in_progress',
+  SUBMITTED: 'submitted',
+  PUBLISHED: 'published',
+} as const satisfies Record<string, ReportStatus>;
+
+export const REPORT_STATUS_LABELS: Record<ReportStatus, string> = {
+  in_progress: 'In Progress',
+  submitted: 'Submitted',
+  published: 'Published',
+};
+
+export function isReportStatus(value: unknown): value is ReportStatus {
+  return typeof value === 'string' && (REPORT_STATUSES as readonly string[]).includes(value);
+}
+
+/** The single canonical "is this report published?" predicate. */
+export function isReportPublished(value: unknown): boolean {
+  return value === REPORT_STATUS.PUBLISHED;
+}

--- a/server/lib/validations/inspection.schema.ts
+++ b/server/lib/validations/inspection.schema.ts
@@ -1,5 +1,6 @@
 import { z } from '@hono/zod-openapi';
 import { createApiResponseSchema } from './shared.schema';
+import { INSPECTION_STATUSES } from '../status/inspection-status';
 
 /**
  * Core Inspection Schema (Output)
@@ -9,7 +10,7 @@ export const InspectionSchema = z.object({
     propertyAddress: z.string().openapi({ example: '123 Main St, Anytown' }).describe('TODO describe propertyAddress field for the OpenInspection MCP integration'),
     clientName: z.string().nullable().openapi({ example: 'John Doe' }).describe('TODO describe clientName field for the OpenInspection MCP integration'),
     clientEmail: z.string().email().nullable().openapi({ example: 'john@example.com' }).describe('TODO describe clientEmail field for the OpenInspection MCP integration'),
-    status: z.enum(['draft', 'completed', 'delivered']).openapi({ example: 'draft' }).describe('TODO describe status field for the OpenInspection MCP integration'),
+    status: z.enum(INSPECTION_STATUSES).openapi({ example: 'requested' }).describe('TODO describe status field for the OpenInspection MCP integration'),
     date: z.string().openapi({ example: '2024-03-20' }).describe('TODO describe date field for the OpenInspection MCP integration'),
     inspectorId: z.string().uuid().nullable().openapi({ example: '550e8400-e29b-41d4-a716-446655440001' }).describe('TODO describe inspectorId field for the OpenInspection MCP integration'),
     templateId: z.string().min(1).nullable().openapi({ example: '550e8400-e29b-41d4-a716-446655440002' }).describe('TODO describe templateId field for the OpenInspection MCP integration'),
@@ -22,7 +23,7 @@ export const InspectionSchema = z.object({
 export const InspectionListQuerySchema = z.object({
     limit: z.coerce.number().min(1).max(100).default(20).openapi({ example: 20 }).describe('TODO describe limit field for the OpenInspection MCP integration'),
     cursor: z.string().optional().openapi({ example: 'eyJpZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCJ9' }).describe('TODO describe cursor field for the OpenInspection MCP integration'),
-    status: z.enum(['draft', 'completed', 'delivered']).optional().openapi({ example: 'completed' }).describe('TODO describe status field for the OpenInspection MCP integration'),
+    status: z.enum(INSPECTION_STATUSES).optional().openapi({ example: 'completed' }).describe('TODO describe status field for the OpenInspection MCP integration'),
     search: z.string().optional().openapi({ example: '123 Main' }).describe('TODO describe search field for the OpenInspection MCP integration'),
     inspectorId: z.string().uuid().optional().openapi({ example: '550e8400-e29b-41d4-a716-446655440001' }).describe('TODO describe inspectorId field for the OpenInspection MCP integration'),
     dateFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (YYYY-MM-DD)').optional().openapi({ example: '2024-01-01' }).describe('TODO describe dateFrom field for the OpenInspection MCP integration'),
@@ -103,7 +104,7 @@ export const UpdateInspectionSchema = z.object({
     date: z.string().datetime().optional().openapi({ example: '2024-03-20T10:00:00Z' }).describe('TODO describe date field for the OpenInspection MCP integration'),
     inspectorId: z.string().uuid().optional().openapi({ example: '550e8400-e29b-41d4-a716-446655440001' }).describe('TODO describe inspectorId field for the OpenInspection MCP integration'),
     price: z.number().min(0).optional().openapi({ example: 450 }).describe('TODO describe price field for the OpenInspection MCP integration'),
-    status: z.enum(['draft', 'completed', 'delivered']).optional().openapi({ example: 'completed' }).describe('TODO describe status field for the OpenInspection MCP integration'),
+    status: z.enum(INSPECTION_STATUSES).optional().openapi({ example: 'completed' }).describe('TODO describe status field for the OpenInspection MCP integration'),
     paymentRequired:   z.boolean().optional().openapi({ example: false }).describe('TODO describe paymentRequired field for the OpenInspection MCP integration'),
     agreementRequired: z.boolean().optional().openapi({ example: false }).describe('TODO describe agreementRequired field for the OpenInspection MCP integration'),
     yearBuilt:      z.number().int().min(1800).max(2100).nullable().optional().openapi({ example: 1990 }).describe('TODO describe yearBuilt field for the OpenInspection MCP integration'),
@@ -233,7 +234,7 @@ export const BulkInspectionSchema = z.object({
     ids: z.array(z.string().uuid()).min(1).max(100).describe('TODO describe ids field for the OpenInspection MCP integration'),
     action: z.enum(['assignInspector', 'updateStatus']).describe('TODO describe action field for the OpenInspection MCP integration'),
     inspectorId: z.string().uuid().optional().describe('TODO describe inspectorId field for the OpenInspection MCP integration'),
-    status: z.enum(['draft', 'completed', 'delivered']).optional().describe('TODO describe status field for the OpenInspection MCP integration'),
+    status: z.enum(INSPECTION_STATUSES).optional().describe('TODO describe status field for the OpenInspection MCP integration'),
 }).openapi('BulkInspection');
 
 /**

--- a/server/services/agent.service.ts
+++ b/server/services/agent.service.ts
@@ -6,6 +6,7 @@ import { contacts } from '../lib/db/schema/contact';
 import { inspections, inspectionResults } from '../lib/db/schema/inspection';
 import { Errors } from '../lib/errors';
 import { logger } from '../lib/logger';
+import { REPORT_STATUS } from '../lib/status/report-status';
 import { hashPassword } from '../lib/password';
 import type { EmailService } from './email.service';
 import {
@@ -565,7 +566,7 @@ export class AgentService {
                     eq(inspectionResults.tenantId, inspections.tenantId),
                 ),
             )
-            .where(eq(inspections.status, 'delivered'))
+            .where(eq(inspections.reportStatus, REPORT_STATUS.PUBLISHED))
             .all();
 
         const agent = await db.select({ email: users.email })

--- a/server/services/automation.service.ts
+++ b/server/services/automation.service.ts
@@ -11,6 +11,7 @@ import type { NotificationService } from './notification.service';
 import type { AgreementService } from './agreement.service';
 import { currentPeriodKey } from '../lib/usage/period';
 import type { EmailService } from './email.service';
+import { isReportPublished, REPORT_STATUS } from '../lib/status/report-status';
 
 // Track L (D7) — default TCPA SMS opt-in disclosure (version 1). Seeded once by
 // ensureSeeds (SaaS) and the standalone raw-SQL path; kept identical in both.
@@ -351,7 +352,8 @@ export class AutomationService {
         // check-then-insert dedup (safe because CF cron runs are effectively serial)
         // is the chosen guard rather than a DB unique constraint.
         if (automation.trigger === 'inspection.reminder' &&
-            ['cancelled', 'completed', 'delivered', 'published'].includes(inspection.status)) {
+            (inspection.status === 'cancelled' || inspection.status === 'completed' ||
+             isReportPublished(inspection.reportStatus))) {
             return { ok: false, reason: 'inspection no longer active' };
         }
         if (!automation.conditions) return { ok: true };
@@ -669,7 +671,8 @@ export class AutomationService {
                     gte(inspections.date, todayStr),
                     lte(inspections.date, upperStr),
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    notInArray(inspections.status, ['cancelled', 'completed', 'delivered', 'published'] as any),
+                    notInArray(inspections.status, ['cancelled', 'completed'] as any),
+                    ne(inspections.reportStatus, REPORT_STATUS.PUBLISHED),
                 ));
 
             for (const insp of upcoming) {

--- a/server/services/inspection-request.service.ts
+++ b/server/services/inspection-request.service.ts
@@ -17,6 +17,7 @@ import { Errors } from '../lib/errors';
 import { safeISODate } from '../lib/date';
 import { logger } from '../lib/logger';
 import { syncInspectionAssignments } from '../lib/db/assignment-links';
+import { INSPECTION_STATUS } from '../lib/status/inspection-status';
 
 export interface CreateRequestInput {
     clientName:      string;
@@ -237,7 +238,7 @@ export class InspectionRequestService {
                 templateSnapshot:         tpl ? tpl.schema : null,
                 templateSnapshotVersion:  tpl ? tpl.version : 1,
                 date:                     input.scheduledAt,
-                status:                   'draft' as const,
+                status:                   INSPECTION_STATUS.REQUESTED,
                 paymentStatus:            'unpaid' as const,
                 price:                    s.price ?? 0,
                 requestId,
@@ -287,7 +288,7 @@ export class InspectionRequestService {
             templateSnapshot:         tpl.schema,
             templateSnapshotVersion:  tpl.version,
             date:                     req.scheduledAt,
-            status:                   'draft' as const,
+            status:                   INSPECTION_STATUS.REQUESTED,
             paymentStatus:            'unpaid' as const,
             price:                    sub.price ?? 0,
             requestId,

--- a/server/services/inspection.service.ts
+++ b/server/services/inspection.service.ts
@@ -2523,6 +2523,7 @@ export class InspectionService {
             clientPhone: string | null;
             clientContactId: string | null;
             status: string;
+            reportStatus: string;
             date: string | null;
             inspectorId: string | null;
             templateId: string | null;
@@ -2614,6 +2615,7 @@ export class InspectionService {
                 clientPhone:       insp.clientPhone ?? null,
                 clientContactId:   insp.clientContactId ?? null,
                 status:            insp.status,
+                reportStatus:      insp.reportStatus as string,
                 date:              insp.date ?? null,
                 inspectorId:       insp.inspectorId ?? null,
                 templateId:        insp.templateId ?? null,

--- a/server/services/inspection.service.ts
+++ b/server/services/inspection.service.ts
@@ -295,7 +295,7 @@ export class InspectionService {
         const db = this.getDrizzle();
         const conditions = [eq(inspections.tenantId, tenantId)];
 
-        if (params.status) conditions.push(eq(inspections.status, params.status as 'draft' | 'completed' | 'delivered'));
+        if (params.status) conditions.push(eq(inspections.status, params.status));
         if (params.inspectorId) conditions.push(eq(inspections.inspectorId, params.inspectorId));
         if (params.dateFrom) conditions.push(gte(inspections.date, params.dateFrom));
         if (params.dateTo) conditions.push(lte(inspections.date, params.dateTo));
@@ -331,7 +331,7 @@ export class InspectionService {
                     conditions.push(sql`${inspections.createdAt} < ${cutoff}`);
                     break;
                 case 'in_progress':
-                    conditions.push(eq(inspections.status, 'in_progress'));
+                    conditions.push(eq(inspections.reportStatus, REPORT_STATUS.IN_PROGRESS));
                     break;
             }
         }
@@ -366,7 +366,7 @@ export class InspectionService {
             propertyAddress: row.propertyAddress as string,
             clientName: row.clientName as string | null,
             clientEmail: row.clientEmail as string | null,
-            status: row.status as string,
+            status: row.status,
             date: row.date as string,
             inspectorId: row.inspectorId as string | null,
             templateId: row.templateId as string | null,
@@ -706,7 +706,7 @@ export class InspectionService {
             templateSnapshot:        baseline.templateSnapshot,
             templateSnapshotVersion: baseline.templateSnapshotVersion,
             date:                    createdAt.toISOString(),
-            status:                  'draft',
+            status:                  INSPECTION_STATUS.REQUESTED,
             paymentStatus:           'unpaid',
             price:                   0,
             paymentRequired:         false,

--- a/server/services/inspection.service.ts
+++ b/server/services/inspection.service.ts
@@ -28,6 +28,8 @@ import type { DefectCommentState } from '../types/inspection-item-state';
 import type { CannedDefect, TemplateSchemaV2 } from '../types/template-schema';
 import { sha256Hex } from './signing-key.service';
 import { RENDER_VERSION } from '../lib/pdf';
+import { INSPECTION_STATUS } from '../lib/status/inspection-status';
+import { REPORT_STATUS, isReportPublished } from '../lib/status/report-status';
 
 /**
  * Image Studio (cover crop) — resolves the cover image URL, preferring the
@@ -364,7 +366,7 @@ export class InspectionService {
             propertyAddress: row.propertyAddress as string,
             clientName: row.clientName as string | null,
             clientEmail: row.clientEmail as string | null,
-            status: row.status as 'draft' | 'completed' | 'delivered',
+            status: row.status as string,
             date: row.date as string,
             inspectorId: row.inspectorId as string | null,
             templateId: row.templateId as string | null,
@@ -384,13 +386,12 @@ export class InspectionService {
             .where(eq(inspections.tenantId, tenantId))
             .groupBy(inspections.status);
 
-        const stats = { total: 0, draft: 0, completed: 0, delivered: 0 };
+        const stats = { total: 0, requested: 0, completed: 0, published: 0 };
         for (const row of counts) {
             const n = Number(row.count);
             stats.total += n;
-            if (row.status === 'draft') stats.draft = n;
-            else if (row.status === 'completed') stats.completed = n;
-            else if (row.status === 'delivered') stats.delivered = n;
+            if (row.status === INSPECTION_STATUS.REQUESTED) stats.requested = n;
+            else if (row.status === INSPECTION_STATUS.COMPLETED) stats.completed = n;
         }
         return stats;
     }
@@ -476,7 +477,7 @@ export class InspectionService {
         if (!this.sdb) throw new Error('ScopedDB session missing');
         const id = crypto.randomUUID();
         const createdAt = new Date();
-        const status = 'draft' as const;
+        const status = INSPECTION_STATUS.REQUESTED;
         const date = data.date || createdAt.toISOString();
 
         let templateSnapshot: unknown = null;
@@ -2856,8 +2857,8 @@ export class InspectionService {
             today:       sql<number>`sum(case when date(${inspections.date}) = ${todayStr} then 1 else 0 end)`,
             upcoming:    sql<number>`sum(case when ${inspections.date} > ${todayStr} and ${inspections.status} not in ('completed','cancelled') then 1 else 0 end)`,
             past:        sql<number>`sum(case when ${inspections.date} < ${todayStr} or ${inspections.status} in ('completed','cancelled') then 1 else 0 end)`,
-            unconfirmed: sql<number>`sum(case when ${inspections.status} = 'scheduled' and ${inspections.createdAt} < ${cutoff} then 1 else 0 end)`,
-            inProgress:  sql<number>`sum(case when ${inspections.status} = 'in_progress' then 1 else 0 end)`,
+            unconfirmed: sql<number>`sum(case when ${inspections.status} = 'requested' and ${inspections.createdAt} < ${cutoff} then 1 else 0 end)`,
+            inProgress:  sql<number>`sum(case when ${inspections.status} = 'completed' and ${inspections.reportStatus} = 'in_progress' then 1 else 0 end)`,
         }).from(inspections).where(eq(inspections.tenantId, tenantId));
 
         const row = result[0] ?? {};
@@ -3063,10 +3064,10 @@ export class InspectionService {
             .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)))
             .get();
         if (!inspection) throw Errors.NotFound('Inspection not found');
-        if (inspection.status === 'delivered') throw Errors.BadRequest('Inspection is already published');
+        if (inspection.status !== INSPECTION_STATUS.COMPLETED) throw Errors.BadRequest('Inspection must be completed before publishing the report.');
 
         await db.update(inspections)
-            .set({ status: 'delivered' })
+            .set({ reportStatus: REPORT_STATUS.PUBLISHED })
             .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)));
         // Await so AutomationService.trigger actually inserts automation_logs
         // before the response goes out — the prior fire-and-forget pattern
@@ -3116,7 +3117,7 @@ export class InspectionService {
         const tenantSlug = tenantRow?.slug ?? '';
         return {
             reportUrl: `/report/${tenantSlug}/${inspectionId}`,
-            status: 'delivered',
+            reportStatus: REPORT_STATUS.PUBLISHED,
         };
     }
 
@@ -3133,9 +3134,9 @@ export class InspectionService {
 
     async confirmInspection(tenantId: string, id: string): Promise<void> {
         const { db, inspection } = await this.fetchForStatusChange(tenantId, id);
-        if (inspection.status === 'cancelled') throw Errors.BadRequest('Cannot confirm a cancelled inspection');
+        if (inspection.status === INSPECTION_STATUS.CANCELLED) throw Errors.BadRequest('Cannot confirm a cancelled inspection');
         await db.update(inspections).set({
-            status:      'confirmed',
+            status:      INSPECTION_STATUS.CONFIRMED,
             confirmedAt: new Date().toISOString(),
         }).where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));
         await fireAutomation(this.db, tenantId, id, 'inspection.confirmed');
@@ -3144,7 +3145,7 @@ export class InspectionService {
     async cancelInspection(tenantId: string, id: string, reason: string, notes?: string): Promise<void> {
         const { db } = await this.fetchForStatusChange(tenantId, id);
         await db.update(inspections).set({
-            status:       'cancelled',
+            status:       INSPECTION_STATUS.CANCELLED,
             cancelReason: reason,
             cancelNotes:  notes ?? null,
         }).where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));
@@ -3153,12 +3154,60 @@ export class InspectionService {
 
     async uncancelInspection(tenantId: string, id: string): Promise<void> {
         const { db, inspection } = await this.fetchForStatusChange(tenantId, id);
-        if (inspection.status !== 'cancelled') throw Errors.BadRequest('Inspection is not cancelled');
+        if (inspection.status !== INSPECTION_STATUS.CANCELLED) throw Errors.BadRequest('Inspection is not cancelled');
         await db.update(inspections).set({
-            status:       'scheduled',
+            status:       INSPECTION_STATUS.SCHEDULED,
             cancelReason: null,
             cancelNotes:  null,
         }).where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)));
+    }
+
+    /**
+     * Submits a completed inspection's report for manager review.
+     * Transitions: reportStatus in_progress → submitted.
+     */
+    async submitReport(inspectionId: string, tenantId: string): Promise<void> {
+        const { db, inspection } = await this.fetchForStatusChange(tenantId, inspectionId);
+        if (inspection.status !== INSPECTION_STATUS.COMPLETED) {
+            throw Errors.BadRequest('Inspection must be completed before submitting the report.');
+        }
+        const reportStatus = inspection.reportStatus as string;
+        if (reportStatus !== REPORT_STATUS.IN_PROGRESS) {
+            throw Errors.BadRequest(`Cannot submit a report in status ${reportStatus}.`);
+        }
+        await db.update(inspections)
+            .set({ reportStatus: REPORT_STATUS.SUBMITTED })
+            .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)));
+    }
+
+    /**
+     * Returns a submitted report to the inspector for revision.
+     * Transitions: reportStatus submitted → in_progress.
+     */
+    async returnReport(inspectionId: string, tenantId: string): Promise<void> {
+        const { db, inspection } = await this.fetchForStatusChange(tenantId, inspectionId);
+        const reportStatus = inspection.reportStatus as string;
+        if (reportStatus !== REPORT_STATUS.SUBMITTED) {
+            throw Errors.BadRequest('Only submitted reports can be returned.');
+        }
+        await db.update(inspections)
+            .set({ reportStatus: REPORT_STATUS.IN_PROGRESS })
+            .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)));
+    }
+
+    /**
+     * Unpublishes a published report, reverting it to in_progress for editing.
+     * Transitions: reportStatus published → in_progress.
+     */
+    async unpublishReport(inspectionId: string, tenantId: string): Promise<void> {
+        const { db, inspection } = await this.fetchForStatusChange(tenantId, inspectionId);
+        const reportStatus = inspection.reportStatus as string;
+        if (reportStatus !== REPORT_STATUS.PUBLISHED) {
+            throw Errors.BadRequest('Only published reports can be unpublished.');
+        }
+        await db.update(inspections)
+            .set({ reportStatus: REPORT_STATUS.IN_PROGRESS })
+            .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)));
     }
 
     /**
@@ -3366,32 +3415,37 @@ export class InspectionService {
         //  - active inspection with an overdue invoice past the invoice threshold.
         const needsAttention = all.filter(i => {
             const d = insDate(i);
-            if (i.status === 'scheduled' && d && d <= in48h) return true;
-            if (i.status === 'in_progress' && d && d <= reportStaleAt) return true;
-            if (i.status !== 'cancelled' && new Date(i.createdAt) <= agreementStaleAt && !signedSet.has(i.id as string)) return true;
-            if (i.status !== 'cancelled' && overdueSet.has(i.id as string)) return true;
+            if (i.status === INSPECTION_STATUS.SCHEDULED && d && d <= in48h) return true;
+            // Report not yet published past threshold (completed but reportStatus still in_progress/submitted)
+            if (i.status === INSPECTION_STATUS.COMPLETED && !isReportPublished(i.reportStatus) && new Date(i.createdAt) <= reportStaleAt) return true;
+            // Submitted reports awaiting manager review
+            if (i.reportStatus === REPORT_STATUS.SUBMITTED) return true;
+            if (i.status !== INSPECTION_STATUS.CANCELLED && new Date(i.createdAt) <= agreementStaleAt && !signedSet.has(i.id as string)) return true;
+            if (i.status !== INSPECTION_STATUS.CANCELLED && overdueSet.has(i.id as string)) return true;
             return false;
         });
 
-        const today = all.filter(i => isToday(i) && i.status !== 'cancelled');
+        const today = all.filter(i => isToday(i) && i.status !== INSPECTION_STATUS.CANCELLED);
 
         const thisWeek = all.filter(i => {
             const d = insDate(i);
-            return d !== null && d > endOfToday && d <= in7days && i.status !== 'cancelled';
+            return d !== null && d > endOfToday && d <= in7days && i.status !== INSPECTION_STATUS.CANCELLED;
         });
 
         const laterAll = all.filter(i => {
             const d = insDate(i);
-            return d !== null && d > in7days && i.status !== 'cancelled';
+            return d !== null && d > in7days && i.status !== INSPECTION_STATUS.CANCELLED;
         });
         const later      = laterAll.slice(0, 50);
         const laterTotal = laterAll.length;
 
-        const recentReports = all.filter(i => i.status === 'completed' || i.status === 'delivered');
+        const recentReports = all.filter(i =>
+            i.status === INSPECTION_STATUS.COMPLETED && isReportPublished(i.reportStatus)
+        );
 
         // Cancelled within last 30 days (no updatedAt on inspections — use createdAt as fallback proxy).
         const cancelled = all.filter(i =>
-            i.status === 'cancelled' && new Date(i.createdAt) >= minus30days
+            i.status === INSPECTION_STATUS.CANCELLED && new Date(i.createdAt) >= minus30days
         ).slice(0, 20);
 
         // Spec 5B P2B — annotate every surfaced inspection with defect counts
@@ -3478,11 +3532,10 @@ export class InspectionService {
                 const inspectorId = r.inspectorId as string | null;
                 const inspectorName = inspectorId ? inspectorNameMap.get(inspectorId) : undefined;
                 // Round-2 F2 — split "report ready" (built/completed) from "sent"
-                // (delivered = publish workflow completed). Older clients still
-                // see `reportPublished` (alias of reportReady) for backward-
-                // compat; new dashboard JSX reads `sent` for the ✈️ icon.
-                const reportReady = r.status === 'completed' || r.status === 'delivered';
-                const sent        = r.status === 'delivered';
+                // (published = publish workflow completed). reportPublished is the
+                // canonical flag; sent is an alias for the ✈️ icon on the dashboard.
+                const reportReady = r.status === INSPECTION_STATUS.COMPLETED;
+                const sent        = isReportPublished((r as { reportStatus?: unknown }).reportStatus);
                 return {
                     ...r,
                     defectStats: statsMap.get(id) ?? { safety: 0, recommendation: 0, maintenance: 0 },
@@ -3495,7 +3548,7 @@ export class InspectionService {
                         paid:            paidIdSet.has(id),
                         sent,
                         flagged:         overdueSet.has(id),
-                        canceled:        r.status === 'cancelled',
+                        canceled:        r.status === INSPECTION_STATUS.CANCELLED,
                     },
                     ...(reqId ? { requestId: reqId, siblingCount } : {}),
                 };

--- a/tests/unit/account-export-delete.spec.ts
+++ b/tests/unit/account-export-delete.spec.ts
@@ -65,13 +65,13 @@ describe('exportAccount', () => {
     it('returns inspections the user authored as inspector', async () => {
         await testDb.insert(schema.inspections).values({
             id: 'i-1', tenantId: TENANT, inspectorId: USER_ID, propertyAddress: '1 St',
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
         // unrelated inspection — different inspector
         await testDb.insert(schema.inspections).values({
             id: 'i-2', tenantId: TENANT, propertyAddress: '2 St',
-            date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 0,
+            date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 0,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
         const result = await exportAccount(testDb as any, USER_ID);

--- a/tests/unit/admin.service.spec.ts
+++ b/tests/unit/admin.service.spec.ts
@@ -212,7 +212,7 @@ describe('AdminService', () => {
             propertyAddress: '99 Actor Ave',
             clientName: 'Actor Client',
             clientEmail,
-            status: 'draft',
+            status: 'requested',
             paymentStatus: 'unpaid',
             price: 0,
             date: new Date().toISOString().split('T')[0],

--- a/tests/unit/agent-routes-c10.spec.ts
+++ b/tests/unit/agent-routes-c10.spec.ts
@@ -33,7 +33,7 @@ describe('agent C-10 routes', () => {
 
     it('GET /api/agent/referrals returns listReferrals data, called with (userId, {limit})', async () => {
         const listReferrals = vi.fn().mockResolvedValue([
-            { id: 'i1', tenantName: 'Acme', propertyAddress: '1 Main', clientName: 'Bob', date: '2026-06-01', status: 'delivered', inspectorName: 'Pat' },
+            { id: 'i1', tenantName: 'Acme', propertyAddress: '1 Main', clientName: 'Bob', date: '2026-06-01', status: 'completed', inspectorName: 'Pat' },
         ]);
         const res = await agentApp({ agent: { listReferrals } }).request('/api/agent/referrals');
         expect(res.status).toBe(200);

--- a/tests/unit/agent-service-listings.spec.ts
+++ b/tests/unit/agent-service-listings.spec.ts
@@ -54,10 +54,10 @@ describe('AgentService.listReferrals — A2', () => {
 
         await testDb.insert(schema.inspections).values([
             { id: 'i-1', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '1 Main', clientName: 'Sarah', date: '2026-06-01', status: 'confirmed', paymentStatus: 'paid', referredByAgentId: 'jane-c1', price: 0, createdAt: new Date() },
-            { id: 'i-2', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '2 Oak', clientName: 'Bob', date: '2026-06-02', status: 'delivered', paymentStatus: 'paid', referredByAgentId: 'jane-c1', price: 0, createdAt: new Date() },
-            { id: 'i-3', tenantId: T2, inspectorId: INSPECTOR_T2, propertyAddress: '3 Elm', clientName: 'Tim', date: '2026-06-03', status: 'draft', paymentStatus: 'unpaid', referredByAgentId: 'jane-c2', price: 0, createdAt: new Date() },
-            { id: 'other-agent-inspection', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '99 Pine', clientName: 'Dan', date: '2026-06-04', status: 'draft', paymentStatus: 'unpaid', referredByAgentId: 'other-c1', price: 0, createdAt: new Date() },
-            { id: 'no-referral-inspection', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '11 Pine', clientName: 'Eve', date: '2026-06-05', status: 'draft', paymentStatus: 'unpaid', referredByAgentId: null, price: 0, createdAt: new Date() },
+            { id: 'i-2', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '2 Oak', clientName: 'Bob', date: '2026-06-02', status: 'completed', reportStatus: 'published', paymentStatus: 'paid', referredByAgentId: 'jane-c1', price: 0, createdAt: new Date() },
+            { id: 'i-3', tenantId: T2, inspectorId: INSPECTOR_T2, propertyAddress: '3 Elm', clientName: 'Tim', date: '2026-06-03', status: 'requested', paymentStatus: 'unpaid', referredByAgentId: 'jane-c2', price: 0, createdAt: new Date() },
+            { id: 'other-agent-inspection', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '99 Pine', clientName: 'Dan', date: '2026-06-04', status: 'requested', paymentStatus: 'unpaid', referredByAgentId: 'other-c1', price: 0, createdAt: new Date() },
+            { id: 'no-referral-inspection', tenantId: T1, inspectorId: INSPECTOR_T1, propertyAddress: '11 Pine', clientName: 'Eve', date: '2026-06-05', status: 'requested', paymentStatus: 'unpaid', referredByAgentId: null, price: 0, createdAt: new Date() },
         ]);
 
         (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(testDb);

--- a/tests/unit/agreement-link.spec.ts
+++ b/tests/unit/agreement-link.spec.ts
@@ -47,7 +47,7 @@ describe('shouldUseCheckoutLink (Track I-a Task 8)', () => {
     async function seedInspection(over: Partial<typeof schema.inspections.$inferInsert> = {}) {
         await db.insert(schema.inspections).values({
             id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', date: '2026-06-01',
-            status: 'draft', paymentStatus: 'unpaid', paymentRequired: true, createdAt: new Date(),
+            status: 'requested', paymentStatus: 'unpaid', paymentRequired: true, createdAt: new Date(),
             ...over,
         } as any);
     }

--- a/tests/unit/agreement-public-routes.spec.ts
+++ b/tests/unit/agreement-public-routes.spec.ts
@@ -104,7 +104,7 @@ async function seedBase(db: BetterSQLite3Database<typeof schema>) {
     } as any);
     await db.insert(schema.inspections).values({
         id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', clientName: 'Jane',
-        clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+        clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
         price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date(),
     } as any);
     await db.insert(schema.agreements).values({

--- a/tests/unit/agreement-send-endpoints.spec.ts
+++ b/tests/unit/agreement-send-endpoints.spec.ts
@@ -43,7 +43,7 @@ let emailSend: ReturnType<typeof vi.fn>;
 
 async function seed() {
     await db.insert(schema.tenants).values({ id: TENANT, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() });
-    await db.insert(schema.inspections).values({ id: INSP_ID, tenantId: TENANT, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() });
+    await db.insert(schema.inspections).values({ id: INSP_ID, tenantId: TENANT, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() });
     await db.insert(schema.agreements).values({ id: AGR_ID, tenantId: TENANT, name: 'Standard Agreement', content: 'Agreement text...', version: 1, createdAt: new Date() });
 }
 

--- a/tests/unit/agreement-signers.spec.ts
+++ b/tests/unit/agreement-signers.spec.ts
@@ -18,7 +18,7 @@ async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
         { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
-        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() },
+        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() },
     ]);
     await testDb.insert(schema.agreements).values([
         { id: AGR_ID, tenantId: TENANT_A, name: 'Standard Agreement', content: 'Agreement text...', version: 1, createdAt: new Date() },
@@ -230,7 +230,7 @@ describe('AgreementService — signer-level envelope state machine', () => {
 
         // one — second inspection/envelope to keep them separate
         const INSP2 = '00000000-0000-0000-0000-000000000011';
-        await testDb.insert(schema.inspections).values({ id: INSP2, tenantId: TENANT_A, propertyAddress: '2 Main', clientName: 'X', clientEmail: 'x@test.com', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 1, createdAt: new Date() });
+        await testDb.insert(schema.inspections).values({ id: INSP2, tenantId: TENANT_A, propertyAddress: '2 Main', clientName: 'X', clientEmail: 'x@test.com', date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 1, createdAt: new Date() });
         const rOne = await svc.findOrCreate(TENANT_A, INSP2, {
             signers: [{ name: 'Jane', email: 'jane@test.com' }, { name: 'John', email: 'john@test.com' }],
             completionPolicy: 'one',

--- a/tests/unit/agreement.service.spec.ts
+++ b/tests/unit/agreement.service.spec.ts
@@ -17,7 +17,7 @@ async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
         { id: TENANT_A, name: 'A', slug: 'a', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
-        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() },
+        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date() },
     ]);
     await testDb.insert(schema.agreements).values([
         { id: AGR_ID, tenantId: TENANT_A, name: 'Standard Agreement', content: 'Agreement text...', version: 1, createdAt: new Date() },

--- a/tests/unit/auto-sign-publish.spec.ts
+++ b/tests/unit/auto-sign-publish.spec.ts
@@ -43,7 +43,7 @@ describe('InspectionService.publishInspection auto-sign behavior', () => {
             id: INSP_ID, tenantId: TENANT,
             inspectorId: USER_ID,
             propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@x',
-            date: '2026-06-01', status: 'draft',
+            date: '2026-06-01', status: 'completed',
             paymentStatus: 'unpaid', price: 50000,
             agreementRequired: false, paymentRequired: false,
             autoSignOnPublish: true,

--- a/tests/unit/automation-channels.spec.ts
+++ b/tests/unit/automation-channels.spec.ts
@@ -62,7 +62,7 @@ describe('AutomationService — channels + sms_body (Track L)', () => {
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT, propertyAddress: '1 Main', clientName: 'Jane',
             clientEmail: 'jane@example.com', clientPhone: '(555) 123-4567', date: '2026-07-01',
-            status: 'published', paymentStatus: 'unpaid', price: 0,
+            status: 'completed', reportStatus: 'published', paymentStatus: 'unpaid', price: 0,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         } as never);
         const created = await svc.create(TENANT, {
@@ -86,7 +86,7 @@ describe('AutomationService — channels + sms_body (Track L)', () => {
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT, propertyAddress: '2 Main', clientName: 'Joe',
             clientEmail: 'joe@example.com', date: '2026-07-02',
-            status: 'published', paymentStatus: 'unpaid', price: 0,
+            status: 'completed', reportStatus: 'published', paymentStatus: 'unpaid', price: 0,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         } as never);
         const created = await svc.create(TENANT, {

--- a/tests/unit/automation-conditions.spec.ts
+++ b/tests/unit/automation-conditions.spec.ts
@@ -59,8 +59,8 @@ async function seedInspection(over: Partial<typeof schema.inspections.$inferInse
     const id = over.id ?? crypto.randomUUID();
     await db.insert(schema.inspections).values({
         id, tenantId: TENANT, propertyAddress: '1 Main', clientName: 'Jane',
-        clientEmail: 'jane@example.com', date: '2026-06-01', status: 'published',
-        paymentStatus: 'unpaid', price: 50000, agreementRequired: false,
+        clientEmail: 'jane@example.com', date: '2026-06-01', status: 'completed',
+        reportStatus: 'published', paymentStatus: 'unpaid', price: 50000, agreementRequired: false,
         paymentRequired: false, createdAt: new Date(), ...over,
     } as never);
     return id;

--- a/tests/unit/automation-flush-sms.spec.ts
+++ b/tests/unit/automation-flush-sms.spec.ts
@@ -38,8 +38,8 @@ async function seedSmsLog(over: { contactId?: string | null } = {}) {
     await db.insert(schema.inspections).values({
         id: inspId, tenantId: TENANT, propertyAddress: '1 Main', clientName: 'Jane',
         clientEmail: 'jane@example.com', clientPhone: '+15551234567',
-        clientContactId: over.contactId ?? null, date: '2026-07-01', status: 'published',
-        paymentStatus: 'paid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+        clientContactId: over.contactId ?? null, date: '2026-07-01', status: 'completed',
+        reportStatus: 'published', paymentStatus: 'paid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
     } as never);
     const ruleId = crypto.randomUUID();
     await db.insert(schema.automations).values({

--- a/tests/unit/automation.service.spec.ts
+++ b/tests/unit/automation.service.spec.ts
@@ -17,7 +17,7 @@ async function seedFor(testDb: BetterSQLite3Database<typeof schema>, agreementRe
         { id: TENANT, name: 'T', slug: 't', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
-        { id: INSP, tenantId: TENANT, propertyAddress: '1 St', clientName: 'J', clientEmail: 'j@t.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired, paymentRequired: false, createdAt: new Date() },
+        { id: INSP, tenantId: TENANT, propertyAddress: '1 St', clientName: 'J', clientEmail: 'j@t.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired, paymentRequired: false, createdAt: new Date() },
     ]);
     await testDb.insert(schema.agreements).values([
         { id: AGR, tenantId: TENANT, name: 'Std', content: 'text', version: 1, createdAt: new Date() },

--- a/tests/unit/calendar-event-style.spec.ts
+++ b/tests/unit/calendar-event-style.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { getCalendarEventStyle } from '../../server/lib/calendar-event-style';
 
 describe('getCalendarEventStyle (iter-2 bug #5)', () => {
-    it('renders draft inspections with a DRAFT prefix and lighter color', () => {
-        const style = getCalendarEventStyle('draft');
+    it('renders requested inspections with a DRAFT prefix and lighter color', () => {
+        const style = getCalendarEventStyle('requested');
         expect(style.titlePrefix).toBe('DRAFT · ');
         expect(style.isDraft).toBe(true);
         expect(style.color).not.toBe('#6366F1');
@@ -15,8 +15,8 @@ describe('getCalendarEventStyle (iter-2 bug #5)', () => {
         expect(style.isDraft).toBe(false);
     });
 
-    it('falls back to brand indigo for confirmed/scheduled/in_progress', () => {
-        for (const s of ['scheduled', 'confirmed', 'in_progress', 'completed', 'delivered']) {
+    it('falls back to brand indigo for scheduled/confirmed/completed', () => {
+        for (const s of ['scheduled', 'confirmed', 'completed']) {
             const style = getCalendarEventStyle(s);
             expect(style.color).toBe('#6366F1');
             expect(style.titlePrefix).toBe('');
@@ -34,7 +34,7 @@ describe('getCalendarEventStyle (iter-2 bug #5)', () => {
     });
 
     it('is case-insensitive on status', () => {
-        expect(getCalendarEventStyle('DRAFT').isDraft).toBe(true);
-        expect(getCalendarEventStyle('Draft').isDraft).toBe(true);
+        expect(getCalendarEventStyle('REQUESTED').isDraft).toBe(true);
+        expect(getCalendarEventStyle('Requested').isDraft).toBe(true);
     });
 });

--- a/tests/unit/checkout-public.spec.ts
+++ b/tests/unit/checkout-public.spec.ts
@@ -85,7 +85,7 @@ async function seedBase(
     } as any);
     await db.insert(schema.inspections).values({
         id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', clientName: 'Jane',
-        clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+        clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
         price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date(),
         ...inspOver,
     } as any);

--- a/tests/unit/contact.service.spec.ts
+++ b/tests/unit/contact.service.spec.ts
@@ -32,10 +32,10 @@ describe('ContactService.listContacts inspectionCount', () => {
             { id: AGENT_BOB, tenantId: TENANT_A, type: 'agent', name: 'Bob', email: 'bob@test.com', createdAt: new Date() },
         ]);
         await testDb.insert(schema.inspections).values([
-            { id: 'i-jane-1', tenantId: TENANT_A, propertyAddress: '1 St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
-            { id: 'i-jane-2', tenantId: TENANT_A, propertyAddress: '2 St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
-            { id: 'i-bob-ref', tenantId: TENANT_A, propertyAddress: '3 St', clientName: 'X', clientEmail: 'x@test.com', referredByAgentId: AGENT_BOB, date: '2026-06-03', status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
-            { id: 'i-other-tenant', tenantId: TENANT_B, propertyAddress: '4 St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-04', status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
+            { id: 'i-jane-1', tenantId: TENANT_A, propertyAddress: '1 St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
+            { id: 'i-jane-2', tenantId: TENANT_A, propertyAddress: '2 St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
+            { id: 'i-bob-ref', tenantId: TENANT_A, propertyAddress: '3 St', clientName: 'X', clientEmail: 'x@test.com', referredByAgentId: AGENT_BOB, date: '2026-06-03', status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
+            { id: 'i-other-tenant', tenantId: TENANT_B, propertyAddress: '4 St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-04', status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date() },
         ]);
 
         (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(testDb);

--- a/tests/unit/cover-crop.spec.ts
+++ b/tests/unit/cover-crop.spec.ts
@@ -73,7 +73,7 @@ describe('InspectionService.setCroppedCover', () => {
     await testDb.insert(schema.inspections).values({
       id: INSPECTION_ID, tenantId: TENANT, templateId: null,
       propertyAddress: '1 Main St', clientName: 'C', clientEmail: 'c@example.com',
-      date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+      date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
       paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
     await testDb.insert(schema.inspectionMediaPool).values({

--- a/tests/unit/erasure-orchestrator.spec.ts
+++ b/tests/unit/erasure-orchestrator.spec.ts
@@ -163,7 +163,7 @@ describe('runErasure', () => {
         const reqId = 'req-draft';
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT_A, propertyAddress: '2 Main', clientName: 'Drafty',
-            clientEmail: SUBJECT_EMAIL, date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 1, createdAt: new Date(),
+            clientEmail: SUBJECT_EMAIL, date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 1, createdAt: new Date(),
         });
         await db.insert(schema.agreementRequests).values({
             id: reqId, tenantId: TENANT_A, inspectionId: inspId, agreementId: 'agr-1',
@@ -202,7 +202,7 @@ describe('runErasure', () => {
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT_A, propertyAddress: '4 Main',
             clientName: 'Jane Subject', clientEmail: SUBJECT_EMAIL, clientPhone: '555-2222',
-            date: '2026-06-04', status: 'in_progress', paymentStatus: 'unpaid', price: 1, createdAt: new Date(),
+            date: '2026-06-04', status: 'completed', reportStatus: 'in_progress', paymentStatus: 'unpaid', price: 1, createdAt: new Date(),
         });
         await db.insert(schema.agreementRequests).values({
             id: reqId, tenantId: TENANT_A, inspectionId: inspId, agreementId: 'agr-1',
@@ -281,7 +281,7 @@ describe('runErasure', () => {
         await db.insert(schema.inspections).values({
             id: 'insp-other-tenant', tenantId: TENANT_B, propertyAddress: '3 Main',
             clientName: 'Cross', clientEmail: SUBJECT_EMAIL, date: '2026-06-03',
-            status: 'draft', paymentStatus: 'unpaid', price: 1, createdAt: new Date(),
+            status: 'requested', paymentStatus: 'unpaid', price: 1, createdAt: new Date(),
         });
 
         await runErasure(db, { tenantId: TENANT_A, subjectEmail: SUBJECT_EMAIL, retentionYears: 6 });

--- a/tests/unit/estimate-range.spec.ts
+++ b/tests/unit/estimate-range.spec.ts
@@ -60,7 +60,7 @@ async function seedFixture(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.inspections).values({
         id: INSPECTION_ID, tenantId: TENANT, templateId: TEMPLATE_ID,
         propertyAddress: '1 Main St', clientName: 'C', clientEmail: 'c@example.com',
-        date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+        date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
 }

--- a/tests/unit/inspection-agreement-request.spec.ts
+++ b/tests/unit/inspection-agreement-request.spec.ts
@@ -91,7 +91,7 @@ describe('POST /api/inspections/:id/agreement-requests (Task 7, #111)', () => {
         await db.insert(schema.inspections).values({
             id: INSP_ID, tenantId: TENANT,
             propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@example.com',
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000,
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
     });
@@ -186,7 +186,7 @@ describe('POST /api/inspections/:id/agreement-requests (Task 7, #111)', () => {
         });
         await db.insert(schema.inspections).values({
             id: 'insp-other', tenantId: OTHER, propertyAddress: 'X',
-            clientName: null, clientEmail: 'x@y.com', date: '2026-06-01', status: 'draft',
+            clientName: null, clientEmail: 'x@y.com', date: '2026-06-01', status: 'requested',
             paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
         const res = await send(`/api/inspections/insp-other/agreement-requests`, '{}');

--- a/tests/unit/inspection-hub.spec.ts
+++ b/tests/unit/inspection-hub.spec.ts
@@ -132,7 +132,7 @@ describe('Issue #111 — InspectionService.getInspectionHub', () => {
         await testDb.insert(schema.inspections).values({
             id: 'insp-other', tenantId: OTHER, propertyAddress: 'X',
             clientName: null, clientEmail: null, clientPhone: null,
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
             price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date(),
         });
 
@@ -144,7 +144,7 @@ describe('Issue #111 — InspectionService.getInspectionHub', () => {
         await testDb.insert(schema.inspections).values({
             id: 'insp-bare', tenantId: TENANT, propertyAddress: '1 Main St',
             clientName: 'Jane', clientEmail: null, clientPhone: null,
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
             price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date(),
         });
 

--- a/tests/unit/inspection-patch-settings.spec.ts
+++ b/tests/unit/inspection-patch-settings.spec.ts
@@ -48,7 +48,7 @@ function buildApp(role: string) {
         c.set(
             'services',
             { inspection: {
-                getInspection: vi.fn().mockResolvedValue({ inspection: { status: 'draft' } }),
+                getInspection: vi.fn().mockResolvedValue({ inspection: { status: 'requested' } }),
                 isInspectionPhotoKey: (iid: string, tid: string, key: string) => realSvc.isInspectionPhotoKey(iid, tid, key),
             } } as never,
         );
@@ -83,7 +83,7 @@ describe('PATCH /api/inspections/:id — settings save (B-22 follow-up)', () => 
         await db.insert(schema.inspections).values({
             id: INSP_ID, tenantId: TENANT,
             propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@x',
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000,
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
         (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(db);

--- a/tests/unit/inspection-people-card.spec.ts
+++ b/tests/unit/inspection-people-card.spec.ts
@@ -83,7 +83,7 @@ describe('Round-2 F3 — InspectionService.getPeopleCard', () => {
             clientEmail:       null,
             clientPhone:       null,
             date:              '2026-06-01',
-            status:            'draft',
+            status:            'requested',
             paymentStatus:     'unpaid',
             price:             0,
             paymentRequired:   false,
@@ -106,7 +106,7 @@ describe('Round-2 F3 — InspectionService.getPeopleCard', () => {
         await testDb.insert(schema.inspections).values({
             id: 'insp-other', tenantId: OTHER,
             propertyAddress: 'X', clientName: null, clientEmail: null, clientPhone: null,
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
             price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date(),
         });
 
@@ -126,7 +126,7 @@ describe('Round-2 F3 — InspectionService.getPeopleCard', () => {
             clientPhone:       null,
             referredByAgentId: 'agent-buyer-1',
             date:              '2026-06-01',
-            status:            'draft',
+            status:            'requested',
             paymentStatus:     'unpaid',
             price:             0,
             paymentRequired:   false,

--- a/tests/unit/inspection-results-batch.spec.ts
+++ b/tests/unit/inspection-results-batch.spec.ts
@@ -33,7 +33,7 @@ describe('applyResultsBatch', () => {
             tenantId: 't-1',
             propertyAddress: '1 Test St',
             date: '2026-01-01',
-            status: 'draft',
+            status: 'requested',
             createdAt: new Date(),
         } as any);
     });

--- a/tests/unit/inspection-service.spec.ts
+++ b/tests/unit/inspection-service.spec.ts
@@ -16,7 +16,7 @@ function makeInspection(overrides: Partial<typeof schema.inspections.$inferInser
         clientName:      'Test Client',
         clientEmail:     'test@example.com',
         date:            '2026-06-01',
-        status:          'draft',
+        status:          'requested',
         paymentStatus:   'unpaid',
         price:           0,
         paymentRequired: false,
@@ -100,7 +100,7 @@ describe('InspectionService.getDashboardBuckets (Spec 3A)', () => {
         const insId = 'insp-stats-1';
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await testDb.insert(schema.inspections).values(makeInspection({
-            id: insId, date: todayStr(), status: 'in_progress',
+            id: insId, date: todayStr(), status: 'completed', reportStatus: 'in_progress',
             templateSnapshot: snap as any,
         }));
         // Per-inspection state: turn ON d_recommend, leave d_safety default-on,
@@ -165,7 +165,7 @@ describe('InspectionService.getDashboardBuckets (Spec 3A)', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             makeInspection({ id: ins1, date: todayStr(),    status: 'confirmed',   templateSnapshot: snap as any }),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            makeInspection({ id: ins2, date: daysFromNow(-2), status: 'in_progress', templateSnapshot: snap as any, createdAt: new Date(Date.now() - 5 * 86400 * 1000) }),
+            makeInspection({ id: ins2, date: daysFromNow(-2), status: 'completed', reportStatus: 'in_progress', templateSnapshot: snap as any, createdAt: new Date(Date.now() - 5 * 86400 * 1000) }),
         ]);
 
         const buckets = await svc.getDashboardBuckets(TENANT);

--- a/tests/unit/inspection-sign-unification.spec.ts
+++ b/tests/unit/inspection-sign-unification.spec.ts
@@ -106,7 +106,7 @@ async function seedBase(db: BetterSQLite3Database<typeof schema>, opts: { withTe
     } as any);
     await db.insert(schema.inspections).values({
         id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', clientName: 'Jane',
-        clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+        clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
         price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date(),
     } as any);
     if (opts.withTemplate ?? true) {
@@ -424,7 +424,7 @@ describe('signedByClient + dashboard truth read from the envelope (Track I-a Tas
         } as any);
         await db.insert(schema.inspections).values({
             id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', clientName: 'Jane',
-            clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+            clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
             price: 50000, agreementRequired: true, paymentRequired: false, createdAt: new Date(),
         } as any);
         await db.insert(schema.agreements).values({

--- a/tests/unit/invoice-request-payment.spec.ts
+++ b/tests/unit/invoice-request-payment.spec.ts
@@ -86,7 +86,7 @@ describe('POST /api/invoices/request-payment (Task 8, #111)', () => {
         await db.insert(schema.inspections).values({
             id: INSP_ID, tenantId: TENANT,
             propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@example.com',
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000,
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
     });
@@ -193,7 +193,7 @@ describe('POST /api/invoices/request-payment (Task 8, #111)', () => {
         });
         await db.insert(schema.inspections).values({
             id: OTHER_INSP_ID, tenantId: OTHER, propertyAddress: 'X',
-            clientName: 'X', clientEmail: 'x@y.com', date: '2026-06-01', status: 'draft',
+            clientName: 'X', clientEmail: 'x@y.com', date: '2026-06-01', status: 'requested',
             paymentStatus: 'unpaid', price: 10000, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
         const res = await post({ inspectionId: OTHER_INSP_ID });

--- a/tests/unit/iter2-bug10-public-invoice.spec.ts
+++ b/tests/unit/iter2-bug10-public-invoice.spec.ts
@@ -18,8 +18,8 @@ async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
         { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
-        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
-        { id: INSP_B, tenantId: TENANT_B, propertyAddress: '2 Other St', clientName: 'Bob', clientEmail: 'bob@test.com', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 30000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+        { id: INSP_B, tenantId: TENANT_B, propertyAddress: '2 Other St', clientName: 'Bob', clientEmail: 'bob@test.com', date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 30000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
     ]);
 }
 
@@ -147,7 +147,7 @@ describe('markPaid idempotency', () => {
         });
         await testDb.insert(schema.inspections).values({
             id: INSP_C, tenantId: TENANT_A, propertyAddress: '3 Test St', clientName: 'Eve', clientEmail: 'eve@test.com',
-            date: '2026-06-07', status: 'draft', paymentStatus: 'unpaid', price: 10000,
+            date: '2026-06-07', status: 'requested', paymentStatus: 'unpaid', price: 10000,
             agreementRequired: false, paymentRequired: true, createdAt: new Date(),
         });
         await testDb.insert(schema.invoices).values({

--- a/tests/unit/iter2-bug9-sign-redirect.spec.ts
+++ b/tests/unit/iter2-bug9-sign-redirect.spec.ts
@@ -19,8 +19,8 @@ async function seedBase(testDb: BetterSQLite3Database<typeof schema>) {
         { id: TENANT_B, name: 'B', slug: 'b', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
     ]);
     await testDb.insert(schema.inspections).values([
-        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
-        { id: INSP_B, tenantId: TENANT_B, propertyAddress: '2 Other St', clientName: 'Bob', clientEmail: 'bob@test.com', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 30000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+        { id: INSP_ID, tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'Jane', clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
+        { id: INSP_B, tenantId: TENANT_B, propertyAddress: '2 Other St', clientName: 'Bob', clientEmail: 'bob@test.com', date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 30000, agreementRequired: true, paymentRequired: true, createdAt: new Date() },
     ]);
     await testDb.insert(schema.agreements).values([
         { id: AGR_ID, tenantId: TENANT_A, name: 'Standard', content: 'Agreement text...', version: 1, createdAt: new Date() },

--- a/tests/unit/observer-link-service.spec.ts
+++ b/tests/unit/observer-link-service.spec.ts
@@ -22,7 +22,7 @@ async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.inspections).values({
         id: INSPECTION, tenantId: TENANT,
         propertyAddress: '1 Main St', date: '2026-06-01',
-        status: 'draft', paymentStatus: 'unpaid', price: 0,
+        status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
 }

--- a/tests/unit/property-facts.spec.ts
+++ b/tests/unit/property-facts.spec.ts
@@ -40,8 +40,8 @@ describe('InspectionService.updatePropertyFacts (G1)', () => {
             { id: TENANT_B, name: 'Globex', slug: 'globex', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
         ]);
         await testDb.insert(schema.inspections).values([
-            { id: 'insp-A', tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'A', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },
-            { id: 'insp-B', tenantId: TENANT_B, propertyAddress: '2 Elm Rd',  clientName: 'B', date: '2026-06-02', status: 'draft', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },
+            { id: 'insp-A', tenantId: TENANT_A, propertyAddress: '1 Main St', clientName: 'A', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },
+            { id: 'insp-B', tenantId: TENANT_B, propertyAddress: '2 Elm Rd',  clientName: 'B', date: '2026-06-02', status: 'requested', paymentStatus: 'unpaid', price: 0, paymentRequired: false, agreementRequired: false, createdAt: new Date() },
         ]);
     });
 

--- a/tests/unit/public-report-endpoint.spec.ts
+++ b/tests/unit/public-report-endpoint.spec.ts
@@ -79,7 +79,7 @@ describe('GET /api/public/observe/inspections/:id — ③-A.4', () => {
     function buildApp(
         claim: ReturnType<typeof vi.fn>,
         getObserveProgress = vi.fn().mockResolvedValue({
-            address: '1 Main St', date: '2026-06-01', inspectorName: 'Pat', status: 'in_progress', sections: [],
+            address: '1 Main St', date: '2026-06-01', inspectorName: 'Pat', status: 'completed', sections: [],
         }),
     ) {
         const app = new OpenAPIHono<HonoConfig>();
@@ -195,7 +195,7 @@ describe('InspectionService.getReportGate — combined checkout routing (Task 7)
         } as any);
         await db.insert(schema.inspections).values({
             id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', clientName: 'Jane',
-            clientEmail: 'jane@test.com', date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid',
+            clientEmail: 'jane@test.com', date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid',
             price: 50000, agreementRequired: true, paymentRequired: true, createdAt: new Date(),
             ...inspOver,
         } as any);

--- a/tests/unit/reinspection-create.spec.ts
+++ b/tests/unit/reinspection-create.spec.ts
@@ -28,7 +28,7 @@ async function seed(testDb: BetterSQLite3Database<typeof schema>) {
         id: ORIGINAL, tenantId: TENANT,
         propertyAddress: '1 Main St', clientName: 'Jane Buyer',
         clientEmail: 'jane@example.com', date: '2026-06-01',
-        status: 'published', paymentStatus: 'unpaid', price: 0,
+        status: 'completed', reportStatus: 'published', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
     // Its r1 snapshot. snapshotOnPublish stores { inspection, data, units };
@@ -52,7 +52,7 @@ async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.inspections).values({
         id: DRAFT, tenantId: TENANT,
         propertyAddress: '2 Side St', date: '2026-06-02',
-        status: 'draft', paymentStatus: 'unpaid', price: 0,
+        status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
 }

--- a/tests/unit/repair-list.service.spec.ts
+++ b/tests/unit/repair-list.service.spec.ts
@@ -82,7 +82,7 @@ async function seedFixture(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.inspections).values({
         id: INSPECTION_ID, tenantId: TENANT, templateId: TEMPLATE_ID,
         propertyAddress: '1 Main St', clientName: 'C', clientEmail: 'c@example.com',
-        date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+        date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
 }

--- a/tests/unit/report-pdf-version.spec.ts
+++ b/tests/unit/report-pdf-version.spec.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { resolveArchiveVersion } from '../../server/api/inspections-pdf-helpers';
 
 describe('resolveArchiveVersion', () => {
-  it('returns latest published version for published/delivered', () => {
+  it('returns latest version when reportStatus is published', () => {
     expect(resolveArchiveVersion('published', [{ versionNumber: 3 }, { versionNumber: 2 }])).toBe(3);
-    expect(resolveArchiveVersion('delivered', [{ versionNumber: 1 }])).toBe(1);
+    expect(resolveArchiveVersion('published', [{ versionNumber: 1 }])).toBe(1);
   });
-  it('returns null for draft/in_progress/completed', () => {
-    expect(resolveArchiveVersion('draft', [{ versionNumber: 3 }])).toBeNull();
-    expect(resolveArchiveVersion('completed', [])).toBeNull();
+  it('returns null for non-published report statuses', () => {
+    expect(resolveArchiveVersion('in_progress', [{ versionNumber: 3 }])).toBeNull();
+    expect(resolveArchiveVersion('submitted', [{ versionNumber: 1 }])).toBeNull();
   });
   it('returns null when published but no versions exist', () => {
     expect(resolveArchiveVersion('published', [])).toBeNull();

--- a/tests/unit/report-review-endpoints.spec.ts
+++ b/tests/unit/report-review-endpoints.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * TDD tests for POST /:id/submit, POST /:id/return, POST /:id/unpublish
+ * HTTP endpoints on the inspections router.
+ *
+ * Capability rules (from capabilities.ts):
+ *   - submit: any role with access to the inspection (owner/manager/inspector)
+ *   - return: requires `publish` capability (owner + manager by default;
+ *     inspector only when not overridden to publish:false)
+ *   - unpublish: requires `publish` capability (same)
+ *
+ * Agent has publish:false (pinned) — used to exercise the 403 path without
+ * needing permission_overrides.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../server/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import type { HonoConfig } from '../../server/types/hono';
+import { AppError } from '../../server/lib/errors';
+import { INSPECTION_STATUS } from '../../server/lib/status/inspection-status';
+import { REPORT_STATUS } from '../../server/lib/status/report-status';
+import type { UserRole } from '../../server/types/auth';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+// Import AFTER mock is hoisted.
+// eslint-disable-next-line import/order
+import { inspectionsRoutes } from '../../server/api/inspections';
+import { InspectionService } from '../../server/services/inspection.service';
+
+const TENANT   = '00000000-0000-0000-0000-000000000001';
+const USER_ID  = '00000000-0000-0000-0000-000000000099';
+const INSP_ID  = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const FAKE_ENV = { DB: {} } as HonoConfig['Bindings'];
+
+// ── app factory ──────────────────────────────────────────────────────────────
+
+/**
+ * Builds a minimal Hono app mounting inspectionsRoutes with a real
+ * InspectionService backed by the in-memory SQLite DB. Capability checks read
+ * permission_overrides from the DB; for these tests we control capabilities
+ * purely through `role` (owner/manager have publish=true, agent has
+ * publish=false/pinned, inspector defaults to publish=true).
+ */
+function buildApp(
+    db: BetterSQLite3Database<typeof schema>,
+    role: UserRole,
+) {
+    (mockDrizzle as ReturnType<typeof vi.fn>).mockReturnValue(db);
+    const svc = new InspectionService({} as D1Database);
+
+    const app = new OpenAPIHono<HonoConfig>();
+
+    app.onError((err, c) => {
+        if (err instanceof AppError) {
+            return c.json({ success: false, error: { code: err.code, message: err.message } }, err.status);
+        }
+        return c.json({ success: false, error: { code: 'internal_error', message: String(err) } }, 500);
+    });
+
+    app.use('*', async (c, next) => {
+        c.set('tenantId', TENANT);
+        c.set('userRole', role);
+        c.set('user', { sub: USER_ID, role, tenantId: TENANT });
+        // sdb is used by requireCapability to resolve permission_overrides.
+        // Provide a minimal stub that returns null overrides (pure role defaults).
+        c.set('sdb', {
+            getById: async () => ({ permissionOverrides: null }),
+        } as HonoConfig['Variables']['sdb']);
+        c.set('services', {
+            inspection: svc,
+            // Stubs for other services the router may touch:
+            reportVersion: { snapshotOnPublish: vi.fn().mockResolvedValue({ versionNumber: 1 }) },
+            reportPdf: { isPipelineEnabled: vi.fn().mockResolvedValue(false) },
+        } as unknown as HonoConfig['Variables']['services']);
+        await next();
+    });
+
+    app.route('/api/inspections', inspectionsRoutes);
+    return app;
+}
+
+// ── seed helpers ─────────────────────────────────────────────────────────────
+
+async function seedInspection(
+    db: BetterSQLite3Database<typeof schema>,
+    overrides: Partial<typeof schema.inspections.$inferInsert> = {},
+) {
+    await db.insert(schema.inspections).values({
+        id:               INSP_ID,
+        tenantId:         TENANT,
+        propertyAddress:  '1 Main St',
+        clientName:       'Test Client',
+        clientEmail:      'client@example.com',
+        date:             '2026-06-01',
+        status:           INSPECTION_STATUS.COMPLETED,
+        reportStatus:     REPORT_STATUS.IN_PROGRESS,
+        paymentStatus:    'unpaid',
+        price:            0,
+        paymentRequired:  false,
+        agreementRequired: false,
+        createdAt:        new Date(),
+        ...overrides,
+    });
+}
+
+async function readReportStatus(db: BetterSQLite3Database<typeof schema>) {
+    const row = await db.select({ reportStatus: schema.inspections.reportStatus })
+        .from(schema.inspections)
+        .where(eq(schema.inspections.id, INSP_ID))
+        .get();
+    return row?.reportStatus;
+}
+
+// ── test suite ───────────────────────────────────────────────────────────────
+
+describe('POST /api/inspections/:id/submit — report review endpoints', () => {
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: ReturnType<typeof createTestDb>['sqlite'];
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        db = fixture.db as BetterSQLite3Database<typeof schema>;
+        sqlite = fixture.sqlite;
+        await setupSchema(sqlite);
+        await db.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        await db.insert(schema.users).values({
+            id: USER_ID, tenantId: TENANT, email: 'user@example.com',
+            passwordHash: 'hash', createdAt: new Date(),
+        });
+    });
+
+    // ── submit ───────────────────────────────────────────────────────────────
+
+    it('inspector POST /submit on in_progress report → 200, reportStatus=submitted', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.IN_PROGRESS });
+        const app = buildApp(db, 'inspector');
+        const res = await app.request(
+            `/api/inspections/${INSP_ID}/submit`,
+            { method: 'POST' },
+            FAKE_ENV,
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json() as { success: boolean };
+        expect(body.success).toBe(true);
+        expect(await readReportStatus(db)).toBe(REPORT_STATUS.SUBMITTED);
+    });
+
+    it('owner POST /submit on in_progress report → 200', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.IN_PROGRESS });
+        const app = buildApp(db, 'owner');
+        const res = await app.request(`/api/inspections/${INSP_ID}/submit`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+    });
+
+    it('agent POST /submit → 403 (agent not in the role gate for inspections)', async () => {
+        await seedInspection(db);
+        const app = buildApp(db, 'agent');
+        const res = await app.request(`/api/inspections/${INSP_ID}/submit`, { method: 'POST' }, FAKE_ENV);
+        // agent is excluded from owner/manager/inspector role gate → 403
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('POST /api/inspections/:id/return — publish-gated', () => {
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: ReturnType<typeof createTestDb>['sqlite'];
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        db = fixture.db as BetterSQLite3Database<typeof schema>;
+        sqlite = fixture.sqlite;
+        await setupSchema(sqlite);
+        await db.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        await db.insert(schema.users).values({
+            id: USER_ID, tenantId: TENANT, email: 'user@example.com',
+            passwordHash: 'hash', createdAt: new Date(),
+        });
+    });
+
+    it('manager POST /return on submitted report → 200, reportStatus=in_progress', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.SUBMITTED });
+        const app = buildApp(db, 'manager');
+        const res = await app.request(`/api/inspections/${INSP_ID}/return`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { success: boolean };
+        expect(body.success).toBe(true);
+        expect(await readReportStatus(db)).toBe(REPORT_STATUS.IN_PROGRESS);
+    });
+
+    it('owner POST /return on submitted report → 200', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.SUBMITTED });
+        const app = buildApp(db, 'owner');
+        const res = await app.request(`/api/inspections/${INSP_ID}/return`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+    });
+
+    it('inspector (publish:false override via sdb) POST /return → 403', async () => {
+        // Simulate an inspector whose publish capability is revoked via
+        // permission_overrides. We override the sdb stub to return {publish:false}.
+        await seedInspection(db, { reportStatus: REPORT_STATUS.SUBMITTED });
+        (mockDrizzle as ReturnType<typeof vi.fn>).mockReturnValue(db);
+        const svc = new InspectionService({} as D1Database);
+
+        const app = new OpenAPIHono<HonoConfig>();
+        app.onError((err, c) => {
+            if (err instanceof AppError) return c.json({ success: false, error: { code: err.code, message: err.message } }, err.status);
+            return c.json({ success: false, error: { code: 'internal_error', message: String(err) } }, 500);
+        });
+        app.use('*', async (c, next) => {
+            c.set('tenantId', TENANT);
+            c.set('userRole', 'inspector');
+            c.set('user', { sub: USER_ID, role: 'inspector', tenantId: TENANT });
+            // Return publish:false override — simulates "requires review" inspector
+            c.set('sdb', {
+                getById: async () => ({ permissionOverrides: { publish: false } }),
+            } as HonoConfig['Variables']['sdb']);
+            c.set('services', {
+                inspection: svc,
+                reportVersion: { snapshotOnPublish: vi.fn().mockResolvedValue({ versionNumber: 1 }) },
+                reportPdf: { isPipelineEnabled: vi.fn().mockResolvedValue(false) },
+            } as unknown as HonoConfig['Variables']['services']);
+            await next();
+        });
+        app.route('/api/inspections', inspectionsRoutes);
+
+        const res = await app.request(`/api/inspections/${INSP_ID}/return`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(403);
+    });
+
+    it('inspector with default publish:true POST /return → 200', async () => {
+        // Inspector's default has publish=true; should be allowed.
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.SUBMITTED });
+        const app = buildApp(db, 'inspector');
+        const res = await app.request(`/api/inspections/${INSP_ID}/return`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+    });
+});
+
+describe('POST /api/inspections/:id/unpublish — publish-gated', () => {
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: ReturnType<typeof createTestDb>['sqlite'];
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        db = fixture.db as BetterSQLite3Database<typeof schema>;
+        sqlite = fixture.sqlite;
+        await setupSchema(sqlite);
+        await db.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        await db.insert(schema.users).values({
+            id: USER_ID, tenantId: TENANT, email: 'user@example.com',
+            passwordHash: 'hash', createdAt: new Date(),
+        });
+    });
+
+    it('manager POST /unpublish on published report → 200, reportStatus=in_progress', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.PUBLISHED });
+        const app = buildApp(db, 'manager');
+        const res = await app.request(`/api/inspections/${INSP_ID}/unpublish`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+        const body = await res.json() as { success: boolean };
+        expect(body.success).toBe(true);
+        expect(await readReportStatus(db)).toBe(REPORT_STATUS.IN_PROGRESS);
+    });
+
+    it('owner POST /unpublish on published report → 200', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.PUBLISHED });
+        const app = buildApp(db, 'owner');
+        const res = await app.request(`/api/inspections/${INSP_ID}/unpublish`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+    });
+
+    it('inspector (publish:false override) POST /unpublish → 403', async () => {
+        await seedInspection(db, { reportStatus: REPORT_STATUS.PUBLISHED });
+        (mockDrizzle as ReturnType<typeof vi.fn>).mockReturnValue(db);
+        const svc = new InspectionService({} as D1Database);
+
+        const app = new OpenAPIHono<HonoConfig>();
+        app.onError((err, c) => {
+            if (err instanceof AppError) return c.json({ success: false, error: { code: err.code, message: err.message } }, err.status);
+            return c.json({ success: false, error: { code: 'internal_error', message: String(err) } }, 500);
+        });
+        app.use('*', async (c, next) => {
+            c.set('tenantId', TENANT);
+            c.set('userRole', 'inspector');
+            c.set('user', { sub: USER_ID, role: 'inspector', tenantId: TENANT });
+            c.set('sdb', {
+                getById: async () => ({ permissionOverrides: { publish: false } }),
+            } as HonoConfig['Variables']['sdb']);
+            c.set('services', {
+                inspection: svc,
+                reportVersion: { snapshotOnPublish: vi.fn().mockResolvedValue({ versionNumber: 1 }) },
+                reportPdf: { isPipelineEnabled: vi.fn().mockResolvedValue(false) },
+            } as unknown as HonoConfig['Variables']['services']);
+            await next();
+        });
+        app.route('/api/inspections', inspectionsRoutes);
+
+        const res = await app.request(`/api/inspections/${INSP_ID}/unpublish`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(403);
+    });
+
+    it('inspector with default publish:true POST /unpublish → 200', async () => {
+        await seedInspection(db, { status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.PUBLISHED });
+        const app = buildApp(db, 'inspector');
+        const res = await app.request(`/api/inspections/${INSP_ID}/unpublish`, { method: 'POST' }, FAKE_ENV);
+        expect(res.status).toBe(200);
+    });
+});

--- a/tests/unit/report-review-workflow.spec.ts
+++ b/tests/unit/report-review-workflow.spec.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InspectionService } from '../../server/services/inspection.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../server/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq, and } from 'drizzle-orm';
+import { INSPECTION_STATUS } from '../../server/lib/status/inspection-status';
+import { REPORT_STATUS } from '../../server/lib/status/report-status';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT = '00000000-0000-0000-0000-000000000001';
+
+/** Helper: returns the current report_status + status for an inspection row. */
+async function readStatuses(db: BetterSQLite3Database<typeof schema>, id: string) {
+    const row = await db.select({
+        status:       schema.inspections.status,
+        reportStatus: schema.inspections.reportStatus,
+    }).from(schema.inspections)
+        .where(eq(schema.inspections.id, id))
+        .get();
+    if (!row) throw new Error(`inspection ${id} not found`);
+    return row;
+}
+
+function makeInspection(overrides: Partial<typeof schema.inspections.$inferInsert> & { id: string }) {
+    return {
+        tenantId:          TENANT,
+        propertyAddress:   '1 Main St',
+        clientName:        'Test Client',
+        clientEmail:       'test@example.com',
+        date:              '2026-06-01',
+        status:            INSPECTION_STATUS.COMPLETED,
+        reportStatus:      REPORT_STATUS.IN_PROGRESS,
+        paymentStatus:     'unpaid',
+        price:             0,
+        paymentRequired:   false,
+        agreementRequired: false,
+        createdAt:         new Date(),
+        ...overrides,
+    } satisfies typeof schema.inspections.$inferInsert;
+}
+
+describe('Report review workflow (submit / publish / return / unpublish)', () => {
+    let svc: InspectionService;
+    let testDb: BetterSQLite3Database<typeof schema>;
+
+    beforeEach(async () => {
+        const fixture = createTestDb();
+        testDb = fixture.db;
+        await setupSchema(fixture.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        svc = new InspectionService({} as D1Database);
+
+        await testDb.insert(schema.tenants).values([
+            { id: TENANT, name: 'Acme', slug: 'acme', status: 'active', deploymentMode: 'shared', tier: 'free', createdAt: new Date() },
+        ]);
+    });
+
+    // ─── publishInspection ────────────────────────────────────────────────────
+
+    it('1. publish sets reportStatus=PUBLISHED and leaves status=COMPLETED', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-pub-1', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.IN_PROGRESS }),
+        ]);
+
+        await svc.publishInspection('insp-pub-1', TENANT, {
+            theme: 'default', notifyClient: false, notifyAgent: false,
+            requireSignature: false, requirePayment: false,
+        });
+
+        const row = await readStatuses(testDb, 'insp-pub-1');
+        expect(row.reportStatus).toBe(REPORT_STATUS.PUBLISHED);
+        expect(row.status).toBe(INSPECTION_STATUS.COMPLETED);
+    });
+
+    it('2. publish throws when inspection status !== completed (e.g. scheduled)', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-pub-2', status: INSPECTION_STATUS.SCHEDULED }),
+        ]);
+
+        await expect(
+            svc.publishInspection('insp-pub-2', TENANT, {
+                theme: 'default', notifyClient: false, notifyAgent: false,
+                requireSignature: false, requirePayment: false,
+            })
+        ).rejects.toThrow(/must be completed/i);
+    });
+
+    it('6. re-publish an already-published completed inspection stays published', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-pub-6', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.PUBLISHED }),
+        ]);
+
+        // Should NOT throw — re-publishing an already-published report is idempotent
+        await svc.publishInspection('insp-pub-6', TENANT, {
+            theme: 'default', notifyClient: false, notifyAgent: false,
+            requireSignature: false, requirePayment: false,
+        });
+
+        const row = await readStatuses(testDb, 'insp-pub-6');
+        expect(row.reportStatus).toBe(REPORT_STATUS.PUBLISHED);
+        expect(row.status).toBe(INSPECTION_STATUS.COMPLETED);
+    });
+
+    // ─── submitReport ─────────────────────────────────────────────────────────
+
+    it('3. submitReport transitions in_progress → submitted (completed inspection)', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-sub-1', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.IN_PROGRESS }),
+        ]);
+
+        await svc.submitReport('insp-sub-1', TENANT);
+
+        const row = await readStatuses(testDb, 'insp-sub-1');
+        expect(row.reportStatus).toBe(REPORT_STATUS.SUBMITTED);
+        expect(row.status).toBe(INSPECTION_STATUS.COMPLETED);
+    });
+
+    it('submitReport throws when inspection status !== completed (e.g. scheduled)', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-sub-2', status: INSPECTION_STATUS.SCHEDULED }),
+        ]);
+
+        await expect(svc.submitReport('insp-sub-2', TENANT))
+            .rejects.toThrow(/must be completed/i);
+    });
+
+    it('submitReport throws when reportStatus is not in_progress (e.g. already submitted)', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-sub-3', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.SUBMITTED }),
+        ]);
+
+        await expect(svc.submitReport('insp-sub-3', TENANT))
+            .rejects.toThrow(/cannot submit/i);
+    });
+
+    // ─── returnReport ─────────────────────────────────────────────────────────
+
+    it('4. returnReport transitions submitted → in_progress', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-ret-1', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.SUBMITTED }),
+        ]);
+
+        await svc.returnReport('insp-ret-1', TENANT);
+
+        const row = await readStatuses(testDb, 'insp-ret-1');
+        expect(row.reportStatus).toBe(REPORT_STATUS.IN_PROGRESS);
+    });
+
+    it('returnReport throws when reportStatus !== submitted', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-ret-2', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.IN_PROGRESS }),
+        ]);
+
+        await expect(svc.returnReport('insp-ret-2', TENANT))
+            .rejects.toThrow(/only submitted/i);
+    });
+
+    // ─── unpublishReport ──────────────────────────────────────────────────────
+
+    it('5. unpublishReport transitions published → in_progress', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-unp-1', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.PUBLISHED }),
+        ]);
+
+        await svc.unpublishReport('insp-unp-1', TENANT);
+
+        const row = await readStatuses(testDb, 'insp-unp-1');
+        expect(row.reportStatus).toBe(REPORT_STATUS.IN_PROGRESS);
+    });
+
+    it('unpublishReport throws when reportStatus !== published', async () => {
+        await testDb.insert(schema.inspections).values([
+            makeInspection({ id: 'insp-unp-2', status: INSPECTION_STATUS.COMPLETED, reportStatus: REPORT_STATUS.SUBMITTED }),
+        ]);
+
+        await expect(svc.unpublishReport('insp-unp-2', TENANT))
+            .rejects.toThrow(/only published/i);
+    });
+});

--- a/tests/unit/report-version-service.spec.ts
+++ b/tests/unit/report-version-service.spec.ts
@@ -19,7 +19,7 @@ async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.inspections).values({
         id: INSPECTION, tenantId: TENANT,
         propertyAddress: '1 Main St', date: '2026-06-01',
-        status: 'draft', paymentStatus: 'unpaid', price: 0,
+        status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
 }

--- a/tests/unit/section-disclaimer-render.spec.ts
+++ b/tests/unit/section-disclaimer-render.spec.ts
@@ -63,7 +63,7 @@ describe('Track E2 — section disclaimer + alwaysPageBreak surfacing', () => {
         await testDb.insert(schema.inspections).values({
             id: INSPECTION_ID, tenantId: TENANT, templateId: TEMPLATE_ID,
             propertyAddress: '1 Main St', clientName: 'C', clientEmail: 'c@example.com',
-            date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+            date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
             paymentRequired: false, agreementRequired: false, createdAt: new Date(),
         });
     });

--- a/tests/unit/sms-api.spec.ts
+++ b/tests/unit/sms-api.spec.ts
@@ -99,7 +99,7 @@ describe('SMS consent API (Track L Task 8)', () => {
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT, propertyAddress: '1 Main', clientName: 'Jane',
             clientEmail: 'jane@x.com', clientContactId: contactId, date: '2026-07-01',
-            status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+            status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         } as never);
 
         const app = buildApp(db);
@@ -117,7 +117,7 @@ describe('SMS consent API (Track L Task 8)', () => {
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT, propertyAddress: '2 Oak', clientName: 'Bob',
             clientEmail: 'bob@x.com', clientContactId: null, date: '2026-07-02',
-            status: 'draft', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+            status: 'requested', paymentStatus: 'unpaid', price: 0, agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         } as never);
 
         const app = buildApp(db);
@@ -139,7 +139,7 @@ describe('SMS consent API (Track L Task 8)', () => {
         const inspId = crypto.randomUUID();
         await db.insert(schema.inspections).values({
             id: inspId, tenantId: TENANT, propertyAddress: '1 Main', clientName: 'Jane',
-            clientContactId: contactId, date: '2026-07-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+            clientContactId: contactId, date: '2026-07-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         } as never);
         await new SmsConsentService({} as D1Database).record(TENANT, contactId, 'granted', 'booking_form', {});

--- a/tests/unit/sms-ensure-contact.spec.ts
+++ b/tests/unit/sms-ensure-contact.spec.ts
@@ -32,7 +32,7 @@ async function seedInspection(over: Partial<typeof schema.inspections.$inferInse
     await db.insert(schema.inspections).values({
         id, tenantId: TENANT, propertyAddress: '1 Main', clientName: 'Jane',
         clientEmail: 'jane@example.com', clientPhone: '(555) 123-4567',
-        date: '2026-07-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+        date: '2026-07-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
         agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         ...over,
     } as never);

--- a/tests/unit/status-split.spec.ts
+++ b/tests/unit/status-split.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  INSPECTION_STATUSES, INSPECTION_STATUS, isInspectionStatus, INSPECTION_STATUS_LABELS,
+} from '../../server/lib/status/inspection-status';
+import {
+  REPORT_STATUSES, REPORT_STATUS, isReportStatus, isReportPublished, REPORT_STATUS_LABELS,
+} from '../../server/lib/status/report-status';
+
+describe('inspection-status source of truth', () => {
+  it('exposes the 5 lifecycle statuses', () => {
+    expect(INSPECTION_STATUSES).toEqual(['requested', 'scheduled', 'confirmed', 'completed', 'cancelled']);
+  });
+  it('named constants match the array', () => {
+    expect(INSPECTION_STATUS.REQUESTED).toBe('requested');
+    expect(INSPECTION_STATUS.CANCELLED).toBe('cancelled');
+  });
+  it('isInspectionStatus narrows correctly', () => {
+    expect(isInspectionStatus('scheduled')).toBe(true);
+    expect(isInspectionStatus('delivered')).toBe(false);
+    expect(isInspectionStatus(null)).toBe(false);
+  });
+  it('has a label for every inspection status', () => {
+    for (const s of INSPECTION_STATUSES) expect(INSPECTION_STATUS_LABELS[s]).toBeTruthy();
+  });
+});
+
+describe('report-status source of truth', () => {
+  it('exposes the 3 report statuses', () => {
+    expect(REPORT_STATUSES).toEqual(['in_progress', 'submitted', 'published']);
+  });
+  it('isReportPublished only true for published', () => {
+    expect(isReportPublished('published')).toBe(true);
+    expect(isReportPublished('submitted')).toBe(false);
+    expect(isReportPublished('in_progress')).toBe(false);
+    expect(isReportPublished(undefined)).toBe(false);
+  });
+  it('isReportStatus narrows', () => {
+    expect(isReportStatus('submitted')).toBe(true);
+    expect(isReportStatus('delivered')).toBe(false);
+  });
+  it('has a label for every report status', () => {
+    for (const s of REPORT_STATUSES) expect(REPORT_STATUS_LABELS[s]).toBeTruthy();
+  });
+});

--- a/tests/unit/tenant-purge.service.spec.ts
+++ b/tests/unit/tenant-purge.service.spec.ts
@@ -55,7 +55,7 @@ describe('TenantPurgeService.purge', () => {
         });
         await testDb.insert(schema.inspections).values({
             id: 'i-1', tenantId: TENANT, propertyAddress: '1 St', date: '2026-06-01',
-            status: 'draft', paymentStatus: 'unpaid', price: 0,
+            status: 'requested', paymentStatus: 'unpaid', price: 0,
             agreementRequired: false, paymentRequired: false, createdAt: new Date(),
         });
     });

--- a/tests/unit/unit-service.spec.ts
+++ b/tests/unit/unit-service.spec.ts
@@ -24,7 +24,7 @@ async function seed(testDb: BetterSQLite3Database<typeof schema>) {
     await testDb.insert(schema.inspections).values({
         id: INSPECTION, tenantId: TENANT,
         propertyAddress: '1 Main St',
-        date: '2026-06-01', status: 'draft', paymentStatus: 'unpaid', price: 0,
+        date: '2026-06-01', status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
 }

--- a/tests/web/dashboard-tabs.spec.ts
+++ b/tests/web/dashboard-tabs.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { tabMatches } from '~/routes/dashboard';
+
+function insp(status: string, reportStatus = 'in_progress', paymentStatus?: string) {
+  return { id: 'i1', date: null, address: null, clientName: null, status, reportStatus, paymentStatus };
+}
+
+describe('tabMatches — all', () => {
+  it('always true', () => {
+    expect(tabMatches('all', insp('requested'))).toBe(true);
+    expect(tabMatches('all', insp('cancelled'))).toBe(true);
+  });
+});
+
+describe('tabMatches — active (requested/scheduled/confirmed)', () => {
+  it.each(['requested', 'scheduled', 'confirmed'])('matches %s', (s) => {
+    expect(tabMatches('active', insp(s))).toBe(true);
+  });
+  it('does not match completed', () => {
+    expect(tabMatches('active', insp('completed'))).toBe(false);
+  });
+  it('does not match cancelled', () => {
+    expect(tabMatches('active', insp('cancelled'))).toBe(false);
+  });
+});
+
+describe('tabMatches — requested', () => {
+  it('matches requested', () => {
+    expect(tabMatches('requested', insp('requested'))).toBe(true);
+  });
+  it('does not match scheduled', () => {
+    expect(tabMatches('requested', insp('scheduled'))).toBe(false);
+  });
+});
+
+describe('tabMatches — to_review', () => {
+  it('matches submitted reportStatus', () => {
+    expect(tabMatches('to_review', insp('completed', 'submitted'))).toBe(true);
+  });
+  it('does not match in_progress', () => {
+    expect(tabMatches('to_review', insp('completed', 'in_progress'))).toBe(false);
+  });
+  it('does not match published', () => {
+    expect(tabMatches('to_review', insp('completed', 'published'))).toBe(false);
+  });
+});
+
+describe('tabMatches — published', () => {
+  it('matches published reportStatus', () => {
+    expect(tabMatches('published', insp('completed', 'published'))).toBe(true);
+  });
+  it('does not match in_progress', () => {
+    expect(tabMatches('published', insp('completed', 'in_progress'))).toBe(false);
+  });
+});
+
+describe('tabMatches — awaiting_payment', () => {
+  it('published + unpaid → true', () => {
+    expect(tabMatches('awaiting_payment', insp('completed', 'published', 'unpaid'))).toBe(true);
+  });
+  it('published + paid → false', () => {
+    expect(tabMatches('awaiting_payment', insp('completed', 'published', 'paid'))).toBe(false);
+  });
+  it('in_progress + unpaid → false', () => {
+    expect(tabMatches('awaiting_payment', insp('completed', 'in_progress', 'unpaid'))).toBe(false);
+  });
+});
+
+describe('tabMatches — cancelled', () => {
+  it('matches cancelled', () => {
+    expect(tabMatches('cancelled', insp('cancelled'))).toBe(true);
+  });
+  it('does not match requested', () => {
+    expect(tabMatches('cancelled', insp('requested'))).toBe(false);
+  });
+});

--- a/tests/web/hub-blocks.spec.ts
+++ b/tests/web/hub-blocks.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { isReportShipped, canPublish, type HubPayload } from '~/lib/hub-blocks';
+
+function hub(overrides: {
+    inspection?: Partial<HubPayload['inspection']>;
+    publishReadiness?: HubPayload['publishReadiness'];
+} = {}): HubPayload {
+    return {
+        inspection: {
+            status: 'requested',
+            reportStatus: 'in_progress',
+            paymentRequired: false,
+            agreementRequired: false,
+            ...overrides.inspection,
+        },
+        agreementRequests: [],
+        invoice: null,
+        publishReadiness: overrides.publishReadiness ?? { ready: false, blockingCount: 0 },
+    } as HubPayload;
+}
+
+describe('isReportShipped', () => {
+    it('published → true', () => {
+        expect(isReportShipped(hub({ inspection: { reportStatus: 'published' } }))).toBe(true);
+    });
+    it('in_progress → false', () => {
+        expect(isReportShipped(hub({ inspection: { reportStatus: 'in_progress' } }))).toBe(false);
+    });
+    it('submitted → false', () => {
+        expect(isReportShipped(hub({ inspection: { reportStatus: 'submitted' } }))).toBe(false);
+    });
+});
+
+describe('canPublish', () => {
+    it('completed + in_progress → true', () => {
+        expect(canPublish(hub({ inspection: { status: 'completed', reportStatus: 'in_progress' } }))).toBe(true);
+    });
+    it('completed + submitted → true (can still publish bypassing review)', () => {
+        expect(canPublish(hub({ inspection: { status: 'completed', reportStatus: 'submitted' } }))).toBe(true);
+    });
+    it('completed + published → false (already published)', () => {
+        expect(canPublish(hub({ inspection: { status: 'completed', reportStatus: 'published' } }))).toBe(false);
+    });
+    it('requested + in_progress → false (not completed)', () => {
+        expect(canPublish(hub({ inspection: { status: 'requested', reportStatus: 'in_progress' } }))).toBe(false);
+    });
+    it('cancelled + in_progress → false (cancelled)', () => {
+        expect(canPublish(hub({ inspection: { status: 'cancelled', reportStatus: 'in_progress' } }))).toBe(false);
+    });
+    it('scheduled + in_progress → false (not completed)', () => {
+        expect(canPublish(hub({ inspection: { status: 'scheduled', reportStatus: 'in_progress' } }))).toBe(false);
+    });
+});

--- a/tests/web/inspection-hub-actions.spec.ts
+++ b/tests/web/inspection-hub-actions.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { reportActions } from '~/routes/inspection-hub';
+
+const publishCaps = { publish: true };
+const noCaps = { publish: false };
+
+describe('reportActions', () => {
+  it('non-completed → []', () => {
+    expect(reportActions(publishCaps, 'in_progress', 'requested')).toEqual([]);
+    expect(reportActions(publishCaps, 'in_progress', 'scheduled')).toEqual([]);
+    expect(reportActions(publishCaps, 'in_progress', 'cancelled')).toEqual([]);
+  });
+
+  it('completed + published + publish cap → unpublish', () => {
+    expect(reportActions(publishCaps, 'published', 'completed')).toEqual(['unpublish']);
+  });
+
+  it('completed + published + no cap → []', () => {
+    expect(reportActions(noCaps, 'published', 'completed')).toEqual([]);
+  });
+
+  it('completed + submitted + publish cap → publish, return', () => {
+    expect(reportActions(publishCaps, 'submitted', 'completed')).toEqual(['publish', 'return']);
+  });
+
+  it('completed + submitted + no cap → []', () => {
+    expect(reportActions(noCaps, 'submitted', 'completed')).toEqual([]);
+  });
+
+  it('completed + in_progress + publish cap → publish', () => {
+    expect(reportActions(publishCaps, 'in_progress', 'completed')).toEqual(['publish']);
+  });
+
+  it('completed + in_progress + no cap → submit', () => {
+    expect(reportActions(noCaps, 'in_progress', 'completed')).toEqual(['submit']);
+  });
+});

--- a/tests/web/inspections-list.spec.ts
+++ b/tests/web/inspections-list.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { groupByInspectionStatus } from '~/routes/inspections';
+
+describe('groupByInspectionStatus', () => {
+  it('groups rows by status in canonical order', () => {
+    const rows = [
+      { id: '1', status: 'completed' },
+      { id: '2', status: 'requested' },
+      { id: '3', status: 'completed' },
+      { id: '4', status: 'scheduled' },
+    ];
+    const groups = groupByInspectionStatus(rows);
+    // canonical order: requested, scheduled, confirmed, completed, cancelled
+    expect(groups.map(g => g.status)).toEqual(['requested', 'scheduled', 'completed']);
+    expect(groups.find(g => g.status === 'requested')?.items).toHaveLength(1);
+    expect(groups.find(g => g.status === 'completed')?.items).toHaveLength(2);
+  });
+
+  it('excludes empty buckets', () => {
+    const rows = [{ id: '1', status: 'cancelled' }];
+    const groups = groupByInspectionStatus(rows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].status).toBe('cancelled');
+  });
+
+  it('uses INSPECTION_STATUS_LABELS for label', () => {
+    const rows = [{ id: '1', status: 'confirmed' }];
+    const groups = groupByInspectionStatus(rows);
+    expect(groups[0].label).toBe('Confirmed');
+  });
+
+  it('returns empty array when no rows', () => {
+    expect(groupByInspectionStatus([])).toEqual([]);
+  });
+
+  it('drops unknown statuses', () => {
+    const rows = [
+      { id: '1', status: 'completed' },
+      { id: '2', status: 'unknown_status' },
+    ];
+    const groups = groupByInspectionStatus(rows);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].status).toBe('completed');
+  });
+});

--- a/tests/web/unit/dashboard-workflow.spec.ts
+++ b/tests/web/unit/dashboard-workflow.spec.ts
@@ -2,62 +2,73 @@ import { describe, it, expect } from "vitest";
 import { matchesWorkflow } from "~/routes/dashboard";
 
 /**
- * #111 — the standalone /reports page is retired and its report-oriented list
- * moves into the dashboard's "Published" workflow tab. These tests pin the
- * widened Published filter and the matching narrowing of the Active tab
- * (report-ready statuses are no longer fieldwork).
+ * Status-split update: the Published tab now matches on reportStatus=published,
+ * and the Active tab matches inspection statuses requested/scheduled/confirmed.
+ * Old statuses (draft/delivered/in_progress/signed) no longer exist in the
+ * canonical model; these tests reflect the new semantics.
  */
 
-// matchesWorkflow only reads `status` (and paymentStatus for awaiting_payment);
-// build a minimal inspection for each status under test.
-function insp(status: string, paymentStatus?: string) {
+// matchesWorkflow reads status (and reportStatus + paymentStatus for some tabs).
+function insp(status: string, paymentStatus?: string, reportStatus = 'in_progress') {
   return {
     id: "i1",
     date: null,
     address: null,
     clientName: null,
     status,
+    reportStatus,
     paymentStatus,
   };
 }
 
-describe("matchesWorkflow — published tab (report view absorption)", () => {
-  it.each(["completed", "delivered", "published", "signed"])(
-    "matches report-ready status %s",
-    (status) => {
-      expect(matchesWorkflow(insp(status), "published")).toBe(true);
+describe("matchesWorkflow — published tab (reportStatus axis)", () => {
+  it("matches published reportStatus", () => {
+    expect(matchesWorkflow(insp("completed", undefined, "published"), "published")).toBe(true);
+  });
+
+  it.each(["in_progress", "submitted"])(
+    "does not match non-published reportStatus %s",
+    (reportStatus) => {
+      expect(matchesWorkflow(insp("completed", undefined, reportStatus), "published")).toBe(false);
     },
   );
 
-  it.each(["draft", "scheduled", "in_progress", "cancelled"])(
-    "does not match non-report status %s",
-    (status) => {
-      expect(matchesWorkflow(insp(status), "published")).toBe(false);
-    },
-  );
+  it("does not match cancelled status (reportStatus published)", () => {
+    // reportStatus=published but inspection cancelled — still matches (report shipped)
+    expect(matchesWorkflow(insp("cancelled", undefined, "published"), "published")).toBe(true);
+  });
 });
 
-describe("matchesWorkflow — active tab (fieldwork only)", () => {
-  it.each(["scheduled", "in_progress", "confirmed", "draft"])(
-    "matches fieldwork status %s",
+describe("matchesWorkflow — active tab (requested/scheduled/confirmed)", () => {
+  it.each(["requested", "scheduled", "confirmed"])(
+    "matches active inspection status %s",
     (status) => {
       expect(matchesWorkflow(insp(status), "active")).toBe(true);
     },
   );
 
-  it("no longer matches completed (report-ready is not fieldwork)", () => {
+  it("does not match completed", () => {
     expect(matchesWorkflow(insp("completed"), "active")).toBe(false);
+  });
+
+  it("does not match cancelled", () => {
+    expect(matchesWorkflow(insp("cancelled"), "active")).toBe(false);
   });
 });
 
 describe("matchesWorkflow — unchanged tab semantics", () => {
-  it("drafts tab matches draft", () => {
-    expect(matchesWorkflow(insp("draft"), "drafts")).toBe(true);
+  it("requested tab matches requested", () => {
+    expect(matchesWorkflow(insp("requested"), "requested")).toBe(true);
   });
 
-  it("awaiting_payment matches delivered+unpaid", () => {
-    expect(matchesWorkflow(insp("delivered", "unpaid"), "awaiting_payment")).toBe(true);
-    expect(matchesWorkflow(insp("delivered", "paid"), "awaiting_payment")).toBe(false);
+  it("awaiting_payment matches published reportStatus + unpaid", () => {
+    expect(matchesWorkflow(insp("completed", "unpaid", "published"), "awaiting_payment")).toBe(true);
+    expect(matchesWorkflow(insp("completed", "paid", "published"), "awaiting_payment")).toBe(false);
+  });
+
+  it("to_review matches submitted reportStatus", () => {
+    expect(matchesWorkflow(insp("completed", undefined, "submitted"), "to_review")).toBe(true);
+    expect(matchesWorkflow(insp("completed", undefined, "in_progress"), "to_review")).toBe(false);
   });
 
   it("cancelled tab matches cancelled", () => {
@@ -65,6 +76,6 @@ describe("matchesWorkflow — unchanged tab semantics", () => {
   });
 
   it("all tab matches anything", () => {
-    expect(matchesWorkflow(insp("draft"), "all")).toBe(true);
+    expect(matchesWorkflow(insp("requested"), "all")).toBe(true);
   });
 });

--- a/tests/web/unit/inspection-hub.spec.ts
+++ b/tests/web/unit/inspection-hub.spec.ts
@@ -19,7 +19,8 @@ function hub(overrides: {
 } = {}): HubPayload {
     return {
         inspection: {
-            status: 'draft',
+            status: 'requested',
+            reportStatus: 'in_progress',
             paymentRequired: false,
             agreementRequired: false,
             ...overrides.inspection,
@@ -127,96 +128,77 @@ describe('deriveBlockStates — invoice block', () => {
     });
 });
 
-describe('deriveBlockStates — report block', () => {
-    it.each(['draft', 'scheduled', 'confirmed', 'in_progress'])(
-        '%s status → neutral / In progress',
-        (status) => {
-            const s = deriveBlockStates(hub({ inspection: { status } }));
-            expect(s.report).toEqual({ tone: 'neutral', label: 'In progress' });
-        },
-    );
-
-    it('completed & ready → monitor / Ready to publish', () => {
-        const s = deriveBlockStates(hub({
-            inspection: { status: 'completed' },
-            publishReadiness: { ready: true, blockingCount: 0 },
-        }));
-        expect(s.report).toEqual({ tone: 'monitor', label: 'Ready to publish' });
+describe('deriveBlockStates — report block (reportStatus axis)', () => {
+    it('in_progress reportStatus → neutral / In Progress', () => {
+        const s = deriveBlockStates(hub({ inspection: { reportStatus: 'in_progress' } }));
+        expect(s.report).toEqual({ tone: 'neutral', label: 'In Progress' });
     });
 
-    it('completed & not ready → warning / N blocker(s)', () => {
-        const s = deriveBlockStates(hub({
-            inspection: { status: 'completed' },
-            publishReadiness: { ready: false, blockingCount: 3 },
-        }));
-        expect(s.report).toEqual({ tone: 'warning', label: '3 blocker(s)' });
+    it('submitted reportStatus → warning / Submitted', () => {
+        const s = deriveBlockStates(hub({ inspection: { reportStatus: 'submitted' } }));
+        expect(s.report).toEqual({ tone: 'warning', label: 'Submitted' });
     });
 
-    it.each(['delivered', 'published'])('%s status → sat / Published', (status) => {
-        const s = deriveBlockStates(hub({ inspection: { status } }));
+    it('published reportStatus → sat / Published', () => {
+        const s = deriveBlockStates(hub({ inspection: { reportStatus: 'published' } }));
         expect(s.report).toEqual({ tone: 'sat', label: 'Published' });
     });
 
-    it('signed status → info / Signed', () => {
-        const s = deriveBlockStates(hub({ inspection: { status: 'signed' } }));
-        expect(s.report).toEqual({ tone: 'info', label: 'Signed' });
-    });
-
-    it('cancelled status → defect / Cancelled', () => {
-        const s = deriveBlockStates(hub({ inspection: { status: 'cancelled' } }));
-        expect(s.report).toEqual({ tone: 'defect', label: 'Cancelled' });
+    it('unknown reportStatus → neutral / In Progress (safe default)', () => {
+        const s = deriveBlockStates(hub({ inspection: { reportStatus: 'unknown_value' } }));
+        expect(s.report).toEqual({ tone: 'neutral', label: 'In Progress' });
     });
 });
 
-describe('canPublish — report publish affordance (Task 9)', () => {
-    it('completed & ready → true (active publish CTA)', () => {
+describe('canPublish — report publish affordance', () => {
+    it('completed + in_progress → true (active publish CTA)', () => {
         expect(canPublish(hub({
-            inspection: { status: 'completed' },
-            publishReadiness: { ready: true, blockingCount: 0 },
+            inspection: { status: 'completed', reportStatus: 'in_progress' },
         }))).toBe(true);
     });
 
-    it('completed & NOT ready → false (disabled, blockers shown)', () => {
+    it('completed + submitted → true (can still publish bypassing review)', () => {
         expect(canPublish(hub({
-            inspection: { status: 'completed' },
-            publishReadiness: { ready: false, blockingCount: 3 },
+            inspection: { status: 'completed', reportStatus: 'submitted' },
+        }))).toBe(true);
+    });
+
+    it('completed + published → false (already published)', () => {
+        expect(canPublish(hub({
+            inspection: { status: 'completed', reportStatus: 'published' },
         }))).toBe(false);
     });
 
-    it('in_progress & ready → false (status gate: nothing to publish yet)', () => {
-        // Even with a ready readiness flag, only `completed` may publish.
+    it('requested + in_progress → false (status gate: not completed yet)', () => {
         expect(canPublish(hub({
-            inspection: { status: 'in_progress' },
-            publishReadiness: { ready: true, blockingCount: 0 },
+            inspection: { status: 'requested', reportStatus: 'in_progress' },
         }))).toBe(false);
     });
 
-    it('cancelled & ready → false (status gate excludes cancelled)', () => {
-        // A stale ready flag on a cancelled inspection must NOT offer a CTA.
+    it('cancelled + in_progress → false (status gate excludes cancelled)', () => {
         expect(canPublish(hub({
-            inspection: { status: 'cancelled' },
-            publishReadiness: { ready: true, blockingCount: 0 },
+            inspection: { status: 'cancelled', reportStatus: 'in_progress' },
         }))).toBe(false);
     });
 
-    it.each(['delivered', 'published', 'signed'])(
-        'already-shipped status %s → false (read-only, no CTA) even if ready',
-        (status) => {
-            expect(canPublish(hub({
-                inspection: { status },
-                publishReadiness: { ready: true, blockingCount: 0 },
-            }))).toBe(false);
-        },
-    );
+    it('scheduled + in_progress → false (not completed)', () => {
+        expect(canPublish(hub({
+            inspection: { status: 'scheduled', reportStatus: 'in_progress' },
+        }))).toBe(false);
+    });
 });
 
 describe('isReportShipped', () => {
-    it.each(['delivered', 'published', 'signed'])('%s → true', (status) => {
-        expect(isReportShipped(hub({ inspection: { status } }))).toBe(true);
+    it('published reportStatus → true', () => {
+        expect(isReportShipped(hub({ inspection: { reportStatus: 'published' } }))).toBe(true);
     });
 
-    it.each(['draft', 'in_progress', 'completed', 'cancelled'])('%s → false', (status) => {
-        expect(isReportShipped(hub({ inspection: { status } }))).toBe(false);
+    it('in_progress reportStatus → false', () => {
+        expect(isReportShipped(hub({ inspection: { reportStatus: 'in_progress' } }))).toBe(false);
+    });
+
+    it('submitted reportStatus → false', () => {
+        expect(isReportShipped(hub({ inspection: { reportStatus: 'submitted' } }))).toBe(false);
     });
 });
 

--- a/tests/workers/db-batch-atomicity.spec.ts
+++ b/tests/workers/db-batch-atomicity.spec.ts
@@ -25,7 +25,7 @@ async function seedSchema(): Promise<void> {
         'CREATE TABLE IF NOT EXISTS inspection_inspectors (inspection_id TEXT NOT NULL, user_id TEXT NOT NULL, tenant_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT \'lead\', created_at INTEGER NOT NULL, PRIMARY KEY (inspection_id, user_id));',
     );
     await b.DB.exec(
-        'CREATE TABLE IF NOT EXISTS inspections (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, inspector_id TEXT, property_address TEXT, date TEXT, status TEXT, request_id TEXT, created_at INTEGER NOT NULL);',
+        'CREATE TABLE IF NOT EXISTS inspections (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, inspector_id TEXT, property_address TEXT, date TEXT, status TEXT, report_status TEXT NOT NULL DEFAULT \'in_progress\', request_id TEXT, created_at INTEGER NOT NULL);',
     );
 }
 
@@ -125,7 +125,7 @@ describe('B-28 arbitrateSlotRace — real D1 semantics', () => {
     async function seedBooking(id: string, requestId: string | null, createdAtMs: number): Promise<void> {
         await b.DB.prepare(
             'INSERT INTO inspections (id, tenant_id, inspector_id, property_address, date, status, request_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-        ).bind(id, TENANT, 'insp-1', '1 Main St', ISO, 'draft', requestId, createdAtMs).run();
+        ).bind(id, TENANT, 'insp-1', '1 Main St', ISO, 'requested', requestId, createdAtMs).run();
         await seedLink(id, 'insp-1');
     }
 

--- a/tests/workers/reinspections.spec.ts
+++ b/tests/workers/reinspections.spec.ts
@@ -144,7 +144,7 @@ async function seedPublishedBaseline(
     const itemIds = Object.keys(items);
     await db.insert(schema.inspections).values({
         id: inspectionId, tenantId, propertyAddress: '123 Birch Lane', date: '2026-06-01',
-        status: 'published', paymentStatus: 'unpaid', price: 0,
+        status: 'completed', reportStatus: 'published', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
         templateSnapshot: templateSnapshot(itemIds) as never,
         templateSnapshotVersion: 1,
@@ -301,7 +301,7 @@ describe('#119 re-inspections — end-to-end (real workerd)', () => {
         // A DRAFT inspection with NO report_versions row.
         await db.insert(schema.inspections).values({
             id: DRAFT, tenantId: TENANT, propertyAddress: '9 Draft Way', date: '2026-06-01',
-            status: 'draft', paymentStatus: 'unpaid', price: 0,
+            status: 'requested', paymentStatus: 'unpaid', price: 0,
             paymentRequired: false, agreementRequired: false, createdAt: new Date(),
             templateSnapshot: templateSnapshot(['x1']) as never, templateSnapshotVersion: 1,
         });

--- a/tests/workers/report-amendments.spec.ts
+++ b/tests/workers/report-amendments.spec.ts
@@ -103,7 +103,7 @@ async function seedInspection(tenantId: string, inspectionId: string): Promise<v
     });
     await db.insert(schema.inspections).values({
         id: inspectionId, tenantId, propertyAddress: '123 Birch Lane', date: '2026-06-01',
-        status: 'draft', paymentStatus: 'unpaid', price: 0,
+        status: 'requested', paymentStatus: 'unpaid', price: 0,
         paymentRequired: false, agreementRequired: false, createdAt: new Date(),
     });
     await db.insert(schema.inspectionResults).values({


### PR DESCRIPTION
## Summary
Splits the conflated `inspections.status` enum (8 values) into two independent axes, mirroring industry practice (Spectora):

- **Inspection lifecycle** `status`: `requested | scheduled | confirmed | completed | cancelled`
- **Report (deliverable)** `report_status` (NEW): `in_progress | submitted | published`

Plus a **report review workflow** (Submit → Publish / Return / Unpublish) gated by the existing `publish` capability, and status values driven from a single source of truth (no hardcoded literals).

### Why
Publishing previously set `status='delivered'`, overwriting the lifecycle state (data loss). `'published'`/`'signed'` were enum values never written (tech debt), and `status==='delivered'||'published'` was hardcoded across ~6+ sites. The report deliverable now has its own lifecycle independent of the inspection event.

## Changes
- **Single source of truth**: `server/lib/status/inspection-status.ts` + `report-status.ts` (const tuple + type + named consts + labels + guards), mirroring `roles.ts`. App re-exports via `app/lib/status.ts`. ESLint guard against bare status literals.
- **Schema/migration**: new `report_status` column; `status` enum reduced to lifecycle. Migration `0007_status_split.sql` is **purely additive** (ADD COLUMN + backfill) to avoid a D1 FK-table rebuild; `status` DB default intentionally left (accepted `db:check` drift, same class as `users.role`).
- **Service**: `publishInspection` sets `report_status='published'` (no longer overwrites `status`); new `submitReport`/`returnReport`/`unpublishReport` with precondition guards; stats/buckets/icons key on `report_status`.
- **API**: `POST /:id/submit` (any authed user), `/return` + `/unpublish` (require `publish` capability); publish endpoint already gated.
- **Frontend**: hub-blocks pills + `canPublish`/`isReportShipped`; inspection-hub Submit/Publish/Return/Unpublish actions; dashboard tabs split by axis (+ `to_review` queue); new `/inspections` list grouped by lifecycle status.

## Behavior notes
- Editing a published report does NOT change its status (living document; Spectora-aligned). Re-publish creates a new version; Unpublish is explicit.
- Migration backfill: `delivered`/`published` → `status=completed` + `report_status=published`; `draft` → `requested`; `in_progress` → `completed` + `report_status=in_progress`.

## Testing
- type-check (app+api): green
- lint: 0 errors
- unit: 1714 pass · web: 380 pass · workers: 41 pass
- db:check: only the accepted pre-existing drift (no `report_status` drift)