### PR TITLE
chore(deps): force undici ^7.28.0 (clear 2 Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -665,16 +665,6 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/@cloudflare/vite-plugin/node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@cloudflare/vite-plugin/node_modules/workerd": {
       "version": "1.20260526.1",
       "resolved": "https://registry.npmmirror.com/workerd/-/workerd-1.20260526.1.tgz",
@@ -8647,9 +8637,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9390,16 +9380,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/wrangler/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/wrangler/node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
   },
   "overrides": {
     "esbuild": "^0.28.1",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "undici": "^7.28.0"
   },
   "optionalDependencies": {
     "@rolldown/binding-linux-x64-gnu": "1.0.3",


### PR DESCRIPTION
Clears the 2 open Dependabot alerts on transitive `undici`:
- **GHSA-vmh5-mc38-953g** (HIGH) — TLS cert validation bypass via SOCKS5 ProxyAgent (>=7.23.0 <7.28.0)
- **GHSA-pr7r-676h-xcf6** (MED) — cross-user info disclosure via shared-cache whitespace bypass (>=7.0.0 <7.28.0)

`undici` is transitive (nested copies under `@cloudflare/vite-plugin`'s miniflare → 7.24.8 and the direct `miniflare` devDep → 7.24.4). Both advisories are fixed in 7.28.0. Added an `overrides` entry pinning `undici` `^7.28.0`, which collapses the whole tree to a single 7.28.0 (`npm ls undici` → `undici@7.28.0`).

Verified: `npm install` clean, `test:workers` 41/41, pre-commit (type-check + build + bundle) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
