### PR TITLE
feat(mcp): Phase E — Resources, Prompts, extended-tier + UI polish

### DIFF
--- a/app/routes/settings-connected-apps.tsx
+++ b/app/routes/settings-connected-apps.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/settings-connected-apps";
 import { requireToken } from "~/lib/session.server";
@@ -91,19 +91,19 @@ export async function action({ request, context }: Route.ActionArgs) {
         param: { id },
         query: {},
       });
-      return { ok: res.ok, intent };
+      return { ok: res.ok, intent, id };
     }
     if (intent === "revoke-admin") {
       const res = await api.mcpGrants.grants[":id"].$delete({
         param: { id },
         query: { admin: "1" },
       });
-      return { ok: res.ok, intent };
+      return { ok: res.ok, intent, id };
     }
   } catch {
-    return { ok: false, intent };
+    return { ok: false, intent, id };
   }
-  return { ok: false, intent };
+  return { ok: false, intent, id };
 }
 
 // ─── Scope display helper ─────────────────────────────────────────────────────
@@ -172,13 +172,16 @@ function formatUnixDate(ts: number): string {
   });
 }
 
-// ─── Grant row (self) ─────────────────────────────────────────────────────────
+// ─── Grant row ────────────────────────────────────────────────────────────────
+// One row for both lists; `showUser` adds the owner line for the admin view.
 
 function GrantRow({
   grant,
+  showUser = false,
   onRequestRevoke,
 }: {
   grant: McpGrant;
+  showUser?: boolean;
   onRequestRevoke: () => void;
 }) {
   return (
@@ -187,48 +190,12 @@ function GrantRow({
         <p className="font-bold text-[13px] text-ih-fg-1 truncate">
           {grant.clientName ?? grant.clientId}
         </p>
-        <div className="mt-0.5">
-          <ScopesSummary scopes={grant.scopes} />
-        </div>
-        <p className="text-[11px] text-ih-fg-4 mt-1">
-          Created {formatUnixDate(grant.createdAt)}{" "}
-          {grant.expiresAt != null
-            ? `· Expires ${formatUnixDate(grant.expiresAt)}`
-            : "· No expiry"}
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={onRequestRevoke}
-        className="text-[12px] text-ih-bad-fg hover:underline font-bold shrink-0"
-      >
-        Revoke
-      </button>
-    </div>
-  );
-}
-
-// ─── Admin grant row ─────────────────────────────────────────────────────────
-
-function AdminGrantRow({
-  grant,
-  onRequestRevoke,
-}: {
-  grant: McpGrant;
-  onRequestRevoke: () => void;
-}) {
-  return (
-    <div className="flex items-start gap-4 px-4 py-3">
-      <div className="flex-1 min-w-0">
-        <p className="font-bold text-[13px] text-ih-fg-1 truncate">
-          {grant.clientName ?? grant.clientId}
-        </p>
-        <p className="text-[12px] text-ih-fg-3">
-          {grant.userEmail ?? grant.userId ?? "Unknown user"}{" "}
-          {grant.userRole ? (
-            <span className="text-ih-fg-4">({grant.userRole})</span>
-          ) : null}
-        </p>
+        {showUser && (
+          <p className="text-[12px] text-ih-fg-3">
+            {grant.userEmail ?? grant.userId ?? "Unknown user"}{" "}
+            {grant.userRole ? <span className="text-ih-fg-4">({grant.userRole})</span> : null}
+          </p>
+        )}
         <div className="mt-0.5">
           <ScopesSummary scopes={grant.scopes} />
         </div>
@@ -259,6 +226,21 @@ export default function SettingsConnectedApps() {
     grant: McpGrant;
     intent: "revoke" | "revoke-admin";
   } | null>(null);
+  // Optimistically hide a grant the moment its revoke is submitted, so the row
+  // disappears immediately instead of waiting on the loader revalidation.
+  const [revokedIds, setRevokedIds] = useState<Set<string>>(new Set());
+
+  // If a revoke fails server-side, restore the row (un-hide it).
+  useEffect(() => {
+    const result = revokeFetcher.data;
+    if (revokeFetcher.state === "idle" && result && result.ok === false && result.id) {
+      setRevokedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(result.id);
+        return next;
+      });
+    }
+  }, [revokeFetcher.state, revokeFetcher.data]);
 
   // Feature-off: MCP not enabled on this deployment.
   if (data.mcpEnabled === false) {
@@ -270,8 +252,10 @@ export default function SettingsConnectedApps() {
     );
   }
 
-  const { self, all } = data;
-  const showAdmin = all !== null;
+  const showAdmin = data.all !== null;
+  // Hide optimistically-revoked grants from both lists.
+  const self = data.self.filter((g) => !revokedIds.has(g.id));
+  const all = data.all ? data.all.filter((g) => !revokedIds.has(g.id)) : null;
 
   return (
     <div className="space-y-[18px]">
@@ -354,9 +338,10 @@ export default function SettingsConnectedApps() {
                   </div>
                   <div className="divide-y divide-ih-border">
                     {grants.map((grant) => (
-                      <AdminGrantRow
+                      <GrantRow
                         key={grant.id}
                         grant={grant}
+                        showUser
                         onRequestRevoke={() =>
                           setPendingRevoke({ grant, intent: "revoke-admin" })
                         }
@@ -383,8 +368,10 @@ export default function SettingsConnectedApps() {
         busy={revokeFetcher.state !== "idle"}
         onConfirm={() => {
           if (pendingRevoke) {
+            const id = pendingRevoke.grant.id;
+            setRevokedIds((prev) => new Set(prev).add(id));
             revokeFetcher.submit(
-              { intent: pendingRevoke.intent, id: pendingRevoke.grant.id },
+              { intent: pendingRevoke.intent, id },
               { method: "POST" },
             );
           }

--- a/docs/developers/connecting-claude-mcp.md
+++ b/docs/developers/connecting-claude-mcp.md
@@ -140,7 +140,27 @@ Each connection has its own consent and its own revocable grant.
 Tools are generated from the API's OpenAPI metadata: every route marked as a
 `primary`-tier MCP route becomes a tool named `openinspection_<operation>`, and a
 tool is only offered to a connection when the connection's granted scope covers
-that route's required scope and module tag. Routes tagged `extended` or
-`excluded` are never exposed as tools. See
-[Route Metadata Conventions](07_route_metadata.md) for how routes opt in, and
-[mcp-oauth-notes.md](mcp-oauth-notes.md) for the server's internal architecture.
+that route's required scope and module tag. Routes tagged `excluded` are never
+exposed. Routes tagged `extended` are off by default; an operator can expose
+them by setting `MCP_EXTENDED_TOOLS=true` in the deployment env (they stay
+scope-gated). See [Route Metadata Conventions](07_route_metadata.md) for how
+routes opt in, and [mcp-oauth-notes.md](mcp-oauth-notes.md) for the server's
+internal architecture.
+
+---
+
+## 8. Resources and prompts
+
+Beyond tools, the connection also exposes:
+
+- **Resources** — read-only views of your data the client can pull into context
+  without invoking a tool. Every granted read (`GET`) route is available as a
+  resource: collections at `openinspection:///api/<thing>` and single records at
+  `openinspection:///api/<thing>/{id}`. They honor the same scope grant as
+  tools, and reads run as you through the same tenant-scoped API.
+- **Prompts** — ready-made templates the client can offer you, such as
+  *Summarize inspection*, *Draft repair request*, *Review findings*, and
+  *Client follow-up email*. Each prompt only appears when your grant covers the
+  data it needs (e.g. the follow-up-email prompt requires the Contacts module).
+  Prompts carry no data themselves — they hand the model a starting instruction
+  that uses the tools and resources above.

--- a/packages/shared-ui/src/Modal.tsx
+++ b/packages/shared-ui/src/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useId, useRef } from "react";
 
 interface ModalProps {
   open: boolean;
@@ -13,6 +13,7 @@ const sizeClasses = { sm: "max-w-sm", md: "max-w-md", lg: "max-w-lg", xl: "max-w
 
 export function Modal({ open, onClose, title, size = "md", children, footer }: ModalProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const titleId = useId();
 
   useEffect(() => {
     if (!open) return;
@@ -25,10 +26,16 @@ export function Modal({ open, onClose, title, size = "md", children, footer }: M
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-[rgba(15,23,42,0.55)]" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div ref={ref} className={`w-full ${sizeClasses[size]} bg-ih-bg-card rounded-xl shadow-ih-popover border border-ih-border max-h-[90vh] overflow-y-auto`}>
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className={`w-full ${sizeClasses[size]} bg-ih-bg-card rounded-xl shadow-ih-popover border border-ih-border max-h-[90vh] overflow-y-auto`}
+      >
         <div className="flex items-center justify-between p-4 border-b border-ih-border">
-          <h2 className="text-lg font-bold text-ih-fg-1">{title}</h2>
-          <button onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-md text-ih-fg-4 hover:text-ih-fg-2">&#x2715;</button>
+          <h2 id={titleId} className="text-lg font-bold text-ih-fg-1">{title}</h2>
+          <button type="button" aria-label="Close" onClick={onClose} className="w-8 h-8 flex items-center justify-center rounded-md text-ih-fg-4 hover:text-ih-fg-2">&#x2715;</button>
         </div>
         <div className="p-4">{children}</div>
         {footer && <div className="flex justify-end gap-3 p-4 border-t border-ih-border">{footer}</div>}

--- a/server/durable-objects/inspector-mcp.ts
+++ b/server/durable-objects/inspector-mcp.ts
@@ -3,11 +3,14 @@
 // registered as MCP tools; each tool handler reconstructs the HTTP request and
 // executes it in-process as the authenticated user via the identity bridge.
 import { McpAgent } from 'agents/mcp';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import snapshot from '../lib/mcp/openapi-snapshot.json';
 import { selectTools, toolNameFromOperationId, type SnapshotEntry } from '../lib/mcp/tools';
+import { selectResources, buildResourceRequest } from '../lib/mcp/resources';
 import { buildToolInput, toZodInputSchema, type ToolInput } from '../lib/mcp/resolve-schema';
+import { registerGrantedPrompts } from '../lib/mcp/prompts';
 import { callApiAsUser } from '../lib/mcp/identity-bridge';
+import { extendedToolsEnabled } from '../lib/mcp/flag';
 import type { AppEnv } from '../types/hono';
 
 // `Env` is the global interface from worker-configuration.d.ts (extends Cloudflare.Env),
@@ -123,7 +126,8 @@ export async function registerGrantedTools(
     makeCtx: () => ExecutionContext = makeExecutionContext,
 ): Promise<void> {
     const all = snapshot as SnapshotEntry[];
-    const granted = selectTools(all, props.scopes);
+    const includeExtended = extendedToolsEnabled(env as unknown as { MCP_EXTENDED_TOOLS?: string });
+    const granted = selectTools(all, props.scopes, { includeExtended });
 
     // Only pay the OpenAPI-document cost when a granted operation actually
     // references a named component schema (`$ref`); read-only param-only tools
@@ -142,7 +146,7 @@ export async function registerGrantedTools(
             // Defense-in-depth: re-assert the scope grant at call time. The
             // authoritative tenant scoping happens downstream via
             // props.tenantId → internal JWT → in-process API tenant filtering.
-            if (selectTools([entry], props.scopes).length === 0) {
+            if (selectTools([entry], props.scopes, { includeExtended }).length === 0) {
                 return {
                     isError: true,
                     content: [{ type: 'text' as const, text: JSON.stringify({ error: 'forbidden', operationId: entry.operationId }) }],
@@ -160,13 +164,62 @@ export async function registerGrantedTools(
     }
 }
 
+/**
+ * Register every granted read-only (GET) operation as an MCP resource (Phase E).
+ * Collection operations (no path param) become static resources; get-by-id
+ * operations become resource templates. Reads run through the same identity
+ * bridge as tools, so tenant scoping + RBAC are unchanged. Extracted from
+ * `init()` for direct testing against a bare `McpServer`.
+ */
+export async function registerGrantedResources(
+    server: McpServer,
+    env: AppEnv,
+    props: McpProps,
+    makeCtx: () => ExecutionContext = makeExecutionContext,
+): Promise<void> {
+    const includeExtended = extendedToolsEnabled(env as unknown as { MCP_EXTENDED_TOOLS?: string });
+    const resources = selectResources(snapshot as SnapshotEntry[], props.scopes, { includeExtended });
+
+    const read = async (entry: SnapshotEntry, vars: Record<string, string>, uri: URL) => {
+        // Defense-in-depth: re-assert the read grant before dispatching.
+        if (selectTools([entry], props.scopes, { includeExtended }).length === 0) {
+            throw new Error(`forbidden: ${entry.operationId}`);
+        }
+        const res = await callApiAsUser(env, props, buildResourceRequest(entry, vars), makeCtx());
+        const text = await readTruncated(res);
+        return { contents: [{ uri: uri.href, mimeType: 'application/json', text }] };
+    };
+
+    for (const r of resources) {
+        const config = {
+            title: (r.entry.summary || r.name).trim(),
+            description: `${r.entry.summary ?? ''}. ${r.entry.description ?? ''}`.trim(),
+            mimeType: 'application/json',
+        };
+        if (r.pathParam === null) {
+            server.registerResource(r.name, r.uri, config, (uri) => read(r.entry, {}, uri));
+        } else {
+            const param = r.pathParam;
+            const template = new ResourceTemplate(r.uri, { list: undefined });
+            server.registerResource(r.name, template, config, (uri, variables) => {
+                const raw = variables[param];
+                const value = Array.isArray(raw) ? raw[0] : raw;
+                return read(r.entry, { [param]: String(value ?? '') }, uri);
+            });
+        }
+    }
+}
+
 export class InspectorMcp extends McpAgent<Env, unknown, McpProps> {
     server = new McpServer({ name: 'OpenInspection', version: '1.0.0' });
 
     async init(): Promise<void> {
         // `this.props` is populated from the OAuth grant before init() runs.
-        // Guard defensively: with no grant there are no tools to expose.
+        // Guard defensively: with no grant there is nothing to expose.
         if (!this.props) return;
-        await registerGrantedTools(this.server, this.env as unknown as AppEnv, this.props);
+        const env = this.env as unknown as AppEnv;
+        await registerGrantedTools(this.server, env, this.props);
+        await registerGrantedResources(this.server, env, this.props);
+        registerGrantedPrompts(this.server, this.props);
     }
 }

--- a/server/lib/mcp/flag.ts
+++ b/server/lib/mcp/flag.ts
@@ -1,4 +1,14 @@
+function truthy(v: string | undefined): boolean {
+  const s = (v ?? '').trim().toLowerCase();
+  return s === 'true' || s === '1';
+}
+
 export function mcpEnabled(env: { MCP_ENABLED?: string }): boolean {
-  const v = (env.MCP_ENABLED ?? '').trim().toLowerCase();
-  return v === 'true' || v === '1';
+  return truthy(env.MCP_ENABLED);
+}
+
+/** Operator opt-in (Phase E) to expose `extended`-tier operations as MCP tools.
+ * Off by default; `excluded`-tier is never exposed regardless. */
+export function extendedToolsEnabled(env: { MCP_EXTENDED_TOOLS?: string }): boolean {
+  return truthy(env.MCP_EXTENDED_TOOLS);
 }

--- a/server/lib/mcp/prompts.ts
+++ b/server/lib/mcp/prompts.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpProps } from '../../durable-objects/inspector-mcp';
+
+/**
+ * MCP Prompts (Phase E): a curated set of argument-bearing prompt templates an
+ * MCP client can offer the user (e.g. "Summarize inspection …"). Prompts carry
+ * NO data themselves — they emit a single user message that instructs the model
+ * to use the granted tools/resources. Each prompt is gated by the scopes its
+ * workflow needs, so a client only sees prompts it can actually fulfil.
+ */
+
+export interface PromptDef {
+    name: string;
+    description: string;
+    /** Zod raw shape for the prompt arguments (all string-valued). */
+    argsSchema: Record<string, z.ZodType>;
+    /** Granted scopes (kind:tag) ALL required for this prompt to be offered. */
+    requires: string[];
+    /** Build the user-message text from the supplied arguments. */
+    build: (args: Record<string, string>) => string;
+}
+
+export const PROMPTS: PromptDef[] = [
+    {
+        name: 'summarize_inspection',
+        description: 'Summarize an inspection — property, key findings, and overall condition.',
+        argsSchema: { inspection_id: z.string().describe('The id of the inspection to summarize') },
+        requires: ['read:inspections'],
+        build: ({ inspection_id }) =>
+            `Summarize OpenInspection inspection \`${inspection_id}\`.\n\n` +
+            `Fetch it with the \`openinspection_get_inspection\` tool (or read the ` +
+            `\`openinspection:///api/inspections/${inspection_id}\` resource), then write a concise ` +
+            `summary covering: the property and client, the inspection status, the most significant ` +
+            `defects grouped by severity, and an overall condition assessment. Be factual and cite ` +
+            `finding locations.`,
+    },
+    {
+        name: 'draft_repair_request',
+        description: "Draft a prioritized repair request from an inspection's findings.",
+        argsSchema: { inspection_id: z.string().describe('The id of the inspection') },
+        requires: ['read:inspections'],
+        build: ({ inspection_id }) =>
+            `Draft a repair request for inspection \`${inspection_id}\`.\n\n` +
+            `Fetch the inspection's findings, then produce a prioritized list of repair items a client ` +
+            `could send to the seller's agent. For each item give a clear title, the affected ` +
+            `system/location, why it matters, and a suggested action. Group by priority ` +
+            `(safety, major, minor). Keep it professional and neutral.`,
+    },
+    {
+        name: 'review_findings',
+        description: 'Review an inspection\'s findings for gaps, unclear wording, or missing photos.',
+        argsSchema: { inspection_id: z.string().describe('The id of the inspection') },
+        requires: ['read:inspections'],
+        build: ({ inspection_id }) =>
+            `Review the findings of inspection \`${inspection_id}\` for quality.\n\n` +
+            `Fetch the inspection, then flag: findings with vague or ambiguous wording, defects missing ` +
+            `a recommended action, items that likely need a photo, and inconsistent severity ratings. ` +
+            `Return concrete, itemized suggestions.`,
+    },
+    {
+        name: 'client_follow_up_email',
+        description: 'Draft a follow-up email to a client contact.',
+        argsSchema: {
+            contact_id: z.string().describe('The id of the client contact'),
+            topic: z.string().describe('What the follow-up is about'),
+        },
+        requires: ['read:contacts'],
+        build: ({ contact_id, topic }) =>
+            `Draft a follow-up email to contact \`${contact_id}\` about: ${topic}.\n\n` +
+            `Fetch the contact's details first, then write a warm, professional email addressed to them ` +
+            `by name. Keep it brief, include a clear next step, and sign off as the inspection company.`,
+    },
+];
+
+/** The prompts whose required scopes are all present in the grant. */
+export function selectPrompts(grantedScopes: string[]): PromptDef[] {
+    const granted = new Set(grantedScopes);
+    const has = (s: string) => {
+        const kind = s.split(':')[0];
+        return granted.has(s) || granted.has(`${kind}:*`);
+    };
+    return PROMPTS.filter((p) => p.requires.every(has));
+}
+
+/** Register the granted prompts on `server`. Synchronous — prompts make no API
+ * calls; they only emit a guiding user message. */
+export function registerGrantedPrompts(server: McpServer, props: McpProps): void {
+    for (const p of selectPrompts(props.scopes)) {
+        server.registerPrompt(
+            p.name,
+            { description: p.description, argsSchema: p.argsSchema },
+            (args) => ({
+                messages: [
+                    {
+                        role: 'user' as const,
+                        content: { type: 'text' as const, text: p.build(args as Record<string, string>) },
+                    },
+                ],
+            }),
+        );
+    }
+}

--- a/server/lib/mcp/resources.ts
+++ b/server/lib/mcp/resources.ts
@@ -1,0 +1,77 @@
+import { selectTools, type SnapshotEntry, type SelectToolsOptions } from './tools';
+
+/**
+ * MCP Resources (Phase E) are read-only views over the API: every GRANTED `GET`
+ * operation with zero or one path parameter is surfaced as a resource so an MCP
+ * client can pull data into context declaratively (vs. invoking a tool).
+ *
+ * - 0 path params  → a static collection resource (e.g. openinspection:///api/inspections)
+ * - 1 path param   → a resource template          (e.g. openinspection:///api/inspections/{id})
+ *
+ * Selection reuses `selectTools` so scope/tier/excluded gating is identical to
+ * tools; we then keep only GETs and drop anything with 2+ path params (no clean
+ * single-variable URI template). Reads execute through the same identity bridge.
+ */
+
+export const RESOURCE_URI_SCHEME = 'openinspection://';
+
+export interface ResourceDescriptor {
+    entry: SnapshotEntry;
+    /** Stable resource name (operationId, snake-cased; no tool prefix). */
+    name: string;
+    /** RFC 6570 URI (a template when `pathParam` is set). */
+    uri: string;
+    /** The single path-parameter name, or null for a collection resource. */
+    pathParam: string | null;
+}
+
+const PATH_PARAM_RE = /\{([^}]+)\}/g;
+
+function pathParamsOf(pathTemplate: string): string[] {
+    return [...pathTemplate.matchAll(PATH_PARAM_RE)].map((m) => m[1]);
+}
+
+/** operationId → snake-case resource name (no `openinspection_` tool prefix). */
+export function resourceNameFromOperationId(op: string): string {
+    return op.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+
+/**
+ * The granted GET operations exposable as resources, as URI descriptors.
+ * Operations with 2+ path params are skipped (logged by the caller if needed).
+ */
+export function selectResources(
+    snapshot: SnapshotEntry[],
+    grantedScopes: string[],
+    opts: SelectToolsOptions = {},
+): ResourceDescriptor[] {
+    const gets = selectTools(snapshot, grantedScopes, opts).filter(
+        (e) => e.method.toLowerCase() === 'get',
+    );
+    const out: ResourceDescriptor[] = [];
+    for (const entry of gets) {
+        const params = pathParamsOf(entry.pathTemplate);
+        if (params.length > 1) continue; // no clean single-variable template
+        out.push({
+            entry,
+            name: resourceNameFromOperationId(entry.operationId),
+            uri: `${RESOURCE_URI_SCHEME}${entry.pathTemplate}`,
+            pathParam: params[0] ?? null,
+        });
+    }
+    return out;
+}
+
+/** Build the in-process GET request for a resource read. Resources address the
+ * default view (no query params); the single path param is substituted. */
+export function buildResourceRequest(
+    entry: SnapshotEntry,
+    vars: Record<string, string>,
+): Request {
+    let pathname = entry.pathTemplate;
+    for (const [name, value] of Object.entries(vars)) {
+        pathname = pathname.replace(`{${name}}`, encodeURIComponent(String(value)));
+    }
+    // Host is irrelevant — the in-process API routes purely on pathname.
+    return new Request(new URL(pathname, 'https://mcp.internal').toString(), { method: 'GET' });
+}

--- a/server/lib/mcp/tools.ts
+++ b/server/lib/mcp/tools.ts
@@ -7,10 +7,20 @@ export function toolNameFromOperationId(op: string): string {
   const snake = op.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
   return `openinspection_${snake}`;
 }
-export function selectTools(snapshot: SnapshotEntry[], grantedScopes: string[]): SnapshotEntry[] {
+export interface SelectToolsOptions {
+  /** When true, `extended`-tier operations are exposed in addition to `primary`
+   * (operator opt-in via the MCP_EXTENDED_TOOLS env). `excluded` is NEVER exposed. */
+  includeExtended?: boolean;
+}
+export function selectTools(
+  snapshot: SnapshotEntry[],
+  grantedScopes: string[],
+  opts: SelectToolsOptions = {},
+): SnapshotEntry[] {
   const granted = new Set(grantedScopes); // 'kind:tag'
   const has = (kind: string, tag: string) => granted.has(`${kind}:${tag}`) || granted.has(`${kind}:*`);
+  const tierOk = (tier: string) => tier === 'primary' || (opts.includeExtended === true && tier === 'extended');
   return snapshot.filter(e =>
-    e.tier === 'primary' && e.scopes.every(k => has(k, e.tag)),
+    tierOk(e.tier) && e.scopes.every(k => has(k, e.tag)),
   );
 }

--- a/tests/unit/mcp/prompts.spec.ts
+++ b/tests/unit/mcp/prompts.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { selectPrompts, PROMPTS } from '../../../server/lib/mcp/prompts';
+
+describe('selectPrompts', () => {
+    it('offers inspection prompts when read:inspections is granted', () => {
+        const names = selectPrompts(['read:inspections']).map((p) => p.name).sort();
+        expect(names).toEqual(['draft_repair_request', 'review_findings', 'summarize_inspection']);
+    });
+
+    it('gates the contacts prompt on read:contacts', () => {
+        expect(selectPrompts(['read:inspections']).map((p) => p.name)).not.toContain('client_follow_up_email');
+        expect(selectPrompts(['read:contacts']).map((p) => p.name)).toContain('client_follow_up_email');
+    });
+
+    it('offers nothing when no relevant scope is granted', () => {
+        expect(selectPrompts(['write:invoices'])).toEqual([]);
+    });
+
+    it('honors the read:* wildcard', () => {
+        expect(selectPrompts(['read:*']).length).toBe(PROMPTS.length);
+    });
+
+    it('build() interpolates arguments into the message text', () => {
+        const p = PROMPTS.find((x) => x.name === 'summarize_inspection')!;
+        const text = p.build({ inspection_id: 'insp-42' });
+        expect(text).toContain('insp-42');
+        expect(text).toContain('openinspection:///api/inspections/insp-42');
+    });
+
+    it('every prompt requires at least one scope (no always-on prompts)', () => {
+        for (const p of PROMPTS) expect(p.requires.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/unit/mcp/resources.spec.ts
+++ b/tests/unit/mcp/resources.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+    selectResources,
+    resourceNameFromOperationId,
+    buildResourceRequest,
+    RESOURCE_URI_SCHEME,
+} from '../../../server/lib/mcp/resources';
+
+const snap = [
+    { operationId: 'listInspections', method: 'get',  pathTemplate: '/api/inspections',        scopes: ['read'],  tag: 'inspections', tier: 'primary',  inputSchema: {} },
+    { operationId: 'getInspection',   method: 'get',  pathTemplate: '/api/inspections/{id}',   scopes: ['read'],  tag: 'inspections', tier: 'primary',  inputSchema: {} },
+    { operationId: 'createInspection',method: 'post', pathTemplate: '/api/inspections',        scopes: ['write'], tag: 'inspections', tier: 'primary',  inputSchema: {} },
+    { operationId: 'getInspItem',     method: 'get',  pathTemplate: '/api/inspections/{id}/items/{itemId}', scopes: ['read'], tag: 'inspections', tier: 'primary', inputSchema: {} },
+    { operationId: 'getRecommendation',method:'get',  pathTemplate: '/api/recommendations/{id}',scopes: ['read'], tag: 'recommendations', tier: 'extended', inputSchema: {} },
+    { operationId: 'listContacts',    method: 'get',  pathTemplate: '/api/contacts',           scopes: ['read'],  tag: 'contacts',    tier: 'primary',  inputSchema: {} },
+] as const;
+
+describe('resourceNameFromOperationId', () => {
+    it('snake-cases without the tool prefix', () => {
+        expect(resourceNameFromOperationId('getInspection')).toBe('get_inspection');
+    });
+});
+
+describe('selectResources', () => {
+    it('exposes granted GETs with 0 or 1 path param; skips POST and 2+ params', () => {
+        const out = selectResources(snap as never, ['read:inspections']);
+        const ops = out.map((r) => r.entry.operationId).sort();
+        expect(ops).toEqual(['getInspection', 'listInspections']);
+        // POST createInspection excluded (not a GET); getInspItem excluded (2 params)
+        expect(ops).not.toContain('createInspection');
+        expect(ops).not.toContain('getInspItem');
+    });
+
+    it('marks collections vs templates and builds the URI', () => {
+        const out = selectResources(snap as never, ['read:inspections']);
+        const list = out.find((r) => r.entry.operationId === 'listInspections')!;
+        const item = out.find((r) => r.entry.operationId === 'getInspection')!;
+        expect(list.pathParam).toBeNull();
+        expect(list.uri).toBe(`${RESOURCE_URI_SCHEME}/api/inspections`);
+        expect(item.pathParam).toBe('id');
+        expect(item.uri).toBe(`${RESOURCE_URI_SCHEME}/api/inspections/{id}`);
+    });
+
+    it('honors scope grants (contacts not granted → absent)', () => {
+        const out = selectResources(snap as never, ['read:inspections']);
+        expect(out.map((r) => r.entry.operationId)).not.toContain('listContacts');
+    });
+
+    it('excludes extended-tier resources unless opted in', () => {
+        const off = selectResources(snap as never, ['read:recommendations']);
+        expect(off.map((r) => r.entry.operationId)).not.toContain('getRecommendation');
+        const on = selectResources(snap as never, ['read:recommendations'], { includeExtended: true });
+        expect(on.map((r) => r.entry.operationId)).toContain('getRecommendation');
+    });
+});
+
+describe('buildResourceRequest', () => {
+    it('GETs the collection path unchanged', () => {
+        const entry = snap.find((e) => e.operationId === 'listInspections')!;
+        const req = buildResourceRequest(entry as never, {});
+        expect(req.method).toBe('GET');
+        expect(new URL(req.url).pathname).toBe('/api/inspections');
+    });
+
+    it('substitutes the path param (URI-encoded)', () => {
+        const entry = snap.find((e) => e.operationId === 'getInspection')!;
+        const req = buildResourceRequest(entry as never, { id: 'abc 123' });
+        expect(new URL(req.url).pathname).toBe('/api/inspections/abc%20123');
+    });
+});

--- a/tests/unit/mcp/tools.spec.ts
+++ b/tests/unit/mcp/tools.spec.ts
@@ -5,6 +5,7 @@ const snap = [
   { operationId: 'listInspections', method: 'get',  pathTemplate: '/api/inspections',     scopes: ['read'],  tag: 'inspections', tier: 'primary',  inputSchema: {} },
   { operationId: 'createInspection',method: 'post', pathTemplate: '/api/inspections',     scopes: ['write'], tag: 'inspections', tier: 'primary',  inputSchema: {} },
   { operationId: 'listInvoices',    method: 'get',  pathTemplate: '/api/invoices',         scopes: ['read'],  tag: 'invoices',    tier: 'primary',  inputSchema: {} },
+  { operationId: 'approveInspection',method:'post', pathTemplate: '/api/inspections/{id}/approve', scopes: ['write'], tag: 'inspections', tier: 'extended', inputSchema: {} },
   { operationId: 'sysadminWipe',    method: 'post', pathTemplate: '/api/sysadmin/wipe',    scopes: ['admin'], tag: 'sysadmin',    tier: 'excluded', inputSchema: {} },
 ] as const;
 
@@ -18,4 +19,18 @@ it('keeps only granted tag+scope, never excluded tier', () => {
 it('read grant excludes write tools', () => {
   const out = selectTools(snap as never, ['read:inspections','read:invoices']);
   expect(out.map(t => t.operationId).sort()).toEqual(['listInspections','listInvoices']);
+});
+it('excludes extended-tier tools by default', () => {
+  const out = selectTools(snap as never, ['read:inspections','write:inspections']);
+  expect(out.map(t => t.operationId)).not.toContain('approveInspection');
+});
+it('includes extended-tier tools when opted in (still scope-gated, never excluded)', () => {
+  const out = selectTools(snap as never, ['read:inspections','write:inspections'], { includeExtended: true });
+  expect(out.map(t => t.operationId)).toContain('approveInspection');
+  expect(out.map(t => t.operationId)).not.toContain('sysadminWipe'); // excluded tier never
+});
+it('extended opt-in still requires the granted scope', () => {
+  const out = selectTools(snap as never, ['read:inspections'], { includeExtended: true });
+  // approveInspection needs write:inspections, not granted here
+  expect(out.map(t => t.operationId)).not.toContain('approveInspection');
 });

--- a/tests/workers/mcp/resources-prompts.spec.ts
+++ b/tests/workers/mcp/resources-prompts.spec.ts
@@ -1,0 +1,114 @@
+// Phase E — Resources + Prompts wiring in the McpAgent, over a real MCP transport.
+//
+// `registerGrantedResources` / `registerGrantedPrompts` (extracted from
+// InspectorMcp.init) are driven against a bare McpServer connected to an
+// in-memory MCP Client, proving in the workerd runtime:
+//   - resources/list + resources/templates/list expose the granted GETs,
+//   - resources/read routes through the identity bridge and returns API JSON,
+//   - prompts/list + prompts/get round-trip with scope gating + arg interpolation.
+//
+// callApiAsUser is stubbed (same rationale as tools-call.spec).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+const bridge = vi.hoisted(() => ({
+    calls: [] as Array<{ method: string; url: string }>,
+    response: () =>
+        new Response(JSON.stringify({ inspections: [{ id: 'i1' }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        }),
+}));
+
+vi.mock('../../../server/lib/mcp/identity-bridge', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../server/lib/mcp/identity-bridge')>();
+    return {
+        ...actual,
+        callApiAsUser: vi.fn(async (_env: unknown, _props: unknown, request: Request) => {
+            bridge.calls.push({ method: request.method, url: request.url });
+            return bridge.response();
+        }),
+    };
+});
+
+import {
+    registerGrantedResources,
+    type McpProps,
+} from '../../../server/durable-objects/inspector-mcp';
+import { registerGrantedPrompts } from '../../../server/lib/mcp/prompts';
+
+const props = (scopes: string[]): McpProps => ({
+    userId: 'u1', tenantId: 't1', tenantSlug: 'acme', role: 'admin', scopes,
+});
+
+async function connectedClient(scopes: string[]): Promise<Client> {
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    await registerGrantedResources(
+        server, {} as never, props(scopes),
+        () => ({ waitUntil() {}, passThroughOnException() {} }) as unknown as ExecutionContext,
+    );
+    registerGrantedPrompts(server, props(scopes));
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(clientTransport);
+    return client;
+}
+
+describe('MCP resources wiring (Phase E)', () => {
+    beforeEach(() => { bridge.calls.length = 0; });
+
+    it('lists the granted collection resource + get-by-id template', async () => {
+        const client = await connectedClient(['read:inspections']);
+        const staticUris = (await client.listResources()).resources.map((r) => r.uri);
+        const templates = (await client.listResourceTemplates()).resourceTemplates.map((t) => t.uriTemplate);
+
+        expect(staticUris).toContain('openinspection:///api/inspections');
+        expect(templates).toContain('openinspection:///api/inspections/{id}');
+        // A non-granted tag is absent.
+        expect(staticUris.some((u) => u.includes('invoice'))).toBe(false);
+        await client.close();
+    });
+
+    it('reads a collection resource through the identity bridge', async () => {
+        const client = await connectedClient(['read:inspections']);
+        const res = await client.readResource({ uri: 'openinspection:///api/inspections' });
+
+        expect(bridge.calls).toHaveLength(1);
+        expect(bridge.calls[0].method).toBe('GET');
+        expect(new URL(bridge.calls[0].url).pathname).toBe('/api/inspections');
+
+        const contents = res.contents as Array<{ uri: string; text: string; mimeType?: string }>;
+        expect(contents[0].mimeType).toBe('application/json');
+        expect(JSON.parse(contents[0].text)).toMatchObject({ inspections: [{ id: 'i1' }] });
+        await client.close();
+    });
+
+    it('substitutes the path param when reading a template resource', async () => {
+        const client = await connectedClient(['read:inspections']);
+        await client.readResource({ uri: 'openinspection:///api/inspections/abc123' });
+        expect(new URL(bridge.calls[0].url).pathname).toBe('/api/inspections/abc123');
+        await client.close();
+    });
+});
+
+describe('MCP prompts wiring (Phase E)', () => {
+    beforeEach(() => { bridge.calls.length = 0; });
+
+    it('lists scope-gated prompts and gets one with interpolated args', async () => {
+        const client = await connectedClient(['read:inspections']);
+        const names = (await client.listPrompts()).prompts.map((p) => p.name);
+        expect(names).toContain('summarize_inspection');
+        expect(names).not.toContain('client_follow_up_email'); // needs read:contacts
+
+        const got = await client.getPrompt({ name: 'summarize_inspection', arguments: { inspection_id: 'insp-7' } });
+        const msg = got.messages[0].content as { type: string; text: string };
+        expect(msg.type).toBe('text');
+        expect(msg.text).toContain('insp-7');
+        // Prompts make NO API calls — they only emit a guiding message.
+        expect(bridge.calls).toHaveLength(0);
+        await client.close();
+    });
+});


### PR DESCRIPTION
Builds on the merged remote-MCP feature (#210), reusing the same scope/tier gating and identity bridge.

## Phase E
- **Resources** — every granted read (`GET`) operation is exposed as an MCP resource: collections (`openinspection:///api/<thing>`) as static resources, get-by-id as resource templates (`.../{id}`). `resources/read` runs through `callApiAsUser`, so tenant scoping + RBAC are unchanged. Derived from the snapshot (0 or 1 path param; 2+ skipped).
- **Prompts** — a curated, scope-gated catalog (`summarize_inspection`, `draft_repair_request`, `review_findings`, `client_follow_up_email`). Prompts make no API calls — they emit a guiding user message; each only appears when the grant covers the data it needs.
- **extended-tier opt-in** — `selectTools` gains `{ includeExtended }`, driven by a new `MCP_EXTENDED_TOOLS` env (off by default; `excluded` tier never exposed). Applied to both selection and the call-time defense-in-depth re-check.

## Polish
- Connected applications: optimistic revoke (row disappears immediately, restores on failure); merged `GrantRow`/`AdminGrantRow` into one row (`showUser` flag, −40 lines of duplication).
- shared-ui `Modal`: `role="dialog"`, `aria-modal`, `aria-labelledby`, close-button `aria-label` (fixes a11y for every modal/ConfirmDialog).

## Testing
- Unit: tools (extended), resources, prompts specs.
- Workers-runtime integration: `resources/list`, `resources/read` (through the bridge), `prompts/list`, `prompts/get` over a real MCP client.
- **Validated live on saas**: consent → token → `initialize` → `resources/list` (collections + templates) → `resources/read` (real data via bridge) → `prompts/list` (scope-gated) → `prompts/get` (arg interpolation), all green.

Docs updated (`connecting-claude-mcp` §7–8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)