### PR TITLE
feat: client documents — per-inspection shared document area (portal Hub + inspector hub)

### DIFF
--- a/app/components/DocumentsSection.tsx
+++ b/app/components/DocumentsSection.tsx
@@ -1,0 +1,360 @@
+/**
+ * Shared per-inspection documents area (unified client portal, section ⑦).
+ *
+ * Used by BOTH the inspector inspection-hub AND the client portal Hub. Pure
+ * presentational + helpers — NO data fetching inside. All upload / delete /
+ * download actions are passed in as callbacks/hrefs by the host route.
+ *
+ * Helpers (`isAcceptedDocument`, `formatSize`, `groupByCategory`) mirror the
+ * server allowlist in `server/services/client-document.service.ts` so the UI can
+ * reject obviously-invalid files BEFORE streaming them (the server still
+ * re-validates by construction).
+ *
+ * lint:ds — literal colors are forbidden; only `ih-*` design tokens are used.
+ */
+import { useRef, useState } from "react";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+/* ------------------------------------------------------------------ */
+/* Allowlist (mirrors server/services/client-document.service.ts) */
+/* ------------------------------------------------------------------ */
+
+export const MAX_BYTES = 100 * 1024 * 1024; // 100 MB
+
+export const ACCEPTED_EXTENSIONS = new Set([
+  "pdf", "jpg", "jpeg", "png", "heic", "heif", "webp",
+  "doc", "docx", "xls", "xlsx", "csv", "dwg", "dxf",
+]);
+export const CAD_EXTENSIONS = new Set(["dwg", "dxf"]);
+export const ACCEPTED_CONTENT_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg", "image/png", "image/heic", "image/heif", "image/webp",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "text/csv",
+]);
+
+const extOf = (name: string) => (name.split(".").pop() ?? "").toLowerCase();
+
+/**
+ * Accept iff the extension is allowed AND (it is a CAD extension OR the MIME is
+ * in the allowlist) AND the size is within the cap. CAD files (.dwg/.dxf) are
+ * accepted by extension because browsers report them as
+ * `application/octet-stream`.
+ */
+export function isAcceptedDocument(file: { name: string; type: string; size: number }): boolean {
+  const ext = extOf(file.name);
+  if (!ACCEPTED_EXTENSIONS.has(ext)) return false;
+  if (!CAD_EXTENSIONS.has(ext) && !ACCEPTED_CONTENT_TYPES.has(file.type)) return false;
+  if (file.size > MAX_BYTES) return false;
+  return true;
+}
+
+/** Human-readable byte size: 1536 → "1.5 KB", 5 MB → "5.0 MB". */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Categories */
+/* ------------------------------------------------------------------ */
+
+export const DOCUMENT_CATEGORIES = [
+  "prior_reports", "plans_drawings", "environmental",
+  "leases_financials", "permits_certificates", "photos", "other",
+] as const;
+export type DocumentCategory = (typeof DOCUMENT_CATEGORIES)[number];
+
+export const CATEGORY_LABELS: Record<DocumentCategory, string> = {
+  prior_reports: "Prior Reports",
+  plans_drawings: "Plans & Drawings",
+  environmental: "Environmental",
+  leases_financials: "Leases & Financials",
+  permits_certificates: "Permits & Certificates",
+  photos: "Photos",
+  other: "Other",
+};
+
+export type DocumentVisibility = "client_visible" | "internal";
+
+export interface DocumentItem {
+  id: string;
+  filename: string;
+  category: DocumentCategory;
+  sizeBytes: number;
+  createdAt: number;
+  uploadedByKind: "client" | "co_client" | "inspector";
+  uploadedByName: string | null;
+  visibility: DocumentVisibility;
+  label: string | null;
+  /** Client list returns this (own = deletable). */
+  isOwn?: boolean;
+  /** Inspector list returns this (compared to currentUserRef). */
+  uploadedByRef?: string;
+}
+
+export interface DocumentGroup {
+  category: DocumentCategory;
+  label: string;
+  items: DocumentItem[];
+}
+
+/**
+ * Group items by category in DOCUMENT_CATEGORIES order, omitting empty
+ * categories. Order within a group preserves the input order.
+ */
+export function groupByCategory(items: DocumentItem[]): DocumentGroup[] {
+  return DOCUMENT_CATEGORIES.map((category) => ({
+    category,
+    label: CATEGORY_LABELS[category],
+    items: items.filter((i) => i.category === category),
+  })).filter((g) => g.items.length > 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* Component */
+/* ------------------------------------------------------------------ */
+
+const ACCEPT_ATTR = Array.from(ACCEPTED_EXTENSIONS).map((e) => `.${e}`).join(",");
+
+export interface DocumentsSectionProps {
+  items: DocumentItem[];
+  canUpload: boolean;
+  showVisibilityToggle?: boolean;
+  allowDeleteAny?: boolean;
+  currentUserRef?: string;
+  downloadHref: (id: string) => string;
+  onUpload: (
+    file: File,
+    opts: { category: DocumentCategory; visibility: DocumentVisibility; label?: string },
+  ) => void;
+  onDelete: (id: string) => void;
+  uploading?: boolean;
+  error?: string | null;
+}
+
+/** A row is deletable in the client list (isOwn) OR the inspector list (uploadedByRef === currentUserRef) OR when allowDeleteAny. */
+function isDeletable(item: DocumentItem, allowDeleteAny: boolean, currentUserRef?: string): boolean {
+  return (
+    allowDeleteAny === true ||
+    item.isOwn === true ||
+    (currentUserRef != null && item.uploadedByRef != null && item.uploadedByRef === currentUserRef)
+  );
+}
+
+function formatDate(ms: number): string {
+  try {
+    return new Date(ms).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  } catch {
+    return "";
+  }
+}
+
+function uploaderLabel(item: DocumentItem): string {
+  if (item.uploadedByName) return item.uploadedByName;
+  return item.uploadedByKind === "inspector" ? "Inspector" : "Client";
+}
+
+export default function DocumentsSection({
+  items,
+  canUpload,
+  showVisibilityToggle = false,
+  allowDeleteAny = false,
+  currentUserRef,
+  downloadHref,
+  onUpload,
+  onDelete,
+  uploading = false,
+  error = null,
+}: DocumentsSectionProps) {
+  const [category, setCategory] = useState<DocumentCategory>("prior_reports");
+  const [visibility, setVisibility] = useState<DocumentVisibility>("client_visible");
+  const [label, setLabel] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const groups = groupByCategory(items);
+
+  const handleFile = (file: File | undefined | null) => {
+    if (!file) return;
+    if (!isAcceptedDocument(file)) {
+      setLocalError("That file type or size isn't allowed (max 100 MB).");
+      return;
+    }
+    setLocalError(null);
+    onUpload(file, { category, visibility, label: label.trim() || undefined });
+    setLabel("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const shownError = error ?? localError;
+
+  return (
+    <section className="rounded-xl border border-ih-border bg-ih-bg-card p-5">
+      <h2 className="text-sm font-bold text-ih-fg-1">Documents</h2>
+      <p className="mt-0.5 text-[12px] text-ih-fg-3">
+        Share files for this inspection. PDF, images, Office docs and CAD up to 100 MB.
+      </p>
+
+      {canUpload && (
+        <div className="mt-4">
+          <div className="flex flex-wrap gap-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-ih-fg-3">Category</span>
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value as DocumentCategory)}
+                disabled={uploading}
+                className="rounded-md border border-ih-border bg-ih-bg-card px-2 py-1.5 text-[13px] text-ih-fg-1 disabled:opacity-50"
+              >
+                {DOCUMENT_CATEGORIES.map((c) => (
+                  <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>
+                ))}
+              </select>
+            </label>
+
+            {showVisibilityToggle && (
+              <label className="flex flex-col gap-1">
+                <span className="text-[10px] font-bold uppercase tracking-widest text-ih-fg-3">Visibility</span>
+                <select
+                  value={visibility}
+                  onChange={(e) => setVisibility(e.target.value as DocumentVisibility)}
+                  disabled={uploading}
+                  className="rounded-md border border-ih-border bg-ih-bg-card px-2 py-1.5 text-[13px] text-ih-fg-1 disabled:opacity-50"
+                >
+                  <option value="client_visible">Client visible</option>
+                  <option value="internal">Internal only</option>
+                </select>
+              </label>
+            )}
+
+            <label className="flex flex-1 flex-col gap-1">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-ih-fg-3">Label (optional)</span>
+              <input
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                disabled={uploading}
+                placeholder="e.g. 2019 termite report"
+                className="rounded-md border border-ih-border bg-ih-bg-card px-2 py-1.5 text-[13px] text-ih-fg-1 placeholder:text-ih-fg-3 disabled:opacity-50"
+              />
+            </label>
+          </div>
+
+          <div
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragOver(false);
+              if (!uploading) handleFile(e.dataTransfer.files?.[0]);
+            }}
+            className={`mt-3 flex flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed px-4 py-6 text-center transition-colors ${
+              dragOver ? "border-ih-primary bg-ih-bg-muted" : "border-ih-border bg-ih-bg-muted"
+            }`}
+          >
+            {uploading ? (
+              <span className="text-[13px] font-semibold text-ih-fg-2">Uploading…</span>
+            ) : (
+              <>
+                <span className="text-[13px] text-ih-fg-2">Drag a file here, or</span>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="rounded-md bg-ih-primary px-3 py-1.5 text-[13px] font-bold text-white transition-opacity hover:opacity-90"
+                >
+                  Choose file
+                </button>
+                <span className="text-[11px] text-ih-fg-3">{ACCEPT_ATTR.replace(/\./g, "").replace(/,/g, ", ")}</span>
+              </>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPT_ATTR}
+              disabled={uploading}
+              onChange={(e) => handleFile(e.target.files?.[0])}
+              className="hidden"
+            />
+          </div>
+
+          {shownError && (
+            <p className="mt-2 text-[12px] font-semibold text-ih-bad-fg">{shownError}</p>
+          )}
+        </div>
+      )}
+
+      <div className="mt-5 flex flex-col gap-5">
+        {groups.length === 0 ? (
+          <p className="rounded-lg bg-ih-bg-muted px-4 py-6 text-center text-[13px] text-ih-fg-3">
+            No documents yet.
+          </p>
+        ) : (
+          groups.map((group) => (
+            <div key={group.category}>
+              <h3 className="text-[11px] font-bold uppercase tracking-widest text-ih-fg-3">
+                {group.label}
+              </h3>
+              <ul className="mt-2 divide-y divide-ih-border rounded-lg border border-ih-border">
+                {group.items.map((item) => {
+                  const deletable = isDeletable(item, allowDeleteAny, currentUserRef);
+                  return (
+                    <li key={item.id} className="flex items-center gap-3 px-3 py-2.5">
+                      <div className="min-w-0 flex-1">
+                        <a
+                          href={downloadHref(item.id)}
+                          className="block truncate text-[13px] font-semibold text-ih-primary hover:underline"
+                        >
+                          {item.label || item.filename}
+                        </a>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-ih-fg-3">
+                          <span>{formatSize(item.sizeBytes)}</span>
+                          <span aria-hidden>·</span>
+                          <span>{uploaderLabel(item)}</span>
+                          <span aria-hidden>·</span>
+                          <span>{formatDate(item.createdAt)}</span>
+                          {item.visibility === "internal" && (
+                            <span className="rounded bg-ih-watch-bg px-1.5 py-0.5 font-bold text-ih-watch-fg">
+                              Internal
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {deletable && (
+                        <button
+                          type="button"
+                          onClick={() => setPendingDeleteId(item.id)}
+                          className="shrink-0 rounded-md px-2 py-1 text-[12px] font-bold text-ih-bad-fg transition-colors hover:bg-ih-bad-bg"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={pendingDeleteId != null}
+        title="Delete document?"
+        message="This permanently removes the file. This cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (pendingDeleteId != null) onDelete(pendingDeleteId);
+          setPendingDeleteId(null);
+        }}
+        onCancel={() => setPendingDeleteId(null)}
+      />
+    </section>
+  );
+}

--- a/app/components/portal/InspectionHub.tsx
+++ b/app/components/portal/InspectionHub.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import InspectionStatusCards, { type StatusOverview } from "./InspectionStatusCards";
 
 /* ------------------------------------------------------------------ */
@@ -11,7 +12,8 @@ export type HubSection =
   | "payment"
   | "progress"
   | "messages"
-  | "repair";
+  | "repair"
+  | "documents";
 
 export interface HubLinkCtx {
   tenant: string;
@@ -50,6 +52,9 @@ export function hubSectionHref(section: HubSection, ctx: HubLinkCtx): string {
       return reportHref;
     case "repair":
       return `/repair-builder/${tenant}/${inspectionId}?token=${t}`;
+    case "documents":
+      // Inline section on THIS page — anchor-scroll, not a deep-link.
+      return "#documents";
   }
 }
 
@@ -65,16 +70,21 @@ const NAV: Array<{ section: HubSection; label: string }> = [
   { section: "progress", label: "Progress" },
   { section: "messages", label: "Messages" },
   { section: "repair", label: "Repair Request" },
+  { section: "documents", label: "Documents" },
 ];
 
 export default function InspectionHub({
   overview,
   ctx,
   activeSection = "overview",
+  documentsSlot,
 }: {
   overview: StatusOverview;
   ctx: HubLinkCtx;
   activeSection?: HubSection;
+  /** Inline Documents section supplied by the route (keeps this component
+   *  data-source-agnostic — see portal-inspection.tsx). */
+  documentsSlot?: React.ReactNode;
 }) {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
@@ -111,6 +121,14 @@ export default function InspectionHub({
 
       {/* Overview body */}
       <InspectionStatusCards overview={overview} />
+
+      {/* Documents — inline section (anchor target for the nav). Supplied by the
+          route so this component stays presentational/data-source-agnostic. */}
+      {documentsSlot && (
+        <section id="documents" className="mt-8 scroll-mt-6">
+          {documentsSlot}
+        </section>
+      )}
     </div>
   );
 }

--- a/app/routes/inspection-hub.tsx
+++ b/app/routes/inspection-hub.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useLoaderData, Link, isRouteErrorResponse, useRouteError, useFetcher, useNavigate } from "react-router";
+import { useLoaderData, Link, isRouteErrorResponse, useRouteError, useFetcher, useNavigate, useRevalidator } from "react-router";
 import type { Route } from "./+types/inspection-hub";
 import { requireToken } from "~/lib/session.server";
 import { createApi } from "~/lib/api-client.server";
@@ -8,6 +8,11 @@ import { deriveBlockStates, formatCents, isReportShipped, type HubPayload } from
 import { INSPECTION_STATUS, REPORT_STATUS, isReportPublished } from "~/lib/status";
 import { getEffectivePriceCents } from "~/lib/effective-price";
 import { PageHeader, Card, Pill, Button, EmptyState } from "@core/shared-ui";
+import DocumentsSection, {
+  type DocumentItem,
+  type DocumentCategory,
+  type DocumentVisibility,
+} from "~/components/DocumentsSection";
 
 export function meta() {
   return [{ title: "Inspection - OpenInspection" }];
@@ -134,7 +139,27 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     // Best-effort: fail open on cap check (canPublishCap stays false)
   }
 
-  return { hub, smsConsent, reinspectCandidates, canPublishCap };
+  // Inspector documents (unified portal section ⑦). The inspector document
+  // routes are not in the typed client, so fetch the list directly via the
+  // in-process API binding, forwarding the request cookie for auth. Best-effort:
+  // a non-OK response degrades to an empty list.
+  let documents: DocumentItem[] = [];
+  try {
+    const apiWorker = (context.cloudflare.env as unknown as { API_WORKER?: { fetch: typeof fetch } })
+      .API_WORKER;
+    const docsRes = await (apiWorker?.fetch ?? fetch)(
+      new Request(`https://internal/api/inspections/${id}/documents`, {
+        headers: { cookie: request.headers.get("cookie") ?? "" },
+      }),
+    );
+    if (docsRes.ok) {
+      documents = (((await docsRes.json()) as { data?: DocumentItem[] }).data ?? []) as DocumentItem[];
+    }
+  } catch {
+    // Best-effort: fail open to empty list
+  }
+
+  return { hub, smsConsent, reinspectCandidates, canPublishCap, documents };
 }
 
 /* ------------------------------------------------------------------ */
@@ -354,10 +379,66 @@ export function reportActions(
 /* ------------------------------------------------------------------ */
 
 export default function InspectionHubPage() {
-  const { hub, smsConsent, reinspectCandidates, canPublishCap } = useLoaderData<typeof loader>();
+  const { hub, smsConsent, reinspectCandidates, canPublishCap, documents } = useLoaderData<typeof loader>();
   const { inspection, people, services, tenantSlug } = hub;
   const blocks = deriveBlockStates(hub);
   const navigate = useNavigate();
+  const revalidator = useRevalidator();
+
+  // Documents (unified portal section ⑦) — client-side upload/delete against the
+  // authed inspector document routes (same-origin → the JWT cookie auto-sends),
+  // then revalidate the loader to refresh the list.
+  const [docUploading, setDocUploading] = useState(false);
+  const [docError, setDocError] = useState<string | null>(null);
+
+  const onDocUpload = async (
+    file: File,
+    opts: { category: DocumentCategory; visibility: DocumentVisibility; label?: string },
+  ) => {
+    setDocError(null);
+    setDocUploading(true);
+    try {
+      const qs = new URLSearchParams({
+        filename: file.name,
+        category: opts.category,
+        visibility: opts.visibility,
+        ...(opts.label ? { label: opts.label } : {}),
+      });
+      const res = await fetch(`/api/inspections/${inspection.id}/documents?${qs}`, {
+        method: "PUT",
+        headers: {
+          "content-type": file.type || "application/octet-stream",
+          "content-length": String(file.size),
+        },
+        body: file,
+      });
+      if (!res.ok) {
+        setDocError("Upload failed. Please try again.");
+        return;
+      }
+      revalidator.revalidate();
+    } catch {
+      setDocError("Upload failed. Please try again.");
+    } finally {
+      setDocUploading(false);
+    }
+  };
+
+  const onDocDelete = async (docId: string) => {
+    setDocError(null);
+    try {
+      const res = await fetch(`/api/inspections/${inspection.id}/documents/${docId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        setDocError("Could not delete the document. Please try again.");
+        return;
+      }
+      revalidator.revalidate();
+    } catch {
+      setDocError("Could not delete the document. Please try again.");
+    }
+  };
 
   // Track L (E) — SMS consent attestation. Dedicated fetcher (never share).
   const attestSms = useFetcher<typeof action>();
@@ -821,6 +902,21 @@ export default function InspectionHubPage() {
           )}
         </Card>
       </div>
+
+      {/* Documents — shared section (unified portal ⑦). Renders regardless of
+          report status (uploads are pre/intra-inspection). Inspector can upload
+          with a visibility toggle and delete any document. */}
+      <DocumentsSection
+        items={documents}
+        canUpload
+        showVisibilityToggle
+        allowDeleteAny
+        downloadHref={(docId) => `/api/inspections/${inspection.id}/documents/${docId}`}
+        onUpload={onDocUpload}
+        onDelete={onDocDelete}
+        uploading={docUploading}
+        error={docError}
+      />
 
       {/* Send-agreement modal — custom (no window.confirm) */}
       {agreementModalOpen && (

--- a/app/routes/public/portal-inspection.tsx
+++ b/app/routes/public/portal-inspection.tsx
@@ -13,7 +13,8 @@
  *   - browser cookie (or the freshly-issued one) → forwarded INTO the overview
  *     call, since the typed client does not auto-forward the browser cookie.
  */
-import { redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData, useRevalidator } from "react-router";
+import { useState } from "react";
 import type { Route } from "./+types/portal-inspection";
 import { createApi } from "~/lib/api-client.server";
 import InspectionHub, {
@@ -21,6 +22,11 @@ import InspectionHub, {
   type HubSection,
 } from "~/components/portal/InspectionHub";
 import type { StatusOverview } from "~/components/portal/InspectionStatusCards";
+import DocumentsSection, {
+  type DocumentItem,
+  type DocumentCategory,
+  type DocumentVisibility,
+} from "~/components/DocumentsSection";
 
 export function meta() {
   return [{ title: "Inspection - OpenInspection" }];
@@ -115,6 +121,25 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
   const ctxToken = overviewToken || token || "";
   const ctx = { tenant, inspectionId, token: ctxToken };
 
+  // Client documents (unified portal section ⑦) — fetch using the SAME cookie
+  // value used for the overview call (freshly-minted exchange cookie or the
+  // incoming browser cookie). Best-effort: a non-OK response → empty list.
+  let documents: DocumentItem[] = [];
+  try {
+    const apiWorker = (context.cloudflare.env as unknown as { API_WORKER?: { fetch: typeof fetch } })
+      .API_WORKER;
+    const docsRes = await (apiWorker?.fetch ?? fetch)(
+      new Request(`https://internal/api/public/inspections/${inspectionId}/documents`, {
+        headers: { cookie: cookieForApi },
+      }),
+    );
+    if (docsRes.ok) {
+      documents = (((await docsRes.json()) as { data?: DocumentItem[] }).data ?? []) as DocumentItem[];
+    }
+  } catch {
+    // Best-effort: fail open to empty list
+  }
+
   // Step 3 — if ?to names a real deep-link section, jump straight there
   // (carrying the token), forwarding any freshly-issued session cookie.
   if (isDeepLinkSection(to)) {
@@ -125,7 +150,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
 
   // Step 4 — render the hub.
   return new Response(
-    JSON.stringify({ overview, ctx }),
+    JSON.stringify({ overview, ctx, documents }),
     {
       headers: {
         "Content-Type": "application/json",
@@ -136,9 +161,94 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
 }
 
 export default function PortalInspection() {
-  const { overview, ctx } = useLoaderData<typeof loader>() as {
+  const { overview, ctx, documents } = useLoaderData<typeof loader>() as {
     overview: StatusOverview;
     ctx: { tenant: string; inspectionId: string; token: string };
+    documents: DocumentItem[];
   };
-  return <InspectionHub overview={overview} ctx={ctx} activeSection="overview" />;
+  const revalidator = useRevalidator();
+  const { inspectionId, token } = ctx;
+
+  // Client-side upload/delete against the public document routes. The client is
+  // authenticated by the __Host-portal_session cookie (auto-sent same-origin);
+  // the token query is a harmless fallback included only when non-empty.
+  const [docUploading, setDocUploading] = useState(false);
+  const [docError, setDocError] = useState<string | null>(null);
+  const tokenSuffix = token ? `?token=${encodeURIComponent(token)}` : "";
+
+  const onUpload = async (
+    file: File,
+    opts: { category: DocumentCategory; visibility: DocumentVisibility; label?: string },
+  ) => {
+    setDocError(null);
+    setDocUploading(true);
+    try {
+      // Client uploads are always client_visible server-side — no visibility param.
+      const qs = new URLSearchParams({
+        filename: file.name,
+        category: opts.category,
+        ...(opts.label ? { label: opts.label } : {}),
+        ...(token ? { token } : {}),
+      });
+      const res = await fetch(
+        `/api/public/inspections/${inspectionId}/documents?${qs}`,
+        {
+          method: "PUT",
+          headers: {
+            "content-type": file.type || "application/octet-stream",
+            "content-length": String(file.size),
+          },
+          body: file,
+        },
+      );
+      if (!res.ok) {
+        setDocError("Upload failed. Please try again.");
+        return;
+      }
+      revalidator.revalidate();
+    } catch {
+      setDocError("Upload failed. Please try again.");
+    } finally {
+      setDocUploading(false);
+    }
+  };
+
+  const onDelete = async (docId: string) => {
+    setDocError(null);
+    try {
+      const res = await fetch(
+        `/api/public/inspections/${inspectionId}/documents/${docId}${tokenSuffix}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        setDocError("Could not delete the document. Please try again.");
+        return;
+      }
+      revalidator.revalidate();
+    } catch {
+      setDocError("Could not delete the document. Please try again.");
+    }
+  };
+
+  return (
+    <InspectionHub
+      overview={overview}
+      ctx={ctx}
+      activeSection="overview"
+      documentsSlot={
+        <DocumentsSection
+          items={documents}
+          canUpload
+          showVisibilityToggle={false}
+          downloadHref={(docId) =>
+            `/api/public/inspections/${inspectionId}/documents/${docId}${tokenSuffix}`
+          }
+          onUpload={onUpload}
+          onDelete={onDelete}
+          uploading={docUploading}
+          error={docError}
+        />
+      }
+    />
+  );
 }

--- a/migrations/0009_client_uploads.sql
+++ b/migrations/0009_client_uploads.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `client_uploads` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text NOT NULL,
+	`inspection_id` text NOT NULL,
+	`uploaded_by_kind` text NOT NULL,
+	`uploaded_by_ref` text NOT NULL,
+	`uploaded_by_name` text,
+	`category` text NOT NULL,
+	`visibility` text NOT NULL,
+	`r2_key` text NOT NULL,
+	`filename` text NOT NULL,
+	`content_type` text NOT NULL,
+	`size_bytes` integer NOT NULL,
+	`label` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_client_uploads_inspection` ON `client_uploads` (`tenant_id`,`inspection_id`);

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,0 +1,8120 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "851d47c3-671b-4fb3-9a60-3914db9d2a14",
+  "prevId": "a55b9244-e5b3-442e-b56d-745de634dbff",
+  "tables": {
+    "agreement_requests": {
+      "name": "agreement_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "signature_base64": {
+          "name": "signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_signature_base64": {
+          "name": "inspector_signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_signed_at": {
+          "name": "inspector_signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_user_id": {
+          "name": "inspector_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_policy": {
+          "name": "completion_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purged_at": {
+          "name": "purged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agreement_requests_token_unique": {
+          "name": "agreement_requests_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_agreement_requests_verify_token": {
+          "name": "idx_agreement_requests_verify_token",
+          "columns": [
+            "verification_token"
+          ],
+          "isUnique": true
+        },
+        "idx_agreement_requests_tenant": {
+          "name": "idx_agreement_requests_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agreement_requests_inspection": {
+          "name": "idx_agreement_requests_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agreement_requests_token_hash": {
+          "name": "idx_agreement_requests_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agreement_requests_tenant_id_tenants_id_fk": {
+          "name": "agreement_requests_tenant_id_tenants_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agreement_requests_inspection_id_inspections_id_fk": {
+          "name": "agreement_requests_inspection_id_inspections_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agreement_requests_agreement_id_agreements_id_fk": {
+          "name": "agreement_requests_agreement_id_agreements_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "agreements",
+          "columnsFrom": [
+            "agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agreement_requests_inspector_user_id_users_id_fk": {
+          "name": "agreement_requests_inspector_user_id_users_id_fk",
+          "tableFrom": "agreement_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agreement_signers": {
+      "name": "agreement_signers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'client'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "signature_base64": {
+          "name": "signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "on_behalf_of": {
+          "name": "on_behalf_of",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "on_behalf_disclaimer": {
+          "name": "on_behalf_disclaimer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminded_at": {
+          "name": "last_reminded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agreement_signers_tenant_request": {
+          "name": "idx_agreement_signers_tenant_request",
+          "columns": [
+            "tenant_id",
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agreement_signers_request_email": {
+          "name": "idx_agreement_signers_request_email",
+          "columns": [
+            "request_id",
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_agreement_signers_token_hash": {
+          "name": "idx_agreement_signers_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agreements": {
+      "name": "agreements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agreements_tenant": {
+          "name": "idx_agreements_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agreements_tenant_id_tenants_id_fk": {
+          "name": "agreements_tenant_id_tenants_id_fk",
+          "tableFrom": "agreements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automation_logs": {
+      "name": "automation_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "send_at": {
+          "name": "send_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_automation_logs_pending": {
+          "name": "idx_automation_logs_pending",
+          "columns": [
+            "tenant_id",
+            "status",
+            "send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_automation_logs_insp": {
+          "name": "idx_automation_logs_insp",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "uq_automation_logs_event": {
+          "name": "uq_automation_logs_event",
+          "columns": [
+            "automation_id",
+            "inspection_id",
+            "event_id"
+          ],
+          "isUnique": true,
+          "where": "event_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "automation_logs_tenant_id_tenants_id_fk": {
+          "name": "automation_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "automation_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_minutes": {
+          "name": "delay_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_template": {
+          "name": "body_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channels": {
+          "name": "channels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"email\"]'"
+        },
+        "sms_body": {
+          "name": "sms_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_automations_tenant": {
+          "name": "idx_automations_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "automations_tenant_id_tenants_id_fk": {
+          "name": "automations_tenant_id_tenants_id_fk",
+          "tableFrom": "automations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "availability": {
+      "name": "availability",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_availability_inspector": {
+          "name": "idx_availability_inspector",
+          "columns": [
+            "inspector_id"
+          ],
+          "isUnique": false
+        },
+        "idx_availability_window_unique": {
+          "name": "idx_availability_window_unique",
+          "columns": [
+            "inspector_id",
+            "day_of_week",
+            "start_time"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "availability_tenant_id_tenants_id_fk": {
+          "name": "availability_tenant_id_tenants_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_inspector_id_users_id_fk": {
+          "name": "availability_inspector_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "availability_overrides": {
+      "name": "availability_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_avail_overrides_insp": {
+          "name": "idx_avail_overrides_insp",
+          "columns": [
+            "inspector_id"
+          ],
+          "isUnique": false
+        },
+        "idx_avail_overrides_block_unique": {
+          "name": "idx_avail_overrides_block_unique",
+          "columns": [
+            "inspector_id",
+            "date"
+          ],
+          "isUnique": true,
+          "where": "is_available = 0"
+        }
+      },
+      "foreignKeys": {
+        "availability_overrides_tenant_id_tenants_id_fk": {
+          "name": "availability_overrides_tenant_id_tenants_id_fk",
+          "tableFrom": "availability_overrides",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_overrides_inspector_id_users_id_fk": {
+          "name": "availability_overrides_inspector_id_users_id_fk",
+          "tableFrom": "availability_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_usage": {
+      "name": "comment_usage",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_comment_usage_user_last_used": {
+          "name": "idx_comment_usage_user_last_used",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_usage_comment_id_comments_id_fk": {
+          "name": "comment_usage_comment_id_comments_id_fk",
+          "tableFrom": "comment_usage",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_usage_tenant_id_user_id_comment_id_pk": {
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "comment_id"
+          ],
+          "name": "comment_usage_tenant_id_user_id_comment_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating_bucket": {
+          "name": "rating_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_ids": {
+          "name": "section_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_labels": {
+          "name": "item_labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_code": {
+          "name": "trigger_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_keywords": {
+          "name": "search_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_label": {
+          "name": "item_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_summary": {
+          "name": "repair_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_min_cents": {
+          "name": "estimate_min_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_max_cents": {
+          "name": "estimate_max_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recommended_contractor_type_id": {
+          "name": "recommended_contractor_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_comments_tenant": {
+          "name": "idx_comments_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_comments_rating_bucket": {
+          "name": "idx_comments_rating_bucket",
+          "columns": [
+            "tenant_id",
+            "rating_bucket"
+          ],
+          "isUnique": false
+        },
+        "idx_comments_library_id": {
+          "name": "idx_comments_library_id",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_tenant_id_tenants_id_fk": {
+          "name": "comments_tenant_id_tenants_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "commercial_subtypes": {
+      "name": "commercial_subtypes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_commercial_subtypes_tenant_name": {
+          "name": "idx_commercial_subtypes_tenant_name",
+          "columns": [
+            "tenant_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "commercial_subtypes_tenant_id_tenants_id_fk": {
+          "name": "commercial_subtypes_tenant_id_tenants_id_fk",
+          "tableFrom": "commercial_subtypes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "concierge_confirm_tokens": {
+      "name": "concierge_confirm_tokens",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_concierge_tokens_expiry": {
+          "name": "idx_concierge_tokens_expiry",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_concierge_confirm_token_hash": {
+          "name": "idx_concierge_confirm_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "concierge_confirm_tokens_inspection_id_inspections_id_fk": {
+          "name": "concierge_confirm_tokens_inspection_id_inspections_id_fk",
+          "tableFrom": "concierge_confirm_tokens",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'client'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contacts_type": {
+          "name": "idx_contacts_type",
+          "columns": [
+            "tenant_id",
+            "type"
+          ],
+          "isUnique": false
+        },
+        "idx_contacts_tenant": {
+          "name": "idx_contacts_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "uq_contacts_tenant_email": {
+          "name": "uq_contacts_tenant_email",
+          "columns": [
+            "tenant_id",
+            "email"
+          ],
+          "isUnique": true,
+          "where": "email IS NOT NULL AND archived_at IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "contacts_tenant_id_tenants_id_fk": {
+          "name": "contacts_tenant_id_tenants_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contractor_types": {
+      "name": "contractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contractor_types_tenant": {
+          "name": "idx_contractor_types_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "customer_messages": {
+      "name": "customer_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_role": {
+          "name": "from_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_msg_inspection": {
+          "name": "idx_msg_inspection",
+          "columns": [
+            "inspection_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_msg_unread": {
+          "name": "idx_msg_unread",
+          "columns": [
+            "tenant_id",
+            "inspection_id",
+            "from_role"
+          ],
+          "isUnique": false,
+          "where": "\"customer_messages\".\"read_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "customer_messages_tenant_id_tenants_id_fk": {
+          "name": "customer_messages_tenant_id_tenants_id_fk",
+          "tableFrom": "customer_messages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_messages_inspection_id_inspections_id_fk": {
+          "name": "customer_messages_inspection_id_inspections_id_fk",
+          "tableFrom": "customer_messages",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discount_codes": {
+      "name": "discount_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discount_codes_tenant": {
+          "name": "idx_discount_codes_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "discount_codes_code_tenant": {
+          "name": "discount_codes_code_tenant",
+          "columns": [
+            "upper(code)",
+            "tenant_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "discount_codes_tenant_id_tenants_id_fk": {
+          "name": "discount_codes_tenant_id_tenants_id_fk",
+          "tableFrom": "discount_codes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "erasure_log": {
+      "name": "erasure_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_basis": {
+          "name": "identity_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decisions_json": {
+          "name": "decisions_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retained_count": {
+          "name": "retained_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "anonymized_count": {
+          "name": "anonymized_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deleted_count": {
+          "name": "deleted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_note": {
+          "name": "response_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_erasure_log_tenant": {
+          "name": "idx_erasure_log_tenant",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "esign_audit_logs": {
+      "name": "esign_audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prev_hash": {
+          "name": "prev_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_fingerprint": {
+          "name": "key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_esign_audit_logs_request": {
+          "name": "idx_esign_audit_logs_request",
+          "columns": [
+            "tenant_id",
+            "request_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_esign_audit_logs_event_dedup": {
+          "name": "idx_esign_audit_logs_event_dedup",
+          "columns": [
+            "tenant_id",
+            "request_id",
+            "event"
+          ],
+          "isUnique": true,
+          "where": "event NOT LIKE 'signer.%'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_types": {
+      "name": "event_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_duration_min": {
+          "name": "default_duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "default_price_cents": {
+          "name": "default_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#6366f1'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_types_tenant_slug_idx": {
+          "name": "event_types_tenant_slug_idx",
+          "columns": [
+            "tenant_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "event_types_tenant_id_tenants_id_fk": {
+          "name": "event_types_tenant_id_tenants_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_access_tokens": {
+      "name": "inspection_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'client'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_iat_token": {
+          "name": "idx_iat_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_iat_inspection": {
+          "name": "idx_iat_inspection",
+          "columns": [
+            "tenant_id",
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_iat_recipient": {
+          "name": "idx_iat_recipient",
+          "columns": [
+            "inspection_id",
+            "recipient_email"
+          ],
+          "isUnique": true
+        },
+        "idx_iat_token_hash": {
+          "name": "idx_iat_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_access_tokens_tenant_id_tenants_id_fk": {
+          "name": "inspection_access_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_access_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_agreements": {
+      "name": "inspection_agreements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signature_base64": {
+          "name": "signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_insp_agreements_tenant": {
+          "name": "idx_insp_agreements_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_insp_agreements_insp": {
+          "name": "idx_insp_agreements_insp",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_agreements_tenant_id_tenants_id_fk": {
+          "name": "inspection_agreements_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_agreements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_agreements_inspection_id_inspections_id_fk": {
+          "name": "inspection_agreements_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_agreements",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_conflicts": {
+      "name": "inspection_conflicts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base": {
+          "name": "base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local": {
+          "name": "local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_conflicts_inspection": {
+          "name": "idx_inspection_conflicts_inspection",
+          "columns": [
+            "inspection_id",
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_events": {
+      "name": "inspection_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results_received_at": {
+          "name": "results_received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gcal_event_id": {
+          "name": "gcal_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "inspection_events_scheduled_idx": {
+          "name": "inspection_events_scheduled_idx",
+          "columns": [
+            "tenant_id",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "inspection_events_inspection_idx": {
+          "name": "inspection_events_inspection_idx",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_events_tenant_id_tenants_id_fk": {
+          "name": "inspection_events_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_events_inspection_id_inspections_id_fk": {
+          "name": "inspection_events_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspection_events_event_type_id_event_types_id_fk": {
+          "name": "inspection_events_event_type_id_event_types_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "event_types",
+          "columnsFrom": [
+            "event_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_events_inspector_id_users_id_fk": {
+          "name": "inspection_events_inspector_id_users_id_fk",
+          "tableFrom": "inspection_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_inspectors": {
+      "name": "inspection_inspectors",
+      "columns": {
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lead'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_insp_inspectors_tenant_user": {
+          "name": "idx_insp_inspectors_tenant_user",
+          "columns": [
+            "tenant_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_insp_inspectors_user": {
+          "name": "idx_insp_inspectors_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inspection_inspectors_inspection_id_user_id_pk": {
+          "columns": [
+            "inspection_id",
+            "user_id"
+          ],
+          "name": "inspection_inspectors_inspection_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_item_tag_links": {
+      "name": "inspection_item_tag_links",
+      "columns": {
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tag_links_tenant": {
+          "name": "idx_tag_links_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tag_links_tag": {
+          "name": "idx_tag_links_tag",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tag_links_inspection_item": {
+          "name": "idx_tag_links_inspection_item",
+          "columns": [
+            "inspection_id",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inspection_item_tag_links_inspection_id_item_id_tag_id_pk": {
+          "columns": [
+            "inspection_id",
+            "item_id",
+            "tag_id"
+          ],
+          "name": "inspection_item_tag_links_inspection_id_item_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_media_pool": {
+      "name": "inspection_media_pool",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_pool_tenant": {
+          "name": "idx_media_pool_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_media_pool_inspection": {
+          "name": "idx_media_pool_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_requests": {
+      "name": "inspection_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_phone": {
+          "name": "client_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_address": {
+          "name": "property_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_city": {
+          "name": "property_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_state": {
+          "name": "property_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_zip": {
+          "name": "property_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unpaid'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_requests_tenant": {
+          "name": "idx_inspection_requests_tenant",
+          "columns": [
+            "tenant_id",
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_inspection_requests_email": {
+          "name": "idx_inspection_requests_email",
+          "columns": [
+            "tenant_id",
+            "client_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_requests_tenant_id_tenants_id_fk": {
+          "name": "inspection_requests_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_requests",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_results": {
+      "name": "inspection_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_system_id": {
+          "name": "rating_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating_system_snapshot": {
+          "name": "rating_system_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_results_tenant": {
+          "name": "idx_results_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_results_inspection": {
+          "name": "idx_results_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "uq_results_inspection": {
+          "name": "uq_results_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_results_tenant_id_tenants_id_fk": {
+          "name": "inspection_results_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_results",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_results_inspection_id_inspections_id_fk": {
+          "name": "inspection_results_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_results",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_services": {
+      "name": "inspection_services",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_override_cents": {
+          "name": "price_override_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_snapshot": {
+          "name": "name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_snapshot_cents": {
+          "name": "price_snapshot_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_insp_services_tenant": {
+          "name": "idx_insp_services_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_insp_services_insp": {
+          "name": "idx_insp_services_insp",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspection_services_tenant_id_tenants_id_fk": {
+          "name": "inspection_services_tenant_id_tenants_id_fk",
+          "tableFrom": "inspection_services",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_services_inspection_id_inspections_id_fk": {
+          "name": "inspection_services_inspection_id_inspections_id_fk",
+          "tableFrom": "inspection_services",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspection_services_service_id_services_id_fk": {
+          "name": "inspection_services_service_id_services_id_fk",
+          "tableFrom": "inspection_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_units": {
+      "name": "inspection_units",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_unit_id": {
+          "name": "parent_unit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unit'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "inspection_units_tenant_inspection_idx": {
+          "name": "inspection_units_tenant_inspection_idx",
+          "columns": [
+            "tenant_id",
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "inspection_units_parent_idx": {
+          "name": "inspection_units_parent_idx",
+          "columns": [
+            "parent_unit_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspections": {
+      "name": "inspections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_id": {
+          "name": "inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_address": {
+          "name": "property_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_place_id": {
+          "name": "address_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_county": {
+          "name": "address_county",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_lat": {
+          "name": "address_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_lng": {
+          "name": "address_lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address_geocoded_at": {
+          "name": "address_geocoded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_contact_id": {
+          "name": "client_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_phone": {
+          "name": "client_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'requested'"
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unpaid'"
+        },
+        "referred_by_agent_id": {
+          "name": "referred_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_notes": {
+          "name": "cancel_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_required": {
+          "name": "payment_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "agreement_required": {
+          "name": "agreement_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_sign_on_publish": {
+          "name": "auto_sign_on_publish",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "discount_code_id": {
+          "name": "discount_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount_cents": {
+          "name": "discount_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "closing_date": {
+          "name": "closing_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sqft": {
+          "name": "sqft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "foundation_type": {
+          "name": "foundation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lot_size": {
+          "name": "lot_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_facts": {
+          "name": "property_facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_photo_id": {
+          "name": "cover_photo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_crop": {
+          "name": "cover_crop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image_key": {
+          "name": "cover_image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_subtype": {
+          "name": "commercial_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "county": {
+          "name": "county",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selling_agent_id": {
+          "name": "selling_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_automations": {
+          "name": "disable_automations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "message_token": {
+          "name": "message_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_snapshot": {
+          "name": "template_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_snapshot_version": {
+          "name": "template_snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "report_theme_override": {
+          "name": "report_theme_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_defect_fields_override": {
+          "name": "require_defect_fields_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concierge_status": {
+          "name": "concierge_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_mode": {
+          "name": "team_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "lead_inspector_id": {
+          "name": "lead_inspector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "helper_inspector_ids": {
+          "name": "helper_inspector_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "data_version": {
+          "name": "data_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "source_inspection_id": {
+          "name": "source_inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_inspection_id": {
+          "name": "root_inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reinspection_round": {
+          "name": "reinspection_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspections_msg_token": {
+          "name": "idx_inspections_msg_token",
+          "columns": [
+            "message_token"
+          ],
+          "isUnique": true
+        },
+        "idx_inspections_tenant": {
+          "name": "idx_inspections_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_request": {
+          "name": "idx_inspections_request",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_inspector": {
+          "name": "idx_inspections_inspector",
+          "columns": [
+            "inspector_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_agent": {
+          "name": "idx_inspections_agent",
+          "columns": [
+            "referred_by_agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_tenant_status": {
+          "name": "idx_inspections_tenant_status",
+          "columns": [
+            "tenant_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_tenant_date": {
+          "name": "idx_inspections_tenant_date",
+          "columns": [
+            "tenant_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_tenant_client_email": {
+          "name": "idx_inspections_tenant_client_email",
+          "columns": [
+            "tenant_id",
+            "client_email"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_inspector_date": {
+          "name": "idx_inspections_inspector_date",
+          "columns": [
+            "inspector_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inspections_root": {
+          "name": "idx_inspections_root",
+          "columns": [
+            "root_inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inspections_tenant_id_tenants_id_fk": {
+          "name": "inspections_tenant_id_tenants_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_inspector_id_users_id_fk": {
+          "name": "inspections_inspector_id_users_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_template_id_templates_id_fk": {
+          "name": "inspections_template_id_templates_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_discount_code_id_discount_codes_id_fk": {
+          "name": "inspections_discount_code_id_discount_codes_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "discount_codes",
+          "columnsFrom": [
+            "discount_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_selling_agent_id_contacts_id_fk": {
+          "name": "inspections_selling_agent_id_contacts_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "selling_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspections_request_id_inspection_requests_id_fk": {
+          "name": "inspections_request_id_inspection_requests_id_fk",
+          "tableFrom": "inspections",
+          "tableTo": "inspection_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_email": {
+          "name": "client_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "line_items": {
+          "name": "line_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "partial_paid_at": {
+          "name": "partial_paid_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qbo_sync_status": {
+          "name": "qbo_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_invoices_tenant": {
+          "name": "idx_invoices_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_inspection": {
+          "name": "idx_invoices_inspection",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_invoices_contact": {
+          "name": "idx_invoices_contact",
+          "columns": [
+            "tenant_id",
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invoices_tenant_id_tenants_id_fk": {
+          "name": "invoices_tenant_id_tenants_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_inspection_id_inspections_id_fk": {
+          "name": "invoices_inspection_id_inspections_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_contact_id_contacts_id_fk": {
+          "name": "invoices_contact_id_contacts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "marketplace_libraries": {
+      "name": "marketplace_libraries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "semver": {
+          "name": "semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_marketplace_libraries_kind_featured": {
+          "name": "idx_marketplace_libraries_kind_featured",
+          "columns": [
+            "kind",
+            "featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "marketplace_templates": {
+      "name": "marketplace_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "semver": {
+          "name": "semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "observer_links": {
+      "name": "observer_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "observer_links_token_unique": {
+          "name": "observer_links_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "observer_links_inspection_idx": {
+          "name": "observer_links_inspection_idx",
+          "columns": [
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_observer_links_token_hash": {
+          "name": "idx_observer_links_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "qbo_connections": {
+      "name": "qbo_connections",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_enabled": {
+          "name": "sync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "default_item_id": {
+          "name": "default_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "qbo_entity_map": {
+      "name": "qbo_entity_map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_type": {
+          "name": "oi_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_id": {
+          "name": "oi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qbo_type": {
+          "name": "qbo_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qbo_id": {
+          "name": "qbo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "qbo_sync_token": {
+          "name": "qbo_sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_qbo_entity_map_qbo": {
+          "name": "idx_qbo_entity_map_qbo",
+          "columns": [
+            "tenant_id",
+            "qbo_type",
+            "qbo_id"
+          ],
+          "isUnique": true
+        },
+        "idx_qbo_entity_map_oi": {
+          "name": "idx_qbo_entity_map_oi",
+          "columns": [
+            "tenant_id",
+            "oi_type",
+            "oi_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "qbo_sync_errors": {
+      "name": "qbo_sync_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_type": {
+          "name": "oi_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oi_id": {
+          "name": "oi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rating_systems": {
+      "name": "rating_systems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "levels": {
+          "name": "levels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rating_systems_tenant_slug": {
+          "name": "idx_rating_systems_tenant_slug",
+          "columns": [
+            "tenant_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_rating_systems_tenant": {
+          "name": "idx_rating_systems_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rating_systems_tenant_id_tenants_id_fk": {
+          "name": "rating_systems_tenant_id_tenants_id_fk",
+          "tableFrom": "rating_systems",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repair_request_items": {
+      "name": "repair_request_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repair_request_id": {
+          "name": "repair_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_label": {
+          "name": "item_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_snapshot": {
+          "name": "comment_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_credit_cents": {
+          "name": "requested_credit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_repair_request_items_rr": {
+          "name": "idx_repair_request_items_rr",
+          "columns": [
+            "repair_request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repair_requests": {
+      "name": "repair_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_kind": {
+          "name": "created_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_ref": {
+          "name": "created_by_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_intro": {
+          "name": "custom_intro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_repair_requests_inspection": {
+          "name": "idx_repair_requests_inspection",
+          "columns": [
+            "tenant_id",
+            "inspection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_repair_requests_share_token": {
+          "name": "idx_repair_requests_share_token",
+          "columns": [
+            "share_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_pdfs": {
+      "name": "report_pdfs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rendered_at": {
+          "name": "rendered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_report_pdfs_inspection_type": {
+          "name": "uq_report_pdfs_inspection_type",
+          "columns": [
+            "inspection_id",
+            "type",
+            "version_number"
+          ],
+          "isUnique": true
+        },
+        "idx_report_pdfs_tenant": {
+          "name": "idx_report_pdfs_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_report_pdfs_status": {
+          "name": "idx_report_pdfs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_report_pdfs_content_hash": {
+          "name": "idx_report_pdfs_content_hash",
+          "columns": [
+            "inspection_id",
+            "type",
+            "content_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "report_pdfs_tenant_id_tenants_id_fk": {
+          "name": "report_pdfs_tenant_id_tenants_id_fk",
+          "tableFrom": "report_pdfs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "report_versions": {
+      "name": "report_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prev_hash": {
+          "name": "prev_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_fingerprint": {
+          "name": "key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_amendment": {
+          "name": "is_amendment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "report_versions_inspection_idx": {
+          "name": "report_versions_inspection_idx",
+          "columns": [
+            "inspection_id",
+            "version_number"
+          ],
+          "isUnique": false
+        },
+        "report_versions_inspection_version_unique": {
+          "name": "report_versions_inspection_version_unique",
+          "columns": [
+            "inspection_id",
+            "version_number"
+          ],
+          "isUnique": true
+        },
+        "idx_report_versions_verify_token": {
+          "name": "idx_report_versions_verify_token",
+          "columns": [
+            "verification_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_inspectors": {
+      "name": "service_inspectors",
+      "columns": {
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_service_inspectors_tenant": {
+          "name": "idx_service_inspectors_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "service_inspectors_service_id_user_id_pk": {
+          "columns": [
+            "service_id",
+            "user_id"
+          ],
+          "name": "service_inspectors_service_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_services_tenant": {
+          "name": "idx_services_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "services_tenant_id_tenants_id_fk": {
+          "name": "services_tenant_id_tenants_id_fk",
+          "tableFrom": "services",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_template_id_templates_id_fk": {
+          "name": "services_template_id_templates_id_fk",
+          "tableFrom": "services",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_agreement_id_agreements_id_fk": {
+          "name": "services_agreement_id_agreements_id_fk",
+          "tableFrom": "services",
+          "tableTo": "agreements",
+          "columnsFrom": [
+            "agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "signing_keys": {
+      "name": "signing_keys",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_enc": {
+          "name": "private_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key_iv": {
+          "name": "private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Ed25519'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signing_keys_tenant_id_tenants_id_fk": {
+          "name": "signing_keys_tenant_id_tenants_id_fk",
+          "tableFrom": "signing_keys",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sms_consent_log": {
+      "name": "sms_consent_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_type": {
+          "name": "recipient_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_via": {
+          "name": "captured_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sms_consent_contact": {
+          "name": "idx_sms_consent_contact",
+          "columns": [
+            "tenant_id",
+            "contact_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sms_disclosure_versions": {
+      "name": "sms_disclosure_versions",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_tenant_name": {
+          "name": "idx_tags_tenant_name",
+          "columns": [
+            "tenant_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_tags_tenant": {
+          "name": "idx_tags_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "templates": {
+      "name": "templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_system_id": {
+          "name": "rating_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commercial_subtype": {
+          "name": "commercial_subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_templates_tenant": {
+          "name": "idx_templates_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_templates_rating_system": {
+          "name": "idx_templates_rating_system",
+          "columns": [
+            "rating_system_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "templates_tenant_id_tenants_id_fk": {
+          "name": "templates_tenant_id_tenants_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_library_imports": {
+      "name": "tenant_library_imports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_semver": {
+          "name": "imported_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_tenant_library_import": {
+          "name": "uq_tenant_library_import",
+          "columns": [
+            "tenant_id",
+            "library_id"
+          ],
+          "isUnique": true
+        },
+        "idx_tenant_library_imports_tenant": {
+          "name": "idx_tenant_library_imports_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_marketplace_import_history": {
+      "name": "tenant_marketplace_import_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_version": {
+          "name": "target_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rows_affected": {
+          "name": "rows_affected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_marketplace_history_tenant": {
+          "name": "idx_marketplace_history_tenant",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_marketplace_history_template": {
+          "name": "idx_marketplace_history_template",
+          "columns": [
+            "template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_marketplace_history_library": {
+          "name": "idx_marketplace_history_library",
+          "columns": [
+            "library_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_marketplace_imports": {
+      "name": "tenant_marketplace_imports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_template_id": {
+          "name": "marketplace_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_semver": {
+          "name": "imported_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_template_id": {
+          "name": "local_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mkt_imports_tmpl": {
+          "name": "idx_mkt_imports_tmpl",
+          "columns": [
+            "marketplace_template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mkt_imports_tenant": {
+          "name": "idx_mkt_imports_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tenant_marketplace_imports_marketplace_template_id_marketplace_templates_id_fk": {
+          "name": "tenant_marketplace_imports_marketplace_template_id_marketplace_templates_id_fk",
+          "tableFrom": "tenant_marketplace_imports",
+          "tableTo": "marketplace_templates",
+          "columnsFrom": [
+            "marketplace_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tenant_marketplace_imports_local_template_id_templates_id_fk": {
+          "name": "tenant_marketplace_imports_local_template_id_templates_id_fk",
+          "tableFrom": "tenant_marketplace_imports",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "local_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_counters": {
+      "name": "usage_counters",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_usage_counters_tenant": {
+          "name": "idx_usage_counters_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_counters_tenant_id_metric_period_key_pk": {
+          "columns": [
+            "tenant_id",
+            "metric",
+            "period_key"
+          ],
+          "name": "usage_counters_tenant_id_metric_period_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_identity_links": {
+      "name": "user_identity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_user_id": {
+          "name": "primary_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_tenant_id": {
+          "name": "linked_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_role": {
+          "name": "linked_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_display_name": {
+          "name": "linked_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "user_identity_links_primary_idx": {
+          "name": "user_identity_links_primary_idx",
+          "columns": [
+            "primary_user_id"
+          ],
+          "isUnique": false
+        },
+        "user_identity_links_primary_linked_unique": {
+          "name": "user_identity_links_primary_linked_unique",
+          "columns": [
+            "primary_user_id",
+            "linked_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_invites": {
+      "name": "agent_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_contact_id": {
+          "name": "inspector_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_invites_email": {
+          "name": "idx_agent_invites_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_invites_tenant": {
+          "name": "idx_agent_invites_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_invites_expiration": {
+          "name": "idx_agent_invites_expiration",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_invites_tenant_id_tenants_id_fk": {
+          "name": "agent_invites_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_invites",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_invites_invited_by_user_id_users_id_fk": {
+          "name": "agent_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "agent_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_tenant_links": {
+      "name": "agent_tenant_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_user_id": {
+          "name": "agent_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_contact_id": {
+          "name": "inspector_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agent_tenant_unique": {
+          "name": "idx_agent_tenant_unique",
+          "columns": [
+            "agent_user_id",
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "idx_agent_tenant_by_tenant": {
+          "name": "idx_agent_tenant_by_tenant",
+          "columns": [
+            "tenant_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_agent_tenant_by_agent": {
+          "name": "idx_agent_tenant_by_agent",
+          "columns": [
+            "agent_user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_tenant_links_agent_user_id_users_id_fk": {
+          "name": "agent_tenant_links_agent_user_id_users_id_fk",
+          "tableFrom": "agent_tenant_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "agent_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_tenant_links_tenant_id_tenants_id_fk": {
+          "name": "agent_tenant_links_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_tenant_links",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_slug": {
+          "name": "inspector_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_tenant_created": {
+          "name": "idx_audit_tenant_created",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_entity": {
+          "name": "idx_audit_entity",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_tenant_id_tenants_id_fk": {
+          "name": "audit_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_templates": {
+      "name": "email_templates",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_templates_tenant_id_tenants_id_fk": {
+          "name": "email_templates_tenant_id_tenants_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_templates_tenant_id_trigger_pk": {
+          "columns": [
+            "tenant_id",
+            "trigger"
+          ],
+          "name": "email_templates_tenant_id_trigger_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_tenant_user_created": {
+          "name": "idx_notifications_tenant_user_created",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_notifications_tenant_user_unread": {
+          "name": "idx_notifications_tenant_user_unread",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_tenant_id_tenants_id_fk": {
+          "name": "notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "parked_cmd_events": {
+      "name": "parked_cmd_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_parked_cmd_events_received_at": {
+          "name": "idx_parked_cmd_events_received_at",
+          "columns": [
+            "received_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_cmd_events": {
+      "name": "processed_cmd_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cmd_type": {
+          "name": "cmd_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slug_reservations": {
+      "name": "slug_reservations",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_outbox": {
+      "name": "sync_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_tried_at": {
+          "name": "last_tried_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sync_outbox_status_created": {
+          "name": "idx_sync_outbox_status_created",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_configs": {
+      "name": "tenant_configs",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_mode": {
+          "name": "email_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'platform'"
+        },
+        "sms_mode": {
+          "name": "sms_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'platform'"
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_inspector_from_name": {
+          "name": "use_inspector_from_name",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "point_of_contact": {
+          "name": "point_of_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'company'"
+        },
+        "billing_url": {
+          "name": "billing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "company_phone": {
+          "name": "company_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "integration_config": {
+          "name": "integration_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dek_enc": {
+          "name": "dek_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ics_token": {
+          "name": "ics_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "widget_allowed_origins": {
+          "name": "widget_allowed_origins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_theme": {
+          "name": "report_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'modern'"
+        },
+        "attention_thresholds": {
+          "name": "attention_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"agreement_unsigned_h\":72,\"invoice_overdue_h\":72,\"report_unpublished_h\":72}'"
+        },
+        "inspection_prefs": {
+          "name": "inspection_prefs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_estimates": {
+          "name": "show_estimates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_repair_list": {
+          "name": "enable_repair_list",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_customer_repair_export": {
+          "name": "enable_customer_repair_export",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "block_unpaid": {
+          "name": "block_unpaid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "block_unsigned_agreement": {
+          "name": "block_unsigned_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "custom_referral_sources": {
+          "name": "custom_referral_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dashboard_column_prefs": {
+          "name": "dashboard_column_prefs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concierge_review_required": {
+          "name": "concierge_review_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_inspector_choice": {
+          "name": "allow_inspector_choice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_pdf_pipeline": {
+          "name": "enable_pdf_pipeline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "team_mode_default": {
+          "name": "team_mode_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "apprentice_review_required": {
+          "name": "apprentice_review_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guest_invites_enabled": {
+          "name": "guest_invites_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "require_defect_fields": {
+          "name": "require_defect_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "agreement_retention_years": {
+          "name": "agreement_retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "reinspection_statuses": {
+          "name": "reinspection_statuses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tenant_configs_tenant_id_tenants_id_fk": {
+          "name": "tenant_configs_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_configs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_destruction_records": {
+      "name": "tenant_destruction_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_slug": {
+          "name": "tenant_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rows_deleted": {
+          "name": "rows_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_objects": {
+          "name": "r2_objects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_bytes": {
+          "name": "r2_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kv_keys": {
+          "name": "kv_keys",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_destruction_tenant": {
+          "name": "idx_destruction_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_destruction_destroyed_at": {
+          "name": "idx_destruction_destroyed_at",
+          "columns": [
+            "destroyed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_invites": {
+      "name": "tenant_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inspector'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_section_ids": {
+          "name": "assigned_section_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_overrides": {
+          "name": "permission_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_invites_tenant": {
+          "name": "idx_invites_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "uq_tenant_invites_pending_email": {
+          "name": "uq_tenant_invites_pending_email",
+          "columns": [
+            "tenant_id",
+            "email"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'"
+        }
+      },
+      "foreignKeys": {
+        "tenant_invites_tenant_id_tenants_id_fk": {
+          "name": "tenant_invites_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_invites",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenants": {
+      "name": "tenants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "stripe_connect_account_id": {
+          "name": "stripe_connect_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "max_users": {
+          "name": "max_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "deployment_mode": {
+          "name": "deployment_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "nachi_number": {
+          "name": "nachi_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_cmd_seq": {
+          "name": "applied_cmd_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "applied_cred_seq": {
+          "name": "applied_cred_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_signature_base64": {
+          "name": "default_signature_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signature_enabled": {
+          "name": "signature_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_areas": {
+          "name": "service_areas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manager'"
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_calendar_id": {
+          "name": "google_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_state": {
+          "name": "onboarding_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "totp_recovery_codes": {
+          "name": "totp_recovery_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_verified_at": {
+          "name": "totp_verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_on_referral": {
+          "name": "notify_on_referral",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_on_report": {
+          "name": "notify_on_report",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_on_paid": {
+          "name": "notify_on_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_section_ids": {
+          "name": "assigned_section_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terms_accepted": {
+          "name": "terms_accepted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_overrides": {
+          "name": "permission_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "users_tenant_email_unique": {
+          "name": "users_tenant_email_unique",
+          "columns": [
+            "tenant_id",
+            "email"
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL"
+        },
+        "idx_users_tenant": {
+          "name": "idx_users_tenant",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_users_slug_per_tenant": {
+          "name": "idx_users_slug_per_tenant",
+          "columns": [
+            "tenant_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "client_uploads": {
+      "name": "client_uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_by_kind": {
+          "name": "uploaded_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_by_ref": {
+          "name": "uploaded_by_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_by_name": {
+          "name": "uploaded_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_client_uploads_inspection": {
+          "name": "idx_client_uploads_inspection",
+          "columns": [
+            "tenant_id",
+            "inspection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "discount_codes_code_tenant": {
+        "columns": {
+          "upper(code)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1781569411887,
       "tag": "0008_repair_requests",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1781600028877,
+      "tag": "0009_client_uploads",
+      "breakpoints": true
     }
   ]
 }

--- a/server/api/client-documents.ts
+++ b/server/api/client-documents.ts
@@ -26,7 +26,7 @@ import type { HonoConfig } from '../types/hono';
 import { resolvePortalAccess } from '../lib/public-access';
 import { verifyPortalSession } from '../lib/portal-session';
 import { contentDisposition } from '../lib/content-disposition';
-import { MAX_BYTES } from '../services/client-document.service';
+import { MAX_BYTES, PayloadTooLargeError } from '../services/client-document.service';
 import { DOCUMENT_CATEGORIES } from '../lib/db/schema';
 
 interface ClientActor {
@@ -97,7 +97,8 @@ clientDocumentsRoutes.put('/inspections/:id/documents', async (c) => {
             c.req.raw.body!,
         );
         return c.json({ data: { id: row.id, filename: row.filename, sizeBytes: row.sizeBytes, category: row.category } });
-    } catch {
+    } catch (err) {
+        if (err instanceof PayloadTooLargeError) return c.json({ error: 'File exceeds 100 MB.' }, 413);
         return c.json({ error: 'Upload rejected.' }, 400);
     }
 });
@@ -119,7 +120,7 @@ clientDocumentsRoutes.get('/inspections/:id/documents', async (c) => {
             createdAt: u.createdAt,
             uploadedByKind: u.uploadedByKind,
             uploadedByName: u.uploadedByName,
-            uploadedByRef: u.uploadedByRef,
+            isOwn: u.uploadedByRef === actor.ref,
             visibility: u.visibility,
             label: u.label,
         }));

--- a/server/api/client-documents.ts
+++ b/server/api/client-documents.ts
@@ -27,7 +27,7 @@ import { resolvePortalAccess } from '../lib/public-access';
 import { verifyPortalSession } from '../lib/portal-session';
 import { contentDisposition } from '../lib/content-disposition';
 import { MAX_BYTES, PayloadTooLargeError } from '../services/client-document.service';
-import { DOCUMENT_CATEGORIES } from '../lib/db/schema';
+import { DOCUMENT_CATEGORIES, DOCUMENT_VISIBILITIES } from '../lib/db/schema';
 
 interface ClientActor {
     tenantId: string;
@@ -168,3 +168,131 @@ clientDocumentsRoutes.delete('/inspections/:id/documents/:docId', async (c) => {
 
 export type ClientDocumentsApi = typeof clientDocumentsRoutes;
 export default clientDocumentsRoutes;
+
+// ---------------------------------------------------------------------------
+// Authed INSPECTOR document routes (unified client portal, section ⑦ — staff
+// side). Same streaming operations as the client routes, but the actor is the
+// authenticated inspector (kind='inspector', ref=userId). Mounted under
+// `/api/inspections` BEHIND the global jwtAuthMiddleware (everything under
+// `/api/inspections/*` not in the isPublic allowlist is authed by default), so
+// the JWT context (`tenantId` + `user.sub`) is already populated here.
+//
+// Differences vs the client routes:
+//   - list returns ALL rows (no visibility filter) — inspector sees everything.
+//   - upload accepts a `visibility` query param (default 'client_visible').
+//   - download has no visibility gate.
+//   - delete allows ANY row in the tenant + inspection (not just own uploads).
+// ---------------------------------------------------------------------------
+
+const inspectorUploadQuerySchema = z.object({
+    filename: z.string().min(1),
+    category: z.enum(DOCUMENT_CATEGORIES),
+    label: z.string().optional(),
+    visibility: z.enum(DOCUMENT_VISIBILITIES).optional().default('client_visible'),
+});
+
+/** Resolve the authed inspector identity from JWT context. null → 401. */
+function resolveInspectorActor(c: Context<HonoConfig>): { tenantId: string; userId: string; name: string | null } | null {
+    const tenantId = c.get('tenantId');
+    const userId = (c.get('user') as { sub?: string } | undefined)?.sub;
+    if (!tenantId || !userId) return null;
+    // The JWT carries no display-name claim; routes that need it look it up.
+    return { tenantId, userId, name: null };
+}
+
+const inspectorDocumentsRoutes = new Hono<HonoConfig>();
+
+// PUT /api/inspections/:id/documents — streaming upload (inspector).
+inspectorDocumentsRoutes.put('/:id/documents', async (c) => {
+    const inspectionId = c.req.param('id');
+    const parsed = inspectorUploadQuerySchema.safeParse({
+        filename: c.req.query('filename'),
+        category: c.req.query('category'),
+        label: c.req.query('label'),
+        visibility: c.req.query('visibility'),
+    });
+    if (!parsed.success) return c.json({ error: 'Invalid upload parameters.' }, 400);
+
+    const actor = resolveInspectorActor(c);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const len = Number(c.req.header('content-length') ?? '0');
+    if (len > MAX_BYTES) return c.json({ error: 'File exceeds 100 MB.' }, 413);
+
+    const contentType = c.req.header('content-type') ?? 'application/octet-stream';
+    const { filename, category, label, visibility } = parsed.data;
+
+    try {
+        const row = await c.var.services.clientDocument.create(
+            actor.tenantId,
+            inspectionId,
+            { kind: 'inspector', ref: actor.userId, name: actor.name },
+            { filename, contentType, category, visibility, label: label ?? null, sizeBytes: len },
+            c.req.raw.body!,
+        );
+        return c.json({ data: { id: row.id, filename: row.filename, sizeBytes: row.sizeBytes, category: row.category, visibility: row.visibility } });
+    } catch (err) {
+        if (err instanceof PayloadTooLargeError) return c.json({ error: 'File exceeds 100 MB.' }, 413);
+        return c.json({ error: 'Upload rejected.' }, 400);
+    }
+});
+
+// GET /api/inspections/:id/documents — list ALL docs (inspector, no filter).
+inspectorDocumentsRoutes.get('/:id/documents', async (c) => {
+    const inspectionId = c.req.param('id');
+    const actor = resolveInspectorActor(c);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const all = await c.var.services.clientDocument.list(actor.tenantId, inspectionId);
+    const data = all.map((u) => ({
+        id: u.id,
+        filename: u.filename,
+        category: u.category,
+        sizeBytes: u.sizeBytes,
+        createdAt: u.createdAt,
+        uploadedByKind: u.uploadedByKind,
+        uploadedByName: u.uploadedByName,
+        uploadedByRef: u.uploadedByRef,
+        visibility: u.visibility,
+        label: u.label,
+    }));
+    return c.json({ data });
+});
+
+// GET /api/inspections/:id/documents/:docId — download (inspector, no gate).
+inspectorDocumentsRoutes.get('/:id/documents/:docId', async (c) => {
+    const inspectionId = c.req.param('id');
+    const docId = c.req.param('docId');
+    const actor = resolveInspectorActor(c);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const row = await c.var.services.clientDocument.get(actor.tenantId, docId);
+    if (!row || row.inspectionId !== inspectionId) return c.json({ error: 'Not found' }, 404);
+    const obj = await c.var.services.clientDocument.getObject(row.r2Key);
+    if (!obj) return c.json({ error: 'Not found' }, 404);
+
+    return new Response(obj.body, {
+        headers: {
+            'Content-Type': row.contentType || 'application/octet-stream',
+            'Content-Disposition': contentDisposition(row.filename, true, 'document'),
+            'X-Content-Type-Options': 'nosniff',
+        },
+    });
+});
+
+// DELETE /api/inspections/:id/documents/:docId — delete ANY row (inspector).
+inspectorDocumentsRoutes.delete('/:id/documents/:docId', async (c) => {
+    const inspectionId = c.req.param('id');
+    const docId = c.req.param('docId');
+    const actor = resolveInspectorActor(c);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const row = await c.var.services.clientDocument.get(actor.tenantId, docId);
+    if (!row || row.inspectionId !== inspectionId) return c.json({ error: 'Not found' }, 404);
+
+    await c.var.services.clientDocument.remove(actor.tenantId, docId);
+    return c.json({ data: { ok: true } });
+});
+
+export type InspectorDocumentsApi = typeof inspectorDocumentsRoutes;
+export { inspectorDocumentsRoutes };

--- a/server/api/client-documents.ts
+++ b/server/api/client-documents.ts
@@ -1,0 +1,169 @@
+/**
+ * Client-facing public document routes (unified client portal, section ⑦).
+ *
+ * Streaming upload / list / download / delete of inspection documents for the
+ * CLIENT side. Gated by EITHER:
+ *   - the unified-portal session cookie `__Host-portal_session` (verified here,
+ *     because the portal session middleware only runs on `/api/portal/*` — NOT
+ *     on `/api/public/*`), resolved to a live grant via
+ *     PortalAccessService.resolveByEmailAndInspection, OR
+ *   - a per-inspection `?token=` (the persistent per-recipient portal token),
+ *     resolved via resolvePortalAccess.
+ *
+ * These are RAW-STREAM routes (the PUT body is `c.req.raw.body`), so they use a
+ * plain Hono router with `app.put/get/delete` rather than OpenAPIHono
+ * `createRoute()` — query validation is `zod.safeParse` per the CLAUDE.md
+ * workaround-route rule.
+ *
+ * The global JWT middleware skips `/api/public/*` (server/index.ts isPublic
+ * allowlist), so authentication is performed entirely inside `resolveClientActor`.
+ */
+import { Hono } from 'hono';
+import { getCookie } from 'hono/cookie';
+import { z } from 'zod';
+import type { Context } from 'hono';
+import type { HonoConfig } from '../types/hono';
+import { resolvePortalAccess } from '../lib/public-access';
+import { verifyPortalSession } from '../lib/portal-session';
+import { contentDisposition } from '../lib/content-disposition';
+import { MAX_BYTES } from '../services/client-document.service';
+import { DOCUMENT_CATEGORIES } from '../lib/db/schema';
+
+interface ClientActor {
+    tenantId: string;
+    kind: 'client' | 'co_client';
+    ref: string;          // recipient email (uploader identity)
+    name: string | null;
+}
+
+/**
+ * Resolve the acting CLIENT for this request. Token path first (URL ?token),
+ * then session-cookie path. Only `client` / `co_client` roles are accepted
+ * (agents are NOT document uploaders here). Returns null → caller 401.
+ */
+async function resolveClientActor(
+    c: Context<HonoConfig>,
+    inspectionId: string,
+): Promise<ClientActor | null> {
+    const token = c.req.query('token');
+    const grant = await resolvePortalAccess(c.var.services.portalAccess, token, inspectionId);
+    if (grant && (grant.role === 'client' || grant.role === 'co_client')) {
+        return { tenantId: grant.tenantId, kind: grant.role, ref: grant.recipientEmail, name: null };
+    }
+    const cookie = getCookie(c, '__Host-portal_session');
+    const sess = cookie ? await verifyPortalSession(c.env.JWT_SECRET, cookie) : null;
+    if (sess) {
+        const row = await c.var.services.portalAccess.resolveByEmailAndInspection(sess.email, inspectionId);
+        if (row && (row.role === 'client' || row.role === 'co_client')) {
+            return { tenantId: row.tenantId, kind: row.role, ref: sess.email, name: null };
+        }
+    }
+    return null;
+}
+
+const uploadQuerySchema = z.object({
+    filename: z.string().min(1),
+    category: z.enum(DOCUMENT_CATEGORIES),
+    label: z.string().optional(),
+});
+
+const clientDocumentsRoutes = new Hono<HonoConfig>();
+
+// PUT /api/public/inspections/:id/documents — streaming upload.
+clientDocumentsRoutes.put('/inspections/:id/documents', async (c) => {
+    const inspectionId = c.req.param('id');
+    const parsed = uploadQuerySchema.safeParse({
+        filename: c.req.query('filename'),
+        category: c.req.query('category'),
+        label: c.req.query('label'),
+    });
+    if (!parsed.success) return c.json({ error: 'Invalid upload parameters.' }, 400);
+
+    const actor = await resolveClientActor(c, inspectionId);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const len = Number(c.req.header('content-length') ?? '0');
+    if (len > MAX_BYTES) return c.json({ error: 'File exceeds 100 MB.' }, 413);
+
+    const contentType = c.req.header('content-type') ?? 'application/octet-stream';
+    const { filename, category, label } = parsed.data;
+
+    try {
+        const row = await c.var.services.clientDocument.create(
+            actor.tenantId,
+            inspectionId,
+            { kind: actor.kind, ref: actor.ref, name: actor.name },
+            { filename, contentType, category, visibility: 'client_visible', label: label ?? null, sizeBytes: len },
+            c.req.raw.body!,
+        );
+        return c.json({ data: { id: row.id, filename: row.filename, sizeBytes: row.sizeBytes, category: row.category } });
+    } catch {
+        return c.json({ error: 'Upload rejected.' }, 400);
+    }
+});
+
+// GET /api/public/inspections/:id/documents — list (client-visible only).
+clientDocumentsRoutes.get('/inspections/:id/documents', async (c) => {
+    const inspectionId = c.req.param('id');
+    const actor = await resolveClientActor(c, inspectionId);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const all = await c.var.services.clientDocument.list(actor.tenantId, inspectionId);
+    const data = all
+        .filter((u) => u.uploadedByKind !== 'inspector' || u.visibility === 'client_visible')
+        .map((u) => ({
+            id: u.id,
+            filename: u.filename,
+            category: u.category,
+            sizeBytes: u.sizeBytes,
+            createdAt: u.createdAt,
+            uploadedByKind: u.uploadedByKind,
+            uploadedByName: u.uploadedByName,
+            uploadedByRef: u.uploadedByRef,
+            visibility: u.visibility,
+            label: u.label,
+        }));
+    return c.json({ data });
+});
+
+// GET /api/public/inspections/:id/documents/:docId — download (attachment).
+clientDocumentsRoutes.get('/inspections/:id/documents/:docId', async (c) => {
+    const inspectionId = c.req.param('id');
+    const docId = c.req.param('docId');
+    const actor = await resolveClientActor(c, inspectionId);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const row = await c.var.services.clientDocument.get(actor.tenantId, docId);
+    if (!row || row.inspectionId !== inspectionId
+        || (row.uploadedByKind === 'inspector' && row.visibility === 'internal')) {
+        return c.json({ error: 'Not found' }, 404);
+    }
+    const obj = await c.var.services.clientDocument.getObject(row.r2Key);
+    if (!obj) return c.json({ error: 'Not found' }, 404);
+
+    return new Response(obj.body, {
+        headers: {
+            'Content-Type': row.contentType || 'application/octet-stream',
+            'Content-Disposition': contentDisposition(row.filename, true, 'document'),
+            'X-Content-Type-Options': 'nosniff',
+        },
+    });
+});
+
+// DELETE /api/public/inspections/:id/documents/:docId — delete own upload only.
+clientDocumentsRoutes.delete('/inspections/:id/documents/:docId', async (c) => {
+    const inspectionId = c.req.param('id');
+    const docId = c.req.param('docId');
+    const actor = await resolveClientActor(c, inspectionId);
+    if (!actor) return c.json({ error: 'Unauthorized' }, 401);
+
+    const row = await c.var.services.clientDocument.get(actor.tenantId, docId);
+    if (!row || row.inspectionId !== inspectionId) return c.json({ error: 'Not found' }, 404);
+    if (row.uploadedByRef !== actor.ref) return c.json({ error: 'Forbidden' }, 403);
+
+    await c.var.services.clientDocument.remove(actor.tenantId, docId);
+    return c.json({ data: { ok: true } });
+});
+
+export type ClientDocumentsApi = typeof clientDocumentsRoutes;
+export default clientDocumentsRoutes;

--- a/server/index.ts
+++ b/server/index.ts
@@ -85,7 +85,7 @@ import tagsRoutes, { inspectionTagRoutes } from './api/tags';
 import publicSlugRoutes from './api/public-slug';
 import publicShareRoutes from './api/public-share';
 import publicReportRoutes from './api/public-report';
-import clientDocumentsRoutes from './api/client-documents';
+import clientDocumentsRoutes, { inspectorDocumentsRoutes } from './api/client-documents';
 import profileRoutes from './api/profile';
 import conciergeRoutes from './api/concierge';
 import sessionContextRoutes from './api/session-context';
@@ -448,6 +448,10 @@ const routes = app
   // so the URL carries inspection id + item id directly. Mounted before the
   // generic inspection routes finish registering so OpenAPI catches both.
   .route('/api/inspections', inspectionTagRoutes)
+  // Unified client portal ⑦ — authed INSPECTOR document routes. Shares the
+  // /api/inspections root (paths are /:id/documents). Behind the global JWT
+  // gate by default (/api/inspections/* is not in the isPublic allowlist).
+  .route('/api/inspections', inspectorDocumentsRoutes)
   .route('/api/tags', tagsRoutes)
   .route('/api/inspection-requests', inspectionRequestsRoutes)
   .route('/api/ai', aiRoutes)

--- a/server/index.ts
+++ b/server/index.ts
@@ -85,6 +85,7 @@ import tagsRoutes, { inspectionTagRoutes } from './api/tags';
 import publicSlugRoutes from './api/public-slug';
 import publicShareRoutes from './api/public-share';
 import publicReportRoutes from './api/public-report';
+import clientDocumentsRoutes from './api/client-documents';
 import profileRoutes from './api/profile';
 import conciergeRoutes from './api/concierge';
 import sessionContextRoutes from './api/session-context';
@@ -465,6 +466,10 @@ const routes = app
   .route('/api/public', repairBuilderRoutes)
   // UC-C-7 — public share-token mint (customer Forward report flow).
   .route('/api/public', publicShareRoutes)
+  // Unified client portal ⑦ — client document streaming upload/list/download/delete
+  // (router defines /inspections/:id/documents). Session- OR token-gated; the
+  // global JWT middleware skips /api/public/* so auth is performed in-route.
+  .route('/api/public', clientDocumentsRoutes)
   // Track L (D6/D9) — public SMS opt-in resolve/confirm + inbound STOP/START webhook.
   .route('/api/public', smsPublicRoutes)
   // Unified client portal — magic-link request/redeem + session-gated data routes.

--- a/server/lib/content-disposition.ts
+++ b/server/lib/content-disposition.ts
@@ -22,11 +22,20 @@ export function sanitizeFilename(name: string | null | undefined, fallback = 'fi
  * named after the original file. Callers flip `download` from a `?download=1`
  * query flag.
  */
+/** RFC 5987 ext-value encoding: percent-encode everything outside the attr-char set. */
+function encodeRfc5987(name: string): string {
+    return encodeURIComponent(name)
+        // encodeURIComponent leaves !'()* — RFC 5987 attr-char forbids them
+        .replace(/['()*!]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+}
+
 export function contentDisposition(
     name: string | null | undefined,
     download: boolean,
     fallback = 'photo',
 ): string {
     const safe = sanitizeFilename(name, fallback);
-    return `${download ? 'attachment' : 'inline'}; filename="${safe}"`;
+    const disp = download ? 'attachment' : 'inline';
+    const star = encodeRfc5987(name && name.trim() ? name : safe);
+    return `${disp}; filename="${safe}"; filename*=UTF-8''${star}`;
 }

--- a/server/lib/db/schema/client-upload.ts
+++ b/server/lib/db/schema/client-upload.ts
@@ -1,0 +1,35 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+
+export const DOCUMENT_CATEGORIES = [
+  'prior_reports', 'plans_drawings', 'environmental',
+  'leases_financials', 'permits_certificates', 'photos', 'other',
+] as const;
+export type DocumentCategory = (typeof DOCUMENT_CATEGORIES)[number];
+
+export const DOCUMENT_VISIBILITIES = ['client_visible', 'internal'] as const;
+export type DocumentVisibility = (typeof DOCUMENT_VISIBILITIES)[number];
+
+export const UPLOADER_KINDS = ['client', 'co_client', 'inspector'] as const;
+export type UploaderKind = (typeof UPLOADER_KINDS)[number];
+
+// Carries BOTH directions despite the client_ prefix (uploaded_by_kind includes 'inspector').
+export const clientUploads = sqliteTable('client_uploads', {
+  id:             text('id').primaryKey(),
+  tenantId:       text('tenant_id').notNull(),
+  inspectionId:   text('inspection_id').notNull(),
+  uploadedByKind: text('uploaded_by_kind', { enum: UPLOADER_KINDS }).notNull(),
+  uploadedByRef:  text('uploaded_by_ref').notNull(),  // client: recipient email; inspector: user id
+  uploadedByName: text('uploaded_by_name'),
+  category:       text('category', { enum: DOCUMENT_CATEGORIES }).notNull(),
+  visibility:     text('visibility', { enum: DOCUMENT_VISIBILITIES }).notNull(),
+  r2Key:          text('r2_key').notNull(),
+  filename:       text('filename').notNull(),         // ORIGINAL name (display + download)
+  contentType:    text('content_type').notNull(),
+  sizeBytes:      integer('size_bytes').notNull(),
+  label:          text('label'),
+  createdAt:      integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+}, (t) => ({
+  idxInspection: index('idx_client_uploads_inspection').on(t.tenantId, t.inspectionId),
+}));
+
+export type ClientUpload = typeof clientUploads.$inferSelect;

--- a/server/lib/db/schema/index.ts
+++ b/server/lib/db/schema/index.ts
@@ -71,3 +71,5 @@ export { usageCounters } from './usage';
 // Repair Request Builder — buyer/agent/inspector negotiation lists per inspection.
 export { repairRequests, repairRequestItems } from './repair-request';
 export type { RepairRequest, RepairRequestItem } from './repair-request';
+// Client documents — bidirectional per-inspection uploads (clients + inspectors).
+export * from './client-upload';

--- a/server/lib/middleware/di.ts
+++ b/server/lib/middleware/di.ts
@@ -50,6 +50,7 @@ import { IdentityService } from '../../services/identity.service';
 import { IntegrationsService } from '../../services/integrations.service';
 import { AnalyticsService } from '../../services/analytics.service';
 import { RepairRequestService } from '../../services/repair-request.service';
+import { ClientDocumentService } from '../../services/client-document.service';
 import { StandaloneProvider } from '../integration/standalone';
 import { PortalProvider } from '../../portal/portal.provider';
 
@@ -353,6 +354,9 @@ export async function diMiddleware(c: Context<HonoConfig>, next: Next) {
                     break;
                 case 'repairRequest':
                     target.repairRequest = new RepairRequestService(c.env.DB);
+                    break;
+                case 'clientDocument':
+                    target.clientDocument = new ClientDocumentService(c.env.DB, c.env.PHOTOS);
                     break;
             }
             return target[prop];

--- a/server/services/client-document.service.ts
+++ b/server/services/client-document.service.ts
@@ -24,6 +24,14 @@ export const ALLOWED_CONTENT_TYPES = new Set([
 
 const extOf = (name: string) => (name.split('.').pop() ?? '').toLowerCase();
 
+/** Thrown when an upload stream exceeds MAX_BYTES mid-stream (maps to HTTP 413). */
+export class PayloadTooLargeError extends Error {
+  constructor(message = 'File exceeds 100 MB.') {
+    super(message);
+    this.name = 'PayloadTooLargeError';
+  }
+}
+
 export interface UploadMeta {
   filename: string;
   contentType: string;
@@ -70,13 +78,49 @@ export class ClientDocumentService {
     this.assertValid({ filename: meta.filename, contentType: meta.contentType, sizeBytes: meta.sizeBytes, currentCount });
     const id = this.genId();
     const r2Key = `uploads/${tenantId}/${inspectionId}/${id}-${sanitizeFilename(meta.filename, 'file')}`;
-    await this.bucket.put(r2Key, body as ReadableStream, { httpMetadata: { contentType: meta.contentType } });
+
+    // Enforce MAX_BYTES against ACTUAL bytes (Content-Length is spoofable). For
+    // non-stream bodies (unit tests) measure byteLength directly; for streams,
+    // count bytes through a TransformStream and abort if the cap is exceeded.
+    let measuredSize: number;
+    if (body instanceof Uint8Array) {
+      measuredSize = body.byteLength;
+      await this.bucket.put(r2Key, body, { httpMetadata: { contentType: meta.contentType } });
+    } else if (body instanceof ArrayBuffer) {
+      measuredSize = body.byteLength;
+      await this.bucket.put(r2Key, body, { httpMetadata: { contentType: meta.contentType } });
+    } else {
+      let total = 0;
+      let overflowed = false;
+      const counter = new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          total += chunk.byteLength;
+          if (total > MAX_BYTES) {
+            overflowed = true;
+            controller.error(new PayloadTooLargeError());
+            return;
+          }
+          controller.enqueue(chunk);
+        },
+      });
+      try {
+        // R2 put is atomic on stream error: if the stream errors mid-flight the
+        // object is NOT persisted. We re-throw PayloadTooLargeError so the route
+        // can map it to 413.
+        await this.bucket.put(r2Key, body.pipeThrough(counter), { httpMetadata: { contentType: meta.contentType } });
+      } catch (err) {
+        if (overflowed || err instanceof PayloadTooLargeError) throw new PayloadTooLargeError();
+        throw err;
+      }
+      measuredSize = total;
+    }
+
     const row = {
       id, tenantId, inspectionId,
       uploadedByKind: by.kind, uploadedByRef: by.ref, uploadedByName: by.name,
       category: meta.category, visibility: meta.visibility,
       r2Key, filename: meta.filename, contentType: meta.contentType,
-      sizeBytes: meta.sizeBytes, label: meta.label,
+      sizeBytes: measuredSize, label: meta.label,
       createdAt: new Date(this.now()),
     };
     await this.db().insert(clientUploads).values(row);

--- a/server/services/client-document.service.ts
+++ b/server/services/client-document.service.ts
@@ -1,0 +1,107 @@
+import { drizzle } from 'drizzle-orm/d1';
+import { and, eq } from 'drizzle-orm';
+import { clientUploads, type DocumentCategory, type DocumentVisibility, type UploaderKind } from '../lib/db/schema';
+import { sanitizeFilename } from '../lib/content-disposition';
+import { Errors } from '../lib/errors';
+
+export const MAX_BYTES = 100 * 1024 * 1024; // 100 MB
+export const MAX_FILES = 50;
+
+export const ALLOWED_EXTENSIONS = new Set([
+  'pdf', 'jpg', 'jpeg', 'png', 'heic', 'heif', 'webp',
+  'doc', 'docx', 'xls', 'xlsx', 'csv', 'dwg', 'dxf',
+]);
+export const CAD_EXTENSIONS = new Set(['dwg', 'dxf']);
+export const ALLOWED_CONTENT_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg', 'image/png', 'image/heic', 'image/heif', 'image/webp',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/csv',
+]);
+
+const extOf = (name: string) => (name.split('.').pop() ?? '').toLowerCase();
+
+export interface UploadMeta {
+  filename: string;
+  contentType: string;
+  category: DocumentCategory;
+  visibility: DocumentVisibility;
+  label: string | null;
+  sizeBytes: number;
+}
+
+export class ClientDocumentService {
+  constructor(
+    private d1: D1Database,
+    private bucket: R2Bucket,
+    private genId: () => string = () => crypto.randomUUID(),
+    private now: () => number = () => Date.now(),
+  ) {}
+  private db() { return drizzle(this.d1); }
+
+  assertValid(p: { filename: string; contentType: string; sizeBytes: number; currentCount: number }) {
+    const ext = extOf(p.filename);
+    if (!ALLOWED_EXTENSIONS.has(ext)) throw Errors.BadRequest('File type not allowed.');
+    if (!CAD_EXTENSIONS.has(ext) && !ALLOWED_CONTENT_TYPES.has(p.contentType)) {
+      throw Errors.BadRequest('File type not allowed.');
+    }
+    if (p.sizeBytes > MAX_BYTES) throw Errors.BadRequest('File exceeds 100 MB.');
+    if (p.currentCount >= MAX_FILES) throw Errors.BadRequest('Upload limit reached (50 files).');
+  }
+
+  async countForUploader(tenantId: string, inspectionId: string, ref: string): Promise<number> {
+    const rows = await this.db().select().from(clientUploads)
+      .where(and(eq(clientUploads.tenantId, tenantId), eq(clientUploads.inspectionId, inspectionId), eq(clientUploads.uploadedByRef, ref)))
+      .all();
+    return rows.length;
+  }
+
+  async create(
+    tenantId: string,
+    inspectionId: string,
+    by: { kind: UploaderKind; ref: string; name: string | null },
+    meta: UploadMeta,
+    body: ReadableStream | Uint8Array | ArrayBuffer,
+  ): Promise<typeof clientUploads.$inferSelect> {
+    const currentCount = await this.countForUploader(tenantId, inspectionId, by.ref);
+    this.assertValid({ filename: meta.filename, contentType: meta.contentType, sizeBytes: meta.sizeBytes, currentCount });
+    const id = this.genId();
+    const r2Key = `uploads/${tenantId}/${inspectionId}/${id}-${sanitizeFilename(meta.filename, 'file')}`;
+    await this.bucket.put(r2Key, body as ReadableStream, { httpMetadata: { contentType: meta.contentType } });
+    const row = {
+      id, tenantId, inspectionId,
+      uploadedByKind: by.kind, uploadedByRef: by.ref, uploadedByName: by.name,
+      category: meta.category, visibility: meta.visibility,
+      r2Key, filename: meta.filename, contentType: meta.contentType,
+      sizeBytes: meta.sizeBytes, label: meta.label,
+      createdAt: new Date(this.now()),
+    };
+    await this.db().insert(clientUploads).values(row);
+    return row as typeof clientUploads.$inferSelect;
+  }
+
+  async list(tenantId: string, inspectionId: string) {
+    return this.db().select().from(clientUploads)
+      .where(and(eq(clientUploads.tenantId, tenantId), eq(clientUploads.inspectionId, inspectionId)))
+      .all();
+  }
+
+  async get(tenantId: string, id: string) {
+    return this.db().select().from(clientUploads)
+      .where(and(eq(clientUploads.tenantId, tenantId), eq(clientUploads.id, id)))
+      .get();
+  }
+
+  async getObject(r2Key: string) { return this.bucket.get(r2Key); }
+
+  async remove(tenantId: string, id: string) {
+    const row = await this.get(tenantId, id);
+    if (!row) return;
+    try { await this.bucket.delete(row.r2Key); } catch { /* non-fatal: orphan object */ }
+    await this.db().delete(clientUploads)
+      .where(and(eq(clientUploads.tenantId, tenantId), eq(clientUploads.id, id)));
+  }
+}

--- a/server/services/client-document.service.ts
+++ b/server/services/client-document.service.ts
@@ -79,9 +79,11 @@ export class ClientDocumentService {
     const id = this.genId();
     const r2Key = `uploads/${tenantId}/${inspectionId}/${id}-${sanitizeFilename(meta.filename, 'file')}`;
 
-    // Enforce MAX_BYTES against ACTUAL bytes (Content-Length is spoofable). For
-    // non-stream bodies (unit tests) measure byteLength directly; for streams,
-    // count bytes through a TransformStream and abort if the cap is exceeded.
+    // Enforce MAX_BYTES against ACTUAL bytes (Content-Length is spoofable). The
+    // non-stream branches (Uint8Array/ArrayBuffer) measure byteLength directly and
+    // are exercised by the unit tests. The ReadableStream branch is the real
+    // client/inspector path (`c.req.raw.body`) and is E2E-verified against workerd
+    // (FixedLengthStream is a workerd-only global, so it is NOT unit-testable).
     let measuredSize: number;
     if (body instanceof Uint8Array) {
       measuredSize = body.byteLength;
@@ -89,7 +91,30 @@ export class ClientDocumentService {
     } else if (body instanceof ArrayBuffer) {
       measuredSize = body.byteLength;
       await this.bucket.put(r2Key, body, { httpMetadata: { contentType: meta.contentType } });
+    } else if (typeof FixedLengthStream !== 'undefined') {
+      // PRODUCTION (workerd) path — E2E-verified; NOT reachable under the Node
+      // unit-test runner because FixedLengthStream is a workerd-only global.
+      // R2 put requires a known content length; FixedLengthStream supplies it AND
+      // enforces that the actual bytes equal the declared (Content-Length-derived)
+      // size — a client that under-declares to stream unbounded data gets aborted.
+      // meta.sizeBytes is already validated <= MAX_BYTES upstream (route 413 fast-path
+      // + assertValid), so this also bounds the stored object to the cap.
+      const fls = new FixedLengthStream(meta.sizeBytes);
+      // pump the request body into the fixed-length stream; R2 reads the readable end.
+      const pumped = body.pipeThrough(fls as unknown as ReadableWritablePair<Uint8Array, Uint8Array>);
+      try {
+        await this.bucket.put(r2Key, pumped, { httpMetadata: { contentType: meta.contentType } });
+      } catch {
+        // A length mismatch (client lied about Content-Length) surfaces here.
+        throw new PayloadTooLargeError();
+      }
+      measuredSize = meta.sizeBytes;
     } else {
+      // FALLBACK for the Node unit-test runner only (no FixedLengthStream global).
+      // Counts ACTUAL bytes through a TransformStream and aborts the put if the
+      // MAX_BYTES cap is exceeded — preserving the cap-enforcement property the
+      // workerd FixedLengthStream gives us. The production path above is the one
+      // that ships; this branch never executes in workerd.
       let total = 0;
       let overflowed = false;
       const counter = new TransformStream<Uint8Array, Uint8Array>({
@@ -104,9 +129,6 @@ export class ClientDocumentService {
         },
       });
       try {
-        // R2 put is atomic on stream error: if the stream errors mid-flight the
-        // object is NOT persisted. We re-throw PayloadTooLargeError so the route
-        // can map it to 413.
         await this.bucket.put(r2Key, body.pipeThrough(counter), { httpMetadata: { contentType: meta.contentType } });
       } catch (err) {
         if (overflowed || err instanceof PayloadTooLargeError) throw new PayloadTooLargeError();

--- a/server/services/portal-access.service.ts
+++ b/server/services/portal-access.service.ts
@@ -138,6 +138,28 @@ export class PortalAccessService {
         };
     }
 
+    /**
+     * Resolve the LIVE (non-revoked, non-expired) grant for a (recipientEmail,
+     * inspectionId) pair — used by the unified-portal SESSION-cookie path, where
+     * there is no URL `?token` to resolve. Returns the authoritative
+     * {tenantId, role, recipientEmail} from the row, or null if no live grant.
+     */
+    async resolveByEmailAndInspection(
+        email: string,
+        inspectionId: string,
+        now: number = Date.now(),
+    ): Promise<{ tenantId: string; role: 'client' | 'co_client' | 'agent'; recipientEmail: string } | null> {
+        const db = this.getDrizzle();
+        const row = await db.select().from(inspectionAccessTokens)
+            .where(and(
+                eq(inspectionAccessTokens.recipientEmail, email),
+                eq(inspectionAccessTokens.inspectionId, inspectionId),
+            )).get();
+        if (!row || row.revokedAt != null) return null;
+        if (row.expiresAt != null && row.expiresAt <= now) return null;
+        return { tenantId: row.tenantId, role: row.role as 'client' | 'co_client' | 'agent', recipientEmail: row.recipientEmail };
+    }
+
     /** Inspector "Reset access link" — revoke a recipient's current token. */
     async revokeForRecipient(inspectionId: string, recipientEmail: string): Promise<void> {
         const db = this.getDrizzle();

--- a/server/services/tenant-purge.service.ts
+++ b/server/services/tenant-purge.service.ts
@@ -8,6 +8,7 @@ import {
     availability, availabilityOverrides, inspectionAgreements,
     eventTypes, inspectionEvents, tenantDestructionRecords,
     inspectionInspectors, serviceInspectors, erasureLog, contractorTypes,
+    clientUploads,
 } from '../lib/db/schema';
 
 const TENANT_TABLES = [
@@ -17,6 +18,9 @@ const TENANT_TABLES = [
     inspectionAgreements, agreementSigners, agreementRequests, agreements, automationLogs,
     inspectionEvents, eventTypes, automations,
     inspectionServices, services, discountCodes, comments, contractorTypes, contacts,
+    // client_uploads (per-inspection documents) carry R2 objects under a SEPARATE
+    // `uploads/` prefix (swept below) — the rows must be purged with the tenant.
+    clientUploads,
     availabilityOverrides, availability, inspectionResults, inspections, templates,
     // erasureLog holds subject_email PII scoped by tenantId — must be purged on
     // whole-tenant teardown. Per-subject erasure retains it (Art. 5(2)/30 proof).
@@ -69,19 +73,24 @@ export class TenantPurgeService {
         }
 
         // 3. R2 list + batch delete (accumulate object count + byte totals for the
-        //    destruction record).
+        //    destruction record). Two prefixes hold this tenant's objects:
+        //      - `tenants/${tenantId}/`  — inspection photos / report assets
+        //      - `uploads/${tenantId}/`  — client_uploads documents (separate tree)
+        //    Both must be swept or the client documents orphan in R2.
         let r2Count = 0;
         let r2Bytes = 0;
-        let cursor: string | undefined;
-        do {
-            const list = await this.r2.list({ prefix: `tenants/${tenantId}/`, limit: 1000, ...(cursor ? { cursor } : {}) });
-            if (list.objects.length) {
-                await this.r2.delete(list.objects.map(o => o.key));
-                r2Count += list.objects.length;
-                r2Bytes += list.objects.reduce((sum, o) => sum + (o.size ?? 0), 0);
-            }
-            cursor = list.truncated ? list.cursor : undefined;
-        } while (cursor);
+        for (const prefix of [`tenants/${tenantId}/`, `uploads/${tenantId}/`]) {
+            let cursor: string | undefined;
+            do {
+                const list = await this.r2.list({ prefix, limit: 1000, ...(cursor ? { cursor } : {}) });
+                if (list.objects.length) {
+                    await this.r2.delete(list.objects.map(o => o.key));
+                    r2Count += list.objects.length;
+                    r2Bytes += list.objects.reduce((sum, o) => sum + (o.size ?? 0), 0);
+                }
+                cursor = list.truncated ? list.cursor : undefined;
+            } while (cursor);
+        }
 
         // 4. KV delete (best-effort)
         let kvCount = 0;

--- a/server/types/hono.ts
+++ b/server/types/hono.ts
@@ -248,6 +248,7 @@ export interface AppServices {
     integrations: import('../services/integrations.service').IntegrationsService;
     analytics: import('../services/analytics.service').AnalyticsService;
     repairRequest: import('../services/repair-request.service').RepairRequestService;
+    clientDocument: import('../services/client-document.service').ClientDocumentService;
 }
 
 /**

--- a/tests/unit/client-document-routes.spec.ts
+++ b/tests/unit/client-document-routes.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createTestDb, setupSchema } from './db';
+import * as schema from '../../server/lib/db/schema';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+// Both ClientDocumentService and PortalAccessService build their drizzle handle
+// via `drizzle(this.db)` (drizzle-orm/d1). Mock that factory to hand back the
+// in-memory better-sqlite3 test DB (mirrors portal-routes.spec.ts).
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+
+import { Hono } from 'hono';
+import type { HonoConfig } from '../../server/types/hono';
+import { ClientDocumentService } from '../../server/services/client-document.service';
+import { PortalAccessService } from '../../server/services/portal-access.service';
+import { signPortalSession } from '../../server/lib/portal-session';
+import clientDocumentsRoutes from '../../server/api/client-documents';
+
+const TENANT = '00000000-0000-0000-0000-0000000000a1';
+const SECRET = 'test-jwt-secret';
+
+// Map-backed fake R2 bucket: supports put/get/delete. get() returns
+// `{ body }` where body is a Uint8Array (good enough for `new Response(body)`).
+function makeFakeBucket() {
+    const store = new Map<string, Uint8Array>();
+    return {
+        async put(key: string, body: ReadableStream | Uint8Array | ArrayBuffer) {
+            let bytes: Uint8Array;
+            if (body instanceof Uint8Array) bytes = body;
+            else if (body instanceof ArrayBuffer) bytes = new Uint8Array(body);
+            else {
+                // ReadableStream — drain it.
+                const reader = (body as ReadableStream).getReader();
+                const chunks: Uint8Array[] = [];
+                for (;;) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    if (value) chunks.push(value as Uint8Array);
+                }
+                const total = chunks.reduce((n, c) => n + c.length, 0);
+                bytes = new Uint8Array(total);
+                let off = 0;
+                for (const c of chunks) { bytes.set(c, off); off += c.length; }
+            }
+            store.set(key, bytes);
+            return { key };
+        },
+        async get(key: string) {
+            const bytes = store.get(key);
+            if (!bytes) return null;
+            return { body: bytes };
+        },
+        async delete(key: string) { store.delete(key); },
+    } as unknown as R2Bucket;
+}
+
+describe('client document routes (token-gated)', () => {
+    let testDb: BetterSQLite3Database<typeof schema>;
+
+    async function seedInspection(id: string, overrides: Partial<typeof schema.inspections.$inferInsert> = {}) {
+        await testDb.insert(schema.inspections).values({
+            id,
+            tenantId: TENANT,
+            propertyAddress: `${id} Main St`,
+            date: '2026-06-01',
+            status: 'requested',
+            reportStatus: 'in_progress',
+            paymentStatus: 'unpaid',
+            createdAt: new Date(),
+            ...overrides,
+        });
+    }
+
+    function buildApp(portalAccess: PortalAccessService, docs: ClientDocumentService) {
+        const app = new Hono<HonoConfig>();
+        app.use('*', async (c, next) => {
+            c.set('services', {
+                portalAccess,
+                clientDocument: docs,
+            } as unknown as HonoConfig['Variables']['services']);
+            await next();
+        });
+        app.route('/api/public', clientDocumentsRoutes);
+        return app;
+    }
+
+    function reqEnv() {
+        return { JWT_SECRET: SECRET } as unknown as HonoConfig['Bindings'];
+    }
+
+    async function seedInspectionWithClientToken() {
+        const inspectionId = 'insp1';
+        await seedInspection(inspectionId);
+        const portalAccess = new PortalAccessService({} as D1Database, { jwtSecret: SECRET });
+        // Real tokens via issueToken so resolvePortalAccess(?token=) resolves.
+        const clientEmail = 'client@x.com';
+        const otherClientEmail = 'other@x.com';
+        const clientToken = await portalAccess.issueToken({
+            tenantId: TENANT, inspectionId, recipientEmail: clientEmail, role: 'client',
+        });
+        const otherClientToken = await portalAccess.issueToken({
+            tenantId: TENANT, inspectionId, recipientEmail: otherClientEmail, role: 'co_client',
+        });
+        const docs = new ClientDocumentService({} as D1Database, makeFakeBucket());
+        const app = buildApp(portalAccess, docs);
+        return { app, inspectionId, clientToken, otherClientToken, clientEmail, otherClientEmail };
+    }
+
+    beforeEach(async () => {
+        const fix = createTestDb();
+        testDb = fix.db;
+        await setupSchema(fix.sqlite);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockDrizzle as any).mockReturnValue(testDb);
+        await testDb.insert(schema.tenants).values({
+            id: TENANT, name: 'Acme', slug: 'acme', status: 'active',
+            deploymentMode: 'shared', tier: 'free', createdAt: new Date(),
+        });
+    });
+
+    it('PUT streams a valid file; bad extension → 400; no token → 401/403', async () => {
+        const { app, inspectionId, clientToken } = await seedInspectionWithClientToken();
+        const ok = await app.request(`/api/public/inspections/${inspectionId}/documents?filename=plan.pdf&category=plans_drawings&token=${clientToken}`,
+            { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '3' }, body: new Uint8Array([1, 2, 3]) }, reqEnv());
+        expect(ok.status).toBe(200);
+        const bad = await app.request(`/api/public/inspections/${inspectionId}/documents?filename=x.exe&category=other&token=${clientToken}`,
+            { method: 'PUT', headers: { 'content-type': 'application/x-msdownload', 'content-length': '1' }, body: new Uint8Array([1]) }, reqEnv());
+        expect(bad.status).toBe(400);
+        const noTok = await app.request(`/api/public/inspections/${inspectionId}/documents?filename=a.pdf&category=other`,
+            { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '1' }, body: new Uint8Array([1]) }, reqEnv());
+        expect([401, 403]).toContain(noTok.status);
+    });
+
+    it('rejects > 100MB via Content-Length with 413 before streaming', async () => {
+        const { app, inspectionId, clientToken } = await seedInspectionWithClientToken();
+        const res = await app.request(`/api/public/inspections/${inspectionId}/documents?filename=a.pdf&category=other&token=${clientToken}`,
+            { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': String(101 * 1024 * 1024) }, body: new Uint8Array([1]) }, reqEnv());
+        expect(res.status).toBe(413);
+    });
+
+    it('GET list hides internal from clients; GET download streams attachment + nosniff + original name', async () => {
+        const { app, inspectionId, clientToken } = await seedInspectionWithClientToken();
+        await app.request(`/api/public/inspections/${inspectionId}/documents?filename=My Report.pdf&category=prior_reports&token=${clientToken}`,
+            { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '3' }, body: new Uint8Array([1, 2, 3]) }, reqEnv());
+        const list = await (await app.request(`/api/public/inspections/${inspectionId}/documents?token=${clientToken}`, {}, reqEnv())).json();
+        expect(list.data.length).toBe(1);
+        const docId = list.data[0].id;
+        const dl = await app.request(`/api/public/inspections/${inspectionId}/documents/${docId}?token=${clientToken}`, {}, reqEnv());
+        expect(dl.status).toBe(200);
+        expect(dl.headers.get('content-disposition')).toMatch(/attachment/);
+        expect(dl.headers.get('content-disposition')).toContain("filename*=UTF-8''My%20Report.pdf");
+        expect(dl.headers.get('x-content-type-options')).toBe('nosniff');
+    });
+
+    it('GET list hides inspector-internal docs but shows inspector client_visible docs', async () => {
+        const { app, inspectionId, clientToken } = await seedInspectionWithClientToken();
+        // Seed two inspector-uploaded rows directly.
+        const docs = new ClientDocumentService({} as D1Database, makeFakeBucket());
+        await docs.create(TENANT, inspectionId, { kind: 'inspector', ref: 'u1', name: 'Inspector' },
+            { filename: 'internal.pdf', contentType: 'application/pdf', category: 'other', visibility: 'internal', label: null, sizeBytes: 1 },
+            new Uint8Array([1]));
+        await docs.create(TENANT, inspectionId, { kind: 'inspector', ref: 'u1', name: 'Inspector' },
+            { filename: 'shared.pdf', contentType: 'application/pdf', category: 'other', visibility: 'client_visible', label: null, sizeBytes: 1 },
+            new Uint8Array([1]));
+        const list = await (await app.request(`/api/public/inspections/${inspectionId}/documents?token=${clientToken}`, {}, reqEnv())).json();
+        const names = list.data.map((d: { filename: string }) => d.filename).sort();
+        expect(names).toEqual(['shared.pdf']);
+        // r2Key must never be leaked.
+        expect(list.data.every((d: Record<string, unknown>) => !('r2Key' in d))).toBe(true);
+    });
+
+    it('client can delete own but not another uploader file', async () => {
+        const { app, inspectionId, clientToken, otherClientToken } = await seedInspectionWithClientToken();
+        const put = await (await app.request(`/api/public/inspections/${inspectionId}/documents?filename=a.pdf&category=other&token=${clientToken}`,
+            { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '1' }, body: new Uint8Array([1]) }, reqEnv())).json();
+        const id = put.data.id;
+        const forbidden = await app.request(`/api/public/inspections/${inspectionId}/documents/${id}?token=${otherClientToken}`, { method: 'DELETE' }, reqEnv());
+        expect([403, 404]).toContain(forbidden.status);
+        const ok = await app.request(`/api/public/inspections/${inspectionId}/documents/${id}?token=${clientToken}`, { method: 'DELETE' }, reqEnv());
+        expect(ok.status).toBe(200);
+    });
+
+    it('SESSION cookie path: GET list returns the client docs via resolveByEmailAndInspection', async () => {
+        const { app, inspectionId, clientToken, clientEmail } = await seedInspectionWithClientToken();
+        // Upload one doc via the token path.
+        await app.request(`/api/public/inspections/${inspectionId}/documents?filename=mine.pdf&category=other&token=${clientToken}`,
+            { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '1' }, body: new Uint8Array([1]) }, reqEnv());
+        // Now list with NO ?token — only the __Host-portal_session cookie.
+        const cookie = await signPortalSession(SECRET, clientEmail);
+        const res = await app.request(`/api/public/inspections/${inspectionId}/documents`, {
+            headers: { cookie: '__Host-portal_session=' + cookie },
+        }, reqEnv());
+        expect(res.status).toBe(200);
+        const list = await res.json();
+        expect(list.data.length).toBe(1);
+        expect(list.data[0].filename).toBe('mine.pdf');
+    });
+});

--- a/tests/unit/client-document-routes.spec.ts
+++ b/tests/unit/client-document-routes.spec.ts
@@ -14,10 +14,11 @@ import type { HonoConfig } from '../../server/types/hono';
 import { ClientDocumentService } from '../../server/services/client-document.service';
 import { PortalAccessService } from '../../server/services/portal-access.service';
 import { signPortalSession } from '../../server/lib/portal-session';
-import clientDocumentsRoutes from '../../server/api/client-documents';
+import clientDocumentsRoutes, { inspectorDocumentsRoutes } from '../../server/api/client-documents';
 
 const TENANT = '00000000-0000-0000-0000-0000000000a1';
 const SECRET = 'test-jwt-secret';
+const INSPECTOR_USER = 'inspector-user-1';
 
 // Map-backed fake R2 bucket: supports put/get/delete. get() returns
 // `{ body }` where body is a Uint8Array (good enough for `new Response(body)`).
@@ -81,6 +82,16 @@ describe('client document routes (token-gated)', () => {
             await next();
         });
         app.route('/api/public', clientDocumentsRoutes);
+        // Authed inspector surface. Mirror the JWT middleware's context contract:
+        // it sets `tenantId` + a `user` object whose `.sub` is the user id. The
+        // global jwtAuthMiddleware would gate this in production; here a tiny
+        // middleware injects the identity so we exercise the router logic itself.
+        app.use('/api/inspections/*', async (c, next) => {
+            c.set('tenantId', TENANT);
+            c.set('user', { sub: INSPECTOR_USER, role: 'inspector', tenantId: TENANT } as never);
+            await next();
+        });
+        app.route('/api/inspections', inspectorDocumentsRoutes);
         return app;
     }
 
@@ -103,7 +114,12 @@ describe('client document routes (token-gated)', () => {
         });
         const docs = new ClientDocumentService({} as D1Database, makeFakeBucket());
         const app = buildApp(portalAccess, docs);
-        return { app, inspectionId, clientToken, otherClientToken, clientEmail, otherClientEmail };
+        // Issue requests as the seeded inspector. Identity is injected by the
+        // `/api/inspections/*` middleware in buildApp (tenantId + user.sub), so
+        // callers just hit the authed paths.
+        const authedInspectorRequest = (path: string, init?: RequestInit) =>
+            app.request(path, init, reqEnv());
+        return { app, inspectionId, clientToken, otherClientToken, clientEmail, otherClientEmail, authedInspectorRequest };
     }
 
     beforeEach(async () => {
@@ -194,5 +210,68 @@ describe('client document routes (token-gated)', () => {
         const list = await res.json();
         expect(list.data.length).toBe(1);
         expect(list.data[0].filename).toBe('mine.pdf');
+    });
+
+    describe('inspector document routes (authed)', () => {
+        it('inspector sees all incl client uploads and internal; can delete any; client cannot see internal', async () => {
+            const { app, inspectionId, clientToken, authedInspectorRequest } = await seedInspectionWithClientToken();
+            // Client uploads a client_visible doc via the public path.
+            await app.request(`/api/public/inspections/${inspectionId}/documents?filename=client.pdf&category=other&token=${clientToken}`,
+                { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '1' }, body: new Uint8Array([1]) }, reqEnv());
+            // Inspector uploads an internal doc via the authed path.
+            const up = await authedInspectorRequest(`/api/inspections/${inspectionId}/documents?filename=internal.pdf&category=other&visibility=internal`,
+                { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '1' }, body: new Uint8Array([1]) });
+            expect(up.status).toBe(200);
+            const upBody = await up.json();
+            expect(upBody.data.visibility).toBe('internal');
+
+            // Inspector list = ALL rows (no visibility filter).
+            const inspRes = await authedInspectorRequest(`/api/inspections/${inspectionId}/documents`);
+            const inspList = await inspRes.json();
+            expect(inspList.data.length).toBe(2);
+            // r2Key must never leak.
+            expect(inspList.data.every((d: Record<string, unknown>) => !('r2Key' in d))).toBe(true);
+            // Inspector sees refs.
+            expect(inspList.data.every((d: Record<string, unknown>) => 'uploadedByRef' in d)).toBe(true);
+
+            // Client list = client_visible only → just the client upload.
+            const cliList = await (await app.request(`/api/public/inspections/${inspectionId}/documents?token=${clientToken}`, {}, reqEnv())).json();
+            expect(cliList.data.length).toBe(1);
+            const clientDocId = cliList.data[0].id;
+
+            // Inspector can download a client-uploaded doc (no visibility gate).
+            const dl = await authedInspectorRequest(`/api/inspections/${inspectionId}/documents/${clientDocId}`);
+            expect(dl.status).toBe(200);
+            expect(dl.headers.get('content-disposition')).toMatch(/attachment/);
+            expect(dl.headers.get('x-content-type-options')).toBe('nosniff');
+
+            // Inspector can delete ANY row (here: the client's upload).
+            const del = await authedInspectorRequest(`/api/inspections/${inspectionId}/documents/${clientDocId}`, { method: 'DELETE' });
+            expect(del.status).toBe(200);
+            const after = await (await authedInspectorRequest(`/api/inspections/${inspectionId}/documents`)).json();
+            expect(after.data.length).toBe(1);
+        });
+
+        it('401 when tenantId/userId missing; bad visibility → 400; 404 on cross-inspection doc', async () => {
+            const { app, inspectionId, authedInspectorRequest } = await seedInspectionWithClientToken();
+            // No-identity app (does not inject tenantId/user).
+            const bare = new Hono<HonoConfig>();
+            bare.use('*', async (c, next) => {
+                c.set('services', { clientDocument: new ClientDocumentService({} as D1Database, makeFakeBucket()) } as never);
+                await next();
+            });
+            bare.route('/api/inspections', inspectorDocumentsRoutes);
+            const unauth = await bare.request(`/api/inspections/${inspectionId}/documents`, {}, reqEnv());
+            expect(unauth.status).toBe(401);
+
+            // Bad visibility enum.
+            const badVis = await authedInspectorRequest(`/api/inspections/${inspectionId}/documents?filename=x.pdf&category=other&visibility=nope`,
+                { method: 'PUT', headers: { 'content-type': 'application/pdf', 'content-length': '1' }, body: new Uint8Array([1]) });
+            expect(badVis.status).toBe(400);
+
+            // 404 when doc belongs to another inspection.
+            const notFound = await authedInspectorRequest(`/api/inspections/${inspectionId}/documents/nonexistent-doc`);
+            expect(notFound.status).toBe(404);
+        });
     });
 });

--- a/tests/unit/client-document-service.spec.ts
+++ b/tests/unit/client-document-service.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as schema from '../../server/lib/db/schema';
+import { createTestDb, setupSchema } from './db';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
+import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
+import {
+  ClientDocumentService, ALLOWED_EXTENSIONS, CAD_EXTENSIONS, MAX_BYTES, MAX_FILES,
+} from '../../server/services/client-document.service';
+
+const TENANT = 't1';
+const INSP = 'insp1';
+
+function fakeBucket() {
+  const store = new Map<string, Uint8Array>();
+  return {
+    store,
+    put: vi.fn(async (key: string, body: Uint8Array) => { store.set(key, body); }),
+    get: vi.fn(async (key: string) => store.has(key) ? { body: store.get(key) } : null),
+    delete: vi.fn(async (key: string) => { store.delete(key); }),
+  };
+}
+
+describe('ClientDocumentService', () => {
+  let db: BetterSQLite3Database<typeof schema>;
+  let bucket: ReturnType<typeof fakeBucket>;
+  let svc: ClientDocumentService;
+  let n = 0;
+
+  beforeEach(async () => {
+    const fixture = createTestDb();
+    db = fixture.db;
+    await setupSchema(fixture.sqlite);
+    (mockDrizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(db);
+    bucket = fakeBucket();
+    svc = new ClientDocumentService({} as D1Database, bucket as unknown as R2Bucket,
+      () => `id-${++n}`, () => 1000);
+  });
+
+  it('rejects disallowed extensions and oversize/over-count', () => {
+    expect(() => svc.assertValid({ filename: 'x.exe', contentType: 'application/x-msdownload', sizeBytes: 10, currentCount: 0 })).toThrow();
+    expect(() => svc.assertValid({ filename: 'a.pdf', contentType: 'application/pdf', sizeBytes: MAX_BYTES + 1, currentCount: 0 })).toThrow();
+    expect(() => svc.assertValid({ filename: 'a.pdf', contentType: 'application/pdf', sizeBytes: 10, currentCount: MAX_FILES })).toThrow();
+    expect(() => svc.assertValid({ filename: 'a.pdf', contentType: 'application/pdf', sizeBytes: 10, currentCount: 0 })).not.toThrow();
+  });
+
+  it('accepts CAD by extension even when content-type is octet-stream', () => {
+    expect(CAD_EXTENSIONS.has('dwg')).toBe(true);
+    expect(() => svc.assertValid({ filename: 'floor.dwg', contentType: 'application/octet-stream', sizeBytes: 10, currentCount: 0 })).not.toThrow();
+    expect(() => svc.assertValid({ filename: 'a.pdf', contentType: 'application/octet-stream', sizeBytes: 10, currentCount: 0 })).toThrow();
+  });
+
+  it('create stores to R2 under the prefix, keeps the ORIGINAL filename, lists, and removes both', async () => {
+    const row = await svc.create(TENANT, INSP,
+      { kind: 'client', ref: 'a@x.com', name: 'Ann' },
+      { filename: 'My Roof Report.pdf', contentType: 'application/pdf', category: 'prior_reports', visibility: 'client_visible', label: null, sizeBytes: 3 },
+      new Uint8Array([1, 2, 3]));
+    expect(row.r2Key).toMatch(/^uploads\/t1\/insp1\/id-1-/);
+    expect(row.filename).toBe('My Roof Report.pdf');
+    expect(bucket.store.has(row.r2Key)).toBe(true);
+    expect((await svc.list(TENANT, INSP)).map((u) => u.id)).toContain(row.id);
+    await svc.remove(TENANT, row.id);
+    expect((await svc.list(TENANT, INSP)).length).toBe(0);
+    expect(bucket.store.has(row.r2Key)).toBe(false);
+  });
+
+  it('count is per uploader ref', async () => {
+    await svc.create(TENANT, INSP, { kind: 'client', ref: 'a@x.com', name: null },
+      { filename: 'a.pdf', contentType: 'application/pdf', category: 'other', visibility: 'client_visible', label: null, sizeBytes: 1 }, new Uint8Array([1]));
+    expect(await svc.countForUploader(TENANT, INSP, 'a@x.com')).toBe(1);
+    expect(await svc.countForUploader(TENANT, INSP, 'b@x.com')).toBe(0);
+  });
+});

--- a/tests/unit/client-document-service.spec.ts
+++ b/tests/unit/client-document-service.spec.ts
@@ -16,9 +16,12 @@ function fakeBucket() {
   const store = new Map<string, Uint8Array>();
   return {
     store,
-    // Mirrors the real R2 put(key, value, options): for ReadableStream values
-    // it drains the stream (so the counting TransformStream runs and can error).
-    // If the stream errors mid-flight, nothing is persisted (atomic on error).
+    // Mirrors the real R2 put(key, value, options) for the NODE unit-test runner.
+    // NOTE: production streams via a workerd-only FixedLengthStream (records the
+    // DECLARED Content-Length and enforces it) — that path is NOT unit-testable
+    // and is covered by E2E. Under Node the service falls back to a byte-counting
+    // TransformStream, so this fake drains the stream (the counter runs and can
+    // error). If the stream errors mid-flight, nothing is persisted (atomic on error).
     put: vi.fn(async (key: string, body: ReadableStream | Uint8Array | ArrayBuffer) => {
       if (body instanceof Uint8Array) { store.set(key, body); return { key }; }
       if (body instanceof ArrayBuffer) { store.set(key, new Uint8Array(body)); return { key }; }
@@ -84,7 +87,12 @@ describe('ClientDocumentService', () => {
     expect(bucket.store.has(row.r2Key)).toBe(false);
   });
 
-  it('create from a ReadableStream persists the MEASURED size, not a lied-about Content-Length', async () => {
+  // Exercises the NODE FALLBACK stream branch (no FixedLengthStream global), which
+  // counts ACTUAL bytes. The PRODUCTION workerd path uses FixedLengthStream — it
+  // records the DECLARED Content-Length and aborts on a length mismatch, and is
+  // covered by E2E (not unit-testable here). This test asserts the fallback's
+  // cap-enforcing byte counting still works under Node.
+  it('create from a ReadableStream (Node fallback) counts ACTUAL bytes, not a lied-about Content-Length', async () => {
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new Uint8Array([1, 2, 3]));
@@ -96,7 +104,7 @@ describe('ClientDocumentService', () => {
       // meta.sizeBytes is a lie (999); the real stream is only 3 bytes.
       { filename: 'lie.pdf', contentType: 'application/pdf', category: 'other', visibility: 'client_visible', label: null, sizeBytes: 999 },
       stream);
-    expect(row.sizeBytes).toBe(3); // measured wins over declared
+    expect(row.sizeBytes).toBe(3); // fallback measures the actual stream
     expect(bucket.store.get(row.r2Key)).toEqual(new Uint8Array([1, 2, 3]));
   });
 

--- a/tests/unit/client-document-service.spec.ts
+++ b/tests/unit/client-document-service.spec.ts
@@ -6,7 +6,7 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 vi.mock('drizzle-orm/d1', () => ({ drizzle: vi.fn() }));
 import { drizzle as mockDrizzle } from 'drizzle-orm/d1';
 import {
-  ClientDocumentService, ALLOWED_EXTENSIONS, CAD_EXTENSIONS, MAX_BYTES, MAX_FILES,
+  ClientDocumentService, ALLOWED_EXTENSIONS, CAD_EXTENSIONS, MAX_BYTES, MAX_FILES, PayloadTooLargeError,
 } from '../../server/services/client-document.service';
 
 const TENANT = 't1';
@@ -16,7 +16,26 @@ function fakeBucket() {
   const store = new Map<string, Uint8Array>();
   return {
     store,
-    put: vi.fn(async (key: string, body: Uint8Array) => { store.set(key, body); }),
+    // Mirrors the real R2 put(key, value, options): for ReadableStream values
+    // it drains the stream (so the counting TransformStream runs and can error).
+    // If the stream errors mid-flight, nothing is persisted (atomic on error).
+    put: vi.fn(async (key: string, body: ReadableStream | Uint8Array | ArrayBuffer) => {
+      if (body instanceof Uint8Array) { store.set(key, body); return { key }; }
+      if (body instanceof ArrayBuffer) { store.set(key, new Uint8Array(body)); return { key }; }
+      const reader = (body as ReadableStream<Uint8Array>).getReader();
+      const chunks: Uint8Array[] = [];
+      for (;;) {
+        const { done, value } = await reader.read(); // throws if the stream errors
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+      const total = chunks.reduce((n, c) => n + c.length, 0);
+      const bytes = new Uint8Array(total);
+      let off = 0;
+      for (const c of chunks) { bytes.set(c, off); off += c.length; }
+      store.set(key, bytes);
+      return { key };
+    }),
     get: vi.fn(async (key: string) => store.has(key) ? { body: store.get(key) } : null),
     delete: vi.fn(async (key: string) => { store.delete(key); }),
   };
@@ -63,6 +82,22 @@ describe('ClientDocumentService', () => {
     await svc.remove(TENANT, row.id);
     expect((await svc.list(TENANT, INSP)).length).toBe(0);
     expect(bucket.store.has(row.r2Key)).toBe(false);
+  });
+
+  it('create from a ReadableStream persists the MEASURED size, not a lied-about Content-Length', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+    const row = await svc.create(TENANT, INSP,
+      { kind: 'client', ref: 'a@x.com', name: 'Ann' },
+      // meta.sizeBytes is a lie (999); the real stream is only 3 bytes.
+      { filename: 'lie.pdf', contentType: 'application/pdf', category: 'other', visibility: 'client_visible', label: null, sizeBytes: 999 },
+      stream);
+    expect(row.sizeBytes).toBe(3); // measured wins over declared
+    expect(bucket.store.get(row.r2Key)).toEqual(new Uint8Array([1, 2, 3]));
   });
 
   it('count is per uploader ref', async () => {

--- a/tests/unit/content-disposition.spec.ts
+++ b/tests/unit/content-disposition.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { contentDisposition, sanitizeFilename } from '../../server/lib/content-disposition';
+
+describe('contentDisposition RFC 5987', () => {
+  it('keeps an ascii fallback and adds an encoded filename* for the original name', () => {
+    const v = contentDisposition('2019 Roof Report.pdf', true);
+    expect(v).toContain('attachment');
+    expect(v).toContain('filename="2019 Roof Report.pdf"');
+    expect(v).toContain("filename*=UTF-8''2019%20Roof%20Report.pdf");
+  });
+  it('percent-encodes non-ascii and RFC5987-reserved chars in filename*', () => {
+    const v = contentDisposition('屋顶 report(1).pdf', true);
+    expect(v).toContain("filename*=UTF-8''");
+    expect(v).toContain('%28'); // ( encoded
+    expect(v).toContain('%29'); // ) encoded
+    expect(v).not.toMatch(/filename\*=UTF-8''[^;]*[()]/); // no raw parens in filename*
+  });
+  it('inline disposition for non-download', () => {
+    expect(contentDisposition('a.png', false)).toMatch(/^inline;/);
+  });
+  it('sanitizeFilename still strips header-breaking chars for the fallback', () => {
+    expect(sanitizeFilename('a"b\\c\r\n.pdf')).toBe('abc.pdf');
+  });
+});

--- a/tests/unit/tenant-purge.service.spec.ts
+++ b/tests/unit/tenant-purge.service.spec.ts
@@ -20,8 +20,16 @@ function makeR2(objects: { key: string; size: number }[]) {
     const deleted: string[] = [];
     return {
         bucket: {
-            list: vi.fn(async () => ({ objects, truncated: false, cursor: undefined })),
-            delete: vi.fn(async (keys: string[]) => { deleted.push(...keys); }),
+            // Prefix-aware so the purge can sweep multiple prefixes (e.g. the
+            // `tenants/` photo tree AND the `uploads/` client-document tree).
+            list: vi.fn(async (opts?: { prefix?: string }) => ({
+                objects: opts?.prefix ? objects.filter(o => o.key.startsWith(opts.prefix!)) : objects,
+                truncated: false,
+                cursor: undefined,
+            })),
+            delete: vi.fn(async (keys: string[] | string) => {
+                deleted.push(...(Array.isArray(keys) ? keys : [keys]));
+            }),
         } as unknown as R2Bucket,
         deleted,
     };
@@ -150,6 +158,34 @@ describe('TenantPurgeService.purge', () => {
 
         const remaining = await testDb.select().from(schema.erasureLog).all();
         expect(remaining).toHaveLength(0);
+    });
+
+    it('purges client_uploads rows AND their R2 objects (uploads/ prefix)', async () => {
+        const { drizzle } = await import('drizzle-orm/d1');
+        (drizzle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(testDb);
+        const docKey = `uploads/${TENANT}/i-1/doc-1-prior-report.pdf`;
+        await testDb.insert(schema.clientUploads).values({
+            id: 'doc-1', tenantId: TENANT, inspectionId: 'i-1',
+            uploadedByKind: 'client', uploadedByRef: 'jane@test.com', uploadedByName: 'Jane',
+            category: 'prior_reports', visibility: 'client_visible',
+            r2Key: docKey, filename: 'prior-report.pdf', contentType: 'application/pdf',
+            sizeBytes: 1234, label: null, createdAt: new Date(),
+        });
+
+        // Both prefixes present: a tenant photo AND the client-document object.
+        const r2 = makeR2([
+            { key: `tenants/${TENANT}/p1.jpg`, size: 100 },
+            { key: docKey, size: 1234 },
+        ]);
+        const kv = makeKv();
+        const svc = new TenantPurgeService({} as D1Database, r2.bucket, kv.ns);
+        await svc.purge(TENANT);
+
+        // (a) rows gone
+        const remaining = await testDb.select().from(schema.clientUploads).all();
+        expect(remaining).toHaveLength(0);
+        // (b) R2 object for the client document was deleted
+        expect(r2.deleted).toContain(docKey);
     });
 
     it('destruction record is non-personal (no email/name/address columns)', async () => {

--- a/tests/web/unit/documents-section.spec.ts
+++ b/tests/web/unit/documents-section.spec.ts
@@ -1,0 +1,27 @@
+// tests/web/unit/documents-section.spec.ts
+import { describe, it, expect } from 'vitest';
+import {
+  formatSize, isAcceptedDocument, groupByCategory, CATEGORY_LABELS,
+} from '~/components/DocumentsSection';
+
+describe('DocumentsSection helpers', () => {
+  it('formats size', () => {
+    expect(formatSize(1536)).toBe('1.5 KB');
+    expect(formatSize(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+  it('accept filter mirrors the server allowlist incl CAD-by-extension', () => {
+    expect(isAcceptedDocument({ name: 'a.pdf', type: 'application/pdf', size: 1000 })).toBe(true);
+    expect(isAcceptedDocument({ name: 'floor.dwg', type: 'application/octet-stream', size: 1000 })).toBe(true);
+    expect(isAcceptedDocument({ name: 'x.exe', type: 'application/x-msdownload', size: 1000 })).toBe(false);
+    expect(isAcceptedDocument({ name: 'big.pdf', type: 'application/pdf', size: 101 * 1024 * 1024 })).toBe(false);
+  });
+  it('groups by category with stable label coverage', () => {
+    const groups = groupByCategory([
+      { id: '1', filename: 'a.pdf', category: 'prior_reports', sizeBytes: 1, createdAt: 1, uploadedByKind: 'client', uploadedByName: null, visibility: 'client_visible', label: null },
+      { id: '2', filename: 'b.pdf', category: 'prior_reports', sizeBytes: 1, createdAt: 1, uploadedByKind: 'client', uploadedByName: null, visibility: 'client_visible', label: null },
+      { id: '3', filename: 'c.dwg', category: 'plans_drawings', sizeBytes: 1, createdAt: 1, uploadedByKind: 'inspector', uploadedByName: 'Bob', visibility: 'client_visible', label: null },
+    ]);
+    expect(groups.find((g) => g.category === 'prior_reports')!.items.length).toBe(2);
+    expect(Object.keys(CATEGORY_LABELS)).toContain('environmental');
+  });
+});


### PR DESCRIPTION
## Client Documents (sub-project ⑦)

A per-inspection shared document area: clients (via the unified-portal session/token) and inspectors (via JWT) upload reference files & concern photos (≤100MB, streamed straight to R2), organized by category with per-file visibility, served back under their original filenames. Surfaced as the portal Hub "Documents" section (client) and an inspection-hub card (inspector).

### Architecture
- One additive table `client_uploads` (carries both directions; `uploaded_by_kind` ∈ client/co_client/inspector). Objects in the existing `PHOTOS` R2 bucket under `uploads/{tenantId}/{inspectionId}/`.
- Uploads stream the raw request body straight into `R2.put()` via `FixedLengthStream` (no buffering, no presign) — the fixed length also enforces the size cap against a spoofed Content-Length.
- Client routes gate on the portal `__Host-portal_session` cookie (verified in-route) OR a per-inspection portal token; inspector routes gate on the JWT. Tenant always resolved from the grant/JWT, never the URL.
- Shared `<DocumentsSection>` renders in both surfaces. Downloads preserve the original filename via RFC 5987 (`filename*`).

### Visibility & access
- Clients see their own + inspector `client_visible` docs; inspector-`internal` docs are hidden from the list AND blocked on direct download. Inspectors see all. Clients delete own-only; inspectors delete any.

### Lifecycle
- `TenantPurgeService.purge` now deletes `client_uploads` rows AND sweeps the `uploads/{tenantId}/` R2 prefix (previously only `tenants/{tenantId}/` was swept — fixed).

### Security
HMAC-verified portal cookie before trust; agent role rejected on client routes; revoked/expired grants rejected; cross-inspection 404 guards on download+delete (both surfaces); internal-doc download gate; size cap enforced on actual streamed bytes; server-side extension+MIME allowlist (no html/svg/js) + `nosniff`+`attachment` on download; no co-client email in the client list (returns `isOwn`). One adversarial route review + one final whole-diff review; all findings fixed.

### Testing
- Gates green: type-check 0, lint (incl DS tokens) 0, unit 1844 / web 417 / workers 41, db:check clean (client_uploads drift-free).
- **Local E2E** (real workerd): full client flow verified — upload → list (isOwn, no email leak) → download (original filename + nosniff) → delete. This caught + fixed a production bug: `R2.put()` rejects an unknown-length `ReadableStream` (unit tests used `Uint8Array` and missed it) → fixed with `FixedLengthStream`.

Depends on the unified client portal foundation (#157, merged). Additive migration `0009_client_uploads.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)