### PR TITLE
fix(sms): brand booking opt-in with company name + OPTOUT/REVOKE stop keywords

### DIFF
--- a/app/components/booking/BookingSteps.tsx
+++ b/app/components/booking/BookingSteps.tsx
@@ -113,6 +113,7 @@ export function ScheduleStep({
   setSmsOptin,
   privacyUrl,
   termsUrl,
+  companyName,
 }: {
   inspectionDate: string;
   setInspectionDate: (v: string) => void;
@@ -132,7 +133,10 @@ export function ScheduleStep({
   setSmsOptin: (v: boolean) => void;
   privacyUrl: string | null;
   termsUrl: string | null;
+  companyName: string;
 }) {
+  // Twilio/CTIA require the opt-in to be branded with the end business name.
+  const company = companyName?.trim() || "your inspection company";
   return (
     <section className="space-y-8">
       <div className="space-y-5">
@@ -231,10 +235,10 @@ export function ScheduleStep({
             className="mt-0.5 h-4 w-4 rounded border-ih-border text-ih-primary focus:ring-ih-primary"
           />
           <span className="text-[13px] text-ih-fg-3 leading-relaxed">
-            Text me appointment &amp; report updates. By checking this box you agree to
-            receive automated text messages about your inspection. Message frequency varies
-            by your inspection activity. Message &amp; data rates may apply; reply STOP to opt
-            out, HELP for help. Consent is not a condition of booking.
+            Text me appointment &amp; report updates from {company}. By checking this box you
+            agree to receive automated text messages from {company} about your inspection.
+            Message frequency varies by your inspection activity. Message &amp; data rates may
+            apply; reply STOP to opt out, HELP for help. Consent is not a condition of booking.
             {(privacyUrl || termsUrl) && (
               <>
                 {" "}

--- a/app/components/booking/BookingWizard.tsx
+++ b/app/components/booking/BookingWizard.tsx
@@ -110,6 +110,7 @@ export function BookingWizard({
           setSmsOptin={setSmsOptin}
           privacyUrl={privacyUrl}
           termsUrl={termsUrl}
+          companyName={profile.company}
         />
       )}
 

--- a/server/api/sms.ts
+++ b/server/api/sms.ts
@@ -48,7 +48,7 @@ import type { HonoConfig } from '../types/hono';
 // STOP-set → revoke; START-set → grant; HELP-set → informational auto-reply
 // (TCPA/CTIA + Twilio toll-free verification require HELP to respond); anything
 // else is logged, not a state change.
-const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT']);
+const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'OPTOUT', 'CANCEL', 'END', 'REVOKE', 'QUIT']);
 const START_WORDS = new Set(['START', 'UNSTOP', 'YES']);
 const HELP_WORDS = new Set(['HELP', 'INFO']);
 


### PR DESCRIPTION
Two compliance gaps found by checking the shipped opt-in against Twilio's verbatim requirements:

1. **Branded opt-in** — Twilio/CTIA require the opt-in to name the end business. The public booking SMS consent checkbox now names the inspection company (`profile.company`), matching `SMS_DISCLOSURE_V1` / `/sms-optin` which already use `{{company_name}}`.
2. **STOP keyword parity** — added `OPTOUT` and `REVOKE` to the inbound STOP set (Twilio Messaging Policy keyword list).

Tests: `sms-api.spec` green. Type-safe (`CompanyProfile.company: string`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)