### PR TITLE
chore(deps): bump react-router to 7.18.1 (CVE-2026-53666/53667/53669)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3669,9 +3669,9 @@
       "license": "MIT"
     },
     "node_modules/@react-router/dev": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmmirror.com/@react-router/dev/-/dev-7.16.0.tgz",
-      "integrity": "sha512-E/uNYnHbo+wepw+FudGwuN6au6y4dOfVuRRANYdCp5T+tLvGU/09s2uGzNQsxqushyae9wvWTLY0qMvvgowIyg==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmmirror.com/@react-router/dev/-/dev-7.18.1.tgz",
+      "integrity": "sha512-1Yu5272BI8g5sl1jwmhM3aFeajXQwNbWP4qrdMYfC+ayT2khxV6KPCitLNJl+jT6DMGEKb/hmwcmKd0lFIBjxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3682,7 +3682,7 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/traverse": "^7.27.7",
         "@babel/types": "^7.27.7",
-        "@react-router/node": "7.16.0",
+        "@react-router/node": "7.18.1",
         "@remix-run/node-fetch-server": "^0.13.0",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
@@ -3711,9 +3711,9 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.16.0",
+        "@react-router/serve": "^7.18.1",
         "@vitejs/plugin-rsc": "~0.5.21",
-        "react-router": "^7.16.0",
+        "react-router": "^7.18.1",
         "react-server-dom-webpack": "^19.2.3",
         "typescript": "^5.1.0 || ^6.0.0",
         "vite": "^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -3752,9 +3752,9 @@
       "license": "MIT"
     },
     "node_modules/@react-router/node": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmmirror.com/@react-router/node/-/node-7.16.0.tgz",
-      "integrity": "sha512-3S54GArZETvcBHt0cFNJS5ZU66bCNVOoS44MVcGjiGjArBXvWx8xIQ5FO9n1azKGEBpDmJN7NbA+cf3oMCJv3g==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmmirror.com/@react-router/node/-/node-7.18.1.tgz",
+      "integrity": "sha512-2GhAwa90z/+GMFM8Q5HsgwzakYogbQcZpqpNonhN4YWDRjWkSz+t5jgwNAFvG8ENR8fKGEVEsOHIaNVDfW9Ouw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3764,7 +3764,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.16.0",
+        "react-router": "7.18.1",
         "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
@@ -12145,9 +12145,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",


### PR DESCRIPTION
Three medium-severity advisories affect `react-router < 7.18.0`, all surfaced by Dependabot after the previous milestone (#279) merged:

- **CVE-2026-53666** (GHSA-337j-9hxr-rhxg) — arbitrary constructor injection via `deserializeErrors()` during SSR hydration.
- **CVE-2026-53667** (GHSA-h8fp-f39c-q6mh) — `RSCErrorHandler` missing protocol validation (XSS).
- **CVE-2026-53669** (GHSA-wrjc-x8rr-h8h6) — open redirect via backslash in `<Link>` and `useNavigate`.

All are fixed in 7.18.0. This bumps `react-router` and `@react-router/dev` to **7.18.1** within the existing `^7.6.0` range — the lockfile is updated in place (no `package.json` range change, and the lock's linux binaries are preserved). react-router is a runtime framework dependency, so the full gate was run locally: type-check (api + app), lint, `test:unit`, `test:web`, and build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
