### PR TITLE
Fix: workspace branding fields read back undefined (unwrap nested GET)

### DIFF
--- a/app/routes/settings-workspace.tsx
+++ b/app/routes/settings-workspace.tsx
@@ -33,7 +33,11 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const api = createApi(context, { token });
   const res = await api.adminBranding.branding.$get({});
   const body = res.ok ? ((await res.json()) as Record<string, unknown>) : {};
-  return { branding: (body.data ?? {}) as Branding };
+  // The branding GET responds { success, data: { branding: {...fields} } }, so the
+  // fields live at body.data.branding — NOT body.data (that wrapper was making every
+  // field read back undefined, e.g. the Report Features toggles always appeared off).
+  const data = (body.data ?? {}) as Record<string, unknown>;
+  return { branding: ((data.branding ?? data) ?? {}) as Branding };
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary

Fixes workspace settings (Company) fields — including the new "Report Features" toggles — always reading back as empty/off even after a successful save.

**Cause:** the branding GET responds `{ success, data: { branding: {...fields} } }`, but the loader read `body.data` (the wrapper object), so `branding.siteName`, `branding.enableCustomerRepairExport`, etc. were all `undefined`. The checkboxes' `defaultChecked={branding.enableCustomerRepairExport ?? false}` therefore always rendered off, regardless of the stored value (verified on prod: the stored value was `true` while the checkbox showed unchecked).

**Fix:** unwrap `body.data.branding` (defensive — falls back to `body.data` if a flat shape is ever returned).

Combined with #153 (which fixed the *write* path — a checked checkbox submits two values and `z.boolean()` in the conform schema blocked the form), the toggle now round-trips correctly.

## Tests
type-check 0, lint 0 (incl. DS conformance). Verified end-to-end on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
