### PR TITLE
Fix Dependabot #27 (@conform-to DoS) + wire password-reset E2E

### DIFF
--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -127,9 +127,12 @@ export default function LoginPage() {
               aria-invalid={fields.email.errors ? true : undefined}
               className="w-full px-3 py-2 rounded-lg border border-ih-border bg-ih-bg-card text-ih-fg-1 text-sm focus:shadow-ih-focus focus:border-ih-primary outline-none"
             />
-            {fields.email.errors && (
-              <p className="mt-1 text-xs text-ih-bad-fg">{fields.email.errors[0]}</p>
-            )}
+            {/* Reserve the error slot's height so the onBlur validation message
+                doesn't shift the "Forgot password?" link below it (which would
+                let a click land above the moved link and miss). */}
+            <p className="mt-1 min-h-4 text-xs text-ih-bad-fg" aria-live="polite">
+              {fields.email.errors?.[0] ?? ""}
+            </p>
           </div>
           <div>
             <div className="flex items-center justify-between mb-1">
@@ -147,9 +150,9 @@ export default function LoginPage() {
               aria-invalid={fields.password.errors ? true : undefined}
               className="w-full px-3 py-2 rounded-lg border border-ih-border bg-ih-bg-card text-ih-fg-1 text-sm focus:shadow-ih-focus focus:border-ih-primary outline-none"
             />
-            {fields.password.errors && (
-              <p className="mt-1 text-xs text-ih-bad-fg">{fields.password.errors[0]}</p>
-            )}
+            <p className="mt-1 min-h-4 text-xs text-ih-bad-fg" aria-live="polite">
+              {fields.password.errors?.[0] ?? ""}
+            </p>
           </div>
 
           {form.errors && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0-rc.1",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.8.1",
-        "@conform-to/react": "^1.19.3",
-        "@conform-to/zod": "^1.19.3",
+        "@conform-to/react": "^1.19.4",
+        "@conform-to/zod": "^1.19.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@stripe/react-stripe-js": "^6.5.0",
         "@stripe/stripe-js": "^9.7.0",
@@ -1282,18 +1282,18 @@
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@conform-to/dom": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmmirror.com/@conform-to/dom/-/dom-1.19.3.tgz",
-      "integrity": "sha512-ugNx4nMiSSEkIepo5rKxUW1I1Iab3ZFuRjNYw2b2zb7BSQJfDq4DwbywaAd55qS/8PVGp1n5G2O6orDHWPWWqA==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmmirror.com/@conform-to/dom/-/dom-1.19.4.tgz",
+      "integrity": "sha512-P/mBdVRl946iE74TXmF5YLY9+1IDrQzxKdj9A7qv7Cd4l/O02EvJskg3X7cHwhmFFIXXgNzSmf/y4B597SS4gg==",
       "license": "MIT"
     },
     "node_modules/@conform-to/react": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmmirror.com/@conform-to/react/-/react-1.19.3.tgz",
-      "integrity": "sha512-qIqvGzoVHQarRSH7r73yBQ3fLYdafhNQcItZt1dT7GK/VMB0A5eJ8fgylcY1zb5CEeZrvACC9zpmcLMqOD2nkA==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmmirror.com/@conform-to/react/-/react-1.19.4.tgz",
+      "integrity": "sha512-Xyw4hbD9467q8PTWW+Nvmf523y814w70eeABRJzVvfnpghGOAWAGt1lpOboAs6sqaKG/eouqifibz/r+PDFZLg==",
       "license": "MIT",
       "dependencies": {
-        "@conform-to/dom": "1.19.3"
+        "@conform-to/dom": "1.19.4"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1301,12 +1301,12 @@
       }
     },
     "node_modules/@conform-to/zod": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmmirror.com/@conform-to/zod/-/zod-1.19.3.tgz",
-      "integrity": "sha512-tlHywfz6W6bYnhmi8ajM1+ZLYjywLJVXteU4wvjc6QM0JT1g61cf4BaQqdDhKaAKl7DzqbZxi/riyMtz9HxyCQ==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmmirror.com/@conform-to/zod/-/zod-1.19.4.tgz",
+      "integrity": "sha512-g80QtotXLcXWCF86Xou/VpI6i+NBOQxYgLS9YCQYrgV27yilZFJYpgWWBsA8YwodmJVBIYm9RawJba7WnUoddA==",
       "license": "MIT",
       "dependencies": {
-        "@conform-to/dom": "1.19.3"
+        "@conform-to/dom": "1.19.4"
       },
       "peerDependencies": {
         "zod": "^3.21.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.1",
-    "@conform-to/react": "^1.19.3",
-    "@conform-to/zod": "^1.19.3",
+    "@conform-to/react": "^1.19.4",
+    "@conform-to/zod": "^1.19.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@stripe/react-stripe-js": "^6.5.0",
     "@stripe/stripe-js": "^9.7.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -152,6 +152,12 @@ export default defineConfig({
             testMatch: 'subsystem-b-team-strip.spec.ts',
         },
         // --- wired during 2026-07 tests reorg (were collected by no project) ---
+        // Standalone password-reset / auth-page unification (#223). No `api`
+        // dependency: every test targets a public/unauthenticated page (forgot,
+        // reset, login link) and never logs in. The "existing email" assertion
+        // holds without a seeded workspace because the forgot flow is
+        // anti-enumeration (same confirmation whether or not the account exists).
+        { name: 'auth-password-reset', testMatch: 'auth-password-reset.spec.ts' },
         { name: 'branding', testMatch: 'branding.spec.ts' },
         { name: 'repair-list', testMatch: 'repair-list.spec.ts' },
         { name: 'report-viewer', testMatch: 'report-viewer.spec.ts' },

--- a/tests/e2e/auth-password-reset.spec.ts
+++ b/tests/e2e/auth-password-reset.spec.ts
@@ -43,6 +43,10 @@ test.describe('Login entry point', () => {
     await page.goto(`${BASE_URL}/login`, { timeout: NAV_TIMEOUT, waitUntil: 'networkidle' });
     const link = page.getByRole('link', { name: /forgot password/i });
     await expect(link).toHaveAttribute('href', '/forgot-password');
+    // Click with the email still autofocused + empty. login.tsx reserves the
+    // field-error slots, so the onBlur validation message no longer shifts the
+    // link — the click lands. This guards against a return of that layout-shift
+    // regression (which would steal the click and strand the user on /login).
     await link.click();
     await expect(page).toHaveURL(/\/forgot-password$/);
     await expect(page.getByRole('heading', { name: /reset your password/i })).toBeVisible();


### PR DESCRIPTION
## Summary

Two related follow-ups to #223 (standalone password reset / auth-page unification):

1. **Security — Dependabot #27 (High):** `@conform-to/dom < 1.19.4` has a `parseSubmission` CPU-exhaustion DoS, hit on every `parseWithZod` call (login / join / forgot / reset). Bump `@conform-to/react` + `@conform-to/zod` to `^1.19.4`; transitive `@conform-to/dom` resolves to `1.19.4` (patched).

2. **Test wiring + UX fix:** the `auth-password-reset` E2E spec added in #223 was never registered as a Playwright project, so `test:e2e` / CI silently skipped it (one project per spec file here). Register it. Running it surfaced a real papercut on `/login`: the email field is autofocused, so clicking **Forgot password?** blurs it → Conform's `onBlur` inserts an error row → the link shifts down between mousedown and mouseup → the real click misses and strands the user on `/login`. Reserve the field-error slots (`min-height` + `aria-live`) so the message no longer shifts the link; the E2E now clicks the link directly to guard the regression.

## Verification

- `@conform-to/dom` resolved to `1.19.4`
- Auth unit tests: 13/13
- `auth-password-reset` E2E: 6 passed / 1 intended skip (valid-token happy path — blocked on capturing the emailed token; service-level success covered in `tests/unit/auth/auth.service.spec.ts`)
- `type-check:fast`, `lint:ds`, and full pre-commit gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)