### PR TITLE
fix(sms): toll-free verification compliance — HELP reply, opt-in legal links, message frequency

### DIFF
--- a/app/components/booking/BookingSteps.tsx
+++ b/app/components/booking/BookingSteps.tsx
@@ -111,6 +111,8 @@ export function ScheduleStep({
   setClientEmail,
   smsOptin,
   setSmsOptin,
+  privacyUrl,
+  termsUrl,
 }: {
   inspectionDate: string;
   setInspectionDate: (v: string) => void;
@@ -128,6 +130,8 @@ export function ScheduleStep({
   setClientEmail: (v: string) => void;
   smsOptin: boolean;
   setSmsOptin: (v: boolean) => void;
+  privacyUrl: string | null;
+  termsUrl: string | null;
 }) {
   return (
     <section className="space-y-8">
@@ -228,8 +232,22 @@ export function ScheduleStep({
           />
           <span className="text-[13px] text-ih-fg-3 leading-relaxed">
             Text me appointment &amp; report updates. By checking this box you agree to
-            receive automated text messages about your inspection. Message &amp; data rates
-            may apply; reply STOP to opt out. Consent is not a condition of booking.
+            receive automated text messages about your inspection. Message frequency varies
+            by your inspection activity. Message &amp; data rates may apply; reply STOP to opt
+            out, HELP for help. Consent is not a condition of booking.
+            {(privacyUrl || termsUrl) && (
+              <>
+                {" "}
+                {privacyUrl && (
+                  <a href={privacyUrl} target="_blank" rel="noreferrer" className="underline">Privacy Policy</a>
+                )}
+                {privacyUrl && termsUrl && <span> · </span>}
+                {termsUrl && (
+                  <a href={termsUrl} target="_blank" rel="noreferrer" className="underline">Terms</a>
+                )}
+                .
+              </>
+            )}
           </span>
         </label>
       </div>

--- a/app/components/booking/BookingWizard.tsx
+++ b/app/components/booking/BookingWizard.tsx
@@ -8,10 +8,12 @@ type BookingFormState = ReturnType<typeof useBookingFormState>;
 export function BookingWizard({
   profile,
   privacyUrl,
+  termsUrl,
   form,
 }: {
   profile: CompanyProfile;
   privacyUrl: string | null;
+  termsUrl: string | null;
   form: BookingFormState;
 }) {
   const {
@@ -106,6 +108,8 @@ export function BookingWizard({
           setClientEmail={setClientEmail}
           smsOptin={smsOptin}
           setSmsOptin={setSmsOptin}
+          privacyUrl={privacyUrl}
+          termsUrl={termsUrl}
         />
       )}
 

--- a/app/routes/public/booking.tsx
+++ b/app/routes/public/booking.tsx
@@ -54,14 +54,15 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
       agentRefSlug,
       brand,
       privacyUrl: legal?.privacyUrl ?? null,
+      termsUrl: legal?.termsUrl ?? null,
     };
   } catch {
-    return { profile: null, preselected: null, error: "Service unavailable", tenant: "", agentRefSlug: null, brand: EMPTY_BRAND as TenantBrand, privacyUrl: null };
+    return { profile: null, preselected: null, error: "Service unavailable", tenant: "", agentRefSlug: null, brand: EMPTY_BRAND as TenantBrand, privacyUrl: null, termsUrl: null };
   }
 }
 
 export default function BookingPage() {
-  const { profile, preselected, error, agentRefSlug, brand, tenant, privacyUrl } = useLoaderData<typeof loader>();
+  const { profile, preselected, error, agentRefSlug, brand, tenant, privacyUrl, termsUrl } = useLoaderData<typeof loader>();
   const form = useBookingFormState({ profile, preselected, tenant, agentRefSlug });
 
   if (error || !profile) {
@@ -74,7 +75,7 @@ export default function BookingPage() {
 
   return (
     <BookingShell profile={profile} brand={brand} privacyUrl={privacyUrl}>
-      <BookingWizard profile={profile} privacyUrl={privacyUrl} form={form} />
+      <BookingWizard profile={profile} privacyUrl={privacyUrl} termsUrl={termsUrl} form={form} />
     </BookingShell>
   );
 }

--- a/app/routes/public/sms-optin.tsx
+++ b/app/routes/public/sms-optin.tsx
@@ -9,6 +9,8 @@ export function meta() {
 interface OptinData {
     companyName: string;
     disclosureText: string;
+    privacyUrl: string | null;
+    termsUrl: string | null;
 }
 
 /* ------------------------------------------------------------------ */
@@ -96,6 +98,17 @@ export default function SmsOptinPage() {
                 </p>
                 <div className="bg-ih-bg-muted border border-ih-border rounded-xl p-4 mb-5">
                     <p className="text-xs text-ih-fg-3 leading-relaxed">{data.disclosureText}</p>
+                    {(data.privacyUrl || data.termsUrl) && (
+                        <p className="text-xs text-ih-fg-3 leading-relaxed mt-2">
+                            {data.privacyUrl && (
+                                <a href={data.privacyUrl} target="_blank" rel="noreferrer" className="underline">Privacy Policy</a>
+                            )}
+                            {data.privacyUrl && data.termsUrl && <span> · </span>}
+                            {data.termsUrl && (
+                                <a href={data.termsUrl} target="_blank" rel="noreferrer" className="underline">Terms of Service</a>
+                            )}
+                        </p>
+                    )}
                 </div>
                 {actionData?.error && (
                     <p className="text-sm text-ih-bad-fg mb-3" role="alert">
@@ -112,7 +125,8 @@ export default function SmsOptinPage() {
                     </button>
                 </Form>
                 <p className="text-xs text-ih-fg-3 mt-4 text-center">
-                    Message &amp; data rates may apply. Reply STOP to opt out.
+                    Message frequency varies by your inspection activity. Message &amp; data rates
+                    may apply. Reply STOP to opt out, HELP for help.
                 </p>
             </div>
         </div>

--- a/scripts/tenant-scoping-baseline.json
+++ b/scripts/tenant-scoping-baseline.json
@@ -18,6 +18,7 @@
   "server/api/inspections/agreements.ts:246",
   "server/api/public-report.ts:291",
   "server/api/public-report.ts:352",
+  "server/api/sms.ts:70",
   "server/services/agent/referral.ts:194",
   "server/services/agreement.service.ts:56",
   "server/services/agreement/envelope-legacy.ts:252",

--- a/server/api/sms.ts
+++ b/server/api/sms.ts
@@ -45,9 +45,33 @@ import { getBaseUrl } from '../lib/url';
 import type { Context } from 'hono';
 import type { HonoConfig } from '../types/hono';
 
-// STOP-set → revoke; START-set → grant; anything else is logged, not a state change.
+// STOP-set → revoke; START-set → grant; HELP-set → informational auto-reply
+// (TCPA/CTIA + Twilio toll-free verification require HELP to respond); anything
+// else is logged, not a state change.
 const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT']);
 const START_WORDS = new Set(['START', 'UNSTOP', 'YES']);
+const HELP_WORDS = new Set(['HELP', 'INFO']);
+
+function escapeXml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+}
+
+/**
+ * Brand name for the HELP auto-reply: the tenant's company name in the
+ * tenant-scoped inbound shape, else the operator's APP_NAME (self-host) or the
+ * platform default. The platform toll-free is shared, so a brand-level name is
+ * the correct identity for a HELP reply on the platform shape.
+ */
+async function helpReplyBrand(c: Context<HonoConfig>, scopeTenantId: string | null): Promise<string> {
+    if (scopeTenantId) {
+        const db = drizzle(c.env.DB);
+        const t = await db.select({ name: tenants.name }).from(tenants)
+            .where(eq(tenants.id, scopeTenantId)).get().catch(() => null);
+        if (t?.name) return t.name;
+    }
+    return (c.env as { APP_NAME?: string }).APP_NAME?.trim() || 'Inspector Hub';
+}
 
 // ─── Public router ───────────────────────────────────────────────────────────
 
@@ -64,6 +88,8 @@ const optinResolveRoute = createRoute(withMcpMetadata({
                 data: z.object({
                     companyName: z.string(),
                     disclosureText: z.string(),
+                    privacyUrl: z.string().nullable(),
+                    termsUrl: z.string().nullable(),
                 }),
             }) } },
             description: 'Resolved opt-in context',
@@ -98,9 +124,12 @@ export const smsPublicRoutes = createApiRouter()
         if (!tenant) throw Errors.NotFound('This opt-in link is invalid or has expired.');
 
         const disc = await new SmsConsentService(c.env.DB).currentDisclosure();
-        const disclosureText = (disc?.text ?? 'By confirming, you agree to receive appointment and report text messages. Message and data rates may apply. Reply STOP to opt out.')
+        const disclosureText = (disc?.text ?? 'By confirming, you agree to receive appointment and report text messages. Message frequency varies by your inspection activity. Message and data rates may apply. Reply STOP to opt out, HELP for help.')
             .replace(/\{\{\s*company_name\s*\}\}/g, tenant.name);
-        return c.json({ success: true as const, data: { companyName: tenant.name, disclosureText } }, 200);
+        const env = c.env as { PRIVACY_URL?: string; TERMS_URL?: string };
+        const privacyUrl = env.PRIVACY_URL?.trim() || null;
+        const termsUrl = env.TERMS_URL?.trim() || null;
+        return c.json({ success: true as const, data: { companyName: tenant.name, disclosureText, privacyUrl, termsUrl } }, 200);
     })
     .openapi(optinConfirmRoute, async (c) => {
         const { token } = c.req.valid('json');
@@ -162,6 +191,14 @@ async function handleInbound(
     const cmd = (params.Body ?? '').trim().toUpperCase();
     const isRevoke = STOP_WORDS.has(cmd);
     const isGrant = START_WORDS.has(cmd);
+
+    // HELP — respond with an informational message identifying the program. Does
+    // not depend on matching a contact (Twilio expects HELP answered regardless).
+    if (HELP_WORDS.has(cmd)) {
+        const brand = await helpReplyBrand(c, opts.scopeTenantId);
+        const msg = `${brand}: appointment & report text alerts. Message frequency varies by your inspection activity. Msg & data rates may apply. Reply STOP to unsubscribe.`;
+        return c.text(`<Response><Message>${escapeXml(msg)}</Message></Response>`, 200, { 'Content-Type': 'text/xml' });
+    }
 
     if (!from) return c.text('<Response/>', 200, { 'Content-Type': 'text/xml' });
 

--- a/server/lib/integration/standalone.ts
+++ b/server/lib/integration/standalone.ts
@@ -118,7 +118,7 @@ async function seedSmsDisclosureV1(db: D1Database): Promise<void> {
             SELECT 1, ?, unixepoch('now') * 1000
             WHERE NOT EXISTS (SELECT 1 FROM sms_disclosure_versions)
         `).bind(
-            'By providing your phone number and opting in, you agree to receive appointment and report text messages from {{company_name}}. Message and data rates may apply. Reply STOP to opt out, HELP for help.',
+            'By providing your phone number and opting in, you agree to receive appointment and report text messages from {{company_name}}. Message frequency varies by your inspection activity. Message and data rates may apply. Reply STOP to opt out, HELP for help.',
         ).run();
     } catch (err) {
         // non-fatal: setup wizard must not fail because of seed data

--- a/server/services/automation/shared.ts
+++ b/server/services/automation/shared.ts
@@ -19,7 +19,7 @@ import { drizzle } from 'drizzle-orm/d1';
 // Track L (D7) — default TCPA SMS opt-in disclosure (version 1). Seeded once by
 // ensureSeeds (SaaS) and the standalone raw-SQL path; kept identical in both.
 export const SMS_DISCLOSURE_V1 =
-    'By providing your phone number and opting in, you agree to receive appointment and report text messages from {{company_name}}. Message and data rates may apply. Reply STOP to opt out, HELP for help.';
+    'By providing your phone number and opting in, you agree to receive appointment and report text messages from {{company_name}}. Message frequency varies by your inspection activity. Message and data rates may apply. Reply STOP to opt out, HELP for help.';
 
 export function interpolate(template: string, vars: Record<string, string>): string {
     return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? '');

--- a/tests/unit/sms-api.spec.ts
+++ b/tests/unit/sms-api.spec.ts
@@ -232,7 +232,7 @@ describe('SMS consent API (Track L Task 8)', () => {
         expect(await new SmsConsentService({} as D1Database).getLatest(TENANT, contactId)).toBe('granted');
     });
 
-    it('opt-in resolve returns disclosure + company name', async () => {
+    it('opt-in resolve returns disclosure + company name + legal links', async () => {
         const contactId = crypto.randomUUID();
         await db.insert(schema.contacts).values({
             id: contactId, tenantId: TENANT, type: 'client', name: 'Jane', email: 'jane@x.com', createdAt: new Date(),
@@ -241,10 +241,44 @@ describe('SMS consent API (Track L Task 8)', () => {
         const token = await mintOptinToken(TENANT, contactId, FAKE_ENV.JWT_SECRET);
 
         const app = buildApp(db);
+        // No PRIVACY_URL/TERMS_URL configured → links resolve to null.
         const res = await app.request(`/api/public/sms/optin-resolve?token=${encodeURIComponent(token)}`, {}, FAKE_ENV, makeExecCtx());
         expect(res.status).toBe(200);
-        const body = await res.json() as { data: { companyName: string; disclosureText: string } };
+        const body = await res.json() as { data: { companyName: string; disclosureText: string; privacyUrl: string | null; termsUrl: string | null } };
         expect(body.data.companyName).toBe('T-acme');
         expect(body.data.disclosureText).toContain('disclosure');
+        expect(body.data.privacyUrl).toBeNull();
+        expect(body.data.termsUrl).toBeNull();
+
+        // With operator legal URLs set, they flow through to the opt-in page.
+        const envWithLegal = { ...FAKE_ENV, PRIVACY_URL: 'https://ops.example/privacy', TERMS_URL: 'https://ops.example/terms' } as unknown as HonoConfig['Bindings'];
+        const res2 = await app.request(`/api/public/sms/optin-resolve?token=${encodeURIComponent(token)}`, {}, envWithLegal, makeExecCtx());
+        const body2 = await res2.json() as { data: { privacyUrl: string | null; termsUrl: string | null } };
+        expect(body2.data.privacyUrl).toBe('https://ops.example/privacy');
+        expect(body2.data.termsUrl).toBe('https://ops.example/terms');
+    });
+
+    it('inbound HELP → 200 TwiML auto-reply identifying the program (no consent change)', async () => {
+        const contactId = crypto.randomUUID();
+        await db.insert(schema.contacts).values({
+            id: contactId, tenantId: TENANT, type: 'client', name: 'Jane', phone: '+15551234567', createdAt: new Date(),
+        } as never);
+        await new SmsConsentService({} as D1Database).record(TENANT, contactId, 'granted', 'admin', {});
+
+        const params = { From: '+15551234567', Body: 'HELP' };
+        const url = `${APP_BASE_URL}/api/public/sms/inbound`;
+        const sig = await signParams(PLATFORM_TOKEN, url, params);
+
+        const app = buildApp(db);
+        const res = await app.request('/api/public/sms/inbound',
+            { ...form(params), headers: { 'content-type': 'application/x-www-form-urlencoded', 'X-Twilio-Signature': sig } },
+            FAKE_ENV, makeExecCtx());
+        expect(res.status).toBe(200);
+        const xml = await res.text();
+        expect(xml).toContain('<Message>');
+        expect(xml).toContain('Inspector Hub'); // APP_NAME unset → platform brand fallback
+        expect(xml).toContain('STOP');
+        // HELP is informational only — consent state is untouched.
+        expect(await new SmsConsentService({} as D1Database).getLatest(TENANT, contactId)).toBe('granted');
     });
 });


### PR DESCRIPTION
Closes the SMS-side gaps required for Twilio toll-free verification (opt-in consent). Shared inbound/disclosure code, so platform / own-key / self-host deployments all benefit.

## Changes
- **Inbound HELP/INFO keyword → TwiML auto-reply** in the shared `handleInbound` (`server/api/sms.ts`). Identifies the program (tenant company name when tenant-scoped, else `APP_NAME`). The disclosure copy promised "HELP for help" but it was previously a no-op; HELP is now answered on both the platform and tenant-scoped inbound webhooks.
- **Privacy / Terms links** on the public booking SMS opt-in checkbox (`BookingSteps`) and the `/sms-optin` double-opt-in page — `optin-resolve` now returns `privacyUrl`/`termsUrl` from the operator's `PRIVACY_URL`/`TERMS_URL`, so self-hosters link their own policy.
- **"Message frequency varies"** added to all disclosure copy: booking checkbox, opt-in page, and the `SMS_DISCLOSURE_V1` seed (both the automation seed and the standalone raw-SQL seed, kept in sync).
- Baselines one `tenants`-by-id self-lookup added by the HELP reply in the tenant-scoping ratchet (looking up the tenants registry by its own PK is the canonical safe pattern, not a cross-tenant read).

## Tests
- `tests/unit/sms-api.spec.ts`: HELP auto-reply (TwiML, brand, no consent-state change) + opt-in legal-link passthrough. Full `verify` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)