### PR TITLE
Revoke client report access when not published (Un-Publish enforcement)

### DIFF
--- a/app/routes/public/report-card-stack.tsx
+++ b/app/routes/public/report-card-stack.tsx
@@ -98,6 +98,7 @@ interface LoaderResult {
  isDelivered: boolean;
  brand: TenantBrand;
  error: string | null;
+ notPublished: boolean;
  reportTheme?: string;
  initialFilter: FilterKey;
  printMode: boolean;
@@ -168,6 +169,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
  isDelivered: d?.isDelivered ?? false,
  brand,
  error: res.ok ? null : "Report not found",
+ notPublished: (res.status as number) === 403,
  reportTheme: (raw?.reportTheme as string | undefined) ?? meta?.theme,
  initialFilter,
  printMode,
@@ -193,6 +195,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
  brand: EMPTY_BRAND,
  coverPhotoUrl: null,
  error: "Service unavailable",
+ notPublished: false,
  initialFilter,
  printMode,
  isPublished: false,
@@ -380,6 +383,14 @@ export default function ReportCardStackPage() {
  };
 
  if (data.error) {
+ if (data.notPublished) {
+ return (
+ <ErrorState
+ title="This report is not published"
+ message="This report is not published. Please contact your inspector if you believe this is a mistake."
+ />
+ );
+ }
  const notFound = data.error === "Report not found";
  return (
  <ErrorState

--- a/app/routes/public/v.$token.tsx
+++ b/app/routes/public/v.$token.tsx
@@ -15,6 +15,7 @@ export interface VerifyInput {
   hashValid?: boolean;
   signatureValid?: boolean;
   chainValid?: boolean;
+  notPublished?: boolean;
   versionNumber?: number;
   publishedAt?: number;
   contentHash?: string;
@@ -22,7 +23,7 @@ export interface VerifyInput {
 }
 
 export interface VerifyModel {
-  state: "verified" | "legacy" | "failed";
+  state: "verified" | "legacy" | "failed" | "not_published";
   versionNumber?: number;
   publishedAt?: number;
   contentHash?: string;
@@ -36,6 +37,7 @@ export function verifyResultModel(v: VerifyInput): VerifyModel {
     contentHash: v.contentHash,
     address: v.propertyAddressMasked,
   };
+  if (v.notPublished) return { state: "not_published", ...base };
   if (v.legacy) return { state: "legacy", ...base };
   if (v.hashValid && v.signatureValid && v.chainValid)
     return { state: "verified", ...base };
@@ -77,6 +79,7 @@ export async function loader({
           hashValid: boolean;
           signatureValid: boolean;
           chainValid: boolean;
+          notPublished: boolean;
           versionNumber: number;
           publishedAt: number;
           contentHash: string | null;
@@ -90,6 +93,7 @@ export async function loader({
             hashValid: v.hashValid,
             signatureValid: v.signatureValid,
             chainValid: v.chainValid,
+            notPublished: v.notPublished,
             versionNumber: v.versionNumber,
             publishedAt: v.publishedAt,
             contentHash: v.contentHash ?? undefined,
@@ -215,6 +219,17 @@ export default function VerifyTokenPage() {
               : ""}
           </p>
         )}
+      </div>
+    );
+  }
+
+  if (model.state === "not_published") {
+    return (
+      <div className="max-w-xl mx-auto p-6">
+        <div className="rounded-lg bg-ih-bad-bg text-ih-bad-fg p-4 text-center mb-6">
+          <p className="text-lg font-bold">Not published</p>
+          <p className="text-[13px] mt-1">This report is not published.</p>
+        </div>
       </div>
     );
   }

--- a/server/api/public-report.ts
+++ b/server/api/public-report.ts
@@ -18,6 +18,7 @@ import type { HonoConfig } from '../types/hono';
 import { logger } from '../lib/logger';
 import { buildRenderReportUrl } from '../lib/public-urls';
 import { getBookingHost, resolveTenantSlug } from '../lib/url';
+import { publicReportAccessAllowed } from '../lib/report-access';
 
 /**
  * Testable core of the owner-session preview fallback. Given a raw session JWT
@@ -594,6 +595,16 @@ export const publicReportRoutes = createApiRouter()
         if (!tenantId) { tenantId = await resolveOwnerPreview(c); ownerPreview = !!tenantId; }
         if (!tenantId) {
             return c.json({ success: false as const, error: { code: 'NOT_FOUND', message: 'Report not found' } }, 404);
+        }
+        // Publish gate: client/token access is revoked while the report is not
+        // published (owner-preview + render-token bypass — they may view drafts).
+        const gateRow = await drizzle(c.env.DB)
+            .select({ reportStatus: inspections.reportStatus })
+            .from(inspections)
+            .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
+            .get();
+        if (!publicReportAccessAllowed({ renderMode, ownerPreview, reportStatus: gateRow?.reportStatus })) {
+            return c.json({ success: false as const, error: { code: 'NOT_PUBLISHED', message: 'This report is not published.' } }, 403);
         }
         // Photo URLs: render mode carries the render token so the headless browser
         // can load photos without a session cookie. Owner-preview points at the

--- a/server/api/public-report.ts
+++ b/server/api/public-report.ts
@@ -19,6 +19,7 @@ import { logger } from '../lib/logger';
 import { buildRenderReportUrl } from '../lib/public-urls';
 import { getBookingHost, resolveTenantSlug } from '../lib/url';
 import { publicReportAccessAllowed } from '../lib/report-access';
+import { isReportPublished } from '../lib/status/report-status';
 
 /**
  * Testable core of the owner-session preview fallback. Given a raw session JWT
@@ -443,6 +444,7 @@ const reportVerifyRoute = createRoute(withMcpMetadata({
             keyAlgorithm: z.string(), legacy: z.boolean(),
             hashValid: z.boolean(), signatureValid: z.boolean(), chainValid: z.boolean(),
             propertyAddressMasked: z.string(),
+            notPublished: z.boolean(),
         })) } }, description: 'Verification result' },
         404: { description: 'Token not found' },
     },
@@ -516,6 +518,7 @@ export const publicReportRoutes = createApiRouter()
             signatureValid: data.verify.signatureValid,
             chainValid:    data.verify.chainValid,
             propertyAddressMasked: data.propertyAddressMasked,
+            notPublished: data.notPublished,
         } }, 200);
     })
     .openapi(reportVerifyPdfRoute, async (c) => {
@@ -533,6 +536,16 @@ export const publicReportRoutes = createApiRouter()
         if (!versionRow) return c.notFound();
 
         const { tenantId, inspectionId, versionNumber, contentHash } = versionRow;
+
+        // Publish gate: the frozen archived PDF is a public client artifact — refuse
+        // while the report is not currently published (re-publishing restores it).
+        const inspRow = await db.select({ reportStatus: inspections.reportStatus })
+          .from(inspections)
+          .where(and(eq(inspections.id, inspectionId), eq(inspections.tenantId, tenantId)))
+          .get();
+        if (!isReportPublished(inspRow?.reportStatus)) {
+          return c.json({ success: false as const, error: { code: 'NOT_PUBLISHED', message: 'This report is not published.' } }, 403);
+        }
 
         if (!c.env.BROWSER || !c.env.PHOTOS) {
             return c.json({ success: false as const, error: { code: 'PDF_UNAVAILABLE', message: 'PDF rendering is not configured on this deployment.' } }, 503);

--- a/server/api/public-report.ts
+++ b/server/api/public-report.ts
@@ -627,20 +627,30 @@ export const publicReportRoutes = createApiRouter()
             const legacy = await c.var.services.inspection.resolveAgentViewToken(token);
             if (legacy && legacy.inspectionId === id) tenantId = legacy.tenantId;
         }
+        let renderMode = false;
+        let ownerPreview = false;
         if (!tenantId && render) {
             const r = await resolveRenderAccess(render, id, c.env.JWT_SECRET);
             if (r) {
                 const db = drizzle(c.env.DB);
                 const row = await db.select({ tenantId: inspections.tenantId })
                     .from(inspections).where(eq(inspections.id, id)).get();
-                if (row) tenantId = row.tenantId;
+                if (row) { tenantId = row.tenantId; renderMode = true; }
             }
         }
         // Owner-session preview — same fallback as the report data route so the
         // owner's tokenless preview can load its photos (the key is re-checked
         // against this tenant + inspection below).
-        if (!tenantId) tenantId = await resolveOwnerPreview(c);
+        if (!tenantId) { tenantId = await resolveOwnerPreview(c); ownerPreview = !!tenantId; }
         if (!tenantId) return c.notFound();
+        const photoGate = await drizzle(c.env.DB)
+            .select({ reportStatus: inspections.reportStatus })
+            .from(inspections)
+            .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
+            .get();
+        if (!publicReportAccessAllowed({ renderMode, ownerPreview, reportStatus: photoGate?.reportStatus })) {
+            return c.notFound();
+        }
         if (!c.env.PHOTOS) return c.notFound();
         // Ownership: keys are `${tenantId}/${inspectionId}/...` — reject anything
         // outside the token's tenant + the requested inspection.

--- a/server/api/public-report.ts
+++ b/server/api/public-report.ts
@@ -704,6 +704,11 @@ export const publicReportRoutes = createApiRouter()
             .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
             .get();
         if (!insp) return c.notFound();
+        // Publish gate: this is a pure client-facing endpoint (no owner-preview, no
+        // render token), so block whenever the report is not currently published.
+        if (!publicReportAccessAllowed({ renderMode: false, ownerPreview: false, reportStatus: insp.reportStatus })) {
+            return c.json({ success: false as const, error: { code: 'NOT_PUBLISHED', message: 'This report is not published.' } }, 403);
+        }
         // Everyday download always tracks current content (versionNumber: null →
         // content-hash cache, renders live data). Frozen per-version PDFs are only
         // served from the verify page via GET /api/public/verify/report/:token/pdf.

--- a/server/api/repair-requests.ts
+++ b/server/api/repair-requests.ts
@@ -26,6 +26,7 @@ import { checkRateLimit } from '../lib/rate-limit';
 import { logger } from '../lib/logger';
 import { writeAuditLog } from '../lib/audit';
 import { withMcpMetadata } from "../lib/route-metadata-standards";
+import { isReportPublished } from '../lib/status/report-status';
 
 const EmailRequestSchema = z.object({
     inspectionId:     z.string().uuid().openapi({ example: '550e8400-e29b-41d4-a716-446655440000' }).describe('TODO describe inspectionId field for the OpenInspection MCP integration'),
@@ -146,10 +147,14 @@ export const repairRequestRoutes = createApiRouter()
         paymentRequired:   inspections.paymentRequired,
         paymentStatus:     inspections.paymentStatus,
         agreementRequired: inspections.agreementRequired,
+        reportStatus:      inspections.reportStatus,
     }).from(inspections)
         .where(and(eq(inspections.id, body.inspectionId), eq(inspections.tenantId, tenantId as string)))
         .get();
     if (!insp) throw Errors.NotFound('Inspection');
+    if (!isReportPublished(insp.reportStatus)) {
+        throw Errors.Forbidden('This report is not published.');
+    }
 
     // Same gating as /report/:id and /r/:id/repair-request.
     if (insp.paymentRequired === true && insp.paymentStatus !== 'paid') {

--- a/server/api/repair-requests.ts
+++ b/server/api/repair-requests.ts
@@ -253,6 +253,17 @@ export const repairRequestRoutes = createApiRouter()
         const { id } = c.req.valid('param');
         const tenantId = (c.get('tenantId') || c.get('resolvedTenantId')) as string | null;
         if (!tenantId) return c.json({ success: false as const, error: { code: 'NOT_FOUND', message: 'Not found' } }, 404);
+        // Publish gate: this public, no-login page feed exposes the defect list +
+        // estimates — pure client content. Block it whenever the report is not
+        // currently published (mirrors the email export; render/owner don't apply).
+        const insp = await drizzle(c.env.DB)
+            .select({ reportStatus: inspections.reportStatus })
+            .from(inspections)
+            .where(and(eq(inspections.id, id), eq(inspections.tenantId, tenantId)))
+            .get();
+        if (!isReportPublished(insp?.reportStatus)) {
+            return c.json({ success: false as const, error: { code: 'NOT_PUBLISHED', message: 'This report is not published.' } }, 403);
+        }
         const data = await c.var.services.inspection.getRepairRequestData(id, tenantId);
         return c.json({ success: true as const, data }, 200);
     });

--- a/server/lib/report-access.ts
+++ b/server/lib/report-access.ts
@@ -1,0 +1,18 @@
+// server/lib/report-access.ts
+import { isReportPublished } from './status/report-status';
+
+/**
+ * Decide whether a PUBLIC report-access request may proceed.
+ * Client/token access is allowed only while the report is currently published.
+ * Owner-preview and headless render-token access always bypass (they must be
+ * able to load in-progress/unpublished reports for editing/preview/rendering).
+ * Reads CURRENT report_status — re-publishing restores access automatically.
+ */
+export function publicReportAccessAllowed(opts: {
+  renderMode: boolean;
+  ownerPreview: boolean;
+  reportStatus: string | null | undefined;
+}): boolean {
+  if (opts.renderMode || opts.ownerPreview) return true;
+  return isReportPublished(opts.reportStatus);
+}

--- a/server/lib/verify-data.ts
+++ b/server/lib/verify-data.ts
@@ -3,6 +3,7 @@ import { eq, and, asc } from 'drizzle-orm';
 import { Context } from 'hono';
 import * as schema from './db/schema';
 import { HonoConfig } from '../types/hono';
+import { isReportPublished } from './status/report-status';
 
 /**
  * Spec 5H P2 — Public verifier (no-auth, court-friendly) data loader.
@@ -51,11 +52,14 @@ export async function loadReportVerifyData(c: Context<HonoConfig>, token: string
     const verify = await c.var.services.reportVersion.verifyByToken(token);
     if (!verify) return null;
     const db = drizzle(c.env.DB, { schema });
-    const ins = await db.select({ propertyAddress: schema.inspections.propertyAddress })
+    const ins = await db.select({
+        propertyAddress: schema.inspections.propertyAddress,
+        reportStatus: schema.inspections.reportStatus,
+    })
         .from(schema.inspections)
         .where(eq(schema.inspections.id, verify.inspectionId))
         .get();
     // Mask the address to a coarse form (no unit/number) for a public endpoint.
     const masked = (ins?.propertyAddress ?? '').replace(/^\S+\s/, '••• ');
-    return { verify, propertyAddressMasked: masked };
+    return { verify, propertyAddressMasked: masked, notPublished: !isReportPublished(ins?.reportStatus) };
 }

--- a/tests/unit/public-report-endpoint.spec.ts
+++ b/tests/unit/public-report-endpoint.spec.ts
@@ -28,8 +28,15 @@ describe('GET /api/public/report/:tenant/:id — ③-A.1', () => {
         getReportData = vi.fn().mockResolvedValue({ inspectionId: 'insp1' }),
         resolveAgentViewToken = vi.fn().mockResolvedValue(null),
     ) {
+        // The publish gate added to reportRoute runs drizzle(c.env.DB).select()...get()
+        // on the resolved (client/legacy) path. These cases all use published
+        // reports, so the chainable fake resolves to report_status='published' and
+        // the gate lets them through (the 404 cases bail before the gate).
+        const publishedDb = { select: () => ({ from: () => ({ where: () => ({ get: async () => ({ reportStatus: 'published' }) }) }) }) };
+        (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(publishedDb as any);
         const app = new OpenAPIHono<HonoConfig>();
         app.use('*', async (c, next) => {
+            (c as unknown as { env: Record<string, unknown> }).env = { DB: {} };
             c.set('services', { portalAccess: { resolveToken }, inspection: { getReportData, resolveAgentViewToken } } as unknown as HonoConfig['Variables']['services']);
             await next();
         });

--- a/tests/unit/repair-request-email-gate.spec.ts
+++ b/tests/unit/repair-request-email-gate.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Gate: POST /api/public/repair-request/email must return 403 when the
+ * inspection's report_status is not 'published'.
+ *
+ * Harness pattern mirrors checkout-public.spec.ts / booking-contact-upsert.spec.ts:
+ *   - vi.mock drizzle-orm/d1 so the handler's `drizzle(c.env.DB)` returns
+ *     the in-memory better-sqlite3 DB.
+ *   - Real seeded DB via createTestDb + setupSchema.
+ *   - rate-limit mocked to no-op (no RATE_LIMITER binding needed).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../server/lib/db/schema';
+import type { HonoConfig } from '../../server/types/hono';
+import { AppError } from '../../server/lib/errors';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+// Must be declared BEFORE importing the routes module so the mock is active
+// when the module is first evaluated.
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+// Rate-limit is a pass-through in tests — no RATE_LIMITER binding required.
+vi.mock('../../server/lib/rate-limit', () => ({
+    checkRateLimit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import routes AFTER mocks are registered.
+// eslint-disable-next-line import/order
+import repairRequestRoutes from '../../server/api/repair-requests';
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000001';
+const INSP_ID   = '550e8400-e29b-41d4-a716-446655440000';
+
+const FAKE_ENV: HonoConfig['Bindings'] = {
+    DB: {} as D1Database,
+    APP_NAME: 'OpenInspection',
+    APP_BASE_URL: 'https://example.test',
+} as unknown as HonoConfig['Bindings'];
+
+const FAKE_EXEC_CTX: ExecutionContext = {
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+};
+
+function buildApp(db: BetterSQLite3Database<typeof schema>) {
+    const app = new OpenAPIHono<HonoConfig>();
+
+    // Map AppError → proper HTTP status so assertions on res.status work.
+    app.onError((err, c) => {
+        if (err instanceof AppError) {
+            return c.json(
+                { success: false, error: { code: err.code, message: err.message } },
+                err.status,
+            );
+        }
+        return c.json({ success: false, error: { code: 'internal_error', message: String(err) } }, 500);
+    });
+
+    app.use('*', async (c, next) => {
+        // tenantId is pre-resolved; handler will use it and skip the DB lookup.
+        c.set('tenantId', TENANT_ID);
+        c.set('services', {
+            email: { sendEmail: vi.fn().mockResolvedValue(undefined) },
+        } as unknown as HonoConfig['Variables']['services']);
+        await next();
+    });
+
+    app.route('/api/public', repairRequestRoutes);
+
+    (mockDrizzle as ReturnType<typeof vi.fn>).mockReturnValue(db);
+
+    return { app };
+}
+
+async function seedBase(
+    db: BetterSQLite3Database<typeof schema>,
+    inspOver: Partial<typeof schema.inspections.$inferInsert> = {},
+) {
+    await db.insert(schema.tenants).values({
+        id: TENANT_ID, name: 'Acme', slug: 'acme', status: 'active',
+        deploymentMode: 'shared', tier: 'free', maxUsers: 5, createdAt: new Date(),
+    } as any);
+
+    // enableCustomerRepairExport has a NOT NULL DEFAULT false — supply true to
+    // pass the opt-in gate and let us reach the reportStatus gate.
+    await db.insert(schema.tenantConfigs).values({
+        tenantId: TENANT_ID,
+        enableCustomerRepairExport: true,
+        updatedAt: new Date(),
+    } as any);
+
+    await db.insert(schema.inspections).values({
+        id: INSP_ID,
+        tenantId: TENANT_ID,
+        propertyAddress: '123 Oak St',
+        clientName: 'Jane',
+        clientEmail: 'jane@test.com',
+        date: '2026-06-01',
+        status: 'completed',
+        reportStatus: 'in_progress',
+        paymentRequired: false,
+        paymentStatus: 'unpaid',
+        agreementRequired: false,
+        price: 50000,
+        createdAt: new Date(),
+        ...inspOver,
+    } as any);
+}
+
+describe('POST /api/public/repair-request/email — reportStatus gate', () => {
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: any;
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        db = setup.db as BetterSQLite3Database<typeof schema>;
+        sqlite = setup.sqlite;
+        await setupSchema(sqlite);
+        (mockDrizzle as ReturnType<typeof vi.fn>).mockReturnValue(db);
+    });
+
+    afterEach(() => {
+        sqlite.close();
+        vi.restoreAllMocks();
+    });
+
+    it('returns 403 when reportStatus is in_progress (not published)', async () => {
+        await seedBase(db, { reportStatus: 'in_progress' });
+        const { app } = buildApp(db);
+        const res = await app.request(
+            '/api/public/repair-request/email',
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ inspectionId: INSP_ID, recipientEmail: 'buyer@x.com' }),
+            },
+            FAKE_ENV,
+            FAKE_EXEC_CTX,
+        );
+        expect(res.status).toBe(403);
+        const body = await res.json() as any;
+        expect(body.success).toBe(false);
+        expect(body.error.message).toMatch(/not published/i);
+    });
+
+    it('returns 403 when reportStatus is submitted (not published)', async () => {
+        await seedBase(db, { reportStatus: 'submitted' });
+        const { app } = buildApp(db);
+        const res = await app.request(
+            '/api/public/repair-request/email',
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ inspectionId: INSP_ID, recipientEmail: 'buyer@x.com' }),
+            },
+            FAKE_ENV,
+            FAKE_EXEC_CTX,
+        );
+        expect(res.status).toBe(403);
+    });
+});

--- a/tests/unit/repair-request-get.spec.ts
+++ b/tests/unit/repair-request-get.spec.ts
@@ -1,18 +1,33 @@
 import { describe, it, expect, vi } from 'vitest';
 import { OpenAPIHono } from '@hono/zod-openapi';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
 import repairRequestRoutes from '../../server/api/repair-requests';
 import type { HonoConfig } from '../../server/types/hono';
+
+// Minimal chainable fake for the publish-gate query: drizzle(env.DB)
+//   .select({reportStatus}).from(inspections).where(...).get() → { reportStatus }
+function gateDb(reportStatus: string) {
+    return { select: () => ({ from: () => ({ where: () => ({ get: async () => ({ reportStatus }) }) }) }) };
+}
 
 /**
  * C-10 ③-D — GET /api/public/repair-request/:id
  * Public (slug-resolved tenant, unguessable id) repair-request page data.
  * tenantId comes from the resolved slug, never the URL. Thin wrapper over
- * inspection.getRepairRequestData.
+ * inspection.getRepairRequestData, gated on the report being published.
  */
 describe('GET /api/public/repair-request/:id — ③-D', () => {
-    function buildApp(tenantId: string | null, getRepairRequestData: ReturnType<typeof vi.fn>) {
+    function buildApp(
+        tenantId: string | null,
+        getRepairRequestData: ReturnType<typeof vi.fn>,
+        reportStatus = 'published',
+    ) {
+        (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(gateDb(reportStatus));
         const app = new OpenAPIHono<HonoConfig>();
         app.use('*', async (c, next) => {
+            c.env = { DB: {} } as unknown as HonoConfig['Bindings'];
             if (tenantId) c.set('tenantId', tenantId);
             c.set('services', { inspection: { getRepairRequestData } } as unknown as HonoConfig['Variables']['services']);
             await next();
@@ -31,12 +46,20 @@ describe('GET /api/public/repair-request/:id — ③-D', () => {
             inspectionId: 'i1', propertyAddress: '1 Main', inspectionDate: '2026-06-01',
             inspectorName: 'Pat', clientEmail: 'buyer@x.com', defects: [], showEstimates: true,
         });
-        const res = await buildApp('t1', fn).request('/api/public/repair-request/i1');
+        const res = await buildApp('t1', fn, 'published').request('/api/public/repair-request/i1');
         expect(res.status).toBe(200);
         const body = await res.json() as { success: boolean; data: { inspectionId: string; clientEmail: string } };
         expect(body.success).toBe(true);
         expect(body.data.inspectionId).toBe('i1');
         expect(body.data.clientEmail).toBe('buyer@x.com');
         expect(fn).toHaveBeenCalledWith('i1', 't1');
+    });
+
+    it('403 and does NOT leak data when the report is not published', async () => {
+        const fn = vi.fn();
+        const res = await buildApp('t1', fn, 'in_progress').request('/api/public/repair-request/i1');
+        expect(res.status).toBe(403);
+        // The defect list / estimates feed must never be reached for an unpublished report.
+        expect(fn).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/report-access-gate.spec.ts
+++ b/tests/unit/report-access-gate.spec.ts
@@ -248,3 +248,72 @@ describe('GET /api/public/report/:tenant/:id/pdf — publish gate', () => {
         expect(body.error.code).toBe('NOT_PUBLISHED');
     });
 });
+
+describe('GET /api/public/verify/report/:token — reflects current publish status', () => {
+    const T = '00000000-0000-0000-0000-0000000000a4';
+    const ID = '00000000-0000-0000-0000-0000000000b4';
+
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: any;
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        db = setup.db as BetterSQLite3Database<typeof schema>;
+        sqlite = setup.sqlite;
+        await setupSchema(sqlite);
+        (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(db);
+
+        // Seed tenant + inspection with report_status='in_progress' (unpublished).
+        await db.insert(schema.tenants).values({
+            id: T, name: 'Verify', slug: 'verify', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        } as any);
+        await db.insert(schema.inspections).values({
+            id: ID, tenantId: T, propertyAddress: '4 Main St', clientName: 'Carol',
+            clientEmail: 'carol@test.com', date: '2026-06-01', status: 'completed',
+            reportStatus: 'in_progress', paymentStatus: 'unpaid', price: 40000,
+            agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+        } as any);
+    });
+
+    afterEach(() => sqlite.close());
+
+    function buildVerifyApp() {
+        const verifyByToken = vi.fn().mockResolvedValue({
+            inspectionId: ID, versionNumber: 1, isAmendment: false, publishedAt: 1000,
+            contentHash: 'h', keyFingerprint: 'f', legacy: false,
+            hashValid: true, signatureValid: true, chainValid: true,
+        });
+        const app = new OpenAPIHono<HonoConfig>();
+        app.use('*', async (c, next) => {
+            (c as unknown as { env: Record<string, unknown> }).env = { DB: {} };
+            c.set('services', { reportVersion: { verifyByToken } } as any);
+            await next();
+        });
+        app.route('/api/public', publicReportRoutes);
+        return app;
+    }
+
+    it('Case A — verify returns notPublished:true when report_status=in_progress', async () => {
+        const app = buildVerifyApp();
+        const res = await app.request('/api/public/verify/report/sometoken');
+        expect(res.status).toBe(200);
+        const body = await res.json() as { data: { notPublished: boolean } };
+        expect(body.data.notPublished).toBe(true);
+    });
+
+    it('Case B — frozen PDF blocked (403) for an unpublished report', async () => {
+        // ALSO seed the report_versions row keyed by verificationToken so the
+        // raw versionRow lookup resolves; the publish gate then fires.
+        await db.insert(schema.reportVersions).values({
+            id: 'rv1', tenantId: T, inspectionId: ID, versionNumber: 1,
+            snapshotJson: '{}', contentHash: 'h', verificationToken: 'vtok',
+            publishedAt: 1000, publishedBy: 'u1', createdAt: new Date().toISOString(),
+        } as any);
+
+        const app = buildVerifyApp();
+        const res = await app.request('/api/public/verify/report/vtok/pdf');
+        expect([403, 404]).toContain(res.status);
+        expect(res.status).toBe(403);
+    });
+});

--- a/tests/unit/report-access-gate.spec.ts
+++ b/tests/unit/report-access-gate.spec.ts
@@ -1,5 +1,5 @@
 // tests/unit/report-access-gate.spec.ts
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
 import { publicReportAccessAllowed } from '../../server/lib/report-access';
 
 describe('publicReportAccessAllowed', () => {
@@ -14,4 +14,138 @@ describe('publicReportAccessAllowed', () => {
   it('owner preview bypasses', () => {
     expect(publicReportAccessAllowed({ renderMode: false, ownerPreview: true, reportStatus: 'in_progress' })).toBe(true);
   });
+});
+
+/**
+ * Integration gate tests for GET /api/public/report/:tenant/:id.
+ *
+ * The publish gate runs a RAW drizzle() query against the inspection row, so we
+ * mock drizzle('drizzle-orm/d1') to return a REAL seeded in-memory DB while
+ * stubbing the service layer (portalAccess.resolveToken / inspection.getReportData).
+ * Client/token access must be revoked (403 NOT_PUBLISHED) while the report is not
+ * published; owner-preview and render-token paths bypass.
+ */
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import publicReportRoutes from '../../server/api/public-report';
+import type { HonoConfig } from '../../server/types/hono';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../server/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { buildKeyring, signJwt, type JwtKeyring } from '../../server/lib/jwt-keyring';
+
+const TENANT_ID = '00000000-0000-0000-0000-0000000000a1';
+const INSP_ID = '00000000-0000-0000-0000-0000000000b1';
+
+// --- ES256 P-256 keypair helpers (copied from owner-preview-access.spec.ts) ---
+interface Pem { privatePem: string; publicPem: string }
+function bufToPem(buf: ArrayBuffer, label: string): string {
+    const bin = String.fromCharCode(...new Uint8Array(buf));
+    const b64 = btoa(bin);
+    const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+    return `-----BEGIN ${label}-----\n${lines}\n-----END ${label}-----`;
+}
+async function genKeypair(): Promise<Pem> {
+    const { privateKey, publicKey } = (await crypto.subtle.generateKey(
+        { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'],
+    )) as CryptoKeyPair;
+    return {
+        privatePem: bufToPem(await crypto.subtle.exportKey('pkcs8', privateKey), 'PRIVATE KEY'),
+        publicPem:  bufToPem(await crypto.subtle.exportKey('spki',  publicKey),  'PUBLIC KEY'),
+    };
+}
+
+describe('GET /api/public/report/:tenant/:id — publish gate', () => {
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: any;
+    let keyring: JwtKeyring;
+
+    beforeAll(async () => {
+        const v1 = await genKeypair();
+        keyring = await buildKeyring({
+            JWT_PRIVATE_KEY_V1: v1.privatePem,
+            JWT_PUBLIC_KEY_V1:  v1.publicPem,
+            JWT_CURRENT_KID: 'v1',
+        });
+    });
+
+    async function seedInspection(reportStatus: string) {
+        await db.insert(schema.tenants).values({
+            id: TENANT_ID, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        } as any);
+        await db.insert(schema.inspections).values({
+            id: INSP_ID, tenantId: TENANT_ID, propertyAddress: '1 Main St', clientName: 'Jane',
+            clientEmail: 'jane@test.com', date: '2026-06-01', status: 'completed',
+            reportStatus, paymentStatus: 'unpaid', price: 50000,
+            agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+        } as any);
+    }
+
+    function buildApp(opts: { withKeyring?: boolean } = {}) {
+        const resolveToken = vi.fn().mockResolvedValue({
+            inspectionId: INSP_ID, tenantId: TENANT_ID, role: 'client',
+            recipientEmail: 'a@b.com', revokedAt: null, expiresAt: null,
+        });
+        const getReportData = vi.fn().mockResolvedValue({ inspectionId: INSP_ID });
+        const resolveAgentViewToken = vi.fn().mockResolvedValue(null);
+        const app = new OpenAPIHono<HonoConfig>();
+        app.use('*', async (c, next) => {
+            // The gate runs drizzle(c.env.DB); the drizzle mock ignores its arg and
+            // returns the seeded db, but c.env.DB must be a defined property.
+            (c as unknown as { env: Record<string, unknown> }).env = { DB: {} };
+            c.set('services', {
+                portalAccess: { resolveToken },
+                inspection: { getReportData, resolveAgentViewToken },
+            } as unknown as HonoConfig['Variables']['services']);
+            if (opts.withKeyring) c.set('keyringPromise', Promise.resolve(keyring));
+            await next();
+        });
+        app.route('/api/public', publicReportRoutes);
+        return { app, getReportData };
+    }
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        db = setup.db as BetterSQLite3Database<typeof schema>;
+        sqlite = setup.sqlite;
+        await setupSchema(sqlite);
+        (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(db);
+    });
+
+    afterEach(() => sqlite.close());
+
+    it('403 NOT_PUBLISHED for a client token when report_status=in_progress', async () => {
+        await seedInspection('in_progress');
+        const { app, getReportData } = buildApp();
+        const res = await app.request(`/api/public/report/acme/${INSP_ID}?token=tok`);
+        expect(res.status).toBe(403);
+        const body = await res.json() as { error: { code: string } };
+        expect(body.error.code).toBe('NOT_PUBLISHED');
+        expect(getReportData).not.toHaveBeenCalled();
+    });
+
+    it('200 for a client token when report_status=published', async () => {
+        await seedInspection('published');
+        const { app, getReportData } = buildApp();
+        const res = await app.request(`/api/public/report/acme/${INSP_ID}?token=tok`);
+        expect(res.status).toBe(200);
+        expect(getReportData).toHaveBeenCalledWith(INSP_ID, TENANT_ID, expect.any(Function));
+    });
+
+    it('owner-preview bypasses the gate (200 even when report_status=in_progress)', async () => {
+        await seedInspection('in_progress');
+        const { app, getReportData } = buildApp({ withKeyring: true });
+        const ownerJwt = await signJwt(
+            { sub: 'u1', 'custom:userRole': 'admin', 'custom:tenantId': TENANT_ID },
+            keyring,
+        );
+        // No token query param → falls through to the owner-preview path.
+        const res = await app.request(`/api/public/report/acme/${INSP_ID}`, {
+            headers: { Authorization: `Bearer ${ownerJwt}` },
+        });
+        expect(res.status).toBe(200);
+        expect(getReportData).toHaveBeenCalledWith(INSP_ID, TENANT_ID, expect.any(Function));
+    });
 });

--- a/tests/unit/report-access-gate.spec.ts
+++ b/tests/unit/report-access-gate.spec.ts
@@ -150,6 +150,57 @@ describe('GET /api/public/report/:tenant/:id — publish gate', () => {
     });
 });
 
+describe('GET /api/public/report/:tenant/:id/photo — publish gate', () => {
+    const T = '00000000-0000-0000-0000-0000000000a3';
+    const ID = '00000000-0000-0000-0000-0000000000b3';
+
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: any;
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        db = setup.db as BetterSQLite3Database<typeof schema>;
+        sqlite = setup.sqlite;
+        await setupSchema(sqlite);
+        (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(db);
+
+        // Seed tenant + inspection with report_status='in_progress'
+        await db.insert(schema.tenants).values({
+            id: T, name: 'Photo', slug: 'photo', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        } as any);
+        await db.insert(schema.inspections).values({
+            id: ID, tenantId: T, propertyAddress: '3 Main St', clientName: 'Alice',
+            clientEmail: 'alice@test.com', date: '2026-06-01', status: 'completed',
+            reportStatus: 'in_progress', paymentStatus: 'unpaid', price: 20000,
+            agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+        } as any);
+    });
+
+    afterEach(() => sqlite.close());
+
+    it('404 for a client token when report_status=in_progress (gate fires before PHOTOS check)', async () => {
+        const app = new OpenAPIHono<HonoConfig>();
+        app.use('*', async (c, next) => {
+            // PHOTOS is intentionally absent — the gate must fire before the PHOTOS check
+            (c as unknown as { env: Record<string, unknown> }).env = { DB: {} } as any;
+            c.set('services', {
+                portalAccess: { resolveToken: vi.fn().mockResolvedValue({
+                    inspectionId: ID, tenantId: T, role: 'client',
+                    recipientEmail: 'a@b.com', revokedAt: null, expiresAt: null,
+                }) },
+                inspection: { resolveAgentViewToken: vi.fn().mockResolvedValue(null) },
+            } as any);
+            await next();
+        });
+        app.route('/api/public', publicReportRoutes);
+
+        const key = encodeURIComponent(`${T}/${ID}/x.jpg`);
+        const res = await app.request(`/api/public/report/photo/${ID}/photo?key=${key}&token=tok`);
+        expect([403, 404]).toContain(res.status);
+    });
+});
+
 describe('GET /api/public/report/:tenant/:id/pdf — publish gate', () => {
     const T = '00000000-0000-0000-0000-0000000000a2';
     const ID = '00000000-0000-0000-0000-0000000000b2';

--- a/tests/unit/report-access-gate.spec.ts
+++ b/tests/unit/report-access-gate.spec.ts
@@ -149,3 +149,51 @@ describe('GET /api/public/report/:tenant/:id — publish gate', () => {
         expect(getReportData).toHaveBeenCalledWith(INSP_ID, TENANT_ID, expect.any(Function));
     });
 });
+
+describe('GET /api/public/report/:tenant/:id/pdf — publish gate', () => {
+    const T = '00000000-0000-0000-0000-0000000000a2';
+    const ID = '00000000-0000-0000-0000-0000000000b2';
+
+    let db: BetterSQLite3Database<typeof schema>;
+    let sqlite: any;
+
+    beforeEach(async () => {
+        const setup = createTestDb();
+        db = setup.db as BetterSQLite3Database<typeof schema>;
+        sqlite = setup.sqlite;
+        await setupSchema(sqlite);
+        (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(db);
+
+        // Seed tenant + inspection with report_status='in_progress'
+        await db.insert(schema.tenants).values({
+            id: T, name: 'Demo', slug: 'demo', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        } as any);
+        await db.insert(schema.inspections).values({
+            id: ID, tenantId: T, propertyAddress: '2 Main St', clientName: 'Bob',
+            clientEmail: 'bob@test.com', date: '2026-06-01', status: 'completed',
+            reportStatus: 'in_progress', paymentStatus: 'unpaid', price: 30000,
+            agreementRequired: false, paymentRequired: false, createdAt: new Date(),
+        } as any);
+    });
+
+    afterEach(() => sqlite.close());
+
+    it('403 NOT_PUBLISHED when report_status=in_progress (pure client endpoint)', async () => {
+        const app = new OpenAPIHono<HonoConfig>();
+        app.use('*', async (c, next) => {
+            c.env = { DB: {}, BROWSER: {}, PHOTOS: {} } as any; // BROWSER+PHOTOS must be truthy to pass the 503 guard
+            c.set('services', {
+                portalAccess: { resolveToken: vi.fn().mockResolvedValue({ inspectionId: ID, tenantId: T, role: 'client', recipientEmail: 'a@b.com', revokedAt: null, expiresAt: null }) },
+                inspection: { resolveAgentViewToken: vi.fn().mockResolvedValue(null) },
+            } as any);
+            await next();
+        });
+        app.route('/api/public', publicReportRoutes);
+
+        const res = await app.request(`/api/public/report/demo/${ID}/pdf?token=tok&type=full`);
+        expect(res.status).toBe(403);
+        const body = await res.json() as { error: { code: string } };
+        expect(body.error.code).toBe('NOT_PUBLISHED');
+    });
+});

--- a/tests/unit/report-access-gate.spec.ts
+++ b/tests/unit/report-access-gate.spec.ts
@@ -1,0 +1,17 @@
+// tests/unit/report-access-gate.spec.ts
+import { describe, it, expect } from 'vitest';
+import { publicReportAccessAllowed } from '../../server/lib/report-access';
+
+describe('publicReportAccessAllowed', () => {
+  it('client token: allowed only when published', () => {
+    expect(publicReportAccessAllowed({ renderMode: false, ownerPreview: false, reportStatus: 'published' })).toBe(true);
+    expect(publicReportAccessAllowed({ renderMode: false, ownerPreview: false, reportStatus: 'in_progress' })).toBe(false);
+    expect(publicReportAccessAllowed({ renderMode: false, ownerPreview: false, reportStatus: 'submitted' })).toBe(false);
+  });
+  it('render mode bypasses (drafts must render headless)', () => {
+    expect(publicReportAccessAllowed({ renderMode: true, ownerPreview: false, reportStatus: 'in_progress' })).toBe(true);
+  });
+  it('owner preview bypasses', () => {
+    expect(publicReportAccessAllowed({ renderMode: false, ownerPreview: true, reportStatus: 'in_progress' })).toBe(true);
+  });
+});

--- a/tests/web/unit/verify-report-page.spec.ts
+++ b/tests/web/unit/verify-report-page.spec.ts
@@ -70,4 +70,14 @@ describe('verifyResultModel', () => {
     expect(result.contentHash).toBe('abc123');
     expect(result.address).toBe('••• Main St');
   });
+
+  it('notPublished overrides to a not_published state', () => {
+    const m = verifyResultModel({ legacy: false, hashValid: true, signatureValid: true, chainValid: true, notPublished: true } as any);
+    expect(m.state).toBe('not_published');
+  });
+
+  it('published verified report still verifies', () => {
+    const m = verifyResultModel({ legacy: false, hashValid: true, signatureValid: true, chainValid: true, notPublished: false } as any);
+    expect(m.state).toBe('verified');
+  });
 });

--- a/tests/workers/reinspections.spec.ts
+++ b/tests/workers/reinspections.spec.ts
@@ -260,6 +260,14 @@ describe('#119 re-inspections — end-to-end (real workerd)', () => {
         expect(r2Data.d4!.original!.notes).toBe(originalNotes.d4);
         expect(r2Data.d5!.original!.notes).toBe(originalNotes.d5);
 
+        // r2 must be published for the client-token public view: the publish gate
+        // (publicReportAccessAllowed) revokes client/token access to a report whose
+        // report_status is not 'published'. snapshotOnPublish only writes the version
+        // snapshot; publishing flips report_status (mirrors InspectionService.publish).
+        await drizzle(env.DB).update(schema.inspections)
+            .set({ reportStatus: 'published' })
+            .where(eq(schema.inspections.id, r2.id));
+
         // 6) Drive the PUBLIC report for r2. Mint a persistent portal token so the
         //    route resolves the tenant from the token (production-shape).
         const token = await portalAccessService().issueToken({


### PR DESCRIPTION
## Summary

When a report is **not currently published** (`report_status != 'published'`, e.g. after an Unpublish action), this revokes all **client-facing** access to it and makes the public verification page fail with a clear "Not published" state — while still allowing owner-preview and headless render-token access. Mirrors Spectora's Un-Publish ("no one can view it").

Fixes a gap from the report status-split work (#147): `unpublishReport` sets `report_status='in_progress'`, but the public report-access routes gated only on token validity, not publish status — so existing client links kept working after Unpublish.

## What changed

- **New shared predicate** `publicReportAccessAllowed({ renderMode, ownerPreview, reportStatus })` (`server/lib/report-access.ts`) — single source of truth: client/token access is allowed only while the report is currently published; owner-preview and render-token always bypass.
- **Gated the client/token path** on every public report-access route:
  - report **data** (`reportRoute`) → 403 `NOT_PUBLISHED`
  - report **PDF** download (`reportPdfDownloadRoute`) → 403
  - report **photo** (`reportPhotoRoute`) → 404 (no leak)
  - **repair-request email export** (POST) → 403
  - **repair-request page-data feed** (GET) → 403 (defect list / estimates never reached)
- **Verification** (`/v/:token`): `loadReportVerifyData` reads current `report_status` and returns `notPublished`; the verify route surfaces it; the frozen-PDF endpoint (`reportVerifyPdfRoute`) refuses when not published.
- **Frontend**: `v.$token.tsx` gains a `not_published` state (precedes all others); `report-card-stack.tsx` maps the 403 into a friendly "This report is not published" page.

## Design notes

- **No DB column** — everything reads current `report_status`, so **re-publishing automatically restores access** (verify recomputes live).
- Owner-preview + render-token bypass preserved (drafts must render headless / be previewable).
- Wording is uniformly **"Not published"** — never "retracted".

## Tests

- `tests/unit/report-access-gate.spec.ts` (predicate + route gates), `repair-request-email-gate.spec.ts`, `repair-request-get.spec.ts` (incl. a leak-prevention assertion), `tests/web/unit/verify-report-page.spec.ts` (model states), plus a workers fix.
- Full gate green: type-check 0, lint 0 (incl. DS conformance), unit 1735, web 401, workers 41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
