### PR TITLE
Fix: Report Features toggles not persisting (literal name attrs)

### DIFF
--- a/app/lib/forms/settings.schema.ts
+++ b/app/lib/forms/settings.schema.ts
@@ -122,11 +122,12 @@ export const workspaceSchema = z.object({
     .optional(),
   reportTheme: z.enum(THEMES).optional(),
   customReferralSources: z.string().optional(),
-  // Track E1 — gate the "Repair List" tab on published reports.
-  // The action reads these via fd.getAll() and appends to body directly;
-  // the schema entries ensure they are present in the field map for conform.
+  // Report-feature flags. Mirrors profileSchema.signatureEnabled: declared here as
+  // z.boolean().optional(), rendered with a hidden "false" + checkbox "true" using
+  // LITERAL name attributes (not fields.x.name), and read via fd.getAll() in the
+  // action. Using fields.x.name instead makes conform manage the field and reject
+  // the string values, silently aborting the save.
   enableRepairList: z.boolean().optional(),
-  // Gate the client-driven "Build repair request" export on published reports.
   enableCustomerRepairExport: z.boolean().optional(),
 });
 

--- a/app/routes/settings-workspace.tsx
+++ b/app/routes/settings-workspace.tsx
@@ -233,10 +233,10 @@ export default function SettingsWorkspacePage() {
           <h3 className="text-[11px] font-bold text-ih-fg-2 uppercase tracking-[0.2em]">Report Features</h3>
 
           <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input type="hidden" name={fields.enableRepairList.name} value="false" />
+            <input type="hidden" name="enableRepairList" value="false" />
             <input
               type="checkbox"
-              name={fields.enableRepairList.name}
+              name="enableRepairList"
               value="true"
               defaultChecked={branding.enableRepairList ?? false}
               className="mt-0.5 h-4 w-4 rounded border-ih-border text-ih-primary"
@@ -250,10 +250,10 @@ export default function SettingsWorkspacePage() {
           </label>
 
           <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input type="hidden" name={fields.enableCustomerRepairExport.name} value="false" />
+            <input type="hidden" name="enableCustomerRepairExport" value="false" />
             <input
               type="checkbox"
-              name={fields.enableCustomerRepairExport.name}
+              name="enableCustomerRepairExport"
               value="true"
               defaultChecked={branding.enableCustomerRepairExport ?? false}
               className="mt-0.5 h-4 w-4 rounded border-ih-border text-ih-primary"


### PR DESCRIPTION
## Summary

Bugfix follow-up to #151. The "Report Features" checkboxes (`enableRepairList`, `enableCustomerRepairExport`) on Company settings did not persist — toggling + Save left them unchanged after reload.

**Cause:** the checkboxes used `name={fields.X.name}` (conform-managed) together with the hidden-`false` + checkbox-`true` + `fd.getAll()` raw-form pattern. Referencing the field via `fields.X` makes conform manage its client-side submit serialization, which conflicts with the manual hidden/checkbox pair and aborts the save.

**Fix:** use **literal `name="..."` attributes** for these two checkboxes, exactly mirroring the working `profileSchema.signatureEnabled` toggle in `settings-profile.tsx`. The fields stay declared in `workspaceSchema` (validation remains in conform); they're just not conform-*managed* inputs, so the raw hidden+checkbox values reach `fd.getAll()` and persist.

## Tests
type-check 0, lint 0 (incl. DS conformance). Verified against the existing working `signatureEnabled` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
