### PR TITLE
chore(hooks+ci): migrate husky→.githooks, Node 22, explicit bundle-size CI gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,16 @@
 #!/usr/bin/env sh
+# .githooks/pre-commit — openinspection
+#
+# Quality gate for commits made inside this repo. Activated automatically by the
+# "prepare" npm script on `npm install`/`npm ci`:
+#     git config core.hooksPath .githooks
+# Bypass (discouraged): git commit --no-verify
+#
+# Mechanism is .githooks + core.hooksPath (no husky), aligned with the
+# superproject and the portal/cms submodules.
+
+# Never run in CI / non-interactive contexts (CI does not commit, but guard anyway).
+[ -n "$CI" ] && exit 0
 
 # Colors
 RED='\033[0;31m'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,8 @@ jobs:
 
       - name: Build (bundle the Worker)
         run: npm run build
+
+      # Bundle-size gate (Workers Free 3 MiB gzipped). Reuses the build/ output
+      # from the previous step (--skip-build); also enforced in pre-commit.
+      - name: Bundle size gate
+        run: npm run check:bundle -- --skip-build

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "fake-indexeddb": "^6.0.0",
         "globals": "^17.4.0",
         "happy-dom": "^20.9.0",
-        "husky": "^9.1.7",
         "konva": "^10.2.5",
         "lint-staged": "^16.4.0",
         "miniflare": "^4.20260405.0",
@@ -5932,22 +5931,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "backup": "node scripts/backup.js",
     "restore": "node scripts/restore.js",
     "rotate:jwt": "node scripts/rotate-jwt-keys.js",
-    "prepare": "husky",
+    "prepare": "node -e \"try{require('child_process').execSync('git config core.hooksPath .githooks',{stdio:'ignore'})}catch(e){}\"",
     "check:bundle": "node scripts/check-bundle-size.mjs"
   },
   "dependencies": {
@@ -118,7 +118,6 @@
     "fake-indexeddb": "^6.0.0",
     "globals": "^17.4.0",
     "happy-dom": "^20.9.0",
-    "husky": "^9.1.7",
     "konva": "^10.2.5",
     "lint-staged": "^16.4.0",
     "miniflare": "^4.20260405.0",


### PR DESCRIPTION
Aligns openinspection's pre-commit + CI with the superproject and the portal/cms submodules.

## Pre-commit mechanism: husky → .githooks
- `prepare` now sets `git config core.hooksPath .githooks` (was `husky`); **husky devDep removed** (regenerated lock).
- `.husky/pre-commit` → `.githooks/pre-commit` (verbatim — same tiered type-check / lint-staged / DS / migration-ref / bundle steps; adds a CI-skip guard + activation header).
- Native git hooks, zero dependency. Functionally identical for CLI/IDE-terminal commits (husky's only real edge — PATH bootstrap for GUI git clients — is unused here). Matches the superproject + cms, which already use `.githooks`.

## CI
- Node **20 → 22** (matches portal/cms; wrangler needs ≥22).
- Added an explicit **bundle-size gate** step (`check:bundle --skip-build`, reusing the build output) so the Workers Free 3 MiB limit is enforced in CI, not just pre-commit — matching cms.

Verified: the migrated hook ran end-to-end on both commits via the new `.githooks` path (type-check / DS / migration-ref / bundle all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
