### PR TITLE
feat: unified client portal foundation (magic-link + My Inspections + Hub + report-email repoint)

### DIFF
--- a/app/components/portal/InspectionHub.tsx
+++ b/app/components/portal/InspectionHub.tsx
@@ -92,22 +92,6 @@ export default function InspectionHub({
           const active = n.section === activeSection;
           const base =
             "px-3 py-1.5 text-xs font-semibold rounded-full transition-colors";
-          if (n.section === "overview") {
-            return (
-              <a
-                key={n.section}
-                href={hubSectionHref(n.section, ctx)}
-                aria-current={active ? "page" : undefined}
-                className={`${base} ${
-                  active
-                    ? "bg-ih-primary text-ih-fg-inverse"
-                    : "text-ih-fg-3 hover:bg-ih-bg-muted"
-                }`}
-              >
-                {n.label}
-              </a>
-            );
-          }
           return (
             <a
               key={n.section}

--- a/app/components/portal/InspectionHub.tsx
+++ b/app/components/portal/InspectionHub.tsx
@@ -1,0 +1,132 @@
+import InspectionStatusCards, { type StatusOverview } from "./InspectionStatusCards";
+
+/* ------------------------------------------------------------------ */
+/* Types */
+/* ------------------------------------------------------------------ */
+
+export type HubSection =
+  | "overview"
+  | "report"
+  | "agreement"
+  | "payment"
+  | "progress"
+  | "messages"
+  | "repair";
+
+export interface HubLinkCtx {
+  tenant: string;
+  inspectionId: string;
+  token: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* Pure model (unit-tested) */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Interim deep-links (phase ①) — these point at existing standalone pages.
+ * Phases ②–⑥ will replace these with inline sections rendered inside the hub.
+ *
+ * Built with template strings (not URL) because the base is relative.
+ */
+export function hubSectionHref(section: HubSection, ctx: HubLinkCtx): string {
+  const { tenant, inspectionId, token } = ctx;
+  const t = encodeURIComponent(token);
+  const reportHref = `/report/${tenant}/${inspectionId}?token=${t}`;
+  switch (section) {
+    case "overview":
+      return `/portal/${tenant}/i/${inspectionId}`;
+    case "report":
+      return reportHref;
+    case "agreement":
+      // The report page hosts the agreement gate; no signer token in hub ctx.
+      return reportHref;
+    case "payment":
+      return `/r/${inspectionId}/invoice`;
+    case "progress":
+      return `/observe/inspections/${inspectionId}?token=${t}`;
+    case "messages":
+      // No messageToken in hub ctx → fall back to the report page.
+      return reportHref;
+    case "repair":
+      return `/repair-builder/${tenant}/${inspectionId}?token=${t}`;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Component */
+/* ------------------------------------------------------------------ */
+
+const NAV: Array<{ section: HubSection; label: string }> = [
+  { section: "overview", label: "Overview" },
+  { section: "report", label: "Report" },
+  { section: "agreement", label: "Agreement" },
+  { section: "payment", label: "Payment" },
+  { section: "progress", label: "Progress" },
+  { section: "messages", label: "Messages" },
+  { section: "repair", label: "Repair Request" },
+];
+
+export default function InspectionHub({
+  overview,
+  ctx,
+  activeSection = "overview",
+}: {
+  overview: StatusOverview;
+  ctx: HubLinkCtx;
+  activeSection?: HubSection;
+}) {
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl sm:text-3xl font-bold leading-tight text-ih-fg-1">
+          {overview.address || "Inspection"}
+        </h1>
+        {overview.date && <p className="mt-1 text-sm text-ih-fg-3">{overview.date}</p>}
+      </div>
+
+      {/* Top nav */}
+      <nav className="mb-6 flex flex-wrap gap-2 border-b border-ih-border pb-3">
+        {NAV.map((n) => {
+          const active = n.section === activeSection;
+          const base =
+            "px-3 py-1.5 text-xs font-semibold rounded-full transition-colors";
+          if (n.section === "overview") {
+            return (
+              <a
+                key={n.section}
+                href={hubSectionHref(n.section, ctx)}
+                aria-current={active ? "page" : undefined}
+                className={`${base} ${
+                  active
+                    ? "bg-ih-primary text-ih-fg-inverse"
+                    : "text-ih-fg-3 hover:bg-ih-bg-muted"
+                }`}
+              >
+                {n.label}
+              </a>
+            );
+          }
+          return (
+            <a
+              key={n.section}
+              href={hubSectionHref(n.section, ctx)}
+              aria-current={active ? "page" : undefined}
+              className={`${base} ${
+                active
+                  ? "bg-ih-primary text-ih-fg-inverse"
+                  : "text-ih-fg-3 hover:bg-ih-bg-muted"
+              }`}
+            >
+              {n.label}
+            </a>
+          );
+        })}
+      </nav>
+
+      {/* Overview body */}
+      <InspectionStatusCards overview={overview} />
+    </div>
+  );
+}

--- a/app/components/portal/InspectionList.tsx
+++ b/app/components/portal/InspectionList.tsx
@@ -1,0 +1,68 @@
+import { EmptyState, Pill } from "@core/shared-ui";
+
+export interface InspectionRow {
+  inspectionId: string;
+  address: string;
+  date: string;
+  inspectionStatus: string;
+  reportPublished: boolean;
+  paymentStatus: string;
+}
+
+function capitalize(s: string): string {
+  if (!s) return "";
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function paymentTone(status: string): "sat" | "warning" {
+  return status.toLowerCase() === "paid" ? "sat" : "warning";
+}
+
+/**
+ * Data-source-agnostic inspection list (props only). The client portal and the
+ * agent portal both feed it rows + an href builder.
+ */
+export default function InspectionList({
+  rows,
+  hrefFor,
+}: {
+  rows: InspectionRow[];
+  hrefFor: (inspectionId: string) => string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="No inspections yet"
+        description="Inspections shared with you will appear here."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((r) => (
+        <a
+          key={r.inspectionId}
+          href={hrefFor(r.inspectionId)}
+          className="block bg-ih-bg-card border border-ih-border rounded-lg p-4 hover:bg-ih-bg-muted transition-colors"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-ih-fg-1 truncate">
+                {r.address || "Inspection"}
+              </div>
+              {r.date && <div className="mt-0.5 text-xs text-ih-fg-3">{r.date}</div>}
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            <Pill tone="neutral">{capitalize(r.inspectionStatus)}</Pill>
+            <Pill tone={r.reportPublished ? "sat" : "np"}>
+              {r.reportPublished ? "Report published" : "Report pending"}
+            </Pill>
+            <Pill tone={paymentTone(r.paymentStatus)}>{capitalize(r.paymentStatus)}</Pill>
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/app/components/portal/InspectionStatusCards.tsx
+++ b/app/components/portal/InspectionStatusCards.tsx
@@ -1,0 +1,129 @@
+import { Pill } from "@core/shared-ui";
+
+/* ------------------------------------------------------------------ */
+/* Types */
+/* ------------------------------------------------------------------ */
+
+export interface StatusOverview {
+  inspectionStatus: string;
+  agreementSigned: boolean;
+  paymentStatus: string;
+  reportPublished: boolean;
+  progress: { completed: number; total: number };
+  unreadMessages: number;
+  address: string;
+  date: string;
+}
+
+export type CardTone = "ok" | "warn" | "bad" | "neutral";
+
+export interface StatusCardModel {
+  key: string;
+  label: string;
+  value: string;
+  badge?: number;
+  tone: CardTone;
+}
+
+/* ------------------------------------------------------------------ */
+/* Pure model (unit-tested) */
+/* ------------------------------------------------------------------ */
+
+function capitalize(s: string): string {
+  if (!s) return "";
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function paymentTone(status: string): CardTone {
+  const s = status.toLowerCase();
+  if (s === "paid") return "ok";
+  // partial / unpaid (and anything else) surface as a warning to nudge action.
+  return "warn";
+}
+
+/**
+ * Build the 6 overview status cards in a fixed key order:
+ * appointment, agreement, payment, report, progress, messages.
+ *
+ * Pure + presentation-agnostic so the default-exported component AND the
+ * agent portal can both consume the same model.
+ */
+export function statusCardModels(ov: StatusOverview): StatusCardModel[] {
+  return [
+    {
+      key: "appointment",
+      label: "Appointment",
+      value: capitalize(ov.inspectionStatus) + (ov.date ? ` · ${ov.date}` : ""),
+      tone: "neutral",
+    },
+    {
+      key: "agreement",
+      label: "Agreement",
+      value: ov.agreementSigned ? "Signed" : "Not signed",
+      tone: ov.agreementSigned ? "ok" : "warn",
+    },
+    {
+      key: "payment",
+      label: "Payment",
+      value: capitalize(ov.paymentStatus),
+      tone: paymentTone(ov.paymentStatus),
+    },
+    {
+      key: "report",
+      label: "Report",
+      value: ov.reportPublished ? "Published" : "Not published",
+      tone: ov.reportPublished ? "ok" : "neutral",
+    },
+    {
+      key: "progress",
+      label: "Progress",
+      value: `${ov.progress.completed}/${ov.progress.total}`,
+      tone: "neutral",
+    },
+    {
+      key: "messages",
+      label: "Messages",
+      value: ov.unreadMessages > 0 ? `${ov.unreadMessages} unread` : "No new messages",
+      badge: ov.unreadMessages || undefined,
+      // CardTone has no 'info'; the badge conveys the unread state.
+      tone: "neutral",
+    },
+  ];
+}
+
+/* ------------------------------------------------------------------ */
+/* Component */
+/* ------------------------------------------------------------------ */
+
+const TONE_CLASSES: Record<CardTone, string> = {
+  ok: "bg-ih-ok-bg text-ih-ok-fg",
+  warn: "bg-ih-watch-bg text-ih-watch-fg",
+  bad: "bg-ih-bad-bg text-ih-bad-fg",
+  neutral: "bg-ih-bg-muted text-ih-fg-2",
+};
+
+export default function InspectionStatusCards({ overview }: { overview: StatusOverview }) {
+  const cards = statusCardModels(overview);
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {cards.map((c) => (
+        <div
+          key={c.key}
+          className={`rounded-lg p-4 ${TONE_CLASSES[c.tone]}`}
+        >
+          <div className="flex items-center justify-between">
+            <div className="text-[10px] font-bold uppercase tracking-widest opacity-70">
+              {c.label}
+            </div>
+            {c.badge != null && (
+              <Pill tone="info" className="text-[10px]">
+                {c.badge}
+              </Pill>
+            )}
+          </div>
+          <div className="mt-1 text-sm font-semibold">{c.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/lib/api-client.server.ts
+++ b/app/lib/api-client.server.ts
@@ -36,6 +36,7 @@ import type {
     MetricsApi,
     NotificationsApi,
     PlacesApi,
+    PortalApi,
     ProfileApi,
     PublicShareApi,
     PublicReportApi,
@@ -139,6 +140,7 @@ export interface Api {
     metrics:            ReturnType<typeof hc<MetricsApi>>;
     notifications:      ReturnType<typeof hc<NotificationsApi>>;
     places:             ReturnType<typeof hc<PlacesApi>>;
+    portal:             ReturnType<typeof hc<PortalApi>>;
     profile:            ReturnType<typeof hc<ProfileApi>>;
     publicShare:        ReturnType<typeof hc<PublicShareApi>>;
     publicReport:       ReturnType<typeof hc<PublicReportApi>>;
@@ -202,6 +204,7 @@ const MOUNT: Record<keyof Api, string> = {
     metrics:            "/api/metrics",
     notifications:      "/api/notifications",
     places:             "/api/places",
+    portal:             "/api/portal",
     profile:            "/api/profile",
     publicShare:        "/api/public",
     publicReport:       "/api/public",
@@ -283,6 +286,7 @@ export function createApi(context: AppLoadContext, opts: CreateApiOptions = {}):
         metrics:            mk<MetricsApi>(MOUNT.metrics),
         notifications:      mk<NotificationsApi>(MOUNT.notifications),
         places:             mk<PlacesApi>(MOUNT.places),
+        portal:             mk<PortalApi>(MOUNT.portal),
         profile:            mk<ProfileApi>(MOUNT.profile),
         publicShare:        mk<PublicShareApi>(MOUNT.publicShare),
         publicReport:       mk<PublicReportApi>(MOUNT.publicReport),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -54,6 +54,10 @@ export default [
     route("sms-optin/:token", "routes/public/sms-optin.tsx"),
     route("repair-request/:shareToken", "routes/public/repair-request.$shareToken.tsx"),
     route("repair-builder/:tenant/:id", "routes/public/repair-builder.$tenant.$id.tsx"),
+    // Unified client portal (phase ①) — magic-link login, My Inspections, per-inspection Hub.
+    route("portal/:tenant", "routes/public/portal.tsx"),
+    route("portal/:tenant/auth", "routes/public/portal-auth.tsx"),
+    route("portal/:tenant/i/:inspectionId", "routes/public/portal-inspection.tsx"),
     route(
       "agreements/print/:token",
       "routes/public/agreement-printable.tsx",

--- a/app/routes/public/portal-auth.tsx
+++ b/app/routes/public/portal-auth.tsx
@@ -1,0 +1,62 @@
+/**
+ * Unified client portal — magic-link redemption.
+ *
+ * Route: /portal/:tenant/auth?link=<magic-link token>
+ *   - Valid link → API sets __Host-portal_session; we forward that Set-Cookie to
+ *     the browser and redirect to /portal/:tenant (now authenticated).
+ *   - Missing link → redirect to /portal/:tenant.
+ *   - Expired/invalid link → "expired" state with a path back to request a new one.
+ */
+import { redirect, useLoaderData } from "react-router";
+import type { Route } from "./+types/portal-auth";
+import { createApi } from "~/lib/api-client.server";
+
+export function meta() {
+  return [{ title: "Signing in - OpenInspection" }];
+}
+
+export async function loader({ params, request, context }: Route.LoaderArgs) {
+  const tenant = params.tenant ?? "";
+  const url = new URL(request.url);
+  const link = url.searchParams.get("link");
+  if (!link) {
+    throw redirect(`/portal/${tenant}`);
+  }
+
+  const api = createApi(context);
+  try {
+    const res = await api.portal[":tenant"].redeem.$get({
+      param: { tenant },
+      query: { link },
+    });
+    if (res.status === 200) {
+      // Forward the session cookie minted by the API to the browser, then land
+      // the user on their My Inspections page (now authenticated).
+      const cookie = res.headers.get("set-cookie");
+      return redirect(`/portal/${tenant}`, {
+        headers: cookie ? { "Set-Cookie": cookie } : undefined,
+      });
+    }
+  } catch {
+    // fall through to expired
+  }
+  return { expired: true as const, tenant };
+}
+
+export default function PortalAuth() {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-md mx-auto px-4 py-16 text-center">
+      <h1 className="text-2xl font-bold text-ih-fg-1 mb-2">This link has expired</h1>
+      <p className="text-[14px] text-ih-fg-3 mb-6">
+        Sign-in links expire after 15 minutes. Request a new one to continue.
+      </p>
+      <a
+        href={`/portal/${data.tenant}`}
+        className="inline-flex items-center h-10 px-5 rounded-lg bg-ih-primary text-ih-fg-inverse text-[14px] font-bold hover:bg-ih-primary-600 transition-colors"
+      >
+        Request a new link
+      </a>
+    </div>
+  );
+}

--- a/app/routes/public/portal-inspection.tsx
+++ b/app/routes/public/portal-inspection.tsx
@@ -98,7 +98,9 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
     if (!res.ok) {
       throw new Response("Not found", { status: 404 });
     }
-    const body = (await res.json()) as { data?: StatusOverview };
+    const body = (await res.json()) as {
+      data?: StatusOverview & { token?: string };
+    };
     if (!body.data) throw new Response("Not found", { status: 404 });
     overview = body.data;
   } catch (err) {
@@ -106,7 +108,12 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
     throw new Response("Not found", { status: 404 });
   }
 
-  const ctx = { tenant, inspectionId, token: token ?? "" };
+  // Prefer the server-issued persistent per-inspection token (always present for
+  // an accessible inspection, including magic-link sessions that carry no
+  // ?token); fall back to the URL ?token (email-CTA arrival) then "".
+  const overviewToken = (overview as StatusOverview & { token?: string }).token;
+  const ctxToken = overviewToken || token || "";
+  const ctx = { tenant, inspectionId, token: ctxToken };
 
   // Step 3 — if ?to names a real deep-link section, jump straight there
   // (carrying the token), forwarding any freshly-issued session cookie.

--- a/app/routes/public/portal-inspection.tsx
+++ b/app/routes/public/portal-inspection.tsx
@@ -67,10 +67,14 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
       if (ex.status === 200) {
         const minted = ex.headers.get("set-cookie");
         if (minted) {
+          // Forward the FULL Set-Cookie value to the browser (it carries
+          // ; Path=/; HttpOnly; Secure; SameSite=Lax attributes).
           cookieToForward = minted;
-          // The Set-Cookie value's first `name=value;` pair is a valid Cookie
-          // header value for the same-request overview call.
-          cookieForApi = minted;
+          // A Cookie request header must be `name=value` only — slice off the
+          // attributes before reusing the minted cookie on the same-request
+          // overview call. Fall back to the incoming browser cookie.
+          const mintedCookiePair = minted.split(";")[0];
+          cookieForApi = mintedCookiePair || browserCookie;
         }
       }
     } catch {

--- a/app/routes/public/portal-inspection.tsx
+++ b/app/routes/public/portal-inspection.tsx
@@ -1,0 +1,133 @@
+/**
+ * Unified client portal — per-inspection Hub.
+ *
+ * Route: /portal/:tenant/i/:inspectionId?token=&to=
+ *   - ?token : a per-inspection access token (email CTA). If present we exchange
+ *     it for a portal session cookie (forwarded to the browser) so a client
+ *     arriving from email lands authenticated.
+ *   - ?to    : optional HubSection — jump straight to that section's interim
+ *     deep-link (carrying the token), instead of rendering the hub.
+ *
+ * Cookie forwarding (both directions):
+ *   - exchange/redeem RESPONSE Set-Cookie → forwarded to the browser.
+ *   - browser cookie (or the freshly-issued one) → forwarded INTO the overview
+ *     call, since the typed client does not auto-forward the browser cookie.
+ */
+import { redirect, useLoaderData } from "react-router";
+import type { Route } from "./+types/portal-inspection";
+import { createApi } from "~/lib/api-client.server";
+import InspectionHub, {
+  hubSectionHref,
+  type HubSection,
+} from "~/components/portal/InspectionHub";
+import type { StatusOverview } from "~/components/portal/InspectionStatusCards";
+
+export function meta() {
+  return [{ title: "Inspection - OpenInspection" }];
+}
+
+// HubSections that have an interim deep-link target (everything except the hub
+// itself, which IS this page). Used to validate the ?to query.
+const DEEP_LINK_SECTIONS: HubSection[] = [
+  "report",
+  "agreement",
+  "payment",
+  "progress",
+  "messages",
+  "repair",
+];
+
+function isDeepLinkSection(v: string | null): v is HubSection {
+  return v !== null && (DEEP_LINK_SECTIONS as string[]).includes(v);
+}
+
+export async function loader({ params, request, context }: Route.LoaderArgs) {
+  const tenant = params.tenant ?? "";
+  const inspectionId = params.inspectionId ?? "";
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  const to = url.searchParams.get("to");
+
+  const api = createApi(context);
+  const browserCookie = request.headers.get("cookie") ?? "";
+
+  // Cookie to forward to the browser (only set if exchange minted a fresh one).
+  let cookieToForward: string | null = null;
+  // Cookie value to present to the overview call: prefer the freshly-issued one.
+  let cookieForApi = browserCookie;
+
+  // Step 1 — if a per-inspection token is present, try to upgrade it into a
+  // portal session. Failure is non-fatal: an existing session may still work.
+  if (token) {
+    try {
+      const ex = await api.portal[":tenant"].exchange.$get({
+        param: { tenant },
+        query: { token, inspectionId },
+      });
+      if (ex.status === 200) {
+        const minted = ex.headers.get("set-cookie");
+        if (minted) {
+          cookieToForward = minted;
+          // The Set-Cookie value's first `name=value;` pair is a valid Cookie
+          // header value for the same-request overview call.
+          cookieForApi = minted;
+        }
+      }
+    } catch {
+      // ignore — fall through to step 2
+    }
+  }
+
+  // Step 2 — fetch the overview, forwarding the (possibly freshly-issued) cookie.
+  let overview: StatusOverview;
+  try {
+    const res = await api.portal[":tenant"].inspections[":inspectionId"].overview.$get(
+      { param: { tenant, inspectionId } },
+      { headers: { Cookie: cookieForApi } },
+    );
+    if (res.status === 401) {
+      throw redirect(`/portal/${tenant}`);
+    }
+    if (res.status === 403 || res.status === 404) {
+      throw new Response("Not found", { status: 404 });
+    }
+    if (!res.ok) {
+      throw new Response("Not found", { status: 404 });
+    }
+    const body = (await res.json()) as { data?: StatusOverview };
+    if (!body.data) throw new Response("Not found", { status: 404 });
+    overview = body.data;
+  } catch (err) {
+    if (err instanceof Response) throw err;
+    throw new Response("Not found", { status: 404 });
+  }
+
+  const ctx = { tenant, inspectionId, token: token ?? "" };
+
+  // Step 3 — if ?to names a real deep-link section, jump straight there
+  // (carrying the token), forwarding any freshly-issued session cookie.
+  if (isDeepLinkSection(to)) {
+    throw redirect(hubSectionHref(to, ctx), {
+      headers: cookieToForward ? { "Set-Cookie": cookieToForward } : undefined,
+    });
+  }
+
+  // Step 4 — render the hub.
+  return new Response(
+    JSON.stringify({ overview, ctx }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        ...(cookieToForward ? { "Set-Cookie": cookieToForward } : {}),
+      },
+    },
+  );
+}
+
+export default function PortalInspection() {
+  const { overview, ctx } = useLoaderData<typeof loader>() as {
+    overview: StatusOverview;
+    ctx: { tenant: string; inspectionId: string; token: string };
+  };
+  return <InspectionHub overview={overview} ctx={ctx} activeSection="overview" />;
+}

--- a/app/routes/public/portal.tsx
+++ b/app/routes/public/portal.tsx
@@ -1,0 +1,147 @@
+/**
+ * Unified client portal — landing route.
+ *
+ * Route: /portal/:tenant
+ *   - Signed in (valid __Host-portal_session cookie) → "My Inspections" list.
+ *   - Signed out → email entry form that requests a magic-link (no enumeration).
+ *
+ * BFF only: all `/api/portal` calls go through the typed client. The browser's
+ * portal-session cookie is forwarded INTO the `me` call (the typed client's
+ * fetch does not auto-forward it).
+ */
+import { Form, useLoaderData, useActionData, useNavigation } from "react-router";
+import type { Route } from "./+types/portal";
+import { createApi } from "~/lib/api-client.server";
+import InspectionList, { type InspectionRow } from "~/components/portal/InspectionList";
+
+export function meta() {
+  return [{ title: "Client Portal - OpenInspection" }];
+}
+
+type LoaderResult =
+  | { authed: true; tenant: string; email: string; inspections: InspectionRow[] }
+  | { authed: false; tenant: string };
+
+export async function loader({
+  params,
+  request,
+  context,
+}: Route.LoaderArgs): Promise<LoaderResult> {
+  const tenant = params.tenant ?? "";
+  const api = createApi(context);
+  const cookie = request.headers.get("cookie") ?? "";
+
+  try {
+    const res = await api.portal[":tenant"].me.$get(
+      { param: { tenant } },
+      { headers: { Cookie: cookie } },
+    );
+    if (res.status === 200) {
+      const body = (await res.json()) as {
+        data?: { email: string; inspections: InspectionRow[] };
+      };
+      const data = body.data;
+      if (data) {
+        return { authed: true, tenant, email: data.email, inspections: data.inspections };
+      }
+    }
+  } catch {
+    // fall through to unauthenticated
+  }
+  return { authed: false, tenant };
+}
+
+export async function action({ params, request, context }: Route.ActionArgs) {
+  const tenant = params.tenant ?? "";
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "").trim();
+  if (!email) return { sent: false as const };
+
+  const api = createApi(context);
+  try {
+    await api.portal[":tenant"]["request-link"].$post({
+      param: { tenant },
+      json: { email },
+    });
+  } catch {
+    // The API never enumerates; we mirror that and always report "sent".
+  }
+  return { sent: true as const };
+}
+
+export default function PortalLanding() {
+  const data = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const submitting = navigation.state === "submitting";
+
+  if (data.authed) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <p className="text-[11px] font-bold tracking-widest uppercase text-ih-fg-4 mb-1">
+            Client Portal
+          </p>
+          <h1 className="text-2xl font-bold text-ih-fg-1">My Inspections</h1>
+          <p className="text-[13px] text-ih-fg-3 mt-1">Signed in as {data.email}</p>
+        </div>
+        <InspectionList
+          rows={data.inspections}
+          hrefFor={(id) => `/portal/${data.tenant}/i/${id}`}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-12">
+      <div className="mb-6">
+        <p className="text-[11px] font-bold tracking-widest uppercase text-ih-fg-4 mb-1">
+          Client Portal
+        </p>
+        <h1 className="text-2xl font-bold text-ih-fg-1">Sign in to your portal</h1>
+        <p className="text-[14px] text-ih-fg-3 mt-1">
+          Enter your email and we&rsquo;ll send you a secure sign-in link.
+        </p>
+      </div>
+
+      {actionData?.sent ? (
+        <div className="bg-ih-bg-card border border-ih-border rounded-xl p-5">
+          <p className="text-[14px] font-semibold text-ih-fg-1">
+            Check your email for a sign-in link.
+          </p>
+          <p className="text-[13px] text-ih-fg-3 mt-1">
+            If an account matches that address, a link is on its way. It expires in 15 minutes.
+          </p>
+        </div>
+      ) : (
+        <Form method="post" className="space-y-3">
+          <div>
+            <label
+              htmlFor="portal-email"
+              className="block text-[11px] font-bold text-ih-fg-4 uppercase tracking-widest mb-1"
+            >
+              Email address
+            </label>
+            <input
+              id="portal-email"
+              name="email"
+              type="email"
+              required
+              autoComplete="email"
+              placeholder="you@example.com"
+              className="w-full h-10 px-3 rounded-md border border-ih-border bg-ih-bg-app text-[14px] text-ih-fg-1 placeholder:text-ih-fg-4 focus:outline-none focus:border-ih-primary"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full h-10 rounded-lg bg-ih-primary text-ih-fg-inverse text-[14px] font-bold hover:bg-ih-primary-600 transition-colors disabled:opacity-50"
+          >
+            {submitting ? "Sending…" : "Email me a sign-in link"}
+          </button>
+        </Form>
+      )}
+    </div>
+  );
+}

--- a/packages/api-types/index.ts
+++ b/packages/api-types/index.ts
@@ -39,6 +39,7 @@ export type { MessagesApi }           from '../../server/api/messages';
 export type { MetricsApi }            from '../../server/api/metrics';
 export type { NotificationsApi }      from '../../server/api/notifications';
 export type { PlacesApi }             from '../../server/api/places';
+export type { PortalApi }             from '../../server/api/portal';
 export type { ProfileApi }            from '../../server/api/profile';
 export type { PublicShareApi }        from '../../server/api/public-share';
 export type { PublicReportApi }       from '../../server/api/public-report';

--- a/server/api/inspections.ts
+++ b/server/api/inspections.ts
@@ -6,6 +6,7 @@ import { requireCapability } from '../lib/middleware/require-capability';
 import { auditFromContext } from '../lib/audit';
 import { getBookingHost, resolveTenantSlug } from '../lib/url';
 import { reportUrl as buildReportUrl, buildRenderReportUrl, agreementSignUrl } from '../lib/public-urls';
+import { buildPortalUrl } from '../lib/portal-urls';
 import { safeISODate } from '../lib/date';
 import { Errors } from '../lib/errors';
 import { contentDisposition } from '../lib/content-disposition';
@@ -2661,7 +2662,9 @@ export const inspectionsRoutes = createApiRouter()
             // can open it (a plain URL 404s "Report not found"). Idempotent per
             // (inspection, recipient) — re-sends keep the same stable link.
             const reportToken = await c.var.services.portalAccess.issueToken({ tenantId, inspectionId: id, recipientEmail: inspection.clientEmail, role: 'client' });
-            const linkUrl = `${buildReportUrl(getBookingHost(c), tenantSlug, id)}?token=${encodeURIComponent(reportToken)}`;
+            // linkUrl now lands the no-login client on the unified portal hub
+            // (overview) carrying the persistent portalAccess token.
+            const linkUrl = buildPortalUrl(getBookingHost(c), tenantSlug, id, reportToken);
             // renderUrl: token-bearing URL for the headless browser PDF render.
             const renderUrl = await buildRenderReportUrl(getBookingHost(c), tenantSlug, id, c.env.JWT_SECRET);
             const clientEmail = inspection.clientEmail;
@@ -2732,7 +2735,9 @@ export const inspectionsRoutes = createApiRouter()
         // found" for a no-login recipient. issueToken is idempotent per
         // (inspection, recipient), so re-sends reuse the same stable link.
         const reportToken = await c.var.services.portalAccess.issueToken({ tenantId, inspectionId: id, recipientEmail: recipient, role: 'client' });
-        const linkUrl = `${buildReportUrl(getBookingHost(c), tenantSlug, id)}?token=${encodeURIComponent(reportToken)}`;
+        // linkUrl now lands the no-login client on the unified portal hub
+        // (overview) carrying the persistent portalAccess token.
+        const linkUrl = buildPortalUrl(getBookingHost(c), tenantSlug, id, reportToken);
         // renderUrl: token-bearing URL for the headless browser PDF render.
         const renderUrl = await buildRenderReportUrl(getBookingHost(c), tenantSlug, id, c.env.JWT_SECRET);
         const address = inspection.propertyAddress as string;

--- a/server/api/inspections.ts
+++ b/server/api/inspections.ts
@@ -4,7 +4,7 @@ import { createApiRouter } from '../lib/openapi-router';
 import { requireRole } from '../lib/middleware/rbac';
 import { requireCapability } from '../lib/middleware/require-capability';
 import { auditFromContext } from '../lib/audit';
-import { getBookingHost, resolveTenantSlug } from '../lib/url';
+import { getBookingHost, getBaseUrl, resolveTenantSlug } from '../lib/url';
 import { reportUrl as buildReportUrl, buildRenderReportUrl, agreementSignUrl } from '../lib/public-urls';
 import { buildPortalUrl } from '../lib/portal-urls';
 import { safeISODate } from '../lib/date';
@@ -2664,7 +2664,7 @@ export const inspectionsRoutes = createApiRouter()
             const reportToken = await c.var.services.portalAccess.issueToken({ tenantId, inspectionId: id, recipientEmail: inspection.clientEmail, role: 'client' });
             // linkUrl now lands the no-login client on the unified portal hub
             // (overview) carrying the persistent portalAccess token.
-            const linkUrl = buildPortalUrl(getBookingHost(c), tenantSlug, id, reportToken);
+            const linkUrl = buildPortalUrl(getBaseUrl(c), tenantSlug, id, reportToken);
             // renderUrl: token-bearing URL for the headless browser PDF render.
             const renderUrl = await buildRenderReportUrl(getBookingHost(c), tenantSlug, id, c.env.JWT_SECRET);
             const clientEmail = inspection.clientEmail;
@@ -2737,7 +2737,7 @@ export const inspectionsRoutes = createApiRouter()
         const reportToken = await c.var.services.portalAccess.issueToken({ tenantId, inspectionId: id, recipientEmail: recipient, role: 'client' });
         // linkUrl now lands the no-login client on the unified portal hub
         // (overview) carrying the persistent portalAccess token.
-        const linkUrl = buildPortalUrl(getBookingHost(c), tenantSlug, id, reportToken);
+        const linkUrl = buildPortalUrl(getBaseUrl(c), tenantSlug, id, reportToken);
         // renderUrl: token-bearing URL for the headless browser PDF render.
         const renderUrl = await buildRenderReportUrl(getBookingHost(c), tenantSlug, id, c.env.JWT_SECRET);
         const address = inspection.propertyAddress as string;

--- a/server/api/portal.ts
+++ b/server/api/portal.ts
@@ -20,10 +20,11 @@
  */
 import { createRoute, z } from '@hono/zod-openapi';
 import type { Context } from 'hono';
-import { getCookie } from 'hono/cookie';
+import { getCookie, setCookie } from 'hono/cookie';
 import { createApiRouter } from '../lib/openapi-router';
 import { withMcpMetadata } from '../lib/route-metadata-standards';
-import { signMagicLink, verifyMagicLink, verifyPortalSession } from '../lib/portal-session';
+import { signMagicLink, verifyMagicLink, verifyPortalSession, signPortalSession } from '../lib/portal-session';
+import { resolvePortalAccess } from '../lib/public-access';
 import { getBaseUrl } from '../lib/url';
 import { logger } from '../lib/logger';
 import type { HonoConfig } from '../types/hono';
@@ -140,9 +141,38 @@ const redeemRoute = createRoute(withMcpMetadata({
     },
     operationId: 'portalRedeemLink',
     description:
-        'Validates a portal magic-link token (typ=ml) and returns the verified email. The ' +
-        'frontend route is responsible for exchanging this for a session cookie; this ' +
-        'endpoint only verifies the signed token and never sets a cookie.',
+        'Validates a portal magic-link token (typ=ml). On success it sets the ' +
+        '__Host-portal_session cookie (httpOnly/secure/SameSite=Lax) carrying the verified ' +
+        'email and returns that email so the frontend can render. Bad/expired token → 401.',
+}, { scopes: [], tier: 'extended' }));
+
+const exchangeRoute = createRoute(withMcpMetadata({
+    method:  'get',
+    path:    '/{tenant}/exchange',
+    tags:    ['public'],
+    summary: 'Upgrade a per-inspection access token into a portal session',
+    request: {
+        params: TenantParam,
+        query: z.object({
+            token:        z.string().describe('Per-inspection client/co_client access token from an email CTA link.'),
+            inspectionId: z.string().describe('Inspection identifier the access token is expected to grant.'),
+        }),
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: z.object({ data: z.object({ email: z.string().describe('Recipient email carried by the access token; also written into the session cookie.') }) }) } },
+            description: 'Token valid for this tenant + inspection; session cookie set and email returned.',
+        },
+        401: { description: 'Access token missing, invalid, expired, revoked, or not for this inspection' },
+        403: { description: 'Token resolves to a different tenant, or to a non-client (e.g. agent) role' },
+        404: { description: 'Tenant slug not found' },
+    },
+    operationId: 'portalExchangeToken',
+    description:
+        'Exchanges a persistent per-(recipient, inspection) access token (the same family used ' +
+        'by the public report links) for a __Host-portal_session cookie, so a client arriving ' +
+        'from an email CTA lands in the portal already authenticated. Asserts the resolved ' +
+        'grant tenant matches the path tenant AND the role is client/co_client (agent → 403).',
 }, { scopes: [], tier: 'extended' }));
 
 const meRoute = createRoute(withMcpMetadata({
@@ -201,13 +231,17 @@ const overviewRoute = createRoute(withMcpMetadata({
 // Router
 // ---------------------------------------------------------------------------
 
-export const portalRoutes = createApiRouter();
+const portalRouter = createApiRouter();
 
-// Session gate covers only the data routes (NOT request-link / redeem).
-portalRoutes.use('/:tenant/me', portalSession);
-portalRoutes.use('/:tenant/inspections/*', portalSession);
+// Session gate covers only the data routes (NOT request-link / redeem / exchange).
+portalRouter.use('/:tenant/me', portalSession);
+portalRouter.use('/:tenant/inspections/*', portalSession);
 
-portalRoutes
+// IMPORTANT: capture the fluent `.openapi()` chain into the exported binding so
+// `typeof portalRoutes` carries every registered route into PortalApi. Assigning
+// the bare router (and applying `.openapi()` as discarded statements) would type
+// the client surface as `unknown` — mirror repair-builder.ts here.
+export const portalRoutes = portalRouter
     .openapi(requestLinkRoute, async (c) => {
         const tenantId = resolveTenantId(c);
         if (!tenantId) return c.json({ error: 'Tenant not found' }, 404);
@@ -279,7 +313,28 @@ portalRoutes
         if (!verified) {
             return c.json({ error: 'Invalid or expired link' }, 401);
         }
+        const sess = await signPortalSession(c.env.JWT_SECRET, verified.email);
+        setCookie(c, PORTAL_SESSION_COOKIE, sess, { httpOnly: true, secure: true, sameSite: 'Lax', path: '/' });
         return c.json({ data: { email: verified.email } }, 200);
+    })
+    .openapi(exchangeRoute, async (c) => {
+        const tenantId = resolveTenantId(c);
+        if (!tenantId) return c.json({ error: 'Tenant not found' }, 404);
+
+        const { token, inspectionId } = c.req.valid('query');
+        const grant = await resolvePortalAccess(c.var.services.portalAccess, token, inspectionId);
+        if (!grant) return c.json({ error: 'Invalid or expired token' }, 401);
+
+        // SECURITY: the token row is authoritative — it must point at THIS tenant
+        // and carry a client/co_client role. Reject agents (and any mismatch) so
+        // an agent's per-inspection token can never mint a client portal session.
+        if (grant.tenantId !== tenantId || (grant.role !== 'client' && grant.role !== 'co_client')) {
+            return c.json({ error: 'Forbidden' }, 403);
+        }
+
+        const sess = await signPortalSession(c.env.JWT_SECRET, grant.recipientEmail);
+        setCookie(c, PORTAL_SESSION_COOKIE, sess, { httpOnly: true, secure: true, sameSite: 'Lax', path: '/' });
+        return c.json({ data: { email: grant.recipientEmail } }, 200);
     })
     .openapi(meRoute, async (c) => {
         const tenantId = resolveTenantId(c);

--- a/server/api/portal.ts
+++ b/server/api/portal.ts
@@ -107,7 +107,7 @@ const requestLinkRoute = createRoute(withMcpMetadata({
     },
     responses: {
         200: {
-            content: { 'application/json': { schema: z.object({ data: z.object({ sent: z.boolean().describe('Always true — response is identical whether or not the email is known.') }) }) } },
+            content: { 'application/json': { schema: z.object({ data: z.object({ sent: z.boolean().describe('Always true — response is identical (payload AND timing) whether or not the email is known; the magic-link send is deferred to waitUntil.') }) }) } },
             description: 'Magic-link request accepted (no email enumeration).',
         },
         404: { description: 'Tenant slug not found' },
@@ -226,13 +226,18 @@ portalRoutes
         }
 
         if (known) {
-            try {
-                const token = await signMagicLink(c.env.JWT_SECRET, email);
-                const baseUrl = getBaseUrl(c).replace(/\/$/, '');
-                const slug = c.get('requestedTenantSlug') || '';
-                const link = `${baseUrl}/portal/${slug}/auth?link=${encodeURIComponent(token)}`;
-                const safeLink = link.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-                const html = `
+            // Do NOT await the send inside the request: awaiting only on the
+            // known path makes known emails respond measurably slower than
+            // unknown ones, which is a timing enumeration oracle. Defer the work
+            // to `waitUntil` so the response returns immediately in all cases.
+            const sendPromise = (async () => {
+                try {
+                    const token = await signMagicLink(c.env.JWT_SECRET, email);
+                    const baseUrl = getBaseUrl(c).replace(/\/$/, '');
+                    const slug = c.get('requestedTenantSlug') || '';
+                    const link = `${baseUrl}/portal/${slug}/auth?link=${encodeURIComponent(token)}`;
+                    const safeLink = link.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+                    const html = `
                     <div style="font-family: -apple-system, system-ui, Segoe UI, Roboto, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #0f172a;">
                         <p style="font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: #64748b; margin: 0 0 4px;">Client Portal</p>
                         <h1 style="font-size: 22px; line-height: 1.25; font-weight: 600; margin: 0 0 16px;">Sign in to your portal</h1>
@@ -245,14 +250,27 @@ portalRoutes
                         <p style="font-size: 12px; color: #94a3b8; margin-top: 24px;">If you didn't request this, you can safely ignore this email.</p>
                     </div>
                 `;
-                await c.var.services.email.sendEmail([email], 'Sign in to your client portal', html);
-            } catch (err) {
-                // Swallow send failures — never leak whether the email was known.
-                logger.error('[portal] magic-link send failed', {}, err instanceof Error ? err : undefined);
+                    await c.var.services.email.sendEmail([email], 'Sign in to your client portal', html);
+                } catch (err) {
+                    // Swallow send failures — never leak whether the email was known.
+                    logger.error('[portal] magic-link send failed', {}, err instanceof Error ? err : undefined);
+                }
+            })();
+            // `c.executionCtx` is the Hono Worker execution context (see di.ts).
+            // Its getter THROWS when no execution context is present (e.g. unit
+            // tests), so probe it defensively rather than via a truthiness check.
+            let execCtx: ExecutionContext | undefined;
+            try {
+                execCtx = c.executionCtx;
+            } catch {
+                execCtx = undefined;
             }
+            if (execCtx) execCtx.waitUntil(sendPromise);
+            else await sendPromise;
         }
 
-        // Identical response in all cases (no enumeration).
+        // Identical response in all cases — timing-identical (send deferred to
+        // waitUntil) AND payload-identical, so there is no enumeration oracle.
         return c.json({ data: { sent: true } }, 200);
     })
     .openapi(redeemRoute, async (c) => {

--- a/server/api/portal.ts
+++ b/server/api/portal.ts
@@ -91,6 +91,10 @@ const HubOverviewSchema = z.object({
     unreadMessages:   z.number().describe('Count of unread inspector messages.'),
 });
 
+const HubOverviewResponseSchema = HubOverviewSchema.extend({
+    token: z.string().describe('Persistent per-inspection access token for building section deep-links.'),
+});
+
 // ---------------------------------------------------------------------------
 // Routes
 // ---------------------------------------------------------------------------
@@ -213,7 +217,7 @@ const overviewRoute = createRoute(withMcpMetadata({
     },
     responses: {
         200: {
-            content: { 'application/json': { schema: z.object({ data: HubOverviewSchema }) } },
+            content: { 'application/json': { schema: z.object({ data: HubOverviewResponseSchema }) } },
             description: 'Six-dimension status snapshot for the inspection.',
         },
         401: { description: 'No valid portal session cookie' },
@@ -356,9 +360,20 @@ export const portalRoutes = portalRouter
             return c.json({ error: 'Not accessible' }, 403);
         }
 
+        // Resolve the recipient's STABLE per-inspection token so the Hub can build
+        // section deep-links even for magic-link sessions (which carry no ?token).
+        // issueToken is idempotent get-or-create; the membership check above already
+        // guarantees a grant exists, so this returns that grant's token — no new row.
+        let token = '';
+        try {
+            token = await c.var.services.portalAccess.issueToken({ tenantId, inspectionId, recipientEmail: email });
+        } catch (err) {
+            logger.error('[portal] overview token issue failed', {}, err instanceof Error ? err : undefined);
+        }
+
         const overview = await c.var.services.portal.hubOverview(tenantId, inspectionId);
         if (!overview) return c.json({ error: 'Inspection not found' }, 404);
-        return c.json({ data: overview }, 200);
+        return c.json({ data: { ...overview, token } }, 200);
     });
 
 export type PortalApi = typeof portalRoutes;

--- a/server/api/portal.ts
+++ b/server/api/portal.ts
@@ -1,0 +1,293 @@
+/**
+ * Unified client portal — public API routes (no-password magic-link auth).
+ *
+ * All routes live under `/api/portal/:tenant`. Tenant is resolved from the
+ * `:tenant` path slug by the `tenantRouter` middleware (the `/api/portal/`
+ * prefix is whitelisted in resolve-by-path-param.ts), NOT from the host —
+ * host→tenant resolution was retired (silo-deconvergence). Handlers read the
+ * resolved tenant via `c.get('tenantId') || c.get('resolvedTenantId')` and
+ * 404 when neither is set (unknown slug).
+ *
+ * Auth model:
+ *   - request-link / redeem are UNAUTHENTICATED entry points.
+ *   - me / inspections/* are gated by a `__Host-portal_session` cookie carrying
+ *     ONLY a verified email (tenant-independent — email ownership is global).
+ *     Cross-tenant isolation holds because every data query is tenant-scoped to
+ *     the path's tenantId (see PortalService).
+ *
+ * Mirrors the conventions of server/api/repair-builder.ts (OpenAPIHono +
+ * createRoute + withMcpMetadata + Zod `.describe()` on every field).
+ */
+import { createRoute, z } from '@hono/zod-openapi';
+import type { Context } from 'hono';
+import { getCookie } from 'hono/cookie';
+import { createApiRouter } from '../lib/openapi-router';
+import { withMcpMetadata } from '../lib/route-metadata-standards';
+import { signMagicLink, verifyMagicLink, verifyPortalSession } from '../lib/portal-session';
+import { getBaseUrl } from '../lib/url';
+import { logger } from '../lib/logger';
+import type { HonoConfig } from '../types/hono';
+
+const PORTAL_SESSION_COOKIE = '__Host-portal_session';
+
+/** Resolves the path-derived tenantId, or null when the slug is unknown. */
+function resolveTenantId(c: Context<HonoConfig>): string | null {
+    return c.get('tenantId') || c.get('resolvedTenantId') || null;
+}
+
+// ---------------------------------------------------------------------------
+// Session middleware (applied only to /me and /inspections/*)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads + verifies the `__Host-portal_session` cookie. On success sets
+ * `portalEmail` on the context; on missing/invalid returns 401. Tenant-agnostic
+ * by design — the cookie carries only a verified email.
+ */
+async function portalSession(c: Context<HonoConfig>, next: () => Promise<void>) {
+    const cookie = getCookie(c, PORTAL_SESSION_COOKIE);
+    const verified = cookie ? await verifyPortalSession(c.env.JWT_SECRET, cookie) : null;
+    if (!verified) {
+        return c.json({ error: 'Not authenticated' }, 401);
+    }
+    c.set('portalEmail', verified.email);
+    await next();
+    return;
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const TenantParam = z.object({
+    tenant: z.string().describe('Tenant slug (resolves the tenant from the URL path).'),
+});
+
+const RequestLinkBody = z.object({
+    email: z.string().email().describe('Recipient email address requesting a portal magic-link.'),
+});
+
+const RecipientInspectionSchema = z.object({
+    inspectionId:     z.string().describe('Inspection identifier the recipient can access.'),
+    address:          z.string().describe('Property address for the inspection.'),
+    date:             z.string().describe('Inspection date (ISO date string).'),
+    inspectionStatus: z.string().describe('Lifecycle status of the inspection.'),
+    reportPublished:  z.boolean().describe('Whether the report has been published.'),
+    paymentStatus:    z.string().describe('Payment status of the inspection.'),
+});
+
+const HubOverviewSchema = z.object({
+    address:          z.string().describe('Property address for the inspection.'),
+    date:             z.string().describe('Inspection date (ISO date string).'),
+    inspectionStatus: z.string().describe('Lifecycle status of the inspection.'),
+    agreementSigned:  z.boolean().describe('Whether the inspection agreement is signed.'),
+    paymentStatus:    z.string().describe('Payment status of the inspection.'),
+    reportPublished:  z.boolean().describe('Whether the report has been published.'),
+    progress:         z.object({
+        completed: z.number().describe('Number of completed report items.'),
+        total:     z.number().describe('Total number of report items.'),
+    }).describe('Observation progress for the inspection report.'),
+    unreadMessages:   z.number().describe('Count of unread inspector messages.'),
+});
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+const requestLinkRoute = createRoute(withMcpMetadata({
+    method:  'post',
+    path:    '/{tenant}/request-link',
+    tags:    ['public'],
+    summary: 'Request a portal magic-link by email',
+    request: {
+        params: TenantParam,
+        body: {
+            content: { 'application/json': { schema: RequestLinkBody } },
+        },
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: z.object({ data: z.object({ sent: z.boolean().describe('Always true — response is identical whether or not the email is known.') }) }) } },
+            description: 'Magic-link request accepted (no email enumeration).',
+        },
+        404: { description: 'Tenant slug not found' },
+    },
+    operationId: 'portalRequestLink',
+    description:
+        'Requests a no-password magic-link for the unified client portal. ALWAYS returns ' +
+        '200 with { sent: true } regardless of whether the email has any access grant, to ' +
+        'prevent account enumeration. When the email owns a live client/co_client access ' +
+        'token in this tenant, an email containing a signed magic-link is sent.',
+}, { scopes: [], tier: 'extended' }));
+
+const redeemRoute = createRoute(withMcpMetadata({
+    method:  'get',
+    path:    '/{tenant}/redeem',
+    tags:    ['public'],
+    summary: 'Validate a portal magic-link token',
+    request: {
+        params: TenantParam,
+        query: z.object({
+            link: z.string().describe('Signed magic-link token to validate.'),
+        }),
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: z.object({ data: z.object({ email: z.string().describe('Verified email carried by the magic-link.') }) }) } },
+            description: 'Magic-link is valid; returns the verified email.',
+        },
+        401: { description: 'Magic-link missing, expired, or invalid' },
+    },
+    operationId: 'portalRedeemLink',
+    description:
+        'Validates a portal magic-link token (typ=ml) and returns the verified email. The ' +
+        'frontend route is responsible for exchanging this for a session cookie; this ' +
+        'endpoint only verifies the signed token and never sets a cookie.',
+}, { scopes: [], tier: 'extended' }));
+
+const meRoute = createRoute(withMcpMetadata({
+    method:  'get',
+    path:    '/{tenant}/me',
+    tags:    ['public'],
+    summary: 'List the signed-in recipient\'s inspections',
+    request: {
+        params: TenantParam,
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: z.object({ data: z.object({
+                email:       z.string().describe('Verified session email.'),
+                inspections: z.array(RecipientInspectionSchema).describe('Inspections this recipient can access in this tenant.'),
+            }) }) } },
+            description: 'The session email plus its accessible inspections.',
+        },
+        401: { description: 'No valid portal session cookie' },
+        404: { description: 'Tenant slug not found' },
+    },
+    operationId: 'portalMe',
+    description:
+        'Returns the session email plus every inspection the recipient can access in this ' +
+        'tenant via a live client/co_client access token. Gated by the __Host-portal_session ' +
+        'cookie; tenant is resolved from the path slug.',
+}, { scopes: [], tier: 'extended' }));
+
+const overviewRoute = createRoute(withMcpMetadata({
+    method:  'get',
+    path:    '/{tenant}/inspections/{inspectionId}/overview',
+    tags:    ['public'],
+    summary: 'Status overview for one accessible inspection',
+    request: {
+        params: TenantParam.extend({
+            inspectionId: z.string().describe('Inspection identifier to fetch the overview for.'),
+        }),
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: z.object({ data: HubOverviewSchema }) } },
+            description: 'Six-dimension status snapshot for the inspection.',
+        },
+        401: { description: 'No valid portal session cookie' },
+        403: { description: 'Inspection is not accessible to this recipient' },
+        404: { description: 'Tenant slug or inspection not found' },
+    },
+    operationId: 'portalInspectionOverview',
+    description:
+        'Returns a six-dimension status snapshot (status / agreement / payment / report / ' +
+        'progress / unread messages) for one inspection. Asserts the inspection is in the ' +
+        'recipient\'s accessible set for this tenant+email before returning data (403 otherwise).',
+}, { scopes: [], tier: 'extended' }));
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export const portalRoutes = createApiRouter();
+
+// Session gate covers only the data routes (NOT request-link / redeem).
+portalRoutes.use('/:tenant/me', portalSession);
+portalRoutes.use('/:tenant/inspections/*', portalSession);
+
+portalRoutes
+    .openapi(requestLinkRoute, async (c) => {
+        const tenantId = resolveTenantId(c);
+        if (!tenantId) return c.json({ error: 'Tenant not found' }, 404);
+
+        const { email } = c.req.valid('json');
+
+        // Look up whether this email has ANY live client/co_client grant in this
+        // tenant. Same DB the PortalService reads (mocked to the test DB in unit
+        // tests). Reuse listRecipientInspections to avoid duplicating the query.
+        let known = false;
+        try {
+            const inspections = await c.var.services.portal.listRecipientInspections(tenantId, email);
+            known = inspections.length > 0;
+        } catch (err) {
+            logger.error('[portal] request-link lookup failed', {}, err instanceof Error ? err : undefined);
+        }
+
+        if (known) {
+            try {
+                const token = await signMagicLink(c.env.JWT_SECRET, email);
+                const baseUrl = getBaseUrl(c).replace(/\/$/, '');
+                const slug = c.get('requestedTenantSlug') || '';
+                const link = `${baseUrl}/portal/${slug}/auth?link=${encodeURIComponent(token)}`;
+                const safeLink = link.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+                const html = `
+                    <div style="font-family: -apple-system, system-ui, Segoe UI, Roboto, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #0f172a;">
+                        <p style="font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: #64748b; margin: 0 0 4px;">Client Portal</p>
+                        <h1 style="font-size: 22px; line-height: 1.25; font-weight: 600; margin: 0 0 16px;">Sign in to your portal</h1>
+                        <p style="font-size: 14px; line-height: 1.5; color: #475569;">
+                            Click the button below to access your inspections. This link expires in 15 minutes.
+                        </p>
+                        <p style="margin-top: 24px;">
+                            <a href="${safeLink}" style="display: inline-block; padding: 10px 16px; background: #0f172a; color: white; text-decoration: none; border-radius: 6px; font-size: 13px; font-weight: 700;">Open my portal</a>
+                        </p>
+                        <p style="font-size: 12px; color: #94a3b8; margin-top: 24px;">If you didn't request this, you can safely ignore this email.</p>
+                    </div>
+                `;
+                await c.var.services.email.sendEmail([email], 'Sign in to your client portal', html);
+            } catch (err) {
+                // Swallow send failures — never leak whether the email was known.
+                logger.error('[portal] magic-link send failed', {}, err instanceof Error ? err : undefined);
+            }
+        }
+
+        // Identical response in all cases (no enumeration).
+        return c.json({ data: { sent: true } }, 200);
+    })
+    .openapi(redeemRoute, async (c) => {
+        const { link } = c.req.valid('query');
+        const verified = await verifyMagicLink(c.env.JWT_SECRET, link);
+        if (!verified) {
+            return c.json({ error: 'Invalid or expired link' }, 401);
+        }
+        return c.json({ data: { email: verified.email } }, 200);
+    })
+    .openapi(meRoute, async (c) => {
+        const tenantId = resolveTenantId(c);
+        if (!tenantId) return c.json({ error: 'Tenant not found' }, 404);
+        const email = c.get('portalEmail') as string;
+
+        const inspections = await c.var.services.portal.listRecipientInspections(tenantId, email);
+        return c.json({ data: { email, inspections } }, 200);
+    })
+    .openapi(overviewRoute, async (c) => {
+        const tenantId = resolveTenantId(c);
+        if (!tenantId) return c.json({ error: 'Tenant not found' }, 404);
+        const email = c.get('portalEmail') as string;
+        const { inspectionId } = c.req.valid('param');
+
+        // Membership check: the inspection must be in the recipient's accessible set.
+        const accessible = await c.var.services.portal.listRecipientInspections(tenantId, email);
+        if (!accessible.some((i) => i.inspectionId === inspectionId)) {
+            return c.json({ error: 'Not accessible' }, 403);
+        }
+
+        const overview = await c.var.services.portal.hubOverview(tenantId, inspectionId);
+        if (!overview) return c.json({ error: 'Inspection not found' }, 404);
+        return c.json({ data: overview }, 200);
+    });
+
+export type PortalApi = typeof portalRoutes;
+
+export default portalRoutes;

--- a/server/features/tenant-routing/resolve-by-path-param.ts
+++ b/server/features/tenant-routing/resolve-by-path-param.ts
@@ -27,6 +27,9 @@ const PUBLIC_PREFIXES = [
     '/checkout/',
     '/m2m/agreement-render/',
     '/api/integrations/stripe/webhook/',
+    // Unified client portal — API routes (this task) + page routes (later task).
+    '/api/portal/',
+    '/portal/',
 ];
 
 export async function resolveByPathParam(c: Context<HonoConfig>, path: string): Promise<boolean> {

--- a/server/index.ts
+++ b/server/index.ts
@@ -80,6 +80,7 @@ import ratingSystemsRoutes from './api/rating-systems';
 import eventsRoutes from './api/events';
 import inspectionRequestsRoutes from './api/inspection-requests';
 import repairBuilderRoutes from './api/repair-builder';
+import portalRoutes from './api/portal';
 import tagsRoutes, { inspectionTagRoutes } from './api/tags';
 import publicSlugRoutes from './api/public-slug';
 import publicShareRoutes from './api/public-share';
@@ -251,7 +252,7 @@ export const jwtAuthMiddleware: MiddlewareHandler<HonoConfig> = async (c, next) 
         path === '/api/concierge/book-info' ||
         path === '/api/concierge/book' ||
         path === '/api/concierge/confirm-info';
-    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/admin/connect') || path.startsWith('/api/admin/silo') || path.startsWith('/api/ics/') || path.startsWith('/api/messages/public/') || path === '/book' || path.startsWith('/book/') || path.startsWith('/inspector/') || path.startsWith('/embed/') || path.startsWith('/photos/') || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/report-view/') || path.startsWith('/r/') || path.startsWith('/agreements/sign/') || path.startsWith('/checkout/') || path.startsWith('/sign/') || path.startsWith('/messages/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || path.startsWith('/v/') || path.startsWith('/.well-known/') || STATIC_ASSET_EXT.test(path) || path === '/api/integrations/qbo/webhook' || path === '/api/integrations/stripe/webhook' || path.startsWith('/api/integrations/stripe/webhook/') || path.startsWith('/repair-request/') || path.startsWith('/repair-builder/');
+    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/admin/connect') || path.startsWith('/api/admin/silo') || path.startsWith('/api/ics/') || path.startsWith('/api/messages/public/') || path === '/book' || path.startsWith('/book/') || path.startsWith('/inspector/') || path.startsWith('/embed/') || path.startsWith('/photos/') || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/report-view/') || path.startsWith('/r/') || path.startsWith('/agreements/sign/') || path.startsWith('/checkout/') || path.startsWith('/sign/') || path.startsWith('/messages/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || path.startsWith('/v/') || path.startsWith('/.well-known/') || STATIC_ASSET_EXT.test(path) || path === '/api/integrations/qbo/webhook' || path === '/api/integrations/stripe/webhook' || path.startsWith('/api/integrations/stripe/webhook/') || path.startsWith('/repair-request/') || path.startsWith('/repair-builder/') || path.startsWith('/api/portal/') || path.startsWith('/portal/');
 
     // Design System 0520 subsystem D P5 — observer surfaces are gated by
     // the dedicated observer-cookie middleware, not JWT.
@@ -466,6 +467,9 @@ const routes = app
   .route('/api/public', publicShareRoutes)
   // Track L (D6/D9) — public SMS opt-in resolve/confirm + inbound STOP/START webhook.
   .route('/api/public', smsPublicRoutes)
+  // Unified client portal — magic-link request/redeem + session-gated data routes.
+  // The :tenant slug lives inside the route definitions (tenantRouter resolves it).
+  .route('/api/portal', portalRoutes)
   .route('/api/admin', adminRoutes)
   // Branding sub-router — extracted to fix hono/client type-collapse (C-10)
   .route('/api/admin', adminBrandingRoutes)

--- a/server/lib/middleware/di.ts
+++ b/server/lib/middleware/di.ts
@@ -12,6 +12,7 @@ import { BookingService } from '../../services/booking.service';
 import { BrandingService } from '../../services/branding.service';
 import { assembleTenantEmailService, loadTenantEmailConfig, type LoadedEmailConfig } from '../email/build-email-service';
 import { InspectionService } from '../../services/inspection.service';
+import { PortalService } from '../../services/portal.service';
 import { TeamService } from '../../services/team.service';
 import { TemplateService } from '../../services/template.service';
 import { AgreementService } from '../../services/agreement.service';
@@ -165,6 +166,14 @@ export async function diMiddleware(c: Context<HonoConfig>, next: Next) {
                     break;
                 case 'inspection':
                     target.inspection = new InspectionService(c.env.DB, c.env.PHOTOS, c.get('sdb'), c.env.TENANT_CACHE);
+                    break;
+                case 'portal':
+                    // PortalService depends on InspectionService — resolve it via the
+                    // proxy target the same way auditLog resolves signingKey.
+                    if (!target.inspection) {
+                        target.inspection = new InspectionService(c.env.DB, c.env.PHOTOS, c.get('sdb'), c.env.TENANT_CACHE);
+                    }
+                    target.portal = new PortalService(c.env.DB, target.inspection);
                     break;
                 case 'team':
                     // Member removal emits `user.deleted` through the same

--- a/server/lib/portal-session.ts
+++ b/server/lib/portal-session.ts
@@ -1,0 +1,113 @@
+/**
+ * Unified client portal — signed magic-link token + session cookie (stateless).
+ *
+ * Mirrors `observer-cookie.ts` exactly: a self-contained
+ * `base64url(JSON body) + '.' + base64url(HMAC-SHA-256 of body64)` envelope.
+ * There is NO database row backing either token — they are pure signed
+ * payloads, so verification is stateless and revocation relies on short
+ * TTLs / re-issuing the session.
+ *
+ * Secret is `JWT_SECRET`, imported raw as an HMAC key (same as
+ * observer-cookie.ts — NOT the m2m-auth HKDF derivation, NOT the JWT keyring).
+ *
+ * A `typ` discriminator distinguishes the two token families so a magic-link
+ * token can never be replayed as a session cookie (or vice versa):
+ *   - magic-link  → typ: 'ml'   (short TTL, default 15 min)
+ *   - session     → typ: 'sess' (long TTL, default 30 days)
+ *
+ * All verify functions return `{ email }` only and never throw — any parse,
+ * signature, type, or expiry failure yields `null`.
+ */
+import { timingSafeEqual } from './password';
+
+const encoder = new TextEncoder();
+
+const MAGIC_LINK_TTL_SECONDS = 900;      // 15 minutes
+const SESSION_TTL_SECONDS = 2592000;     // 30 days
+
+type PortalTokenType = 'ml' | 'sess';
+
+interface PortalPayload {
+    typ:   PortalTokenType;
+    email: string;
+    exp:   number;   // epoch seconds
+}
+
+async function hmacB64(secret: string, msg: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+        'raw', encoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false, ['sign', 'verify'],
+    );
+    const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(msg));
+    return base64Url(new Uint8Array(sig));
+}
+
+function base64Url(bytes: Uint8Array): string {
+    let s = '';
+    for (const b of bytes) s += String.fromCharCode(b);
+    return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(s: string): string {
+    const padded = s + '='.repeat((4 - (s.length % 4)) % 4);
+    return atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+}
+
+async function signToken(secret: string, typ: PortalTokenType, email: string, ttlSeconds: number): Promise<string> {
+    const payload: PortalPayload = {
+        typ,
+        email,
+        exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+    };
+    const body64 = base64Url(encoder.encode(JSON.stringify(payload)));
+    const sig    = await hmacB64(secret, body64);
+    return `${body64}.${sig}`;
+}
+
+async function verifyToken(secret: string, expectedTyp: PortalTokenType, token: string): Promise<{ email: string } | null> {
+    if (!token || typeof token !== 'string') return null;
+    const parts = token.split('.');
+    if (parts.length !== 2) return null;
+    const [body64, providedSig] = parts;
+    if (!body64 || !providedSig) return null;
+
+    let expectedSig: string;
+    try {
+        expectedSig = await hmacB64(secret, body64);
+    } catch {
+        return null;
+    }
+    if (!timingSafeEqual(providedSig, expectedSig)) return null;
+
+    let payload: PortalPayload;
+    try {
+        payload = JSON.parse(base64UrlDecode(body64)) as PortalPayload;
+    } catch {
+        return null;
+    }
+
+    if (!payload || typeof payload !== 'object') return null;
+    if (payload.typ !== expectedTyp) return null;
+    if (typeof payload.email !== 'string' || payload.email.length === 0) return null;
+    if (typeof payload.exp !== 'number') return null;
+    if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+
+    return { email: payload.email };
+}
+
+export function signMagicLink(secret: string, email: string, ttlSeconds: number = MAGIC_LINK_TTL_SECONDS): Promise<string> {
+    return signToken(secret, 'ml', email, ttlSeconds);
+}
+
+export function verifyMagicLink(secret: string, token: string): Promise<{ email: string } | null> {
+    return verifyToken(secret, 'ml', token);
+}
+
+export function signPortalSession(secret: string, email: string, ttlSeconds: number = SESSION_TTL_SECONDS): Promise<string> {
+    return signToken(secret, 'sess', email, ttlSeconds);
+}
+
+export function verifyPortalSession(secret: string, token: string): Promise<{ email: string } | null> {
+    return verifyToken(secret, 'sess', token);
+}

--- a/server/lib/portal-urls.ts
+++ b/server/lib/portal-urls.ts
@@ -1,0 +1,11 @@
+// Unified client portal CTA URL builder. The hub lives at
+// /portal/:tenant/i/:inspectionId?token=<portalAccessToken>&to=<section>.
+export type PortalSection = 'overview' | 'report' | 'agreement' | 'payment' | 'progress' | 'messages' | 'repair';
+export function buildPortalUrl(
+    baseUrl: string, tenantSlug: string, inspectionId: string, token: string, section: PortalSection = 'overview',
+): string {
+    const base = baseUrl.replace(/\/$/, '');
+    let url = `${base}/portal/${encodeURIComponent(tenantSlug)}/i/${encodeURIComponent(inspectionId)}?token=${encodeURIComponent(token)}`;
+    if (section !== 'overview') url += `&to=${encodeURIComponent(section)}`;
+    return url;
+}

--- a/server/services/portal.service.ts
+++ b/server/services/portal.service.ts
@@ -12,7 +12,7 @@
  * Multi-tenant: EVERY query filters by tenantId explicitly (see CLAUDE.md).
  */
 import { drizzle } from 'drizzle-orm/d1';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or, gt } from 'drizzle-orm';
 import { inspectionAccessTokens, inspections, agreementRequests, customerMessages } from '../lib/db/schema';
 import { isReportPublished } from '../lib/status/report-status';
 
@@ -54,11 +54,12 @@ export class PortalService {
     }
 
     /**
-     * Inspections this recipient can access via a live (non-revoked) client /
-     * co_client token. Deduplicated by inspection id.
+     * Inspections this recipient can access via a live (non-revoked,
+     * non-expired) client / co_client token. Deduplicated by inspection id.
      */
     async listRecipientInspections(tenantId: string, email: string): Promise<RecipientInspection[]> {
         const db = this.d();
+        const now = Date.now();
 
         const grants = await db
             .select({ inspectionId: inspectionAccessTokens.inspectionId })
@@ -69,6 +70,10 @@ export class PortalService {
                     eq(inspectionAccessTokens.recipientEmail, email),
                     inArray(inspectionAccessTokens.role, ['client', 'co_client']),
                     isNull(inspectionAccessTokens.revokedAt),
+                    // A grant is live only when not yet expired. `expiresAt` is
+                    // epoch ms (NULL = never expires), consistent with Date.now().
+                    // Mirrors resolvePortalAccess (server/lib/public-access.ts).
+                    or(isNull(inspectionAccessTokens.expiresAt), gt(inspectionAccessTokens.expiresAt, now)),
                 ),
             );
 

--- a/server/services/portal.service.ts
+++ b/server/services/portal.service.ts
@@ -1,0 +1,157 @@
+/**
+ * Unified client portal — read-side aggregation service.
+ *
+ * Two responsibilities, both pure reads over EXISTING tables (no portal table):
+ *   1. `listRecipientInspections` — every inspection a recipient email can see
+ *      via a live `inspectionAccessTokens` grant (client / co_client only;
+ *      agent grants are out of scope for the client hub).
+ *   2. `hubOverview` — a 6-dimension status snapshot for one inspection used by
+ *      the portal landing card (status / agreement / payment / report / progress
+ *      / unread messages).
+ *
+ * Multi-tenant: EVERY query filters by tenantId explicitly (see CLAUDE.md).
+ */
+import { drizzle } from 'drizzle-orm/d1';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { inspectionAccessTokens, inspections, agreementRequests, customerMessages } from '../lib/db/schema';
+import { isReportPublished } from '../lib/status/report-status';
+
+interface ObserveProgressLike {
+    getObserveProgress: (
+        inspectionId: string,
+        tenantId: string,
+    ) => Promise<{ sections: Array<{ totalItems: number; completedItems: number }> }>;
+}
+
+export interface RecipientInspection {
+    inspectionId: string;
+    address: string;
+    date: string;
+    inspectionStatus: string;
+    reportPublished: boolean;
+    paymentStatus: string;
+}
+
+export interface HubOverview {
+    address: string;
+    date: string;
+    inspectionStatus: string;
+    agreementSigned: boolean;
+    paymentStatus: string;
+    reportPublished: boolean;
+    progress: { completed: number; total: number };
+    unreadMessages: number;
+}
+
+export class PortalService {
+    constructor(
+        private db: D1Database,
+        private inspectionSvc: ObserveProgressLike,
+    ) {}
+
+    private d() {
+        return drizzle(this.db);
+    }
+
+    /**
+     * Inspections this recipient can access via a live (non-revoked) client /
+     * co_client token. Deduplicated by inspection id.
+     */
+    async listRecipientInspections(tenantId: string, email: string): Promise<RecipientInspection[]> {
+        const db = this.d();
+
+        const grants = await db
+            .select({ inspectionId: inspectionAccessTokens.inspectionId })
+            .from(inspectionAccessTokens)
+            .where(
+                and(
+                    eq(inspectionAccessTokens.tenantId, tenantId),
+                    eq(inspectionAccessTokens.recipientEmail, email),
+                    inArray(inspectionAccessTokens.role, ['client', 'co_client']),
+                    isNull(inspectionAccessTokens.revokedAt),
+                ),
+            );
+
+        const ids = [...new Set(grants.map((g) => g.inspectionId))];
+        if (ids.length === 0) return [];
+
+        const rows = await db
+            .select()
+            .from(inspections)
+            .where(and(eq(inspections.tenantId, tenantId), inArray(inspections.id, ids)));
+
+        return rows.map((r) => ({
+            inspectionId: r.id,
+            address: r.propertyAddress,
+            date: r.date,
+            inspectionStatus: r.status,
+            reportPublished: isReportPublished(r.reportStatus),
+            paymentStatus: r.paymentStatus,
+        }));
+    }
+
+    /**
+     * 6-dimension status snapshot for one inspection. Returns null if the
+     * inspection does not exist under this tenant.
+     */
+    async hubOverview(tenantId: string, inspectionId: string): Promise<HubOverview | null> {
+        const db = this.d();
+
+        const insp = await db
+            .select()
+            .from(inspections)
+            .where(and(eq(inspections.tenantId, tenantId), eq(inspections.id, inspectionId)))
+            .get();
+
+        if (!insp) return null;
+
+        const signed = await db
+            .select({ id: agreementRequests.id })
+            .from(agreementRequests)
+            .where(
+                and(
+                    eq(agreementRequests.tenantId, tenantId),
+                    eq(agreementRequests.inspectionId, inspectionId),
+                    eq(agreementRequests.status, 'signed'),
+                ),
+            )
+            .get();
+
+        const unread = await db
+            .select({ id: customerMessages.id })
+            .from(customerMessages)
+            .where(
+                and(
+                    eq(customerMessages.tenantId, tenantId),
+                    eq(customerMessages.inspectionId, inspectionId),
+                    isNull(customerMessages.readAt),
+                    eq(customerMessages.fromRole, 'inspector'),
+                ),
+            );
+
+        let progress = { completed: 0, total: 0 };
+        try {
+            const observed = await this.inspectionSvc.getObserveProgress(inspectionId, tenantId);
+            progress = observed.sections.reduce(
+                (acc, s) => ({
+                    completed: acc.completed + s.completedItems,
+                    total: acc.total + s.totalItems,
+                }),
+                { completed: 0, total: 0 },
+            );
+        } catch {
+            progress = { completed: 0, total: 0 };
+        }
+
+        return {
+            address: insp.propertyAddress,
+            date: insp.date,
+            inspectionStatus: insp.status,
+            agreementSigned: !!signed,
+            paymentStatus: insp.paymentStatus,
+            reportPublished: isReportPublished(insp.reportStatus),
+            progress,
+            unreadMessages: unread.length,
+        };
+    }
+}

--- a/server/types/hono.ts
+++ b/server/types/hono.ts
@@ -256,6 +256,11 @@ export interface AppServices {
 export type AppVariables = AuthVariables & {
     services: AppServices;
     profile: DeploymentProfile;
+    /** Unified client portal — verified email from the __Host-portal_session
+     *  cookie, set by the portal session middleware (server/api/portal.ts).
+     *  Tenant-independent (email ownership is global); cross-tenant isolation
+     *  comes from every portal query being scoped to the path's tenantId. */
+    portalEmail?: string;
 };
 
 /**

--- a/server/types/hono.ts
+++ b/server/types/hono.ts
@@ -211,6 +211,7 @@ export interface AppServices {
     contact: ContactService;
     invoice: InvoiceService;
     portalAccess: PortalAccessService;
+    portal: import('../services/portal.service').PortalService;
     service: ServiceService;
     automation: AutomationService;
     marketplace: MarketplaceService;

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -185,6 +185,27 @@ describe('portal API', () => {
         });
     }
 
+    // Minimal PortalAccessResolver stub: resolveToken reads the seeded access
+    // token rows directly from the test DB (mirrors PortalAccessService.resolveToken
+    // shape — returns inspectionId/tenantId/role/recipientEmail/revokedAt/expiresAt).
+    function makePortalAccessStub() {
+        return {
+            resolveToken: async (token: string) => {
+                const rows = await testDb.select().from(schema.inspectionAccessTokens);
+                const row = rows.find((r) => r.token === token);
+                if (!row) return null;
+                return {
+                    inspectionId: row.inspectionId,
+                    tenantId: row.tenantId,
+                    role: row.role as 'client' | 'co_client' | 'agent',
+                    recipientEmail: row.recipientEmail,
+                    revokedAt: row.revokedAt,
+                    expiresAt: row.expiresAt,
+                };
+            },
+        };
+    }
+
     function buildApp(tenantId: string | null = TENANT) {
         const portalSvc = new PortalService({} as D1Database, inspStub);
         sendEmail = vi.fn().mockResolvedValue({ delivered: true });
@@ -197,11 +218,30 @@ describe('portal API', () => {
             c.set('services', {
                 portal: portalSvc,
                 email: { sendEmail },
+                portalAccess: makePortalAccessStub(),
             } as unknown as HonoConfig['Variables']['services']);
             await next();
         });
         app.route('/api/portal', portalRoutes);
         return app;
+    }
+
+    // Seed a token and return its raw token string (needed for the exchange tests,
+    // which must present the token by value).
+    async function seedTokenReturning(inspectionId: string, recipientEmail: string, role: 'client' | 'co_client' | 'agent' = 'client') {
+        const token = crypto.randomUUID();
+        await testDb.insert(schema.inspectionAccessTokens).values({
+            id: crypto.randomUUID(),
+            tenantId: TENANT,
+            inspectionId,
+            recipientEmail,
+            role,
+            token,
+            createdAt: Date.now(),
+            expiresAt: null,
+            revokedAt: null,
+        });
+        return token;
     }
 
     // JWT_SECRET is injected via the env arg to app.request().
@@ -269,9 +309,59 @@ describe('portal API', () => {
         const ok = await app.request(`/api/portal/acme/redeem?link=${encodeURIComponent(token)}`, {}, reqEnv());
         expect(ok.status).toBe(200);
         expect((await ok.json()).data.email).toBe('a@x.com');
+        // Redeem now establishes the session: __Host-portal_session must be set.
+        expect(ok.headers.get('set-cookie') ?? '').toContain('__Host-portal_session=');
 
         const bad = await app.request('/api/portal/acme/redeem?link=garbage', {}, reqEnv());
         expect(bad.status).toBe(401);
+    });
+
+    it('GET /exchange with a valid client token for the matching inspection → 200 + Set-Cookie', async () => {
+        await seedInspection('insp1');
+        const token = await seedTokenReturning('insp1', 'a@x.com', 'client');
+        const app = buildApp();
+        const res = await app.request(
+            `/api/portal/acme/exchange?token=${encodeURIComponent(token)}&inspectionId=insp1`,
+            {}, reqEnv());
+        expect(res.status).toBe(200);
+        expect((await res.json()).data.email).toBe('a@x.com');
+        expect(res.headers.get('set-cookie') ?? '').toContain('__Host-portal_session=');
+    });
+
+    it('GET /exchange with a bad token → 401', async () => {
+        await seedInspection('insp1');
+        const app = buildApp();
+        const res = await app.request(
+            '/api/portal/acme/exchange?token=garbage&inspectionId=insp1', {}, reqEnv());
+        expect(res.status).toBe(401);
+    });
+
+    it('GET /exchange rejects a token whose inspection does not match → 401', async () => {
+        await seedInspection('insp1');
+        await seedInspection('insp2');
+        const token = await seedTokenReturning('insp1', 'a@x.com', 'client');
+        const app = buildApp();
+        const res = await app.request(
+            `/api/portal/acme/exchange?token=${encodeURIComponent(token)}&inspectionId=insp2`,
+            {}, reqEnv());
+        expect(res.status).toBe(401);
+    });
+
+    it('GET /exchange rejects an agent-role token → 403', async () => {
+        await seedInspection('insp1');
+        const token = await seedTokenReturning('insp1', 'agent@x.com', 'agent');
+        const app = buildApp();
+        const res = await app.request(
+            `/api/portal/acme/exchange?token=${encodeURIComponent(token)}&inspectionId=insp1`,
+            {}, reqEnv());
+        expect(res.status).toBe(403);
+    });
+
+    it('GET /exchange returns 404 when the tenant slug is unresolved', async () => {
+        const app = buildApp(null);
+        const res = await app.request(
+            '/api/portal/nope/exchange?token=x&inspectionId=insp1', {}, reqEnv());
+        expect(res.status).toBe(404);
     });
 
     it('GET /me without a session cookie → 401', async () => {

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PortalService } from '../../server/services/portal.service';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../server/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+// PortalService builds its drizzle handle via `drizzle(this.db)` (drizzle-orm/d1).
+// Mock that factory to hand back the in-memory better-sqlite3 test DB, mirroring
+// the harness used by portal-access.spec.ts.
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+const TENANT = '00000000-0000-0000-0000-0000000000a1';
+
+// A stub InspectionService.getObserveProgress — the unit under test only sums
+// totalItems/completedItems across the returned sections.
+const inspStub = {
+    getObserveProgress: async () => ({
+        sections: [
+            { totalItems: 5, completedItems: 2 },
+            { totalItems: 3, completedItems: 3 },
+        ],
+    }),
+};
+
+describe('PortalService', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let svc: PortalService;
+
+    async function seedInspection(id: string, overrides: Partial<typeof schema.inspections.$inferInsert> = {}) {
+        await testDb.insert(schema.inspections).values({
+            id,
+            tenantId: TENANT,
+            propertyAddress: `${id} Main St`,
+            date: '2026-06-01',
+            status: 'requested',
+            reportStatus: 'in_progress',
+            paymentStatus: 'unpaid',
+            createdAt: new Date(),
+            ...overrides,
+        });
+    }
+
+    async function seedToken(inspectionId: string, recipientEmail: string, role: 'client' | 'co_client' | 'agent', revokedAt: number | null = null) {
+        await testDb.insert(schema.inspectionAccessTokens).values({
+            id: crypto.randomUUID(),
+            tenantId: TENANT,
+            inspectionId,
+            recipientEmail,
+            role,
+            token: crypto.randomUUID(),
+            createdAt: Date.now(),
+            expiresAt: null,
+            revokedAt,
+        });
+    }
+
+    beforeEach(async () => {
+        const fix = createTestDb();
+        testDb = fix.db;
+        await setupSchema(fix.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        await testDb.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+        svc = new PortalService({} as D1Database, inspStub);
+    });
+
+    it('listRecipientInspections returns only this email + client/co_client roles, dedup, excludes revoked', async () => {
+        for (const id of ['insp1', 'insp2', 'insp3', 'insp4', 'insp5']) await seedInspection(id);
+        await seedToken('insp1', 'a@x.com', 'client');
+        await seedToken('insp2', 'a@x.com', 'co_client');
+        await seedToken('insp3', 'a@x.com', 'agent');       // excluded — agent role
+        await seedToken('insp4', 'b@x.com', 'client');      // excluded — other email
+        await seedToken('insp5', 'a@x.com', 'client', 1);   // excluded — revoked
+
+        const rows = await svc.listRecipientInspections(TENANT, 'a@x.com');
+        const ids = rows.map((r) => r.inspectionId).sort();
+        expect(ids).toEqual(['insp1', 'insp2']);
+    });
+
+    it('listRecipientInspections returns [] when the recipient has no live tokens', async () => {
+        await seedInspection('insp1');
+        await seedToken('insp1', 'someone@x.com', 'client');
+        expect(await svc.listRecipientInspections(TENANT, 'nobody@x.com')).toEqual([]);
+    });
+
+    it('hubOverview returns the 6 status dimensions', async () => {
+        await seedInspection('insp1', { reportStatus: 'published', paymentStatus: 'paid' });
+        const agreementId = crypto.randomUUID();
+        await testDb.insert(schema.agreements).values({
+            id: agreementId, tenantId: TENANT, name: 'A', content: 'terms', createdAt: new Date(),
+        });
+        await testDb.insert(schema.agreementRequests).values({
+            id: crypto.randomUUID(), tenantId: TENANT, inspectionId: 'insp1',
+            agreementId, clientEmail: 'a@x.com',
+            token: crypto.randomUUID(), status: 'signed', createdAt: new Date(),
+        });
+        await testDb.insert(schema.customerMessages).values([
+            { id: crypto.randomUUID(), tenantId: TENANT, inspectionId: 'insp1', fromRole: 'inspector', body: 'hi', readAt: null, createdAt: Date.now() },
+            { id: crypto.randomUUID(), tenantId: TENANT, inspectionId: 'insp1', fromRole: 'inspector', body: 'read', readAt: Date.now(), createdAt: Date.now() },
+            { id: crypto.randomUUID(), tenantId: TENANT, inspectionId: 'insp1', fromRole: 'client', body: 'mine', readAt: null, createdAt: Date.now() },
+        ]);
+
+        const ov = await svc.hubOverview(TENANT, 'insp1');
+        expect(ov).toMatchObject({
+            inspectionStatus: expect.any(String),
+            agreementSigned: true,
+            paymentStatus: 'paid',
+            reportPublished: true,
+            progress: expect.objectContaining({ completed: 5, total: 8 }),
+            unreadMessages: 1,
+        });
+    });
+
+    it('hubOverview falls back to {completed:0,total:0} when progress build throws', async () => {
+        await seedInspection('insp1');
+        const throwingSvc = new PortalService({} as D1Database, {
+            getObserveProgress: async () => { throw new Error('no report'); },
+        });
+        const ov = await throwingSvc.hubOverview(TENANT, 'insp1');
+        expect(ov?.progress).toEqual({ completed: 0, total: 0 });
+    });
+
+    it('hubOverview returns null for an unknown inspection', async () => {
+        expect(await svc.hubOverview(TENANT, 'nope')).toBeNull();
+    });
+});

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -409,3 +409,19 @@ describe('portal API', () => {
         expect(res.status).toBe(403);
     });
 });
+
+import { buildPortalUrl } from '../../server/lib/portal-urls';
+describe('buildPortalUrl', () => {
+  it('points at the tenant-scoped portal hub with token; omits to= for overview', () => {
+    expect(buildPortalUrl('https://app.x.io', 'acme', 'insp1', 'tok9'))
+      .toBe('https://app.x.io/portal/acme/i/insp1?token=tok9');
+  });
+  it('adds to=<section> for non-overview sections', () => {
+    expect(buildPortalUrl('https://app.x.io', 'acme', 'insp1', 'tok9', 'report'))
+      .toBe('https://app.x.io/portal/acme/i/insp1?token=tok9&to=report');
+  });
+  it('strips a trailing slash on baseUrl', () => {
+    expect(buildPortalUrl('https://app.x.io/', 'acme', 'insp1', 'tok9'))
+      .toBe('https://app.x.io/portal/acme/i/insp1?token=tok9');
+  });
+});

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -424,4 +424,23 @@ describe('buildPortalUrl', () => {
     expect(buildPortalUrl('https://app.x.io/', 'acme', 'insp1', 'tok9'))
       .toBe('https://app.x.io/portal/acme/i/insp1?token=tok9');
   });
+
+  // Regression: the report-ready email must carry an ABSOLUTE link (scheme +
+  // host) so mail clients treat it as a URL, not a relative path. The prior
+  // bug was the *caller* wiring (inspections.ts passed getBookingHost(c), a
+  // bare host, where buildPortalUrl expects a full origin). buildPortalUrl
+  // does not invent a scheme, so its baseUrl MUST already include one — this
+  // test pins the contract that protects the fixed call sites.
+  it('keeps the link absolute (starts with http) when given a full origin', () => {
+    const url = buildPortalUrl('https://app.x.io', 'acme', 'insp1', 'tok9');
+    expect(url.startsWith('http')).toBe(true);
+    expect(new URL(url).protocol).toMatch(/^https?:$/);
+  });
+
+  it('produces a scheme-less (broken) link when given a BARE host — documents the prior caller bug', () => {
+    // This is the old buggy behavior: passing a bare host yields a relative-looking
+    // value with no scheme. The fix was at the call site (getBaseUrl, not getBookingHost).
+    const url = buildPortalUrl('inspectorhub.io', 'acme', 'insp1', 'tok9');
+    expect(url.startsWith('http')).toBe(false);
+  });
 });

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -203,6 +203,31 @@ describe('portal API', () => {
                     expiresAt: row.expiresAt,
                 };
             },
+            // Idempotent get-or-create stub: returns the seeded row's plaintext
+            // token for (inspection, recipient). The overview tests seed live rows
+            // with a real `token` value, so this hands back that stable string.
+            issueToken: async (input: { tenantId: string; inspectionId: string; recipientEmail: string }) => {
+                const rows = await testDb.select().from(schema.inspectionAccessTokens);
+                const row = rows.find(
+                    (r) => r.inspectionId === input.inspectionId
+                        && r.recipientEmail === input.recipientEmail
+                        && r.revokedAt == null,
+                );
+                if (row) return row.token;
+                const token = crypto.randomUUID();
+                await testDb.insert(schema.inspectionAccessTokens).values({
+                    id: crypto.randomUUID(),
+                    tenantId: input.tenantId,
+                    inspectionId: input.inspectionId,
+                    recipientEmail: input.recipientEmail,
+                    role: 'client',
+                    token,
+                    createdAt: Date.now(),
+                    expiresAt: null,
+                    revokedAt: null,
+                });
+                return token;
+            },
         };
     }
 
@@ -393,7 +418,12 @@ describe('portal API', () => {
             headers: { cookie: '__Host-portal_session=' + cookie },
         }, reqEnv());
         expect(res.status).toBe(200);
-        expect((await res.json()).data.address).toContain('insp1');
+        const body = await res.json();
+        expect(body.data.address).toContain('insp1');
+        // The Hub needs the recipient's persistent per-inspection token to build
+        // section deep-links (works for magic-link sessions with no URL ?token).
+        expect(typeof body.data.token).toBe('string');
+        expect(body.data.token.length).toBeGreaterThan(0);
     });
 
     it('GET /inspections/:id/overview → 403 for an inspection the email does NOT own', async () => {

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -128,3 +128,181 @@ describe('PortalService', () => {
         expect(await svc.hubOverview(TENANT, 'nope')).toBeNull();
     });
 });
+
+// ---------------------------------------------------------------------------
+// Task 3 — portal API routes + session middleware
+// ---------------------------------------------------------------------------
+import { OpenAPIHono } from '@hono/zod-openapi';
+import type { HonoConfig } from '../../server/types/hono';
+import { signPortalSession, signMagicLink } from '../../server/lib/portal-session';
+// eslint-disable-next-line import/order
+import portalRoutes from '../../server/api/portal';
+
+const SECRET = 'test-jwt-secret';
+
+describe('portal API', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+    let sendEmail: ReturnType<typeof vi.fn>;
+
+    async function seedInspection(id: string, overrides: Partial<typeof schema.inspections.$inferInsert> = {}) {
+        await testDb.insert(schema.inspections).values({
+            id,
+            tenantId: TENANT,
+            propertyAddress: `${id} Main St`,
+            date: '2026-06-01',
+            status: 'requested',
+            reportStatus: 'in_progress',
+            paymentStatus: 'unpaid',
+            createdAt: new Date(),
+            ...overrides,
+        });
+    }
+
+    async function seedToken(inspectionId: string, recipientEmail: string, role: 'client' | 'co_client' | 'agent' = 'client', revokedAt: number | null = null) {
+        await testDb.insert(schema.inspectionAccessTokens).values({
+            id: crypto.randomUUID(),
+            tenantId: TENANT,
+            inspectionId,
+            recipientEmail,
+            role,
+            token: crypto.randomUUID(),
+            createdAt: Date.now(),
+            expiresAt: null,
+            revokedAt,
+        });
+    }
+
+    function buildApp(tenantId: string | null = TENANT) {
+        const portalSvc = new PortalService({} as D1Database, inspStub);
+        sendEmail = vi.fn().mockResolvedValue({ delivered: true });
+        const app = new OpenAPIHono<HonoConfig>();
+        app.use('*', async (c, next) => {
+            if (tenantId) {
+                c.set('tenantId', tenantId);
+                c.set('requestedTenantSlug', 'acme');
+            }
+            c.set('services', {
+                portal: portalSvc,
+                email: { sendEmail },
+            } as unknown as HonoConfig['Variables']['services']);
+            await next();
+        });
+        app.route('/api/portal', portalRoutes);
+        return app;
+    }
+
+    // JWT_SECRET is injected via the env arg to app.request().
+    function reqEnv() {
+        return { JWT_SECRET: SECRET, APP_BASE_URL: 'https://example.test' } as unknown as HonoConfig['Bindings'];
+    }
+
+    beforeEach(async () => {
+        const fix = createTestDb();
+        testDb = fix.db;
+        await setupSchema(fix.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        await testDb.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+    });
+
+    it('POST /request-link returns 200 for a known recipient and sends an email', async () => {
+        await seedInspection('insp1');
+        await seedToken('insp1', 'a@x.com', 'client');
+        const app = buildApp();
+        const res = await app.request('/api/portal/acme/request-link', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ email: 'a@x.com' }),
+        }, reqEnv());
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.data.sent).toBe(true);
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+        const htmlArg = sendEmail.mock.calls[0][2] as string;
+        expect(htmlArg).toContain('/portal/acme/auth?link=');
+    });
+
+    it('POST /request-link returns 200 for an UNKNOWN email and does NOT send (no enumeration)', async () => {
+        await seedInspection('insp1');
+        await seedToken('insp1', 'a@x.com', 'client');
+        const app = buildApp();
+        const res = await app.request('/api/portal/acme/request-link', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ email: 'nobody@x.com' }),
+        }, reqEnv());
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.data.sent).toBe(true);
+        expect(sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('POST /request-link returns 404 when the tenant slug is unresolved', async () => {
+        const app = buildApp(null);
+        const res = await app.request('/api/portal/nope/request-link', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ email: 'a@x.com' }),
+        }, reqEnv());
+        expect(res.status).toBe(404);
+    });
+
+    it('GET /redeem validates the magic link → 200 with email; bad token → 401', async () => {
+        const app = buildApp();
+        const token = await signMagicLink(SECRET, 'a@x.com');
+        const ok = await app.request(`/api/portal/acme/redeem?link=${encodeURIComponent(token)}`, {}, reqEnv());
+        expect(ok.status).toBe(200);
+        expect((await ok.json()).data.email).toBe('a@x.com');
+
+        const bad = await app.request('/api/portal/acme/redeem?link=garbage', {}, reqEnv());
+        expect(bad.status).toBe(401);
+    });
+
+    it('GET /me without a session cookie → 401', async () => {
+        const app = buildApp();
+        const res = await app.request('/api/portal/acme/me', {}, reqEnv());
+        expect(res.status).toBe(401);
+    });
+
+    it('GET /me with a valid session cookie → data.inspections populated', async () => {
+        await seedInspection('insp1');
+        await seedToken('insp1', 'a@x.com', 'client');
+        const app = buildApp();
+        const cookie = await signPortalSession(SECRET, 'a@x.com');
+        const res = await app.request('/api/portal/acme/me', {
+            headers: { cookie: '__Host-portal_session=' + cookie },
+        }, reqEnv());
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json.data.email).toBe('a@x.com');
+        expect(json.data.inspections.length).toBeGreaterThan(0);
+    });
+
+    it('GET /inspections/:id/overview → 200 for an owned inspection', async () => {
+        await seedInspection('insp1');
+        await seedToken('insp1', 'a@x.com', 'client');
+        const app = buildApp();
+        const cookie = await signPortalSession(SECRET, 'a@x.com');
+        const res = await app.request('/api/portal/acme/inspections/insp1/overview', {
+            headers: { cookie: '__Host-portal_session=' + cookie },
+        }, reqEnv());
+        expect(res.status).toBe(200);
+        expect((await res.json()).data.address).toContain('insp1');
+    });
+
+    it('GET /inspections/:id/overview → 403 for an inspection the email does NOT own', async () => {
+        await seedInspection('insp1');
+        await seedInspection('insp2');
+        await seedToken('insp1', 'a@x.com', 'client');
+        await seedToken('insp2', 'other@x.com', 'client');
+        const app = buildApp();
+        const cookie = await signPortalSession(SECRET, 'a@x.com');
+        const res = await app.request('/api/portal/acme/inspections/insp2/overview', {
+            headers: { cookie: '__Host-portal_session=' + cookie },
+        }, reqEnv());
+        expect(res.status).toBe(403);
+    });
+});

--- a/tests/unit/portal-routes.spec.ts
+++ b/tests/unit/portal-routes.spec.ts
@@ -41,7 +41,7 @@ describe('PortalService', () => {
         });
     }
 
-    async function seedToken(inspectionId: string, recipientEmail: string, role: 'client' | 'co_client' | 'agent', revokedAt: number | null = null) {
+    async function seedToken(inspectionId: string, recipientEmail: string, role: 'client' | 'co_client' | 'agent', revokedAt: number | null = null, expiresAt: number | null = null) {
         await testDb.insert(schema.inspectionAccessTokens).values({
             id: crypto.randomUUID(),
             tenantId: TENANT,
@@ -50,7 +50,7 @@ describe('PortalService', () => {
             role,
             token: crypto.randomUUID(),
             createdAt: Date.now(),
-            expiresAt: null,
+            expiresAt,
             revokedAt,
         });
     }
@@ -79,6 +79,19 @@ describe('PortalService', () => {
         const rows = await svc.listRecipientInspections(TENANT, 'a@x.com');
         const ids = rows.map((r) => r.inspectionId).sort();
         expect(ids).toEqual(['insp1', 'insp2']);
+    });
+
+    it('listRecipientInspections enforces expiresAt: excludes past-expiry, includes future-expiry and null-expiry', async () => {
+        for (const id of ['inspNull', 'inspFuture', 'inspPast']) await seedInspection(id);
+        const past = Date.now() - 60_000;   // expired one minute ago
+        const future = Date.now() + 60_000; // expires one minute from now
+        await seedToken('inspNull', 'a@x.com', 'client', null, null);     // never expires → included
+        await seedToken('inspFuture', 'a@x.com', 'client', null, future); // not yet expired → included
+        await seedToken('inspPast', 'a@x.com', 'client', null, past);     // expired → excluded
+
+        const rows = await svc.listRecipientInspections(TENANT, 'a@x.com');
+        const ids = rows.map((r) => r.inspectionId).sort();
+        expect(ids).toEqual(['inspFuture', 'inspNull']);
     });
 
     it('listRecipientInspections returns [] when the recipient has no live tokens', async () => {

--- a/tests/unit/portal-session.spec.ts
+++ b/tests/unit/portal-session.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { signMagicLink, verifyMagicLink, signPortalSession, verifyPortalSession } from '../../server/lib/portal-session';
+
+const SECRET = 'test-jwt-secret';
+describe('portal magic-link + session (HMAC, no DB)', () => {
+  it('round-trips a magic-link token within expiry', async () => {
+    const tok = await signMagicLink(SECRET, 'a@x.com', 900); // 15 min
+    expect(await verifyMagicLink(SECRET, tok)).toEqual({ email: 'a@x.com' });
+  });
+  it('rejects an expired magic-link', async () => {
+    const tok = await signMagicLink(SECRET, 'a@x.com', -1);
+    expect(await verifyMagicLink(SECRET, tok)).toBeNull();
+  });
+  it('rejects a tampered magic-link', async () => {
+    const tok = await signMagicLink(SECRET, 'a@x.com', 900);
+    expect(await verifyMagicLink(SECRET, tok.slice(0, -2) + 'xx')).toBeNull();
+  });
+  it('round-trips a session cookie', async () => {
+    const c = await signPortalSession(SECRET, 'a@x.com', 2592000); // 30d
+    expect(await verifyPortalSession(SECRET, c)).toEqual({ email: 'a@x.com' });
+  });
+  it('rejects tampered/expired session', async () => {
+    expect(await verifyPortalSession(SECRET, 'garbage.sig')).toBeNull();
+    const exp = await signPortalSession(SECRET, 'a@x.com', -1);
+    expect(await verifyPortalSession(SECRET, exp)).toBeNull();
+  });
+  it('does not accept a magic-link token as a session cookie or vice versa (typ discriminator)', async () => {
+    const ml = await signMagicLink(SECRET, 'a@x.com', 900);
+    expect(await verifyPortalSession(SECRET, ml)).toBeNull();
+    const sess = await signPortalSession(SECRET, 'a@x.com', 2592000);
+    expect(await verifyMagicLink(SECRET, sess)).toBeNull();
+  });
+});

--- a/tests/web/unit/portal-hub.spec.ts
+++ b/tests/web/unit/portal-hub.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { statusCardModels } from '../../../app/components/portal/InspectionStatusCards';
+import { hubSectionHref } from '../../../app/components/portal/InspectionHub';
+describe('portal hub models', () => {
+  it('statusCardModels renders 6 cards with correct states', () => {
+    const cards = statusCardModels({ inspectionStatus:'completed', agreementSigned:true, paymentStatus:'paid', reportPublished:true, progress:{completed:8,total:10}, unreadMessages:2, address:'1 A St', date:'2026-06-16' });
+    const byKey = Object.fromEntries(cards.map(c => [c.key, c]));
+    expect(byKey.report.value).toMatch(/Published/i);
+    expect(byKey.progress.value).toMatch(/8\/10|80%/);
+    expect(byKey.messages.badge).toBe(2);
+    expect(cards.length).toBe(6);
+  });
+  it('report card shows Not published when unpublished', () => {
+    const cards = statusCardModels({ inspectionStatus:'completed', agreementSigned:false, paymentStatus:'unpaid', reportPublished:false, progress:{completed:0,total:0}, unreadMessages:0, address:'', date:'' });
+    expect(cards.find(c=>c.key==='report')!.value).toMatch(/Not published/i);
+  });
+  it('hubSectionHref builds interim deep-links to existing pages (phase ①)', () => {
+    expect(hubSectionHref('report', { tenant:'t', inspectionId:'i', token:'k' })).toContain('/report/');
+    expect(hubSectionHref('payment', { tenant:'t', inspectionId:'i', token:'k' })).toContain('/r/i/invoice');
+  });
+});


### PR DESCRIPTION
## Unified Client Portal — Foundation (sub-project ①)

Gives clients ONE recipient-level portal: a no-password email **magic-link** session that lists all their inspections (**My Inspections**) and opens a per-inspection **Hub** with a 6-dimension status Overview + section nav. Report-ready lifecycle emails now land clients in the portal.

### Architecture (no new table)
- **Magic-link + session** are HMAC-signed `{typ,email,exp}` tokens (mirror `observer-cookie.ts`); redeeming sets a `__Host-portal_session` cookie carrying only the verified email. A recipient's inspections resolve via the existing `inspection_access_tokens` (role client/co_client, non-revoked, non-expired).
- **Tenant-slug-scoped routes** (`/portal/:tenant/...`) — host→tenant resolution was retired (silo-deconvergence), so the portal resolves tenant from the path slug like `/report/:tenant/:id`. The session cookie is email-only; tenant always comes from the path, so cross-tenant isolation holds.
- Shared components (`InspectionStatusCards`/`InspectionList`/`InspectionHub`) are data-source-agnostic for later agent-portal reuse.

### Scope
- **In:** magic-link auth (no table), My Inspections, 6-dim Hub Overview + nav (interim deep-links to existing pages), report-ready email CTA repoint, shared components.
- **Deferred to ②–⑥:** inlining Report/Agreement/Payment/Progress/Messages/RRB sections. Agreement/payment/message email CTAs are intentionally NOT repointed yet (their interim hub sections can't reconstruct the specialized signer/message tokens — repointing now would break those flows).

### Security
Magic-link/session HMAC-verified before trust with constant-time compare + `typ` discrimination; enumeration-safe `request-link` (identical body + timing via `waitUntil`); `expiresAt` enforced; `/overview` membership check (403); token→session `exchange` enforces tenant-match + client/co_client role (agent rejected); `__Host-` cookie attrs (Secure/HttpOnly/Path=/). Two adversarial reviews + a final whole-diff review; all findings fixed.

### Testing
- Unit (api) + web + workers gates green: type-check 0, lint (incl DS tokens) clean, 1824 unit / 414 web / 41 workers passing.
- **Local Chrome E2E** verified end-to-end: login → magic-link redeem → cookie → My Inspections → Hub Overview (6 correct status cards) + nav; no enumeration; 401/403 correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)