### PR TITLE
fix(deps): dompurify 3.4.12 -> 3.4.13 (IN_PLACE hook removal XSS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6973,9 +6973,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
A new advisory landed between this release's up-front Dependabot check (0 alerts)
and its post-merge re-check (1). Medium severity, **runtime scope**: removing an
`IN_PLACE` hook can leave a detached subtree executable.

This is not routine housekeeping here. Agreement HTML renders through
`SanitizedHtml`/DOMPurify and that path is security-critical — the sanitizer *is*
the control, so a hole in it is the whole control.

Lockfile updated in place with `npm update`; the multi-platform entries are intact
(346 linux entries), because re-resolving on Windows drops the linux binaries and
breaks the ubuntu runner.

Full suite green locally before pushing: lint (24 gates), `test:unit` 723 files /
5236 tests, `test:web` 335 / 2232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)