### PR TITLE
chore(deps): align wrangler to ^4.102.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "typescript-eslint": "^8.56.1",
         "vite": "^8.0.16",
         "vitest": "^4.1.3",
-        "wrangler": "^4.95.0"
+        "wrangler": "^4.102.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -696,6 +696,42 @@
         "@cloudflare/workerd-windows-64": "1.20260526.1"
       }
     },
+    "node_modules/@cloudflare/vite-plugin/node_modules/wrangler": {
+      "version": "4.95.0",
+      "resolved": "https://registry.npmmirror.com/wrangler/-/wrangler-4.95.0.tgz",
+      "integrity": "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260526.0",
+        "path-to-regexp": "6.3.0",
+        "rosie-skills": "^0.6.3",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260526.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260526.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/vite-plugin/node_modules/ws": {
       "version": "8.20.1",
       "resolved": "https://registry.npmmirror.com/ws/-/ws-8.20.1.tgz",
@@ -894,9 +930,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260530.1",
-      "resolved": "https://registry.npmmirror.com/@cloudflare/workers-types/-/workers-types-4.20260530.1.tgz",
-      "integrity": "sha512-H0BcFCJqqDwoDUY88mv3qJuA3DUdnMmtUdsHRrEZY+SRhXOK8TyFqFb+iS7A/84+qzpTFmFzWo6JN9tVALO2nw==",
+      "version": "4.20260619.1",
+      "resolved": "https://registry.npmmirror.com/@cloudflare/workers-types/-/workers-types-4.20260619.1.tgz",
+      "integrity": "sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ==",
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "peer": true
@@ -7934,7 +7970,7 @@
     },
     "node_modules/rosie-skills-darwin-arm64": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+      "resolved": "https://registry.npmmirror.com/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
       "integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
       "cpu": [
         "arm64"
@@ -7948,7 +7984,7 @@
     },
     "node_modules/rosie-skills-freebsd-x64": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+      "resolved": "https://registry.npmmirror.com/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
       "integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
       "cpu": [
         "x64"
@@ -7962,7 +7998,7 @@
     },
     "node_modules/rosie-skills-linux-x64": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+      "resolved": "https://registry.npmmirror.com/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
       "integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
       "cpu": [
         "x64"
@@ -9215,23 +9251,23 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.95.0",
-      "resolved": "https://registry.npmmirror.com/wrangler/-/wrangler-4.95.0.tgz",
-      "integrity": "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==",
+      "version": "4.102.0",
+      "resolved": "https://registry.npmmirror.com/wrangler/-/wrangler-4.102.0.tgz",
+      "integrity": "sha512-GPljlQs9a+/Ai2h0TdEUYaaWv9upK4fUteSWTPlruas7tdixiIwr74CZSWHcEPuRgZYkyYKHIBbT1w+BYPkPrw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260526.0",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260617.0",
         "path-to-regexp": "6.3.0",
-        "rosie-skills": "^0.6.3",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260526.1"
+        "workerd": "1.20260617.1"
       },
       "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
@@ -9239,10 +9275,10 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260526.1"
+        "@cloudflare/workers-types": "^4.20260617.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -9250,10 +9286,78 @@
         }
       }
     },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmmirror.com/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmmirror.com/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmmirror.com/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmmirror.com/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260526.1",
-      "resolved": "https://registry.npmmirror.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz",
-      "integrity": "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmmirror.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
       "cpu": [
         "x64"
       ],
@@ -9268,17 +9372,17 @@
       }
     },
     "node_modules/wrangler/node_modules/miniflare": {
-      "version": "4.20260526.0",
-      "resolved": "https://registry.npmmirror.com/miniflare/-/miniflare-4.20260526.0.tgz",
-      "integrity": "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==",
+      "version": "4.20260617.0",
+      "resolved": "https://registry.npmmirror.com/miniflare/-/miniflare-4.20260617.0.tgz",
+      "integrity": "sha512-A+H5gcOCQZsKFg7/daZUtx8WHn4gGxwUfH1jnNDAisyAWSvvSZHe+GCeQWs16uthnUDcm72UQIQ1NXDJtnuo9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.24.8",
-        "workerd": "1.20260526.1",
-        "ws": "8.20.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260617.1",
+        "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -9289,9 +9393,9 @@
       }
     },
     "node_modules/wrangler/node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9299,9 +9403,9 @@
       }
     },
     "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20260526.1",
-      "resolved": "https://registry.npmmirror.com/workerd/-/workerd-1.20260526.1.tgz",
-      "integrity": "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmmirror.com/workerd/-/workerd-1.20260617.1.tgz",
+      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -9312,17 +9416,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260526.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260526.1",
-        "@cloudflare/workerd-linux-64": "1.20260526.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260526.1",
-        "@cloudflare/workerd-windows-64": "1.20260526.1"
+        "@cloudflare/workerd-darwin-64": "1.20260617.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+        "@cloudflare/workerd-linux-64": "1.20260617.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
+        "@cloudflare/workerd-windows-64": "1.20260617.1"
       }
     },
     "node_modules/wrangler/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "typescript-eslint": "^8.56.1",
     "vite": "^8.0.16",
     "vitest": "^4.1.3",
-    "wrangler": "^4.95.0"
+    "wrangler": "^4.102.0"
   },
   "overrides": {
     "esbuild": "^0.28.1",

--- a/server/api/portal.ts
+++ b/server/api/portal.ts
@@ -361,7 +361,10 @@ export const portalRoutes = portalRouter
             // `c.executionCtx` is the Hono Worker execution context (see di.ts).
             // Its getter THROWS when no execution context is present (e.g. unit
             // tests), so probe it defensively rather than via a truthiness check.
-            let execCtx: ExecutionContext | undefined;
+            // Only `waitUntil` is used; typed structurally so Hono's
+            // `c.executionCtx` (whose ExecutionContext type lags
+            // @cloudflare/workers-types) assigns without a version-skew error.
+            let execCtx: Pick<ExecutionContext, 'waitUntil'> | undefined;
             try {
                 execCtx = c.executionCtx;
             } catch {

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -90,7 +90,10 @@ export interface AuditParams {
     entityId?: string | undefined;
     metadata?: Record<string, unknown> | undefined;
     ipAddress?: string | undefined;
-    executionCtx?: ExecutionContext | undefined;
+    // Only `waitUntil` is used; typed structurally so Hono's `c.executionCtx`
+    // (whose ExecutionContext type lags @cloudflare/workers-types — newer
+    // versions add members like `tracing`) assigns without a version-skew error.
+    executionCtx?: Pick<ExecutionContext, 'waitUntil'> | undefined;
 }
 
 /**


### PR DESCRIPTION
Aligns wrangler across the three submodules. Portal moved to ^4.102.0 via Dependabot; oi was on ^4.95.0.

- `wrangler` ^4.95.0 → **^4.102.0**.
- The bump pulls a newer `@cloudflare/workers-types` whose `ExecutionContext` adds a required `tracing` member, which Hono's `c.executionCtx` type doesn't carry yet. The two call sites that only use `waitUntil` (`server/lib/audit.ts`, `server/api/portal.ts`) are retyped structurally as `Pick<ExecutionContext, 'waitUntil'>` — bridges the version skew without a cast and is future-proof against further workers-types additions.

Verified locally: `npm install` resolves cleanly (no peer conflicts with vitest-pool-workers 0.14.2), `type-check` 0/0, `test:workers` 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
