### PR TITLE
Speed up the local commit gate (and one measurement that cancelled a change)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,6 +6,14 @@
 #     git config core.hooksPath .githooks
 # Bypass (discouraged): git commit --no-verify
 #
+# If you do bypass it AND the commit touches TypeScript, run
+# `npm run type-check:app` (plus type-check:api if server/ moved) immediately
+# afterwards. tsc's incremental build-info is only refreshed by a run that
+# completes, so skipping the hook leaves it describing the PREVIOUS tree and the
+# next type-check pays full cold cost — measured here: 21s warm, 357s cold. That
+# cold run then blows whatever timeout made --no-verify attractive, and the loop
+# feeds itself. Ask how this was measured: by falling into it.
+#
 # Mechanism is .githooks + core.hooksPath (no husky), aligned with the
 # superproject and the portal/cms submodules.
 
@@ -91,7 +99,7 @@ else
     GEN_OK=1
     GEN_NOTE=""
     if needs_paraglide; then
-        if npm run i18n:compile > /dev/null 2>&1; then
+        if npm run i18n:compile:cached > /dev/null 2>&1; then
             GEN_NOTE="${GEN_NOTE}, regenerated messages"
         else
             GEN_OK=0
@@ -104,8 +112,26 @@ else
             GEN_OK=0
         fi
     fi
+    # The api program includes server/** and nothing else, so staged changes
+    # confined to app/ packages/ workers/ cannot affect it. That pass was being
+    # run anyway: 11s warm, and 152s when its build-info had gone cold — paid on
+    # every front-end commit for a program the commit cannot reach.
+    #
+    # Config changes (tsconfig, package.json, vite/react-router config) still run
+    # BOTH, because those can move either program's inputs.
+    APP_ONLY=0
+    if [ -z "$CONFIG_STAGED" ] && [ -z "$(echo "$TS_STAGED" | grep -E '^server/')" ]; then
+        APP_ONLY=1
+    fi
+
     if [ "$GEN_OK" -eq 0 ]; then
         fail "Type generation failed  →  npm run type-check"
+    elif [ "$APP_ONLY" -eq 1 ]; then
+        if npm run type-check:app > /dev/null 2>&1; then
+            pass "Type check passed (tsc, app pass only — no staged server/ changes${GEN_NOTE})"
+        else
+            fail "Type check failed  →  npm run type-check:app"
+        fi
     elif npm run type-check:app > /dev/null 2>&1 && npm run type-check:api > /dev/null 2>&1; then
         pass "Type check passed (tsc${GEN_NOTE})"
     else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,15 @@ jobs:
       # server/generated/version.ts is git-ignored and produced by the build;
       # type-check imports it, so stamp it on a fresh checkout.
       - run: npm run gen-version
-      - run: npm run i18n:compile
+      # Keyed on the compiler's INPUTS, so a hit can only ever restore output
+      # that those exact inputs produced — unlike a build-info cache, there is no
+      # staleness to reason about. The stamp inside app/paraglide comes back with
+      # it, so the script below sees "unchanged" and skips a ~66s compile.
+      - uses: actions/cache@v4
+        with:
+          path: app/paraglide
+          key: paraglide-${{ hashFiles('messages/**', 'project.inlang/**') }}
+      - run: npm run i18n:compile:cached
       - run: npx react-router typegen
       - run: npm run type-check:app
 
@@ -97,7 +105,15 @@ jobs:
         with: { node-version: 22.22.x, cache: npm }
       - run: npm ci
       - run: npm run gen-version
-      - run: npm run i18n:compile
+      # Keyed on the compiler's INPUTS, so a hit can only ever restore output
+      # that those exact inputs produced — unlike a build-info cache, there is no
+      # staleness to reason about. The stamp inside app/paraglide comes back with
+      # it, so the script below sees "unchanged" and skips a ~66s compile.
+      - uses: actions/cache@v4
+        with:
+          path: app/paraglide
+          key: paraglide-${{ hashFiles('messages/**', 'project.inlang/**') }}
+      - run: npm run i18n:compile:cached
       - run: npx react-router typegen
       - run: npm run test:types
 
@@ -116,7 +132,15 @@ jobs:
         with: { node-version: 22.22.x, cache: npm }
       - run: npm ci
       - run: npm run gen-version
-      - run: npm run i18n:compile
+      # Keyed on the compiler's INPUTS, so a hit can only ever restore output
+      # that those exact inputs produced — unlike a build-info cache, there is no
+      # staleness to reason about. The stamp inside app/paraglide comes back with
+      # it, so the script below sees "unchanged" and skips a ~66s compile.
+      - uses: actions/cache@v4
+        with:
+          path: app/paraglide
+          key: paraglide-${{ hashFiles('messages/**', 'project.inlang/**') }}
+      - run: npm run i18n:compile:cached
       - run: npx react-router typegen
       - run: npm run lint:eslint
 
@@ -131,7 +155,15 @@ jobs:
         with: { node-version: 22.22.x, cache: npm }
       - run: npm ci
       - run: npm run gen-version
-      - run: npm run i18n:compile
+      # Keyed on the compiler's INPUTS, so a hit can only ever restore output
+      # that those exact inputs produced — unlike a build-info cache, there is no
+      # staleness to reason about. The stamp inside app/paraglide comes back with
+      # it, so the script below sees "unchanged" and skips a ~66s compile.
+      - uses: actions/cache@v4
+        with:
+          path: app/paraglide
+          key: paraglide-${{ hashFiles('messages/**', 'project.inlang/**') }}
+      - run: npm run i18n:compile:cached
       # knip resolves every `./+types/*` import a route file makes, so it needs
       # the generated route types present or it reports the whole of app/routes
       # as unresolved. In the old serial job these existed only because
@@ -179,7 +211,15 @@ jobs:
         with: { node-version: 22.22.x, cache: npm }
       - run: npm ci
       - run: npm run gen-version
-      - run: npm run i18n:compile
+      # Keyed on the compiler's INPUTS, so a hit can only ever restore output
+      # that those exact inputs produced — unlike a build-info cache, there is no
+      # staleness to reason about. The stamp inside app/paraglide comes back with
+      # it, so the script below sees "unchanged" and skips a ~66s compile.
+      - uses: actions/cache@v4
+        with:
+          path: app/paraglide
+          key: paraglide-${{ hashFiles('messages/**', 'project.inlang/**') }}
+      - run: npm run i18n:compile:cached
       - run: npx react-router typegen
       - run: npm run test:web
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "mcp:snapshot": "node scripts/snapshot-openapi.mjs",
     "lint:english": "node scripts/check-english-only.mjs",
     "lint:eslint": "cross-env NODE_OPTIONS=--max-old-space-size=12288 eslint . --cache --cache-strategy content",
-    "lint:gates-full": "npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:migrefs && npm run lint:english && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope && npm run lint:status-literals && npm run lint:tests && npm run lint:deadcode && npm run lint:timestamps && npm run lint:tz && npm run lint:i18n && npm run lint:i18n-catalog && npm run lint:naming"
+    "lint:gates-full": "npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:migrefs && npm run lint:english && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope && npm run lint:status-literals && npm run lint:tests && npm run lint:deadcode && npm run lint:timestamps && npm run lint:tz && npm run lint:i18n && npm run lint:i18n-catalog && npm run lint:naming",
+    "i18n:compile:cached": "node scripts/i18n-compile-if-changed.mjs"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.1",

--- a/scripts/i18n-compile-if-changed.mjs
+++ b/scripts/i18n-compile-if-changed.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Run the paraglide compiler only when its inputs actually changed.
+ *
+ * `npm run i18n:compile` takes ~66s on this project (4000+ message keys) and is
+ * run by the pre-commit hook and by four CI jobs. It is a pure function of
+ * `messages/**` plus `project.inlang/`, so most of those runs recompute an
+ * identical `app/paraglide/` from identical inputs.
+ *
+ * The guard is a content hash rather than mtimes, deliberately: a fresh
+ * checkout, a `git stash pop`, or a branch switch all rewrite files whose
+ * content is unchanged, and an mtime check would rebuild for every one of them.
+ *
+ * It is also conservative in one direction only. Anything it cannot be sure
+ * about — no stamp, unreadable stamp, missing output directory, hash mismatch —
+ * compiles. Skipping happens solely when the stamp matches AND the output
+ * exists, because a stale `app/paraglide/` is a wrong build, while a redundant
+ * compile only costs a minute.
+ *
+ * Pass --force to compile regardless (useful when debugging the compiler).
+ */
+import { createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const OUT_DIR = 'app/paraglide';
+// The stamp lives INSIDE the output directory on purpose: anything that caches
+// or restores `app/paraglide` (CI does) carries the record of which inputs
+// produced it, so a restored directory is trusted only for the exact inputs
+// that built it. Keeping the stamp elsewhere would make every fresh checkout
+// recompile even with the output already in hand.
+const STAMP = 'app/paraglide/.inputs-hash';
+const INPUT_DIRS = ['messages', 'project.inlang'];
+const force = process.argv.includes('--force');
+
+/** Every input file, sorted, so the hash does not depend on directory order. */
+function walk(dir, acc = []) {
+    if (!existsSync(dir)) return acc;
+    for (const name of readdirSync(dir).sort()) {
+        const p = join(dir, name);
+        if (statSync(p).isDirectory()) walk(p, acc);
+        else acc.push(p);
+    }
+    return acc;
+}
+
+function inputHash() {
+    const h = createHash('sha256');
+    for (const f of INPUT_DIRS.flatMap((d) => walk(d))) {
+        h.update(f);
+        h.update(readFileSync(f));
+    }
+    return h.digest('hex');
+}
+
+function compile() {
+    execSync('npm run i18n:compile', { stdio: 'inherit' });
+}
+
+const hash = inputHash();
+
+if (force) {
+    console.log('[i18n] --force: compiling.');
+    compile();
+} else if (!existsSync(OUT_DIR)) {
+    console.log(`[i18n] ${OUT_DIR} missing — compiling.`);
+    compile();
+} else {
+    let previous = null;
+    try {
+        previous = readFileSync(STAMP, 'utf8').trim();
+    } catch {
+        // No stamp yet, or unreadable — fall through and compile.
+    }
+    if (previous === hash) {
+        console.log('[i18n] inputs unchanged — skipped.');
+        process.exit(0);
+    }
+    console.log(previous ? '[i18n] inputs changed — compiling.' : '[i18n] no stamp — compiling.');
+    compile();
+}
+
+// Stamp only AFTER a compile that did not throw: recording the hash for a failed
+// run would make the next one skip and leave app/paraglide half-written.
+try {
+    execSync('node -e "require(\'node:fs\').mkdirSync(\'node_modules/.cache\',{recursive:true})"');
+    writeFileSync(STAMP, hash);
+} catch {
+    // A missing stamp only costs a redundant compile next time.
+}


### PR DESCRIPTION
Follow-up to #287, which parallelised CI. This does the same for the local
commit gate — and reports one measurement that killed a change rather than
shipping it.

## What got faster

**An "app only" tier for the pre-commit type-check.** The hook had tiers for
skip, api-only and everything, but not for the commonest case. `tsconfig.api.json`
includes `server/**` and nothing else, so a commit touching only `app/` cannot
affect that program — it was running anyway, at 11s warm and 152s once its
build-info had gone cold.

**`i18n:compile` behind a content hash: 66s becomes 1s** when the inputs are
unchanged. A content hash rather than mtimes on purpose — a fresh checkout, a
stash pop or a branch switch all rewrite files whose content is identical, and
every one of those would rebuild on an mtime check.

The stamp lives *inside* `app/paraglide`. That is what makes it work in CI,
where `node_modules` is not carried between jobs: the workflow caches that
directory keyed on `hashFiles` of the inputs, so the stamp returns with the
output it describes. Unlike a build-info cache there is no staleness to reason
about — the cache **key** is the input hash, so a hit can only restore output
those exact inputs produced.

Both guards fail toward doing the work. No stamp, unreadable stamp, missing
output, any mismatch: compile. Skipping happens only on positive evidence.

## What did not get faster, and why

**eslint sharding was measured, and the premise was wrong.** The plan was to
split the type-aware pass by directory. Measured:

| scope | time |
|---|---:|
| all of `app/` | 208s |
| `app/routes` alone | **207s** |
| `app/components` alone | **204s** |
| `app/lib app/hooks` alone | **151s** |

Linting one subdirectory costs almost exactly what linting everything costs.
The expense is building the type-aware program, and every shard pays it in
full — three shards sum to 428s against 301s for a single run. Wall clock would
improve by ~1.5 min while tripling billed minutes. The lever does not exist, so
this is written down instead of attempted again.

## One note in the hook

`--no-verify` on a TypeScript commit leaves tsc's incremental build-info
describing the previous tree, so the next type-check pays 357s instead of 21s —
which then blows whatever timeout made `--no-verify` attractive. That loop is
not hypothetical; the numbers come from falling into it while landing #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
