### PR TITLE
A claim whose holder died blocked the key forever

### DIFF
--- a/server/lib/idempotency/store.ts
+++ b/server/lib/idempotency/store.ts
@@ -9,7 +9,7 @@
  * Kept free of Hono and of anything outside `server/lib/` so portal can vendor
  * it byte-for-byte.
  */
-import { and, eq } from 'drizzle-orm';
+import { and, eq, lt } from 'drizzle-orm';
 import type { DrizzleD1Database } from 'drizzle-orm/d1';
 import { idempotencyKeys } from '../db/schema/idempotency';
 
@@ -63,6 +63,40 @@ export async function claimKey(db: DrizzleD1Database, args: ClaimArgs): Promise<
     if (row.state === 'done') {
         return { state: 'done', status: row.responseStatus ?? 200, body: row.responseBody ?? '' };
     }
+
+    // An `in_flight` row whose TTL has passed is a claim nobody is honouring:
+    // the holder died without unwinding. `releaseKey` only runs from a caught
+    // exception, so a CPU-limit kill, an eviction or a mid-request deploy all
+    // leave the row exactly like this — and nothing sweeps `expires_at`, so it
+    // would sit here forever.
+    //
+    // Refusing such a row is NOT the safe direction. For a webhook it means the
+    // caller ACKs, the provider stops retrying, and the event is lost with no
+    // signal at all. Taking the claim over risks running twice only in the case
+    // where the original holder is somehow still alive past its own deadline —
+    // which is the failure the TTL is there to bound.
+    //
+    // The steal is one conditional UPDATE, so concurrent stealers cannot both
+    // win: the second no longer matches `expires_at < now`.
+    if (row.expiresAt && row.expiresAt.getTime() <= now) {
+        const stolen = await db
+            .update(idempotencyKeys)
+            .set({
+                fingerprint: args.fingerprint,
+                state:       'in_flight',
+                createdAt:   new Date(now),
+                expiresAt:   new Date(now + args.ttlMs),
+            })
+            .where(and(
+                eq(idempotencyKeys.tenantId, args.tenantId),
+                eq(idempotencyKeys.key, args.key),
+                eq(idempotencyKeys.state, 'in_flight'),
+                lt(idempotencyKeys.expiresAt, new Date(now + 1)),
+            ))
+            .returning({ key: idempotencyKeys.key });
+        if (stolen.length > 0) return 'claimed';
+    }
+
     return { state: 'in_flight' };
 }
 

--- a/tests/unit/idempotency/store.spec.ts
+++ b/tests/unit/idempotency/store.spec.ts
@@ -39,3 +39,47 @@ describe('idempotency store', () => {
         expect(await claimKey(db as never, { ...BASE, tenantId: 't2' })).toBe('claimed');
     });
 });
+
+/**
+ * `releaseKey` only runs from a caught exception. A CPU-limit kill, an eviction
+ * or a deploy mid-request leaves the row `in_flight` with nobody coming back for
+ * it, and nothing sweeps `expires_at` — so before this behaviour existed the row
+ * blocked the key permanently.
+ *
+ * For a webhook that is not a safe refusal: the caller ACKs, the provider stops
+ * retrying, and the event is lost with no signal. These tests pin the takeover
+ * and, just as importantly, pin that a claim still inside its TTL is NOT stolen.
+ */
+describe('idempotency store — a claim whose holder never came back', () => {
+    beforeEach(async () => {
+        const t = createTestDb();
+        await setupSchema(t.sqlite);
+        db = t.db;
+    });
+
+    it('re-claims an in_flight row whose TTL has passed', async () => {
+        expect(await claimKey(db as never, { ...BASE, ttlMs: 1 })).toBe('claimed');
+        await new Promise((r) => setTimeout(r, 5));
+        expect(await claimKey(db as never, { ...BASE, ttlMs: 86_400_000 })).toBe('claimed');
+    });
+
+    it('does NOT steal a claim that is still inside its TTL', async () => {
+        expect(await claimKey(db as never, BASE)).toBe('claimed');
+        expect(await claimKey(db as never, BASE)).toEqual({ state: 'in_flight' });
+    });
+
+    it('a completed row is replayed, not stolen, even past its TTL', async () => {
+        await claimKey(db as never, { ...BASE, ttlMs: 1 });
+        await completeKey(db as never, { tenantId: 't1', key: 'k1', status: 201, body: '{"id":"abc"}' });
+        await new Promise((r) => setTimeout(r, 5));
+        expect(await claimKey(db as never, { ...BASE, ttlMs: 1 }))
+            .toEqual({ state: 'done', status: 201, body: '{"id":"abc"}' });
+    });
+
+    it('the takeover re-arms the deadline, so the next caller is refused', async () => {
+        await claimKey(db as never, { ...BASE, ttlMs: 1 });
+        await new Promise((r) => setTimeout(r, 5));
+        expect(await claimKey(db as never, { ...BASE, ttlMs: 86_400_000 })).toBe('claimed');
+        expect(await claimKey(db as never, { ...BASE, ttlMs: 86_400_000 })).toEqual({ state: 'in_flight' });
+    });
+});


### PR DESCRIPTION
`releaseKey` only runs from a caught exception. A CPU-limit kill, an eviction, or a deploy mid-request leaves the `idempotency_keys` row `in_flight` with nobody coming back for it — and nothing sweeps `expires_at`, so the TTL written at claim time was decorative. The row sat there permanently and the key was blocked forever.

What that costs depends on the caller:

- Through the Hono middleware it is a permanent `409 IDEMPOTENCY_IN_FLIGHT` on that key. Visible, and merely wrong.
- Through an adapter that ACKs on a refused claim — a webhook handler, for instance — it is silent data loss: the provider receives a `200`, stops retrying, and the event is never applied. Nothing anywhere records that it was dropped.

An `in_flight` row past its deadline is now taken over. The steal is one conditional `UPDATE`, so two concurrent stealers cannot both win — the second no longer matches `expires_at`. A `done` row is still replayed rather than stolen, and a claim inside its TTL is still refused.

Taking the claim over risks running the handler twice only where the original holder is somehow still alive past its own deadline, which is precisely the failure the TTL exists to bound. Refusing forever is not the safer direction; it just moves the damage somewhere no one is looking.

Proved by deleting the takeover: the two new tests go red with `expected { state: 'in_flight' } to be 'claimed'`, while the two guarding against over-stealing stay green either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
