### PR TITLE
chore(hooks): use tsgo for the pre-commit type-check (CI tsc stays authoritative)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,12 +30,15 @@ step() { printf '\n  →  %b\n' "$1"; }
 printf '%b\n' "${BOLD}── OpenInspection (Pre-commit Checks) ───────────────────────────${NC}"
 
 # 1. Type check — SCOPED to what the staged changes can actually affect.
-#    CI's required "verify" check is the authoritative full gate; this hook is
-#    a fast local guard. Tiers:
-#      - no staged .ts/.tsx or ts-config files  → skip tsc entirely
-#        (docs, assets, hooks, fixtures — a markdown edit must not cost minutes)
-#      - staged TS confined to server/          → api pass only (type-check:api)
-#      - anything touching app/ workers/ packages/ or ts-config files → full
+#    CI's required "verify" check runs tsc and is the authoritative full gate;
+#    this hook is a fast LOCAL guard and uses tsgo (@typescript/native-preview),
+#    which is ~5-10x faster than tsc so a commit does not cost minutes. tsgo is a
+#    preview compiler and can differ subtly from tsc — CI's tsc remains the truth.
+#    Tiers:
+#      - no staged .ts/.tsx or ts-config files  → skip type check entirely
+#        (docs, assets, hooks, fixtures — a markdown edit must not cost seconds)
+#      - staged TS confined to server/          → api pass only (type-check:api:fast)
+#      - anything touching app/ workers/ packages/ or ts-config files → full (type-check:fast)
 STAGED=$(git diff --cached --name-only --diff-filter=ACMRD)
 TS_STAGED=$(echo "$STAGED" | grep -E '\.(ts|tsx)$' || true)
 CONFIG_STAGED=$(echo "$STAGED" | grep -E '^(tsconfig|package\.json|package-lock\.json|vite\.config|react-router\.config|worker-configuration)' || true)
@@ -44,16 +47,16 @@ step "Type check"
 if [ -z "$TS_STAGED" ] && [ -z "$CONFIG_STAGED" ]; then
     pass "Skipped — no staged TypeScript/config changes (CI verify remains the full gate)"
 elif [ -z "$CONFIG_STAGED" ] && [ -z "$(echo "$TS_STAGED" | grep -vE '^(server|tests)/')" ]; then
-    if npm run type-check:api > /dev/null 2>&1; then
-        pass "Type check passed (api pass only — staged TS confined to server/ and tests/)"
+    if npm run type-check:api:fast > /dev/null 2>&1; then
+        pass "Type check passed (tsgo, api pass only — staged TS confined to server/ and tests/)"
     else
-        fail "Type check failed  →  npm run type-check:api"
+        fail "Type check failed  →  npm run type-check:api:fast (authoritative: npm run type-check:api)"
     fi
 else
-    if npm run type-check > /dev/null 2>&1; then
-        pass "Type check passed"
+    if npm run type-check:fast > /dev/null 2>&1; then
+        pass "Type check passed (tsgo)"
     else
-        fail "Type check failed  →  npm run type-check"
+        fail "Type check failed  →  npm run type-check:fast (authoritative: npm run type-check)"
     fi
 fi
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "type-check:app": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc -p tsconfig.json --noEmit",
     "type-check:api": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc -p tsconfig.api.json --noEmit",
     "type-check:fast": "react-router typegen && tsgo -p tsconfig.json --noEmit && tsgo -p tsconfig.api.json --noEmit",
+    "type-check:api:fast": "tsgo -p tsconfig.api.json --noEmit",
     "lint": "eslint . && npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:migrefs && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope",
     "lint:ds": "node scripts/check-ds-tokens.mjs",
     "lint:svg": "node scripts/check-svg-dimensions.mjs",


### PR DESCRIPTION
The pre-commit type-check ran `tsc`, which costs 2-3 minutes on app-touching commits. This switches the **local** guard to **tsgo** (`@typescript/native-preview`, already a devDependency) — ~5-10x faster — via a new `type-check:api:fast` and the existing `type-check:fast`.

- `type-check` / `type-check:api` (tsc) are unchanged and still what CI's `verify` job runs — **tsc remains the authoritative gate**.
- tsgo is a preview compiler and can differ subtly from tsc; the fail messages point at both the fast command and the authoritative tsc one.
- Part of aligning the pre-commit hook across the openinspection/portal/cms repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)