### PR TITLE
Fix: surface repair-feature flags in report data (client Build-repair-request entry)

### DIFF
--- a/server/services/inspection.service.ts
+++ b/server/services/inspection.service.ts
@@ -2218,16 +2218,25 @@ export class InspectionService {
         // report renders "Estimated cost: $X – $Y" badges on defect cards.
         let showEstimates = false;
         let reportTheme: 'modern' | 'classic' | 'minimal' = 'modern';
+        // Per-tenant report-feature flags surfaced to the published report so the
+        // client report can render the "View Repair List" and "Build repair request"
+        // entries. Read live here (not part of the cached report content).
+        let enableRepairList = false;
+        let enableCustomerRepairExport = false;
         try {
             const cfg = await db.select({
                 showEstimates: tenantConfigs.showEstimates,
                 reportTheme:   tenantConfigs.reportTheme,
+                enableRepairList: tenantConfigs.enableRepairList,
+                enableCustomerRepairExport: tenantConfigs.enableCustomerRepairExport,
             })
                 .from(tenantConfigs)
                 .where(eq(tenantConfigs.tenantId, tenantId))
                 .get();
             if (cfg) {
                 showEstimates = Boolean(cfg.showEstimates);
+                enableRepairList = Boolean(cfg.enableRepairList);
+                enableCustomerRepairExport = Boolean(cfg.enableCustomerRepairExport);
                 if (cfg.reportTheme === 'classic' || cfg.reportTheme === 'minimal') {
                     reportTheme = cfg.reportTheme;
                 }
@@ -2362,6 +2371,8 @@ export class InspectionService {
                 { id: 'Not Inspected', label: 'Not Inspected', abbreviation: 'NI', color: '#3b82f6', severity: 'minor', isDefect: false },
             ],
             showEstimates,
+            enableRepairList,
+            enableCustomerRepairExport,
             propertyFacts,
             // Layer-2 report signature + verification (see docs/superpowers/specs/report-signature).
             isPublished,


### PR DESCRIPTION
## Summary

Surfaces the two per-tenant report-feature flags (`enableRepairList`, `enableCustomerRepairExport`) in the public report data so the client report's entry points actually render.

**Bug:** `report-card-stack.tsx` gates "View Repair List" on `enableRepairList` and "Build repair request" on `enableCustomerRepairExport`, both read from the report data (`getReportData`). But `getReportData` only read `showEstimates`/`reportTheme` from `tenant_configs` and never surfaced these flags — so both entries were always hidden (the client/inspector could never reach the Repair Request Builder from their report; only the agent-dashboard entry, which isn't flag-gated, worked).

**Fix:** read both flags live alongside `showEstimates` in `getReportData` and include them in the report payload. (Verified on prod: with the tenant flag enabled, the client report now shows "Build repair request".)

## Tests
type-check 0; existing public-report / repair-builder unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
