### PR TITLE
test: close skipped-test coverage gaps (Media Center service + presence-DO roster)

### DIFF
--- a/tests/unit/inspection-presence-do.spec.ts
+++ b/tests/unit/inspection-presence-do.spec.ts
@@ -2,10 +2,9 @@
  * Design System 0520 subsystem B phase 2 task 2.8 — Durable Object smoke
  * placeholder.
  *
- * Full DO integration testing requires `@cloudflare/vitest-pool-workers`
- * which is not yet set up in this repo's vitest config (the DOs import
- * `cloudflare:workers` which is unavailable in the default node env).
- * Until that pool lands, the DO behaviour is covered indirectly by:
+ * Real DO-runtime roster-broadcast coverage now lives in the workerd pool:
+ * tests/workers/presence-do.spec.ts (the DO imports `cloudflare:workers`,
+ * unavailable in this node env). The DO behaviour is additionally covered by:
  *
  *   1. The protocol helpers (tests/unit/presence-protocol.spec.ts) which
  *      verify the wire-format contract shared between the DO and the
@@ -14,11 +13,9 @@
  *      two browser windows to the same inspection and asserts roster
  *      synchronisation across them.
  *
- * This file exists so the test report explicitly lists the DO as covered
- * (even if by placeholder) — making the coverage gap visible at a glance
- * rather than silently absent. The static-source assertion below catches
- * regressions where someone refactors the file path / class name without
- * updating wrangler.jsonc's [[durable_objects.bindings]].
+ * This node-env file keeps only the static binding-contract checks below —
+ * they catch regressions where someone refactors the file path / class name
+ * without updating wrangler.jsonc's [[durable_objects.bindings]].
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -44,8 +41,4 @@ describe('Presence Durable Objects — smoke', () => {
         expect(cfg).toMatch(/"class_name":\s*"InspectionPresenceDO"/);
         expect(cfg).toMatch(/"class_name":\s*"TenantPresenceDO"/);
     });
-
-    // TODO(B2): wire @cloudflare/vitest-pool-workers and replace this stub
-    // with real WebSocket roster broadcast assertions.
-    it.skip('roster broadcast on join (placeholder — needs vitest-pool-workers)', () => {});
 });

--- a/tests/unit/media-center.spec.ts
+++ b/tests/unit/media-center.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { InspectionService } from '../../server/services/inspection.service';
+import { ScopedDB, type DrizzleDB } from '../../server/lib/db/scoped';
 import { createTestDb, setupSchema } from './db';
 import * as schema from '../../server/lib/db/schema';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
@@ -22,10 +23,10 @@ const INSPECTION_ID = '11111111-1111-1111-1111-111111111111';
  *     deletes the underlying object
  *   - tenant isolation — a pool row owned by a different tenant is invisible
  */
-// Skipped: 5 of 7 cases require ScopedDB session wiring; runtime code works
-// in production (sdb is provided via DI middleware), but the unit fixture
-// mocks at the drizzle layer only. Follow-up: add an sdb mock helper.
-describe.skip('InspectionService — Media Center (Round-2 backlog #9)', () => {
+// The 5 sdb-backed cases need a ScopedDB wired over the test db (the methods
+// run through this.photo → ScopedDB, provided in production via DI). We build
+// one over the same better-sqlite3 fixture the drizzle mock returns.
+describe('InspectionService — Media Center (Round-2 backlog #9)', () => {
     let svc: InspectionService;
     let testDb: BetterSQLite3Database<typeof schema>;
     const r2Mock = {
@@ -39,8 +40,11 @@ describe.skip('InspectionService — Media Center (Round-2 backlog #9)', () => {
         await setupSchema(fixture.sqlite);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockDrizzle as any).mockReturnValue(testDb);
+        // Wire a ScopedDB over the same fixture db so this.photo's tenant-scoped
+        // reads/writes resolve (mirrors the DI-provided sdb in production).
+        const sdb = new ScopedDB(testDb as unknown as DrizzleDB, TENANT);
         // Cast r2Mock to the R2Bucket shape we use (put/delete only).
-        svc = new InspectionService({} as D1Database, r2Mock as unknown as R2Bucket);
+        svc = new InspectionService({} as D1Database, r2Mock as unknown as R2Bucket, sdb);
         r2Mock.put.mockClear();
         r2Mock.delete.mockClear();
 
@@ -120,7 +124,7 @@ describe.skip('InspectionService — Media Center (Round-2 backlog #9)', () => {
             photoIndex:   0,
             annotated:    false,
         });
-        expect(cover1!.url).toContain('/photos/k-cover-1');
+        expect(cover1!.url).toContain('/photo?key=k-cover-1');
 
         // The annotated copy is preferred for display, the photoIndex still
         // points at index 1 of the photos array (so the editor can resolve
@@ -148,7 +152,7 @@ describe.skip('InspectionService — Media Center (Round-2 backlog #9)', () => {
 
         const out = await svc.getMediaCenter(INSPECTION_ID, TENANT);
         expect(out.pool.map(p => p.id)).toEqual([b.id, a.id]); // newest first
-        expect(out.pool[0]?.url).toContain('/photos/');
+        expect(out.pool[0]?.url).toContain('/photo?key=');
     });
 
     it('attachPoolPhoto moves a pool row into results.data and removes the pool entry', async () => {

--- a/tests/unit/rating-system.spec.ts
+++ b/tests/unit/rating-system.spec.ts
@@ -119,8 +119,11 @@ describe('RatingSystemService — seed + tenant scope', () => {
     it('makes default flag mutually exclusive within a tenant', async () => {
         await svc.seedDefaults(TENANT_A);
         const seed = (await svc.list(TENANT_A)).find(s => s.slug === 'trec')!;
-        const a = await svc.clone(seed.id, TENANT_A, 'A');
-        const b = await svc.clone(seed.id, TENANT_A, 'B');
+        // Pass explicit slugs: clone()'s default slug is `${src}-copy-${Date.now()}`,
+        // which collides when two clones land in the same millisecond (flaky slug
+        // conflict on the 2nd create). Distinct slugs make this deterministic.
+        const a = await svc.clone(seed.id, TENANT_A, 'A', 'rs-default-a');
+        const b = await svc.clone(seed.id, TENANT_A, 'B', 'rs-default-b');
         await svc.update(a.id, TENANT_A, { isDefault: true });
         await svc.update(b.id, TENANT_A, { isDefault: true });
 

--- a/tests/workers/presence-do.spec.ts
+++ b/tests/workers/presence-do.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * InspectionPresenceDO — real-runtime (workerd) roster broadcast.
+ *
+ * Replaces the node-env placeholder in tests/unit/inspection-presence-do.spec.ts
+ * (which could only do a static class-name check — the DO imports
+ * `cloudflare:workers`, unavailable in the node pool). Here the DO runs in the
+ * real workerd isolate via the vitest-pool-workers binding, so we drive its
+ * actual WebSocket hibernation + `broadcastRoster()` path.
+ *
+ * Protocol (see inspection-presence.ts): a `/ws` upgrade carrying x-user-* headers
+ * is accepted; on every roster change the DO broadcasts `{ type:'roster', users }`
+ * to all live connections. We assert:
+ *   1. A second client joining broadcasts an updated roster to the FIRST client.
+ *   2. The DO's own roster state lists both connections.
+ *   3. Closing a connection broadcasts a roster without the departed user.
+ */
+
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import type { InspectionPresenceDO } from '../../server/durable-objects/inspection-presence';
+
+interface TestBindings {
+    INSPECTION_PRESENCE: DurableObjectNamespace<InspectionPresenceDO>;
+}
+const b = env as unknown as TestBindings;
+
+interface RosterMsg { type: 'roster'; users: Array<{ userId: string; role: string; focusItemId: string | null }> }
+interface PresenceInternals { snapshotRoster(): Array<{ userId: string }> }
+
+/** Build a `/ws` upgrade request with the identity headers the worker stamps. */
+function wsUpgrade(userId: string, name: string, role: 'inspector' | 'observer' = 'inspector'): Request {
+    return new Request('https://do.local/api/inspections/x/presence/ws', {
+        headers: {
+            Upgrade: 'websocket',
+            'x-user-id': userId,
+            'x-user-name': name,
+            'x-user-role': role,
+        },
+    });
+}
+
+/** Accept the client end of a DO-returned WebSocket and collect roster frames. */
+function captureRosters(ws: WebSocket): RosterMsg[] {
+    const frames: RosterMsg[] = [];
+    ws.accept();
+    ws.addEventListener('message', (e: MessageEvent) => {
+        if (typeof e.data !== 'string') return;
+        try {
+            const m = JSON.parse(e.data);
+            if (m && m.type === 'roster') frames.push(m as RosterMsg);
+        } catch { /* ignore non-JSON */ }
+    });
+    return frames;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+const ids = (m: RosterMsg | undefined) => (m?.users ?? []).map((u) => u.userId).sort();
+
+describe('InspectionPresenceDO — roster broadcast (workerd)', () => {
+    it('broadcasts the updated roster to an existing client when a new client joins', async () => {
+        const inspectionId = 'presence-join-' + crypto.randomUUID().slice(0, 8);
+        const stub = b.INSPECTION_PRESENCE.get(b.INSPECTION_PRESENCE.idFromName(inspectionId));
+
+        // Client A joins; start capturing AFTER the open so we observe the
+        // broadcast triggered by B's later join (A's own-join frame may predate
+        // the listener — that path is covered by the snapshotRoster assertion).
+        const respA = await stub.fetch(wsUpgrade('uA', 'Alice'));
+        expect(respA.status).toBe(101);
+        const aFrames = captureRosters(respA.webSocket!);
+
+        // Client B joins → DO broadcasts roster [A, B] to every connection.
+        const respB = await stub.fetch(wsUpgrade('uB', 'Bob'));
+        expect(respB.status).toBe(101);
+        respB.webSocket!.accept();
+
+        await flush();
+
+        // A received a roster broadcast naming both users.
+        expect(aFrames.length).toBeGreaterThan(0);
+        expect(ids(aFrames[aFrames.length - 1])).toEqual(['uA', 'uB']);
+
+        // The DO's own roster state lists both live connections.
+        await runInDurableObject(stub, async (instance: InspectionPresenceDO) => {
+            const roster = (instance as unknown as PresenceInternals).snapshotRoster();
+            expect(roster.map((u) => u.userId).sort()).toEqual(['uA', 'uB']);
+        });
+    });
+
+    it('broadcasts a roster without the departed user when a connection closes', async () => {
+        const inspectionId = 'presence-leave-' + crypto.randomUUID().slice(0, 8);
+        const stub = b.INSPECTION_PRESENCE.get(b.INSPECTION_PRESENCE.idFromName(inspectionId));
+
+        const respA = await stub.fetch(wsUpgrade('uA', 'Alice'));
+        const aWs = respA.webSocket!;
+        const aFrames = captureRosters(aWs);
+
+        const respB = await stub.fetch(wsUpgrade('uB', 'Bob'));
+        const bWs = respB.webSocket!;
+        bWs.accept();
+        await flush();
+        expect(ids(aFrames[aFrames.length - 1])).toEqual(['uA', 'uB']);
+
+        // B leaves → webSocketClose fires → broadcastRoster to remaining (A).
+        bWs.close(1000, 'bye');
+        await flush();
+
+        expect(ids(aFrames[aFrames.length - 1])).toEqual(['uA']);
+
+        await runInDurableObject(stub, async (instance: InspectionPresenceDO) => {
+            const roster = (instance as unknown as PresenceInternals).snapshotRoster();
+            expect(roster.map((u) => u.userId)).toEqual(['uA']);
+        });
+    });
+
+    it('rejects a WS upgrade with no x-user-id (worker-stamped identity required)', async () => {
+        const inspectionId = 'presence-auth-' + crypto.randomUUID().slice(0, 8);
+        const stub = b.INSPECTION_PRESENCE.get(b.INSPECTION_PRESENCE.idFromName(inspectionId));
+        const resp = await stub.fetch(new Request('https://do.local/presence/ws', {
+            headers: { Upgrade: 'websocket', 'x-user-name': 'NoId' },
+        }));
+        expect(resp.status).toBe(401);
+    });
+});

--- a/tests/workers/test-worker.ts
+++ b/tests/workers/test-worker.ts
@@ -12,6 +12,7 @@
 // Re-export the DO so vitest-pool-workers can bind it as INSPECTION_DOC.
 // runInDurableObject() only works with DOs defined in the `main` worker.
 export { InspectionDocDO } from '../../server/durable-objects/inspection-doc';
+export { InspectionPresenceDO } from '../../server/durable-objects/inspection-presence';
 
 interface TestEnv {
     DB: D1Database;

--- a/vitest.workers.config.ts
+++ b/vitest.workers.config.ts
@@ -44,6 +44,8 @@ export default defineConfig({
                 // The class is re-exported from test-worker.ts (required: main worker).
                 durableObjects: {
                     INSPECTION_DOC: 'InspectionDocDO',
+                    // Presence DO (WebSocket roster broadcast) — presence-do.spec.ts.
+                    INSPECTION_PRESENCE: 'InspectionPresenceDO',
                 },
             },
         }),


### PR DESCRIPTION
The unit suite carried 8 `describe.skip`/`it.skip` cases that masked real gaps. This un-skips/closes them — **test-only, no runtime change**.

## Media Center service layer (7)
`InspectionPhotoService` aggregation / pool upload / attach-move+append / delete+R2 / tenant-isolation was untested in CI (only the client-side `flattenMedia` helper was covered). The suite was skipped because the fixture omitted the `ScopedDB` (`sdb`) constructor arg, so the sdb-backed cases threw. Wired a `ScopedDB` over the test db and un-skipped: 5 passed immediately; 2 had **stale URL assertions** (`/photos/{key}` → the current `/api/inspections/:id/photo?key={key}` from the Hono mounted-router catch-all fix) — corrected. Now 7/7.

## Presence DO roster broadcast (1)
The node-env case was an empty `it.skip` placeholder (asserted nothing). Added real **workerd-runtime** coverage in `tests/workers/presence-do.spec.ts` (bound `INSPECTION_PRESENCE` in the vitest-pool-workers config + re-exported the DO from `test-worker.ts`):
- a second client joining broadcasts an updated roster to the first connection;
- closing a connection broadcasts a roster without the departed user;
- a `/ws` upgrade with no `x-user-id` is rejected (401).

Removed the empty placeholder; the node file keeps its binding-contract checks.

## Result
`test:unit` **2169 passed, 0 skipped** (was 2162 passed | 8 skipped) · `test:workers` **69** (was 66) · `test:web` 590 · type-check 0/0 · lint/DS/migref/bundle green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)