### PR TITLE
docs: design system guide + testing guide rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,8 @@ flat until a family reaches ~5 specs, then gets a domain dir (`mcp/` is the
 example). `tests/e2e/` stays flat: one spec file = one playwright project. Every
 spec must be collected by exactly one config (playwright projects must resolve).
 Fully-skipped specs need a `TODO(...)` naming their blocker. Name new specs after
-behavior, not sprints. Full rationale + the cross-repo convention:
-`docs/superpowers/plans/2026-07-03-tests-layout-convention.md`.
+behavior, not sprints. Full rules for classification, writing, and run
+initialization: `docs/developers/05_testing.md`.
 
 ## Core Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ These are summarized from `CLAUDE.md` — read that file for the canonical, exha
 - **Auth**: HS256 JWT in HttpOnly cookie, PBKDF2 password hashing. Never use a fallback secret. Read `CLAUDE.md` § JWT & Auth Security Rules.
 - **Multi-tenant**: Every D1 table includes `tenant_id`. Use `c.var.services.xxx` (DI proxy) — services auto-scope to the tenant.
 - **Logging**: Server-side code uses `import { logger } from '../lib/logger'`. Browser-side `console.*` is fine.
-- **CSS**: Tailwind utilities + canonical v3 tokens defined in `server/styles/input.css`. No `font-black` outside stat numbers, no `rounded-2xl`, no `tracking-tightest`. The design system reference is at `docs/superpowers/plans/2026-05-08-sprint1-design-system-reference.md`.
+- **CSS**: Tailwind v4 utilities + the Design System 0523 token layer defined in `app/styles/tailwind.css` (`bg-ih-*`, `text-ih-*`, `shadow-ih-*`). No raw palette classes (`bg-slate-200`, `shadow-lg`, ...) — enforced by `npm run lint:ds`. Full reference: [`docs/developers/11_design_system.md`](docs/developers/11_design_system.md).
 
 ## Commit style
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Deep dive: [`docs/developers/02_deploy.md`](docs/developers/02_deploy.md). Archi
 
 - [Deploy](docs/developers/02_deploy.md) — first-time setup on Cloudflare
 - [Architecture](docs/developers/01_architecture.md) — module map, request flow, cost model
+- [Design System](docs/developers/11_design_system.md) — tokens, shared-ui components, dark mode, `lint:ds`
 - [Contributing](CONTRIBUTING.md) — code conventions and PR process
 - [Community](docs/community.md) — Discussions categories and where to talk
 

--- a/docs/developers/05_testing.md
+++ b/docs/developers/05_testing.md
@@ -1,191 +1,284 @@
 # Testing — apps/openinspection
 
-The single Worker serves both the API and the React Router v7 UI, so tests cover both surfaces against one running worker. API tests live in `tests/`; web tests live in `tests/web/`.
+The single Worker serves both the typed JSON API and the React Router v7 UI, so
+tests cover both surfaces. There are four suites, each pinned to a **location**:
+a spec's directory alone decides which config runs it. This document is the
+canonical reference for the three things you need to get right: **where a spec
+lives**, **how to write it**, and **how the run is initialized**.
 
-## Quick Start
+The layout is enforced — `npm run lint:tests` (`scripts/check-test-layout.mjs`)
+fails the build on a misplaced spec, and it runs in `npm run lint` + pre-commit.
 
-### API E2E Tests
+---
 
-End-to-end tests use [Playwright](https://playwright.dev/). Tests run against a live local dev server — no mocking, no test database. Hits real Worker endpoints backed by Wrangler's local D1 and R2 emulation.
+## 1. Directory classification (`directory = suite`)
+
+| Location | Suite | Command | Config | Runtime |
+|---|---|---|---|---|
+| `app/**/*.test.{ts,tsx}` (co-located) | web unit | `test:web` | `vitest.config.ts` | happy-dom |
+| `tests/unit/<domain>/**/*.spec.ts` | api/service unit | `test:unit` | `vitest.api.config.ts` | node (+ better-sqlite3) |
+| `tests/workers/**/*.spec.ts` | worker-runtime | `test:workers` | `vitest.workers.config.ts` | real `workerd` |
+| `tests/e2e/*.spec.ts` | end-to-end | `test:e2e` | `playwright.config.ts` (seeds real D1) | built worker + browser |
+| `tests/**/*.spec-d.ts` | type-level | `test:types` | `vitest.typecheck.config.ts` | tsc typecheck |
+
+### Choosing a home for a new spec
+
+1. **Frontend component / loader / hook test?** → **co-locate** it beside the
+   thing it tests as `Foo.test.tsx` (or `__tests__/Foo.test.tsx`) under `app/`.
+   Never put a web test in `tests/`. The retired `tests/web/` tree does not come
+   back.
+2. **Server-side, no browser.** Does it depend on real Cloudflare runtime
+   semantics — Queue delivery, Durable Objects, `workerd`-only APIs?
+   - **Yes** → `tests/workers/` (real `workerd` via
+     `@cloudflare/vitest-pool-workers`; miniflare bindings are declared inline in
+     the config, no wrangler file needed).
+   - **No** → `tests/unit/<domain>/` (node env, stubs + `better-sqlite3`).
+3. **Full-stack / browser / anything that hits a running worker** →
+   `tests/e2e/`. One flat directory; `globalSetup` seeds real D1 so every E2E
+   exercises the actual database.
+
+### The rules the gate enforces
+
+- **No flat specs.** `tests/*.spec.ts`, `tests/web/*.spec.ts`, and
+  `tests/unit/*.spec.ts` are rejected — a unit spec must live in a **domain
+  directory** named after the `server/api/` module or service family it
+  exercises (`tests/unit/auth/`, `tests/unit/inspections/`, …).
+- **These directories must not exist:** `tests/web/unit`, `tests/web/e2e`,
+  `tests/integration`. Frontend co-locates under `app/`; E2E is the single
+  `tests/e2e/`.
+- **`tests/workers/` stays flat** until a family reaches ~5 specs, then gets a
+  domain dir (`tests/workers/mcp/` is the precedent).
+- **`tests/e2e/` stays flat:** one spec file = one Playwright project, and every
+  project's `testMatch` string literal must resolve to a real file in
+  `tests/e2e/` (the gate checks this too).
+- **Name specs after behavior, not sprints** (`estimate-range.spec.ts`, not
+  `sprint2-s4.spec.ts`). Legacy sprint-named specs are grandfathered.
+
+### Where shared infrastructure lives (NOT spec files)
+
+```
+tests/
+  global-setup.ts        # E2E: wipe + migrate local D1 (Playwright globalSetup)
+  seed-fixtures.ts       # E2E: optional multi-user seed (SEED_E2E=1)
+  setup-web.ts           # web-unit hermeticity guard (setupFiles for vitest.config.ts)
+  helpers/               # cross-suite helpers (e.g. dev-vars.ts)
+  fixtures/              # payloads grouped by event family, versioned filenames
+  unit/
+    setup-client.ts      # setupFiles for vitest.api.config.ts
+    db.ts, mocks.ts      # shared unit infra (better-sqlite3 harness, stubs)
+    stubs/, helpers/
+    <domain>/*.spec.ts   # ← the only place unit specs go
+  workers/*.spec.ts
+  e2e/
+    *.spec.ts
+    helpers/             # e2e-only helpers (csrf.ts, …)
+```
+
+---
+
+## 2. Writing tests
+
+### Web unit (`app/**/*.test.tsx`)
+
+- Runs in **happy-dom**, hermetic — **no live worker**. The `tests/setup-web.ts`
+  guard **fails any test that makes a real `fetch`**. A loader/action test must
+  stub the network: `vi.stubGlobal('fetch', …)` (a stub replaces
+  `globalThis.fetch`, so the guard is bypassed for hermetic tests). This exists
+  because `getApiUrl()` falls back to `localhost:8788` and the BFF's
+  graceful-degradation `catch` would otherwise swallow a real ECONNREFUSED and
+  let the test pass while only ever exercising the error path.
+
+### API / service unit (`tests/unit/<domain>/*.spec.ts`)
+
+- Node env, `better-sqlite3` in-memory DB — no worker, no network. Use the shared
+  `tests/unit/db.ts` harness and `tests/unit/mocks.ts` stubs.
+- A file that needs a DOM opts in per-file with `// @vitest-environment happy-dom`
+  (vitest v4 replacement for `environmentMatchGlobs`).
+- Prefer asserting **service-layer** behavior directly over reconstructing HTTP.
+
+### Worker-runtime (`tests/workers/*.spec.ts`)
+
+- Runs in real `workerd` via `@cloudflare/vitest-pool-workers`. Reserve this for
+  behavior that only reproduces on the real runtime: Queue publish/consume,
+  sweeper republish, DLQ writeback, Durable Objects. Bindings are declared inline
+  in `vitest.workers.config.ts`.
+- When a workers spec hand-maintains DDL (e.g. a `tenant_configs` table), assert
+  it against the Drizzle schema instead of trusting a "keep in sync" comment —
+  `tests/unit/inline-ddl-schema-sync.spec.ts` is the pattern.
+
+### E2E (`tests/e2e/*.spec.ts`)
+
+- **One spec = one Playwright project.** Register the project in
+  `playwright.config.ts` with a `testMatch` pointing at the file. `workers: 1` —
+  every project shares ONE `wrangler dev` worker and ONE mutable D1, so specs
+  must not assume isolation.
+- **Ordering & dependencies.** The `api` project runs **first**: it asserts
+  `POST /api/auth/setup` returns a fresh 200 and creates the shared admin
+  (`admin@autotest.com` / `Password123!`). Any project that logs in as that admin
+  must declare `dependencies: ['api']` so it is runnable in isolation (otherwise
+  login 401s — no workspace).
+- **Auth is cookie-based.** Page loaders authenticate via the
+  `__Host-inspector_token` HttpOnly cookie, not a Bearer header. RBAC is enforced
+  on the API, not by page-level role redirects.
+- **Serial-block masking.** A `test.describe.serial` block skips the rest of the
+  block on the first failure — a later failure can hide behind an earlier one. When
+  greening the suite, re-run the **full** suite on a **fresh build** (see below),
+  not just the spec you touched.
+- **Known-unwritable surfaces.** Some paths can't be driven end-to-end locally
+  (e.g. Download-PDF needs a Browser Rendering binding that crashes the isolate
+  when absent). Verify the reachable leg (the public-report render path) and keep
+  the rest unit-covered; leave a comment saying why.
+- **Skips must be honest.** A fully-skipped spec needs a `TODO(...)` naming its
+  blocker. Do **not** silently `test.skip(!seededId)` on a seed that always
+  400s — that reads as green while testing nothing (`report-gate.spec.ts` is a
+  `describe.skip` with a TODO for exactly this reason).
+
+### Type-level (`tests/**/*.spec-d.ts`)
+
+- `expectTypeOf` / `assertType` checks. Collected only by `test:types`; the
+  runtime configs ignore `.spec-d.ts`.
+
+---
+
+## 3. Initialization
+
+### `.dev.vars` — `scripts/gen-e2e-dev-vars.mjs`
+
+`wrangler dev` reads secrets from `.dev.vars`, and the specs read `SETUP_CODE`
+from it via `tests/helpers/dev-vars.ts`. A fresh checkout has none, so the worker
+boots without JWT keys and `/api/auth/setup` fails. The script provisions a
+throwaway file and is **idempotent — it never overwrites an existing
+`.dev.vars`** (your real local one is respected). Every value is freshly
+generated; nothing is hard-coded:
+
+| Key | Value | Why |
+|---|---|---|
+| `SETUP_CODE` | `000000` | The specs post a fixed `verificationCode: '000000'`; a **documented test fixture**, not a secret. |
+| `DISABLE_RATE_LIMIT` | `1` | The suite drives many logins from ONE IP; the limiter is 10/60s per IP and would flakily 429. Honored only by `checkRateLimit` when set; **defaults to enforced**, so no real deploy is affected. |
+| `JWT_SECRET` | random 32 bytes | KDF input. |
+| `JWT_PRIVATE_KEY_V1` / `JWT_PUBLIC_KEY_V1` | fresh ES256 (P-256) keypair | Single-line PEM (the keyring strips whitespace; `.dev.vars` is parsed line-by-line). |
+
+### `globalSetup` — `tests/global-setup.ts` (E2E only)
+
+Runs once before the Playwright suite. It:
+
+1. `npm run db:migrate` (idempotent) so the schema is current.
+2. Enumerates **every** table from `sqlite_master` and wipes them in one batch
+   under `PRAGMA defer_foreign_keys = ON` (never a hand-maintained table list —
+   that can't stay complete as the schema grows). `d1_migrations` and `_cf_*`
+   bookkeeping are preserved so migrations stay applied.
+3. Clears all local KV keys (setup codes, `pwchanged:*`, cached tenants).
+4. If `SEED_E2E=1`, runs `seedFixtures()` (`tests/seed-fixtures.ts`) — a
+   multi-user/multi-tenant seed the subsystem-C/D/E specs need. **Off by
+   default** so the self-seeding `api`/`browser` specs still see a clean
+   workspace.
+
+It resolves the **same** wrangler config the `webServer` builds against
+(`WRANGLER_CONFIG` > `wrangler.local.jsonc` > `wrangler.jsonc`) and targets the
+`DB` **binding** (not a database name) via `-c` — an earlier bug executed against
+a name absent from the config, so every DELETE errored silently and the DB was
+never cleared.
+
+### The E2E worker — `playwright.config.ts`
+
+- `webServer`: `npm run build && wrangler dev -c build/server/wrangler.json
+  --port 8789`, `reuseExistingServer: true`.
+- **Stale-build trap:** because `reuseExistingServer` is true, a local run serves
+  whatever `build/` already exists. To replicate CI's fresh run, clear state
+  first:
+  ```bash
+  rm -rf build .wrangler/state && npm run test:e2e
+  ```
+- `retries: CI ? 2 : 0` — a backstop for transient WebSocket/Durable-Object blips
+  in the collab specs. Locally 0, for fast honest feedback.
+
+### CI (`.github/workflows/ci.yml`)
+
+Two parallel jobs:
+
+- **`verify`** — `npm ci` → `gen-version` → `type-check` → `lint` (eslint +
+  `lint:ds` + `lint:erasure` + `lint:migrefs` + `lint:tests`) → `db:check` →
+  `test:unit` → `test:workers` → `test:web` → `build` → bundle-size.
+- **`e2e`** — `npm ci` → `gen-version` → `node scripts/gen-e2e-dev-vars.mjs` →
+  `playwright install chromium` → `npm run test:e2e`. Playwright's `webServer`
+  builds + boots the worker; `globalSetup` seeds D1.
+
+CodeQL runs separately (`codeql.yml`).
+
+---
+
+## 4. Gotchas & anti-patterns (hard-won)
+
+**Fake-green tests are the suite's worst failure mode.** A test that never
+asserts, swallows the path it claims to cover, or skips itself silently reports
+green while testing nothing. Three shapes to reject in review:
+
+- **Silent conditional skip.** `test.skip(!seededId, …)` on a seed that always
+  400s → every case skips forever, invisibly. If a precondition genuinely can't
+  be met, that's a `TODO(...)`-annotated `describe.skip`, not a runtime skip that
+  masquerades as a pass (this is why `report-gate.spec.ts` is a `describe.skip`).
+- **Swallowed error path.** A web-unit test whose real `fetch` ECONNREFUSEs and
+  is caught by the BFF's graceful-degradation `catch` passes while only ever
+  exercising the error branch. The `tests/setup-web.ts` guard fails these — do
+  not stub around it just to make it pass.
+- **No-assert body.** A test that runs code but asserts nothing (or asserts a
+  tautology). Every test must assert an observable outcome.
+
+**Assert against the REAL contract, not a remembered one.** Specs rot when the
+API moves under them and the symptom is a silent 400/404, not a red assertion:
+
+- E-05 patched a nonexistent `PATCH /:id/results`; the real write path is
+  `POST /:id/results/batch`. When a **seed step** returns 400/404, verify the
+  route still exists before trusting the green further down — a dead route turns
+  the whole spec into a no-op.
+- Public-report status codes are contract and they differ: an **unpublished**
+  inspection → **404** `Report not found`; a **published-then-unpublished** one →
+  **403** `NOT_PUBLISHED`. Assert the exact code your setup produces; use a
+  tolerant matcher only when both are legitimately reachable.
+
+**Flake-retry discipline — retries hide real bugs if applied bluntly.**
+
+- Retry **only** transient socket errors (`ECONNRESET`, `ECONNREFUSED`,
+  `socket hang up`, `EPIPE`). A `401`, `429`, or assertion failure MUST throw
+  immediately — retrying it converts a real regression into a slow flake. The
+  collab login helper does exactly this (4 attempts, connection-error-only,
+  backoff).
+- The collab root cause was a **stale keep-alive socket** left after the
+  WebSocket/Durable-Object-heavy editing spec; the next login reused the dead
+  socket and ECONNRESET once. `retries: CI ? 2 : 0` is the backstop, not the fix.
+- One shared runner IP trips the login limiter (10/60s) as a `429` — that is what
+  `DISABLE_RATE_LIMIT` exists for, not something to paper over with retries.
+
+**Publish crashes the isolate without a Browser Rendering binding.**
+`POST /:id/publish` enqueues a PDF via `env.BROWSER.quickAction`; with no
+`BROWSER` binding the worker dies with a 503 and
+`The RPC receiver does not implement quickAction` / `worker restarted`. The
+publish→PDF leg cannot be driven end-to-end locally — verify the public-report
+render path instead and keep the Download-PDF FAB unit-covered.
+
+---
+
+## Quick reference
 
 ```bash
-# Terminal 1
-npm run dev          # build-based; http://localhost:8788
+npm run test:web                       # web unit (happy-dom, hermetic)
+npm run test:unit                      # api/service unit (node + better-sqlite3)
+npm run test:workers                   # real workerd (queues, DOs)
+npm run test:e2e                       # Playwright, seeds real D1
+npm run test:types                     # type-level (*.spec-d.ts)
+npm run lint:tests                     # layout gate
 
-# Terminal 2
-npx playwright test --config playwright.api.config.ts
+# fresh full E2E (what CI does):
+rm -rf build .wrangler/state && npm run test:e2e
+
+# single E2E project / grep:
+npx playwright test --project=browser
+npx playwright test --grep "estimate range"
+
+# also seed the C/D/E multi-user fixtures:
+SEED_E2E=1 npm run test:e2e
 ```
 
-API unit tests run with `npm run test:unit` (vitest, `vitest.api.config.ts`).
-
-### Worker-runtime tests (queues)
-
-`npm run test:workers` runs `tests/workers/**` against real workerd via
-`@cloudflare/vitest-pool-workers` (`vitest.workers.config.ts` — the vitest-v4
-`cloudflareTest` Vite-plugin shape; miniflare bindings are declared inline, so no
-wrangler config is needed). It covers the sync-outbox queue paths: publish,
-sweeper republish, and DLQ writeback, including a real queue traversal to a test
-consumer. CI runs this after the unit suites.
-
-### Web Tests
-
-Web unit + E2E tests live in `tests/web/`. They test the React Router v7 React UI against the same running worker.
-
-```bash
-# Terminal 1: Start the worker (build-based)
-npm run dev          # http://localhost:8788
-
-# Terminal 2: Run web unit tests
-npm run test:web     # vitest, vitest.config.ts
-```
-
-## Test Results
-
-Tests pass on a **fresh database**. Tests that require known credentials skip gracefully when run against a pre-existing database.
-
-## Fresh DB vs Pre-existing DB
-
-`beforeAll` runs `POST /setup` to initialise the workspace:
-
-- **200 (first run)** — `setupToken` is stored and shared across all authenticated blocks. All 128 tests execute.
-- **409 (already seeded)** — `setupToken` stays empty. Tests that depend on known credentials or a specific DB state skip gracefully with a clear message.
-
-**To run the full suite against a fresh database:**
-
-```bash
-rm -rf .wrangler/state/v3/d1
-npm run db:migrate
-npm run dev
-
-# In another terminal:
-npx playwright test --config playwright.api.config.ts
-```
-
-## Test Structure
-
-| Section | What it covers |
-|---|---|
-| API Health | `GET /status` |
-| Public API | Booking profile, availability, demo report endpoints |
-| Login Page | HTML render, field validation, credential check, cookie set |
-| Dashboard Auth Guard | Unauthenticated access redirects to `/login` |
-| Bot Protection | Turnstile script present; dev-tenant bypass documented |
-| Public Booking API | `GET /inspectors`, `GET /availability/:id`, `POST /book` |
-| Protected API Enforcement | All protected routes return 401 without a token |
-| Agreement & Signing | Demo agreement fetch and e-signature POST |
-| Checkout & Stripe | Mock checkout URL, webhook signature validation, payment-success redirect |
-| Join Page | HTML render |
-| Setup Wizard | Field validation, subdomain format, 409 on re-run |
-| Field-Level Merge | PATCH results merges fields; last-write-wins per item key |
-| Availability CRUD | Auth enforcement + full CRUD (PUT schedule, POST/GET/DELETE overrides) |
-| Template CRUD | Auth enforcement + create/update/version-bump/delete + 409 when in use |
-| Invite & Join Flow | `POST /api/admin/invite` → token → `POST /api/auth/join` → login |
-| Password Change | Auth enforcement, wrong-password rejection, success, old/new login checks |
-| Password Reset | `POST /forgot-password` (no-enumeration, 200 for unknown email) + `POST /reset-password` (invalid token, short password) |
-| Inspection CRUD | Create, list, get with template, complete, status reflects update |
-| DELETE Inspection | Auth enforcement, removal, 404 after deletion |
-| Admin Export | Full tenant data export for admin/owner |
-| Team Members | `GET /api/admin/members` returns members + pending invites |
-| Agreement CRUD | Auth enforcement + create/list/update (version bump)/delete + 404 lifecycle |
-| Agent Referral Booking | Create inspection with `referredByAgentId`, verify in `my-reports` and leaderboard |
-| Agent CRM | `GET /api/agent/my-reports` (agent-scoped), `GET /api/agent/leaderboard` (admin-scoped) |
-| Google Calendar | Auth enforcement on connect/disconnect/sync |
-| AI Comment Assist | Auth enforcement; 500 without `GEMINI_API_KEY` |
-
-## Key Flows
-
-### Invite & Join Flow
-
-1. Admin calls `POST /api/admin/invite` → `inviteLink` returned with `token` query param
-2. New user POSTs `{ token, password }` to `POST /api/auth/join`
-3. httpOnly `inspector_token` cookie is set; user can log in immediately
-4. Re-using the same token returns **400** `already been used`
-
-### Password Reset Flow
-
-1. `POST /api/auth/forgot-password` — always returns **200** (no email enumeration)
-2. KV-backed one-time token stored with 1-hour TTL
-3. `POST /api/auth/reset-password` — validates token, updates password hash, deletes token
-4. Invalid/expired token returns **400**; password under 8 chars returns **400**
-
-### Agent Referral Flow
-
-1. Admin creates inspection with `referredByAgentId` via `POST /api/inspections`
-2. Agent calls `GET /api/agent/my-reports` — sees inspections where `referredByAgentId` matches their JWT `sub`
-3. Admin calls `GET /api/agent/leaderboard` — referral counts grouped by agent
-4. Public booking via `POST /public/book` with `agentId` body field also stores the referral
-   (Note: dev-mode tenantId is the subdomain string `'dev'`, not the UUID — verified separately via authenticated endpoint)
-
-### Password Change Flow
-
-1. Wrong `currentPassword` → **401**
-2. `newPassword` shorter than 8 chars → **400**
-3. Correct `currentPassword` + valid `newPassword` → **200**
-4. Old password rejected by `POST /api/auth/login` → **401**
-5. New password accepted → **200**
-
-## Graceful Skip Pattern
-
-Tests that need a real tenantId use `setupToken` from `beforeAll`:
-
-```typescript
-test('protected action', async ({ request }) => {
-  test.skip(!setupToken, 'Skipping: requires fresh DB');
-  // ...
-});
-```
-
-Tests with inter-test state dependencies (create → update → delete) use a shared variable in a `test.describe` block:
-
-```typescript
-test.describe('agreement CRUD (authenticated)', () => {
-  let agreementId = '';
-
-  test('POST creates agreement', async ({ request }) => {
-    // ...stores agreementId
-  });
-
-  test('DELETE removes agreement', async ({ request }) => {
-    test.skip(!agreementId, 'Skipping: requires agreement from previous test');
-    // ...
-  });
-});
-```
-
-## Playwright Config
-
-API E2E config lives at `playwright.api.config.ts` (web E2E uses `playwright.config.ts`). Tests run serially (1 worker) — some describe blocks have stateful dependencies (create → update → delete).
-
-## Useful Commands
-
-```bash
-npx playwright test --config playwright.api.config.ts --grep "availability"
-npx playwright test --config playwright.api.config.ts --grep "agent referral"
-npx playwright test --config playwright.api.config.ts --reporter=list
-```
-
-## CI Notes
-
-- Dev server must be running before tests.
-- `npm run db:migrate` must run at least once before `npm run dev`.
-- Local D1 state: `.wrangler/state/v3/d1/` — delete to reset.
-- Real API keys (Resend, Stripe, Gemini) are not required. Calls are skipped or use mock fallbacks when keys are absent.
-- **Turnstile is required** — `TURNSTILE_SECRET_KEY` must be set even for local dev and CI. Use Cloudflare's always-pass test secret (`1x0000000000000000000000000000000AA`). If absent, `POST /api/book` throws a 500 error.
-- The Cloudflare Turnstile test keys in `.dev.vars.example` always pass validation — safe for CI.
-
-## Web Tests
-
-Web tests live in `tests/web/` and cover the React Router v7 React UI.
-
-### Running
-
-```bash
-npm run test:web                          # run all web unit tests (vitest.config.ts)
-npm run test:web -- --grep "dashboard"    # filter by name
-```
-
-### Requirements
-
-- The single Worker (`npm run dev` in root, port 8788) must be running for E2E flows.
-- The worker must have a seeded database (run `npm run db:migrate` first).
-- Same `.dev.vars` / Turnstile key requirements as the API E2E tests.
+The cross-repo rationale for `directory = suite` (shared with the portal and CMS
+repos) lives in the private superproject at
+`docs/superpowers/plans/2026-07-03-tests-layout-convention.md`.

--- a/docs/developers/11_design_system.md
+++ b/docs/developers/11_design_system.md
@@ -1,0 +1,314 @@
+# Design System — Tokens, Components, Conformance
+
+OpenInspection ships with a small, opinionated design system ("Design System
+0523") rather than raw Tailwind utilities. It has three layers:
+
+1. **Token layer** — CSS custom properties + a Tailwind v4 `@theme` block
+   (`app/styles/tailwind.css`) that map semantic names (`bg-ih-bg-card`,
+   `text-ih-fg-2`, `bg-ih-ok`) to real colors, and flip automatically for dark
+   mode.
+2. **Component primitives** — `packages/shared-ui/src/` — a small set of
+   token-based React components (Button, Card, Modal, Input, ...) shared by
+   both the standalone engine and (via the package) any SaaS overlay.
+3. **Conformance tooling** — `npm run lint:ds` (`scripts/check-ds-tokens.mjs`)
+   fails the build when UI code bypasses the token layer with raw Tailwind
+   palette classes.
+
+If you're adding or changing UI, this doc is the reference for what exists
+today — don't invent new tokens or components ad hoc; extend what's here.
+
+---
+
+## 1. Token layer
+
+All tokens are CSS custom properties, declared once in `app/styles/tailwind.css`
+and re-exposed as Tailwind utilities via a `@theme` block (so `bg-ih-primary`,
+`text-ih-fg-1`, etc. work as ordinary Tailwind classes). Components must
+consume tokens, not literal colors — dark mode is then "free": swapping the
+`:root` custom properties is enough, no per-component dark-mode code needed.
+
+### Color tokens
+
+| Token | Purpose |
+|---|---|
+| `--color-ih-primary` / `-600` / `-700` | Brand color + hover/active shades |
+| `--color-ih-primary-tint` | Low-opacity primary wash (selected tab pill, badges) |
+| `--color-ih-primary-glow` | Focus-ring glow color (see `shadow-ih-focus`) |
+| `--color-ih-primary-fg` | Foreground for content on `bg-ih-primary`; defaults to white, but flips to dark text per-surface when a bright custom brand color is set (YIQ contrast pick) |
+| `--color-ih-fg-1` … `-5` | Text scale from near-black/white (`-1`, headings/body) down to faint (`-5`, disabled/hairline) |
+| `--color-ih-fg-inverse` | Text on an inverted surface (`bg-ih-bg-inverse`, `bg-ih-primary`) |
+| `--color-ih-bg-app` | Page background |
+| `--color-ih-bg-card` | Card/panel/input surface |
+| `--color-ih-bg-muted` | Subtle fill (badges, disabled zones, hover rows) |
+| `--color-ih-bg-inverse` | Inverted surface (tooltips, photo-studio chrome) |
+| `--color-ih-border` / `-strong` | Hairline border / emphasized border |
+| `--color-ih-agent-accent` / `-fg` | Sub-brand accent reserved for the Agent portal surface |
+
+### Status tones
+
+Four semantic tones, each with a `-bg` (tint) and `-fg` (text/icon) pair:
+`ih-ok`, `ih-watch`, `ih-bad`, `ih-info`. Use these for anything that
+communicates state — never reach for a raw `emerald-500` or `red-600`.
+
+| Tone | Meaning | Example usage |
+|---|---|---|
+| `ih-ok` | Satisfactory / success | "Satisfactory" rating pill, success toast accent |
+| `ih-watch` | Needs monitoring / warning | "Monitor" rating pill, warning banners |
+| `ih-bad` | Defect / error | "Defect" rating pill, error toast accent, form field errors |
+| `ih-info` | Informational | Info banners, neutral callouts |
+
+### Shadows
+
+Exactly two elevations exist — do not use Tailwind's `shadow-sm/md/lg/xl/2xl`:
+
+| Token | Use |
+|---|---|
+| `shadow-ih-card` | Resting elevation for cards/panels |
+| `shadow-ih-popover` | Elevated overlays — `Modal`, dropdowns, toasts |
+| `shadow-ih-focus` | Focus ring (`0 0 0 3px var(--ih-primary-glow)`) — applied via `focus:shadow-ih-focus` |
+
+### Fonts
+
+`font-ih-display` (Bricolage Grotesque, headings), `font-ih-body` (Inter,
+default body), `font-ih-mono` (JetBrains Mono, `.ih-kbd` and code).
+
+### Dark mode
+
+The `data-color-scheme` attribute on `<html>` selects the palette:
+`"light"` (default), `"dark"`, or `"field"`. `useTheme()`
+(`app/hooks/useTheme.ts`) is the single place that resolves the user's
+preference (including `"auto"` → OS media query) and writes the attribute —
+components never branch on scheme themselves. Do not use Tailwind's
+`dark:` variant for OpenInspection colors; token consumption makes it
+redundant (the `.dark` class is still added alongside `data-color-scheme` so
+plain `dark:` utilities keep working for third-party components that need
+them).
+
+`"field"` is a first-class third scheme (not just "auto → dark"): a
+high-contrast, large-type (18px base) variant of dark for outdoor/sunlight
+field use. It inherits the dark palette and overrides foregrounds, background,
+and borders for higher contrast.
+
+### How to add a token
+
+1. Add the CSS custom property to both the `:root` block (light) and the
+   `html[data-color-scheme="dark"]` block (dark) in `app/styles/tailwind.css`
+   — every token needs a value in both, or dark mode silently falls back to
+   the light value.
+2. Expose it as a Tailwind utility by adding a matching line to the `@theme`
+   block (`--color-ih-foo: var(--ih-foo);`).
+3. Consume it as `bg-ih-foo` / `text-ih-foo` / etc. Never reference the raw
+   `--ih-foo` CSS variable directly from a component unless there is no
+   Tailwind utility surface for it (e.g. inline `style={{ boxShadow: ... }}`).
+4. Run `npm run lint:ds` — new raw palette usage elsewhere won't be caught by
+   adding a token, but it confirms you haven't introduced a violation.
+
+---
+
+## 2. Typography & utility classes
+
+A handful of non-component CSS utility classes live in `tailwind.css` for
+patterns that recur across many components:
+
+| Class | Purpose |
+|---|---|
+| `.ih-eyebrow` | 9px, bold, uppercase, letter-spaced label style (used by the deprecated `Eyebrow` component and a few standalone labels) |
+| `.ih-input` | The canonical 36px-tall block input style (border, radius, focus ring). `Input` and most raw `<input>`/`<select>` field markup in `app/` build on this class directly |
+| `.ih-kbd` | Keyboard-shortcut chip (monospace, bordered) |
+| `.ih-pill` (+ `--sat` / `--monitor` / `--defect` / `--ni`) | Base pill shape; the shared-ui `Pill` component composes this with a `tone` prop — prefer the component over the raw class in new code |
+| `.ih-row` / `.ih-row__hover` | Hover-reveal pattern: child marked `.ih-row__hover` is invisible until the `.ih-row` ancestor is hovered or has `.is-active` |
+| `.ih-sidebar` | Sidebar width transition, driven by `html[data-sidebar-collapsed]` |
+
+Use these for the exact pattern they name. For anything else, compose
+Tailwind utilities from the token layer directly (`text-[13px] text-ih-fg-2
+font-bold`, etc.) — there is no separate general-purpose typography scale
+beyond the ad hoc pixel sizes already used throughout `app/components/`.
+
+---
+
+## 3. Component primitives
+
+`packages/shared-ui/src/` (exported from `index.ts`) — 13 components. **Check
+here before hand-rolling UI.** A new repeated pattern (a card variant used in
+three places, a new pill tone) belongs in `shared-ui`, not copy-pasted across
+route files.
+
+| Component | Purpose | Key props / variants |
+|---|---|---|
+| `Button` | Primary interactive control | `variant`: `primary` \| `secondary` \| `ghost` \| `danger`; `size`: `sm` \| `md` \| `lg`; `icon` |
+| `Pill` | Small status/tag chip | `tone`: `sat` \| `monitor` \| `defect` \| `ni` \| `np` \| `info` \| `gen` \| `primary` \| `neutral` \| `warning`; `dot` (leading dot) |
+| `Icon` | Inline SVG icon from a fixed named set | `name` (see `ICON_PATHS` in `Icon.tsx` for the full list — dashboard, calendar, check, edit, camera, ...), `size`, `strokeWidth` |
+| `Card` | Bordered/rounded/elevated surface container | no variants — compose with `className` |
+| `Input` | Labeled text input built on `.ih-input` | `label`, `error` (red border + message), `hint` (shown only when no error) |
+| `Modal` | Dialog overlay (`role="dialog"` + `aria-modal`), Escape-to-close, click-outside-to-close | `open`, `onClose`, `title`, `size`: `sm` \| `md` \| `lg` \| `xl`, `footer` |
+| `EmptyState` | Centered icon + title + description + action for empty lists | `icon`, `title`, `description`, `action` |
+| `Eyebrow` | **Deprecated** small label chip (bg tint + text) | `color`: `slate` \| `indigo` \| `emerald` \| `amber` \| `rose` — kept for back-compat; new pages use a breadcrumb + a `Pill` in `PageHeader`'s `meta` instead |
+| `PageHeader` | Page title row with optional meta line and trailing actions | `title`, `meta`, `actions`; `eyebrow`/`eyebrowColor` are deprecated (same reason as `Eyebrow`) |
+| `Pagination` | Page-number nav + page-size selector | `page`, `pageSize`, `total`, `totalPages`, `onPageChange`, `onPageSizeChange`, `pageSizeOptions` |
+| `Skeleton` | Loading placeholder block | `variant`: `text` \| `block`, `width` |
+| `TabStrip` | Underline-style tab bar with optional counts | `tabs` (`{id, label, count?}[]`), `activeId`, `onChange` |
+| `FileDropzone` | Drag-and-drop / click-to-pick file input with a full state machine (idle → drag-over → busy → selected → error) | `accept`, `onFile`, `fileName`/`fileSize` (controlled selection display), `busy`, `error`, `hint`, `onClear`. Also exports `firstFileFromDrop`, `formatFileSize`, `truncateMiddle` helpers |
+
+`Eyebrow` and `PageHeader`'s `eyebrow`/`eyebrowColor` props are deprecated but
+still shipped for back-compat — don't use them on new pages.
+
+---
+
+## 4. Interaction patterns
+
+Two container shapes cover essentially every editable field in the app:
+**inline editing** (no submit button) and **forms** (explicit Save/submit).
+Getting this choice right matters more than pixel details — it's the
+difference between an editor that feels fluid and one that feels bureaucratic
+in the wrong places, or reckless in the wrong others.
+
+### Inline editing (no submit button)
+
+Use inline editing **only when ALL of these hold**:
+
+1. **Single, self-contained field** — no cross-field validation or
+   dependencies.
+2. **Auto-save semantics** — the value persists on change/blur (or flows into
+   the editor draft handled by the sync layer); a save failure surfaces as an
+   error toast without interrupting typing.
+3. **Continuous workflow** — the edit happens inline with surrounding context
+   that must stay visible (renaming a section, rating items, writing report
+   narratives).
+4. **Low risk, no side effects** — saving never sends, publishes, creates an
+   entity, or bills.
+
+Canonical examples in this repo:
+
+- **Template editor section title** — `app/components/template/SectionsList.tsx`:
+  a transparent-background `<input>` with a focus underline
+  (`border-b-2 border-transparent focus:border-ih-primary`), committing on
+  every keystroke via `renameSection`.
+- **Inspection editor field entry** — `app/components/form/FormField.tsx`:
+  each item type (`text`, `number`, `select`, `boolean`, ...) renders a bare
+  controlled input wired straight to `onChange`; there is no per-field save
+  button, the value flows into the inspection's sync layer.
+- **PCA narrative textareas** — same pattern, a `textarea` with
+  `onChange`-driven persistence for free-text report narrative.
+
+**Only two inline input visual styles are sanctioned** — do not invent a
+third:
+
+1. **Transparent title style**: `bg-transparent border-b-2 border-transparent
+   focus:border-ih-primary outline-none` — for large, title-like inline text
+   (section titles, item labels).
+2. **`.ih-input` block style**: the bordered, `bg-ih-bg-card` block input —
+   for ordinary field values (`FormField` renderers, most `Input` usage).
+
+### Forms (explicit Save/submit)
+
+A form is **required when ANY of these hold**:
+
+1. **Multiple fields submitted together**, or cross-field validation/
+   dependencies.
+2. **Submission has side effects** — sends email/SMS, publishes, creates an
+   entity, charges money.
+3. **Explicit confirmation semantics are needed** — a Save/Cancel pair, or an
+   unsaved-changes guard.
+
+**Rule of thumb: if an "unsaved state" can exist, it's a form; a single field
+that saves on blur can be edited inline.**
+
+Container choice:
+
+- **Page-level forms** for settings-style surfaces — see
+  `app/routes/settings-workspace.tsx`: a React Router `action` + Zod schema
+  (`workspaceSchema`) via `@conform-to/react`/`@conform-to/zod`, with
+  `useForm({ shouldValidate: "onBlur", shouldRevalidate: "onInput" })` — this
+  is the **eager-after-error** pattern: don't validate until the field is
+  first touched/blurred, then revalidate on every subsequent change so the
+  error clears as soon as the user fixes it.
+- **`Modal`** for short or critical confirmations (destructive actions,
+  small single-purpose dialogs) — build on the shared `Modal` component's
+  `footer` slot for the Save/Cancel button pair.
+
+### Toasts
+
+`app/hooks/useToast.ts` (`pushToast`) + `app/components/Toast.tsx`
+(`ToastPortal`, mounted once near the root). Three variants:
+
+| Variant | Visual | When |
+|---|---|---|
+| `neutral` (default) | Plain card, no accent | Informational, low-stakes confirmations (e.g. "Entered next section: Roof") |
+| `success` | Left accent bar in `ih-ok` | A background action completed (e.g. photo upload succeeded) |
+| `error` | Left accent bar in `ih-bad` + inline `!` marker | A background/auto-save action failed (e.g. "Save failed — your last change did NOT reach the server") |
+
+Toast vs. inline error: toast a **background/async** outcome the user isn't
+actively looking at (auto-save, background upload); show an **inline** error
+(the `Input`/`FormField` `error` prop, or a form's field-level Zod error) when
+the user is actively looking at the field that failed validation.
+
+Toasts also support an optional `actionLabel`/`onAction` (e.g. "Undo" after a
+batch rating change) and a caller-specified `durationMs`.
+
+### Never use native dialogs
+
+Never use `window.confirm` / `window.alert` / `window.prompt` for
+confirmations — always use the shared `Modal` component with explicit
+Save/Cancel (or Confirm/Cancel) actions in its `footer`.
+
+---
+
+## 5. Conformance tooling — `npm run lint:ds`
+
+`scripts/check-ds-tokens.mjs` scans `app/` and `packages/shared-ui/src/` for
+four violation classes:
+
+1. **Dead `-bg0` pseudo-token** — `ih-(ok|watch|bad|primary)-bg0` generates no
+   utility and silently ships invisible elements.
+2. **Raw palette utilities** — any Tailwind color-prefixed class
+   (`bg-`/`text-`/`border-`/`ring-`/`shadow-`/... ) against a raw hue
+   (`slate`, `red`, `indigo`, `emerald`, ...) with a numeric shade, e.g.
+   `bg-slate-200`, `text-indigo-600`. These bypass dark mode and the brand
+   hue entirely.
+3. **Literal `bg-white` / `bg-black`** on in-app surfaces.
+4. **Non-token shadows** — `shadow-sm|md|lg|xl|2xl`. Only `shadow-ih-card` and
+   `shadow-ih-popover` are sanctioned.
+
+### Escape hatches
+
+- **`ds-allow` comment** — on the offending line, or anywhere in the 10 lines
+  above it — excuses the violation. Always state the reason (fixed-dark
+  surfaces, print output, email bodies rendered in external clients).
+- **`print:`-variant utilities are ignored** — print output is intentionally
+  fixed-color.
+- **File allowlist** — a short, justified list in `FILE_ALLOWLIST` inside the
+  script (currently: the printable agreement route, the email-template
+  preview, and the Media/Photo Studio chrome components, which are
+  intentionally fixed-dark regardless of theme). Keep this list short; prefer
+  a `ds-allow` comment for anything narrower than a whole file.
+
+### Where it runs
+
+- `npm run lint` (part of the aggregate lint script alongside `lint:svg`,
+  `lint:erasure`, `lint:migrefs`, `lint:filesize`, `lint:dup`,
+  `lint:tenant-scope`, `lint:tests`).
+- Pre-commit (`.githooks/pre-commit`) — runs on every commit that touches
+  non-docs/tests files.
+- CI (`.github/workflows/ci.yml`, `verify` job) via `npm run lint`.
+
+---
+
+## 6. Contributing checklist
+
+Before opening a PR that touches UI:
+
+- [ ] **Tokens only** — no raw Tailwind palette classes, `bg-white`/`bg-black`,
+      or `shadow-sm/md/lg/xl/2xl`. Run `npm run lint:ds` locally.
+- [ ] **Dark mode checked** — toggle `data-color-scheme="dark"` on `<html>`
+      (or use the in-app theme switcher) and confirm the surface still reads
+      correctly. Token-only components get this for free; anything with a
+      hardcoded color won't.
+- [ ] **Reuse primitives** — check `packages/shared-ui/src/index.ts` before
+      writing a new button/card/modal/pill. If you're duplicating a pattern a
+      third time, promote it into `shared-ui` instead of copy-pasting again.
+- [ ] **Interaction pattern matches the rules above** — a single auto-saving
+      field is inline; anything with cross-field validation, side effects, or
+      an unsaved state is a form (page-level or `Modal`).
+- [ ] **No native dialogs** — `window.confirm`/`alert`/`prompt` are banned;
+      use `Modal`.
+- [ ] `npm run lint:ds` and `npm run lint` pass.


### PR DESCRIPTION
## Summary

Two documentation additions for contributors:

- **New `docs/developers/11_design_system.md`** — documents the Design System 0523: the token layer (colors, status tones, shadows, fonts, dark/field mode), the 13 `shared-ui` primitives, typography utility classes, interaction-pattern rules (when to use inline editing vs an explicit form, toast semantics, no native dialogs), and the `npm run lint:ds` conformance tooling with its escape hatches.
- **Testing guide rewrite** (`docs/developers/05_testing.md`) — follow-up to the test-tree reorganization in #220: directory=suite rules, spec-placement decision guide, and E2E gotchas.

Also fixes a stale CSS bullet in `CONTRIBUTING.md` that pointed at a nonexistent stylesheet path, and links the new guide from the README documentation index.

Docs-only change — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxjBCDB1TeLsU8js8XvkuF