### PR TITLE
E2E email sink: cover the password-reset happy path

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,15 @@ export default defineConfig({
     },
     tsconfig: './tsconfig.playwright.json',
     webServer: {
-        command: 'npm run build && npx wrangler dev -c build/server/wrangler.json --persist-to .wrangler/state --port 8789',
+        // --var injects E2E-only bindings onto the Playwright worker WITHOUT
+        // touching .dev.vars, so `npm run dev` is unaffected:
+        //   E2E_EMAIL_SINK=1   — capture outbound email to KV (read back via
+        //                        /api/__test__/last-email) so the reset-token
+        //                        happy path is testable end to end.
+        //   SETUP_CODE=000000  — matches the api project's setup fixture in BOTH
+        //                        CI and local (local .dev.vars may differ).
+        //   DISABLE_RATE_LIMIT=1 — the seeded suite drives many logins from one IP.
+        command: 'npm run build && npx wrangler dev -c build/server/wrangler.json --persist-to .wrangler/state --port 8789 --var E2E_EMAIL_SINK:1 --var SETUP_CODE:000000 --var DISABLE_RATE_LIMIT:1',
         url: 'http://127.0.0.1:8789/status',
         reuseExistingServer: true,
         stdout: 'pipe',
@@ -152,12 +160,12 @@ export default defineConfig({
             testMatch: 'subsystem-b-team-strip.spec.ts',
         },
         // --- wired during 2026-07 tests reorg (were collected by no project) ---
-        // Standalone password-reset / auth-page unification (#223). No `api`
-        // dependency: every test targets a public/unauthenticated page (forgot,
-        // reset, login link) and never logs in. The "existing email" assertion
-        // holds without a seeded workspace because the forgot flow is
-        // anti-enumeration (same confirmation whether or not the account exists).
-        { name: 'auth-password-reset', testMatch: 'auth-password-reset.spec.ts' },
+        // Standalone password-reset / auth-page unification (#223, #224). The
+        // public-page tests (forgot / reset / login link) need no seed, but the
+        // valid-token happy path invites a throwaway member off the shared admin,
+        // so depend on `api` (which seeds admin@autotest.com). The reset token is
+        // read back from the E2E email sink (E2E_EMAIL_SINK, wired on the worker).
+        { name: 'auth-password-reset', testMatch: 'auth-password-reset.spec.ts', dependencies: ['api'] },
         { name: 'branding', testMatch: 'branding.spec.ts' },
         { name: 'repair-list', testMatch: 'repair-list.spec.ts' },
         { name: 'report-viewer', testMatch: 'report-viewer.spec.ts' },

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -6,7 +6,7 @@
   "app/routes/inspections.tsx": 902,
   "server/durable-objects/inspection-doc.ts": 896,
   "server/services/booking.service.ts": 848,
-  "server/index.ts": 827,
+  "server/index.ts": 830,
   "server/api/sms.ts": 818,
   "server/services/inspection.service.ts": 739,
   "app/routes/settings-communication-templates.tsx": 731,

--- a/server/api/test-hooks.ts
+++ b/server/api/test-hooks.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono';
+import type { HonoConfig } from '../types/hono';
+import { sinkKey } from '../lib/email/providers/recording';
+
+/**
+ * TEST-ONLY routes, fail-closed behind `E2E_EMAIL_SINK`. In every real deploy
+ * the flag is unset, so each handler returns 404 and reveals nothing. Exists so
+ * E2E can read back the password-reset link that is emailed (never returned by
+ * any API) — captured by RecordingEmailProvider. Mounted at `/api/__test__`.
+ */
+const testHooks = new Hono<HonoConfig>();
+
+testHooks.get('/last-email', async (c) => {
+  // Fail closed: the route only exists when the sink is explicitly enabled.
+  if (c.env.E2E_EMAIL_SINK !== '1') return c.json({ error: 'Not found' }, 404);
+
+  const to = c.req.query('to');
+  if (!to) return c.json({ error: 'Missing "to" query param' }, 400);
+
+  const raw = await c.env.TENANT_CACHE.get(sinkKey(to));
+  if (!raw) return c.json({ error: 'No email recorded for that recipient' }, 404);
+
+  return c.json({ data: JSON.parse(raw) }, 200);
+});
+
+export default testHooks;

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { loadVerifyData } from './lib/verify-data';
 
 
 import coreAuthRoutes from './api/auth';
+import testHooksRoutes from './api/test-hooks';
 import identityRoutes from './api/identity';
 import integrationsApiRoutes from './api/integrations';
 import analyticsRoutes from './api/analytics';
@@ -257,7 +258,7 @@ export const jwtAuthMiddleware: MiddlewareHandler<HonoConfig> = async (c, next) 
         path === '/api/concierge/book-info' ||
         path === '/api/concierge/book' ||
         path === '/api/concierge/confirm-info';
-    const isPublic = path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/admin/connect') || path.startsWith('/api/admin/silo') || path.startsWith('/api/ics/') || path === '/book' || path.startsWith('/book/') || path.startsWith('/inspector/') || path.startsWith('/embed/') || path.startsWith('/photos/') || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/report-view/') || path.startsWith('/invoice/') || path.startsWith('/agreements/sign/') || path.startsWith('/checkout/') || path.startsWith('/sign/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || path.startsWith('/v/') || path.startsWith('/.well-known/') || STATIC_ASSET_EXT.test(path) || path === '/api/integrations/qbo/webhook' || path === '/api/integrations/stripe/webhook' || path.startsWith('/api/integrations/stripe/webhook/') || path.startsWith('/repair-request/') || path.startsWith('/repair-builder/') || path.startsWith('/api/portal/') || path.startsWith('/portal/');
+    const isPublic = path.startsWith('/api/__test__/') || path.startsWith('/api/public/') || path.startsWith('/api/integration/') || path.startsWith('/api/admin/connect') || path.startsWith('/api/admin/silo') || path.startsWith('/api/ics/') || path === '/book' || path.startsWith('/book/') || path.startsWith('/inspector/') || path.startsWith('/embed/') || path.startsWith('/photos/') || path === '/' || path === '/status' || path.startsWith('/static/') || path.startsWith('/report/') || path.startsWith('/report-view/') || path.startsWith('/invoice/') || path.startsWith('/agreements/sign/') || path.startsWith('/checkout/') || path.startsWith('/sign/') || path.startsWith('/m2m/') || path.startsWith('/verify/') || path.startsWith('/v/') || path.startsWith('/.well-known/') || STATIC_ASSET_EXT.test(path) || path === '/api/integrations/qbo/webhook' || path === '/api/integrations/stripe/webhook' || path.startsWith('/api/integrations/stripe/webhook/') || path.startsWith('/repair-request/') || path.startsWith('/repair-builder/') || path.startsWith('/api/portal/') || path.startsWith('/portal/');
 
     // Design System 0520 subsystem D P5 — observer surfaces are gated by
     // the dedicated observer-cookie middleware, not JWT.
@@ -432,6 +433,8 @@ const routes = app
   // Mount auth routes at canonical API path AND at root so that /setup, /login (POST), /join (POST) work without redirects
   .route('/api/auth', coreAuthRoutes)
   .route('/', coreAuthRoutes)
+  // Test-only hooks, fail-closed behind E2E_EMAIL_SINK (404 in prod). See test-hooks.ts.
+  .route('/api/__test__', testHooksRoutes)
   .route('/api/billing', billingRoutes)
   .route('/api/usage', usageRoutes)
   // Design System 0520 subsystem E — identity / integrations / analytics.

--- a/server/lib/email/build-email-service.ts
+++ b/server/lib/email/build-email-service.ts
@@ -11,6 +11,7 @@ import { resolveEmailProvider, coerceEmailByoProvider, type EmailByoProvider } f
 import { buildEmailSuppression } from './suppression';
 import { logger } from '../logger';
 import { ResendProvider } from './providers/resend';
+import { RecordingEmailProvider } from './providers/recording';
 import { drizzle } from 'drizzle-orm/d1';
 import { eq } from 'drizzle-orm';
 import { tenantConfigs } from '../db/schema';
@@ -24,6 +25,8 @@ export interface EmailServiceEnv {
     DB: D1Database;
     APP_MODE?: string;
     TENANT_CACHE: KVNamespace;
+    /** Test-only email sink flag (see AppEnv.E2E_EMAIL_SINK). '1' ⇒ capture, don't send. */
+    E2E_EMAIL_SINK?: string;
     JWT_SECRET: string;
     JWT_SECRET_PREVIOUS?: string;
     RESEND_API_KEY?: string;
@@ -182,6 +185,24 @@ export function assembleTenantEmailService(
     const suppression = meterTenantId
         ? buildEmailSuppression(env.DB, meterTenantId)
         : undefined;
+
+    // TEST-ONLY email sink (E2E). Capture every message to KV instead of
+    // sending, so E2E can read back links it cannot see from the browser (the
+    // password-reset token). Sentinel apiKey + a non-empty From make `sendEmail`
+    // reach the provider (its missing-key / missing-sender guards would otherwise
+    // short-circuit); suppression/quota gates are dropped. Strictly gated on
+    // E2E_EMAIL_SINK — unset in every real deploy, so this never runs in prod.
+    if (env.E2E_EMAIL_SINK === '1') {
+        return new EmailService(
+            'e2e-email-sink',
+            fromAddress || 'e2e-sink@openinspection.test',
+            appName, emailIdentity, renderer, meter,
+            new RecordingEmailProvider(env.TENANT_CACHE),
+            undefined,
+            undefined,
+        );
+    }
+
     return new EmailService(apiKeySentinel, fromAddress, appName, emailIdentity, renderer, meter, provider, suppression, quota);
 }
 

--- a/server/lib/email/providers/recording.ts
+++ b/server/lib/email/providers/recording.ts
@@ -1,0 +1,69 @@
+import type {
+  EmailProvider,
+  EmailSendArgs,
+  EmailWebhookContext,
+  NormalizedEmailEvent,
+} from '../provider';
+
+/** KV key prefix for captured E2E emails. One entry per recipient. */
+const SINK_PREFIX = 'e2e_email:';
+/** Short TTL — captured bodies are read back within a single test run. */
+const SINK_TTL_SECONDS = 600;
+
+/** KV key for a recipient's last captured email (normalized: trimmed + lowercased). */
+export function sinkKey(recipient: string): string {
+  return `${SINK_PREFIX}${recipient.trim().toLowerCase()}`;
+}
+
+/** Shape stored per recipient and returned by the `/api/__test__/last-email` route. */
+interface RecordedEmail {
+  subject: string;
+  html: string;
+  text: string | null;
+}
+
+/**
+ * TEST-ONLY email transport. Instead of sending, it records each outbound
+ * message to KV so an E2E test can read back a link it otherwise could never
+ * observe from the browser — most importantly the password-reset token, which
+ * is emailed and never returned by any API.
+ *
+ * Wired ONLY when `env.E2E_EMAIL_SINK === '1'` (see build-email-service.ts).
+ * It MUST NOT be reachable in production: no real email leaves the worker and
+ * the captured bodies are read back exclusively via a matching env-gated route.
+ * Every deploy leaves the flag unset, so this class is never constructed there.
+ */
+export class RecordingEmailProvider implements EmailProvider {
+  constructor(private kv: KVNamespace) {}
+
+  async sendEmail(args: EmailSendArgs): Promise<{ ok: true; id?: string }> {
+    const recipients = Array.isArray(args.to) ? args.to : [args.to];
+    const record: RecordedEmail = {
+      subject: args.subject,
+      html: args.html,
+      text: args.text ?? null,
+    };
+    const serialized = JSON.stringify(record);
+    // Store under every recipient so a lookup by any To address hits.
+    await Promise.all(
+      recipients
+        .filter((r): r is string => typeof r === 'string' && r.length > 0)
+        .map((r) => this.kv.put(sinkKey(r), serialized, { expirationTtl: SINK_TTL_SECONDS })),
+    );
+    return { ok: true, id: 'e2e-sink' };
+  }
+
+  // The remaining EmailProvider surface is inert for the sink: it never
+  // validates credentials or receives inbound webhooks.
+  async validateCredentials(): Promise<{ ok: true }> {
+    return { ok: true };
+  }
+
+  async verifyWebhookSignature(_ctx: EmailWebhookContext): Promise<boolean> {
+    return false;
+  }
+
+  parseWebhookEvents(_rawBody: string): NormalizedEmailEvent[] {
+    return [];
+  }
+}

--- a/server/types/hono.ts
+++ b/server/types/hono.ts
@@ -88,6 +88,13 @@ export interface AppEnv {
     // suite's concentrated single-IP logins don't trip the 10/60s login limiter.
     // Unset (the default) everywhere else — production/self-host stays enforced.
     DISABLE_RATE_LIMIT?: string;
+    // Test-only email sink: when '1', every outbound email is captured to KV
+    // instead of sent (RecordingEmailProvider) and the env-gated
+    // `/api/__test__/last-email` route reads it back — so E2E can obtain the
+    // password-reset token, which is emailed and never returned by an API. Set
+    // ONLY on the Playwright worker (playwright.config.ts `--var`). Unset (the
+    // default) everywhere else — production/self-host never sink or expose it.
+    E2E_EMAIL_SINK?: string;
 
     // Payments
     STRIPE_SECRET_KEY?: string;

--- a/tests/e2e/auth-password-reset.spec.ts
+++ b/tests/e2e/auth-password-reset.spec.ts
@@ -5,13 +5,54 @@
  * worker. Anti-enumeration is the load-bearing assertion: an existing and an
  * unknown email MUST land on the identical confirmation. Base URL + seeded
  * admin mirror standalone-browser.spec.ts.
+ *
+ * The valid-token happy path reads the reset link back from the E2E email sink
+ * (E2E_EMAIL_SINK, wired on the Playwright worker) via /api/__test__/last-email.
  */
 import { test, expect } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { csrfHeaders } from './helpers/csrf';
 
 const BASE_URL = 'http://127.0.0.1:8789';
 const NAV_TIMEOUT = 15000;
 const KNOWN_EMAIL = 'admin@autotest.com';
+const ADMIN_PASSWORD = 'Password123!';
 const INVALID_TOKEN = '00000000-0000-0000-0000-000000000000';
+
+/** Log in via the API and return the session JWT (from the Set-Cookie). */
+async function loginApi(request: APIRequestContext, email: string, password: string): Promise<string> {
+  const { headers } = csrfHeaders();
+  const res = await request.post(`${BASE_URL}/api/auth/login`, {
+    data: { email, password },
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+  expect(res.status(), `login ${email}`).toBe(200);
+  const cookie = res.headers()['set-cookie'] ?? '';
+  return cookie.match(/__Host-inspector_token=([^;]+)/)?.[1] ?? '';
+}
+
+/** Admin-invite a member and return the join token from the invite link. */
+async function inviteMember(request: APIRequestContext, adminToken: string, email: string): Promise<string> {
+  const res = await request.post(`${BASE_URL}/api/team/invite`, {
+    data: { email, role: 'inspector' },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` },
+  });
+  expect(res.status(), 'invite must return 201').toBe(201);
+  const body = await res.json();
+  const link = body.data?.inviteLink ?? body.inviteLink ?? '';
+  const token = new URL(link).searchParams.get('token') ?? '';
+  expect(token, 'invite link must carry a token').toBeTruthy();
+  return token;
+}
+
+/** Accept an invite (sets the member's initial password). */
+async function acceptInvite(request: APIRequestContext, token: string, password: string): Promise<void> {
+  const res = await request.post(`${BASE_URL}/api/auth/join`, {
+    data: { token, password, name: 'Reset E2E User' },
+    headers: { 'Content-Type': 'application/json' },
+  });
+  expect(res.status(), 'join must return 200').toBe(200);
+}
 
 test.describe('Forgot password', () => {
   test('an existing email lands on the check-inbox confirmation', async ({ page }) => {
@@ -70,10 +111,48 @@ test.describe('Reset password', () => {
     await expect(page.getByText('Password must be at least 8 characters')).toBeVisible();
   });
 
-  // TODO(reset-happy-path): a *valid* reset token is minted by
-  // createPasswordResetToken and emailed — no API returns it, so the browser
-  // can't obtain one. Blocked on a test-only token capture (email sink or a
-  // seeded token fixture). Service-level reset success is covered in
-  // tests/unit/auth/auth.service.spec.ts.
-  test.skip('a valid token updates the password and allows login', async () => {});
+  test('a valid token updates the password, and the new password logs in', async ({ page, request }) => {
+    // Use a throwaway member so we never mutate the shared admin/inspector creds
+    // that other projects log in with.
+    const email = 'pwreset-e2e@autotest.com';
+    const initialPassword = 'InitialPass1!';
+    const newPassword = 'BrandNewPass9!';
+
+    // 1. Create the member (invite + accept) off the seeded admin.
+    const adminToken = await loginApi(request, KNOWN_EMAIL, ADMIN_PASSWORD);
+    expect(adminToken, 'admin must authenticate').toBeTruthy();
+    const joinToken = await inviteMember(request, adminToken, email);
+    await acceptInvite(request, joinToken, initialPassword);
+
+    // 2. Request a reset through the real UI; the email sink captures the link.
+    await page.goto(`${BASE_URL}/forgot-password`, { timeout: NAV_TIMEOUT, waitUntil: 'networkidle' });
+    await page.locator('input[type="email"]').fill(email);
+    await page.getByRole('button', { name: /send reset link/i }).click();
+    await expect(page.getByRole('heading', { name: /check your inbox/i })).toBeVisible();
+
+    // 3. Read the reset link back out of the sink and extract the token.
+    const sink = await request.get(`${BASE_URL}/api/__test__/last-email?to=${encodeURIComponent(email)}`);
+    expect(sink.status(), 'sink must have captured the reset email').toBe(200);
+    const { data } = await sink.json();
+    const match = String(data.html).match(/reset-password\?token=([A-Za-z0-9-]+)/);
+    expect(match, 'reset email must contain a reset-password link').toBeTruthy();
+    const token = match![1];
+
+    // 4. Set a NEW password (different from the initial one) via the reset UI.
+    await page.goto(`${BASE_URL}/reset-password?token=${token}`, { timeout: NAV_TIMEOUT, waitUntil: 'networkidle' });
+    await page.locator('input[type="password"]').fill(newPassword);
+    await page.getByRole('button', { name: /update password/i }).click();
+    await expect(page.getByRole('heading', { name: /password updated/i })).toBeVisible();
+
+    // 5. The new password authenticates.
+    const newToken = await loginApi(request, email, newPassword);
+    expect(newToken, 'new password should authenticate').toBeTruthy();
+
+    // 6. The old password no longer works.
+    const stale = await request.post(`${BASE_URL}/api/auth/login`, {
+      data: { email, password: initialPassword },
+      headers: { 'Content-Type': 'application/json', ...csrfHeaders().headers },
+    });
+    expect(stale.status(), 'old password must be rejected after reset').toBe(401);
+  });
 });

--- a/tests/unit/email/recording-provider.spec.ts
+++ b/tests/unit/email/recording-provider.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { RecordingEmailProvider, sinkKey } from '../../../server/lib/email/providers/recording';
+
+/** Minimal Map-backed KV double — only get/put are exercised. */
+function fakeKV() {
+  const store = new Map<string, string>();
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v); },
+  } as unknown as KVNamespace;
+  return { kv, store };
+}
+
+describe('sinkKey', () => {
+  it('normalizes the recipient (trim + lowercase) under the e2e_email: prefix', () => {
+    expect(sinkKey('  Foo@Bar.COM ')).toBe('e2e_email:foo@bar.com');
+  });
+});
+
+describe('RecordingEmailProvider', () => {
+  it('records the message under the normalized recipient key and returns ok', async () => {
+    const { kv } = fakeKV();
+    const res = await new RecordingEmailProvider(kv).sendEmail({
+      from: 'noreply@x.com',
+      to: 'User@Example.com',
+      subject: 'Reset your password',
+      html: '<a href="https://app.test/reset-password?token=abc-123">Reset</a>',
+    });
+    expect(res.ok).toBe(true);
+
+    const raw = await kv.get(sinkKey('user@example.com'));
+    expect(raw).toBeTruthy();
+    const rec = JSON.parse(raw!);
+    expect(rec.subject).toBe('Reset your password');
+    expect(rec.html).toContain('reset-password?token=abc-123');
+    expect(rec.text).toBeNull();
+  });
+
+  it('records under every recipient when `to` is an array', async () => {
+    const { kv } = fakeKV();
+    await new RecordingEmailProvider(kv).sendEmail({
+      from: 'noreply@x.com',
+      to: ['One@x.com', 'two@y.com'],
+      subject: 's',
+      html: 'h',
+      text: 'plain',
+    });
+    expect(await kv.get(sinkKey('one@x.com'))).toBeTruthy();
+    const two = JSON.parse((await kv.get(sinkKey('two@y.com')))!);
+    expect(two.text).toBe('plain');
+  });
+
+  it('never sends and never throws for the inert webhook surface', async () => {
+    const { kv } = fakeKV();
+    const p = new RecordingEmailProvider(kv);
+    expect(await p.validateCredentials()).toEqual({ ok: true });
+    expect(await p.verifyWebhookSignature({} as never)).toBe(false);
+    expect(p.parseWebhookEvents('{}')).toEqual([]);
+  });
+});

--- a/tests/unit/test-hooks/last-email.spec.ts
+++ b/tests/unit/test-hooks/last-email.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import testHooks from '../../../server/api/test-hooks';
+import { sinkKey } from '../../../server/lib/email/providers/recording';
+
+/** Map-backed KV double — only get/put are exercised. */
+function kvWith(entries: Record<string, string> = {}): KVNamespace {
+  const store = new Map(Object.entries(entries));
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v); },
+  } as unknown as KVNamespace;
+}
+
+/** Invoke the mounted router with a given env (Hono's 3rd request arg = Bindings). */
+function call(env: Record<string, unknown>, path = '/last-email?to=a@b.com') {
+  return testHooks.request(path, {}, env as never);
+}
+
+describe('GET /api/__test__/last-email — fail-closed gate', () => {
+  it('404s when E2E_EMAIL_SINK is unset (the production default)', async () => {
+    const res = await call({ TENANT_CACHE: kvWith() });
+    expect(res.status).toBe(404);
+  });
+
+  it('404s when the flag is any value other than "1"', async () => {
+    const res = await call({ E2E_EMAIL_SINK: '0', TENANT_CACHE: kvWith() });
+    expect(res.status).toBe(404);
+  });
+
+  it('400s when `to` is missing (sink enabled)', async () => {
+    const res = await call({ E2E_EMAIL_SINK: '1', TENANT_CACHE: kvWith() }, '/last-email');
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when no email was recorded for the recipient', async () => {
+    const res = await call({ E2E_EMAIL_SINK: '1', TENANT_CACHE: kvWith() }, '/last-email?to=nobody@b.com');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the recorded email when the sink is enabled and one exists', async () => {
+    const kv = kvWith({
+      [sinkKey('a@b.com')]: JSON.stringify({
+        subject: 'Reset your password',
+        html: '<a href="https://app/reset-password?token=xyz-1">Reset</a>',
+        text: null,
+      }),
+    });
+    const res = await call({ E2E_EMAIL_SINK: '1', TENANT_CACHE: kv });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.subject).toBe('Reset your password');
+    expect(body.data.html).toContain('token=xyz-1');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last gap from #224: the valid-token password-reset **happy path** was a `test.skip` because the reset token is emailed and never returned by an API, so the browser could not obtain one.

This adds a **test-only email sink**, both halves fail-closed behind `E2E_EMAIL_SINK` (unset in every real deploy):

- **`RecordingEmailProvider`** — when `E2E_EMAIL_SINK=1`, `assembleTenantEmailService` injects it so every outbound message is captured to KV (`e2e_email:<recipient>`) instead of sent. Sentinel apiKey + sender let `sendEmail` reach the provider; suppression/quota gates are dropped.
- **`GET /api/__test__/last-email`** — env-gated read-back. Returns `404` whenever the flag ≠ `1`, so the token-bearing endpoint reveals nothing in production/self-host.
- The flags are injected onto the Playwright worker via `wrangler dev --var` (so `npm run dev` is untouched): `E2E_EMAIL_SINK`, plus `SETUP_CODE=000000` / `DISABLE_RATE_LIMIT=1` to make the seeded suite deterministic locally as well as in CI.
- The skipped test becomes a real **invite → forgot → reset → login** chain against a *throwaway* member (never mutating the shared admin/inspector creds); it also asserts the old password is rejected after reset. `auth-password-reset` now `dependencies: ['api']` for the seeded admin.

## Verification

- `auth-password-reset` E2E: **31 passed** (incl. the new happy path)
- Unit: `RecordingEmailProvider` + the fail-closed route gate — 9 passed
- Full `test:unit` 2790 passed / 1 skip, full `type-check` clean, `lint` clean (DS + dead-code + file-size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)