### PR TITLE
Fix: report-feature toggles silently fail to submit (remove from conform schema)

### DIFF
--- a/app/lib/forms/settings.schema.ts
+++ b/app/lib/forms/settings.schema.ts
@@ -122,13 +122,13 @@ export const workspaceSchema = z.object({
     .optional(),
   reportTheme: z.enum(THEMES).optional(),
   customReferralSources: z.string().optional(),
-  // Report-feature flags. Mirrors profileSchema.signatureEnabled: declared here as
-  // z.boolean().optional(), rendered with a hidden "false" + checkbox "true" using
-  // LITERAL name attributes (not fields.x.name), and read via fd.getAll() in the
-  // action. Using fields.x.name instead makes conform manage the field and reject
-  // the string values, silently aborting the save.
-  enableRepairList: z.boolean().optional(),
-  enableCustomerRepairExport: z.boolean().optional(),
+  // NOTE: the report-feature flags (enableRepairList / enableCustomerRepairExport)
+  // are intentionally NOT declared here. They render as a hidden "false" + checkbox
+  // "true" pair (LITERAL name attrs) and are read via fd.getAll() in the action — a
+  // boolean flag has no validation rules. If declared as z.boolean() here, a CHECKED
+  // box submits two values ["false","true"]; conform feeds that array to z.boolean()
+  // → parse error → the whole form silently fails to submit (you can never turn it
+  // on). Keeping them out of the conform field map is the fix.
 });
 
 export type WorkspaceInput = z.infer<typeof workspaceSchema>;

--- a/tests/web/unit/settings-workspace-flags.spec.ts
+++ b/tests/web/unit/settings-workspace-flags.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { parseWithZod } from '@conform-to/zod/v4';
+import { workspaceSchema } from '../../../app/lib/forms/settings.schema';
+
+/**
+ * Regression: the "Report Features" checkboxes (enableRepairList /
+ * enableCustomerRepairExport) render as a hidden "false" + checkbox "true" pair,
+ * so a CHECKED box submits the field twice (["false","true"]). These flags must
+ * NOT be in workspaceSchema — if they were declared z.boolean(), conform would
+ * feed the array to z.boolean() and the whole form would fail to submit (the flag
+ * could never be turned on). They're read via fd.getAll() in the action instead.
+ */
+function fd(pairs: [string, string][]) {
+  const f = new FormData();
+  for (const [k, v] of pairs) f.append(k, v);
+  return f;
+}
+
+describe('workspace settings — report-feature flags do not block submit', () => {
+  it('a checked flag (doubled value) still parses successfully', () => {
+    const f = fd([
+      ['siteName', 'Acme'],
+      ['reportTheme', 'modern'],
+      ['enableRepairList', 'false'],
+      ['enableCustomerRepairExport', 'false'],
+      ['enableCustomerRepairExport', 'true'], // checkbox adds the second value
+    ]);
+    const submission = parseWithZod(f, { schema: workspaceSchema });
+    expect(submission.status).toBe('success');
+  });
+
+  it('getAll last-value-wins yields the checkbox state', () => {
+    const f = fd([
+      ['enableCustomerRepairExport', 'false'],
+      ['enableCustomerRepairExport', 'true'],
+    ]);
+    const vals = f.getAll('enableCustomerRepairExport');
+    expect(vals[vals.length - 1] === 'true').toBe(true);
+    const unchecked = fd([['enableCustomerRepairExport', 'false']]);
+    const u = unchecked.getAll('enableCustomerRepairExport');
+    expect(u[u.length - 1] === 'true').toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Real fix for the "Report Features" toggles not persisting (follow-up to #151/#152). The earlier #152 (literal `name` attrs) was necessary but **not sufficient** — the actual blocker is conform validation.

**Root cause (proven by a regression test):** a *checked* checkbox submits the field twice — hidden `"false"` + checkbox `"true"` → `["false","true"]`. Because `enableRepairList` / `enableCustomerRepairExport` were declared `z.boolean()` in `workspaceSchema`, conform's `parseWithZod` fed that array to `z.boolean()` and returned `status: 'error'`, so the form **silently never submitted** (no POST) — the flag could never be turned on.

**Fix:** remove the two flags from `workspaceSchema`. A boolean flag has no validation rules; they're read via `fd.getAll()` in the action (last-value-wins). Keeping them out of the conform field map lets the form submit.

Adds `tests/web/unit/settings-workspace-flags.spec.ts` asserting a checked (doubled-value) flag parses as `success`.

> Note: `profileSchema.signatureEnabled` has the same latent pattern (defaults on, so off→on is rarely exercised) — flagged as a follow-up.

## Tests
type-check 0, lint 0, web (incl. new regression) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
