### PR TITLE
Fix: conform-native checkboxes for report-feature toggles (save + round-trip)

### DIFF
--- a/app/lib/forms/settings.schema.ts
+++ b/app/lib/forms/settings.schema.ts
@@ -122,13 +122,12 @@ export const workspaceSchema = z.object({
     .optional(),
   reportTheme: z.enum(THEMES).optional(),
   customReferralSources: z.string().optional(),
-  // NOTE: the report-feature flags (enableRepairList / enableCustomerRepairExport)
-  // are intentionally NOT declared here. They render as a hidden "false" + checkbox
-  // "true" pair (LITERAL name attrs) and are read via fd.getAll() in the action — a
-  // boolean flag has no validation rules. If declared as z.boolean() here, a CHECKED
-  // box submits two values ["false","true"]; conform feeds that array to z.boolean()
-  // → parse error → the whole form silently fails to submit (you can never turn it
-  // on). Keeping them out of the conform field map is the fix.
+  // Report-feature flags. Rendered as conform-native checkboxes (single input,
+  // value "on", NO hidden "false" sibling) so a checked box submits ONE value that
+  // conform coerces to a boolean — read from submission.value in the action. (An
+  // earlier hidden+checkbox pair submitted two values and broke z.boolean parsing.)
+  enableRepairList: z.boolean().optional(),
+  enableCustomerRepairExport: z.boolean().optional(),
 });
 
 export type WorkspaceInput = z.infer<typeof workspaceSchema>;

--- a/app/routes/settings-workspace.tsx
+++ b/app/routes/settings-workspace.tsx
@@ -79,12 +79,11 @@ export async function action({ request, context }: Route.ActionArgs) {
       .filter(Boolean);
   }
 
-  // Boolean feature flags — read via getAll() so the hidden "false" sibling
-  // and the checkbox "true" value are both visible; last entry wins.
-  const repairListVals = fd.getAll("enableRepairList");
-  body.enableRepairList = repairListVals[repairListVals.length - 1] === "true";
-  const repairExportVals = fd.getAll("enableCustomerRepairExport");
-  body.enableCustomerRepairExport = repairExportVals[repairExportVals.length - 1] === "true";
+  // Boolean feature flags — conform-native checkboxes coerce to boolean in
+  // submission.value (checked → true, absent → undefined). Always send an explicit
+  // boolean so unchecking persists false.
+  body.enableRepairList = v.enableRepairList ?? false;
+  body.enableCustomerRepairExport = v.enableCustomerRepairExport ?? false;
 
   const api = createApi(context, { token });
   // Body is runtime-assembled from Zod-validated form values matching UpdateBrandingSchema;
@@ -237,11 +236,10 @@ export default function SettingsWorkspacePage() {
           <h3 className="text-[11px] font-bold text-ih-fg-2 uppercase tracking-[0.2em]">Report Features</h3>
 
           <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input type="hidden" name="enableRepairList" value="false" />
             <input
               type="checkbox"
               name="enableRepairList"
-              value="true"
+              value="on"
               defaultChecked={branding.enableRepairList ?? false}
               className="mt-0.5 h-4 w-4 rounded border-ih-border text-ih-primary"
             />
@@ -254,11 +252,10 @@ export default function SettingsWorkspacePage() {
           </label>
 
           <label className="flex items-start gap-3 cursor-pointer select-none">
-            <input type="hidden" name="enableCustomerRepairExport" value="false" />
             <input
               type="checkbox"
               name="enableCustomerRepairExport"
-              value="true"
+              value="on"
               defaultChecked={branding.enableCustomerRepairExport ?? false}
               className="mt-0.5 h-4 w-4 rounded border-ih-border text-ih-primary"
             />

--- a/tests/web/unit/settings-workspace-flags.spec.ts
+++ b/tests/web/unit/settings-workspace-flags.spec.ts
@@ -4,11 +4,14 @@ import { workspaceSchema } from '../../../app/lib/forms/settings.schema';
 
 /**
  * Regression: the "Report Features" checkboxes (enableRepairList /
- * enableCustomerRepairExport) render as a hidden "false" + checkbox "true" pair,
- * so a CHECKED box submits the field twice (["false","true"]). These flags must
- * NOT be in workspaceSchema — if they were declared z.boolean(), conform would
- * feed the array to z.boolean() and the whole form would fail to submit (the flag
- * could never be turned on). They're read via fd.getAll() in the action instead.
+ * enableCustomerRepairExport) are conform-native checkboxes — a SINGLE input with
+ * value "on" and NO hidden "false" sibling. A checked box submits one "on" value
+ * that conform coerces to a boolean in submission.value; an unchecked box submits
+ * nothing (→ undefined → treated as false in the action).
+ *
+ * History: an earlier hidden("false")+checkbox("true") pair submitted the field
+ * TWICE; with z.boolean() in the schema, conform fed that array to z.boolean() and
+ * the whole form silently failed to submit (the flag could never be turned on).
  */
 function fd(pairs: [string, string][]) {
   const f = new FormData();
@@ -16,28 +19,26 @@ function fd(pairs: [string, string][]) {
   return f;
 }
 
-describe('workspace settings — report-feature flags do not block submit', () => {
-  it('a checked flag (doubled value) still parses successfully', () => {
-    const f = fd([
-      ['siteName', 'Acme'],
-      ['reportTheme', 'modern'],
-      ['enableRepairList', 'false'],
-      ['enableCustomerRepairExport', 'false'],
-      ['enableCustomerRepairExport', 'true'], // checkbox adds the second value
-    ]);
-    const submission = parseWithZod(f, { schema: workspaceSchema });
+describe('workspace settings — report-feature checkboxes coerce to booleans', () => {
+  it('checked ("on") → success with the flag true', () => {
+    const submission = parseWithZod(
+      fd([['siteName', 'Acme'], ['reportTheme', 'modern'], ['enableCustomerRepairExport', 'on']]),
+      { schema: workspaceSchema },
+    );
     expect(submission.status).toBe('success');
+    if (submission.status === 'success') {
+      expect(submission.value.enableCustomerRepairExport).toBe(true);
+    }
   });
 
-  it('getAll last-value-wins yields the checkbox state', () => {
-    const f = fd([
-      ['enableCustomerRepairExport', 'false'],
-      ['enableCustomerRepairExport', 'true'],
-    ]);
-    const vals = f.getAll('enableCustomerRepairExport');
-    expect(vals[vals.length - 1] === 'true').toBe(true);
-    const unchecked = fd([['enableCustomerRepairExport', 'false']]);
-    const u = unchecked.getAll('enableCustomerRepairExport');
-    expect(u[u.length - 1] === 'true').toBe(false);
+  it('unchecked (absent) → success with the flag falsy', () => {
+    const submission = parseWithZod(
+      fd([['siteName', 'Acme'], ['reportTheme', 'modern']]),
+      { schema: workspaceSchema },
+    );
+    expect(submission.status).toBe('success');
+    if (submission.status === 'success') {
+      expect(submission.value.enableCustomerRepairExport ?? false).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Final fix so the "Report Features" toggles (Repair Request Builder + Repair List) actually save and round-trip via the Company settings UI. Together with #153 (write/parse) and #154 (read-back unwrap), this completes the toggle.

**Change:** replace the manual hidden(`"false"`)+checkbox(`"true"`)+`fd.getAll()` pattern with **conform-native checkboxes** — a single input `value="on"`, no hidden sibling, flags declared `z.boolean().optional()` in `workspaceSchema`, and read from `submission.value` in the action.

**Why the old pattern failed:** a checked box submitted the field twice (`["false","true"]`); with `z.boolean()` in the schema that broke conform parsing, and reading via `getAll` missed conform's actually-submitted value (conform submits its registered/parsed fields). The native checkbox submits one `"on"` value that conform coerces to a boolean — verified on prod end-to-end (toggle on → save → reload stays on; off → blocked).

## Tests
Updated `settings-workspace-flags.spec.ts` (checked→true, unchecked→false). type-check 0, lint 0 (incl. DS conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
