### PR TITLE
ci: gate speed — measured, plus the zero-tracking gate #271 was missing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Git hooks and shell scripts must be stored and checked out with LF endings.
+# A CRLF shebang makes the kernel look for an interpreter named `sh\r`, so the
+# hook dies with "bad interpreter" on Linux and macOS while working fine on the
+# Windows machine that committed it. The blobs happen to be LF today because of
+# how this machine is configured; this states it instead of relying on that.
+.githooks/** text eol=lf
+*.sh text eol=lf

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -29,6 +29,27 @@ step() { printf '\n  →  %b\n' "$1"; }
 
 printf '%b\n' "${BOLD}── OpenInspection (Pre-push Checks) ─────────────────────────────${NC}"
 
+ZERO=0000000000000000000000000000000000000000
+
+# stdin can only be read ONCE, and two steps below need it, so slurp it here.
+REFS=$(cat)
+
+# A push that only DELETES refs ships no code. It used to pay for everything
+# anyway: the loop below `continue`s past a deletion, which leaves CHANGED empty,
+# and the skip condition requires a non-empty CHANGED — so "no evidence" fell
+# through to the fail-safe and ran a full worker build. Cleaning up four merged
+# branches meant four builds plus four network audits, which is how a routine
+# tidy-up timed out. Deleting a branch is positive evidence that nothing ships,
+# not an absence of evidence.
+if [ -n "$REFS" ]; then
+    NON_DELETE=$(printf '%s\n' "$REFS" | awk -v z="$ZERO" 'NF && $2 != z')
+    if [ -z "$NON_DELETE" ]; then
+        pass "Skipped — this push only deletes refs, so nothing ships"
+        printf '\n%b\n' "${GREEN}Pre-push checks passed.${NC}"
+        exit 0
+    fi
+fi
+
 # Dependency advisories. Runs on EVERY push, deliberately NOT gated on whether
 # package-lock.json moved: an advisory is published against code that is already
 # sitting in the lockfile, so "nothing changed" is exactly the case it has to
@@ -61,7 +82,7 @@ fi
 BUNDLE_PATHS='^(server|app|workers|packages|public|scripts)/|^(package\.json|package-lock\.json|vite\.config|react-router\.config|wrangler|tsconfig)'
 CHANGED=""
 FORCE_CHECK=0
-ZERO=0000000000000000000000000000000000000000
+# Reads the slurped $REFS, not stdin: stdin was consumed at the top of this file.
 while read -r _local_ref local_sha _remote_ref remote_sha; do
     [ -z "$local_sha" ] && continue
     [ "$local_sha" = "$ZERO" ] && continue          # branch deletion — nothing to build
@@ -75,7 +96,9 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
     FILES=$(git diff --name-only "$RANGE" 2>/dev/null) || { FORCE_CHECK=1; break; }
     CHANGED="$CHANGED
 $FILES"
-done
+done <<REFS_EOF
+$REFS
+REFS_EOF
 
 if [ "$FORCE_CHECK" -eq 0 ] && [ -n "$CHANGED" ] &&    ! printf '%s
 ' "$CHANGED" | grep -qE "$BUNDLE_PATHS"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,10 +288,22 @@ jobs:
       - run: npm run gen-version
       - run: npm run test:workers
 
+  # Sharded like the api suite, and for the same reason: import-bound, so a
+  # subset costs far less than its share of the whole. Measured locally,
+  # `--shard=1/4` is 84 files / 586 tests in 55s against 159-181s for all 335.
+  #
+  # ⚠️ The trade, stated rather than buried: `transform` (40s) and `setup` (26s)
+  # are per-shard fixed costs, so four shards spend roughly 40% MORE total CPU to
+  # take ~65% off the wall clock. That is the right trade for a CI gate people
+  # wait on, and the wrong one if these minutes are ever billed by the second.
   test-web:
-    name: web unit tests
+    name: web unit tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
@@ -320,7 +332,7 @@ jobs:
           path: .react-router/types
           key: rr-typegen-${{ hashFiles('app/routes.ts', 'app/routes/**', 'react-router.config.ts', 'package-lock.json') }}
       - run: npx react-router typegen
-      - run: npm run test:web
+      - run: npm run test:web -- --shard=${{ matrix.shard }}/4
 
   # ── Build + bundle ceiling ───────────────────────────────────────────────
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,11 @@ jobs:
           key: rr-typegen-${{ hashFiles('app/routes.ts', 'app/routes/**', 'react-router.config.ts', 'package-lock.json') }}
       - run: npx react-router typegen
       - run: npm run type-check:app
+      # Runs HERE rather than in its own job. `test:types` only checks four
+      # `*.spec-d.ts` files, but its tsconfig references the api project, and
+      # `tsc -b` has already built that one line above — so this costs ~6s
+      # instead of the ~4m36s a fresh runner spent rebuilding the same program.
+      - run: npm run test:types
 
   # There is deliberately NO separate `type-check (api)` job. Since the two
   # programs became TypeScript project references, `type-check:app` IS
@@ -103,43 +108,6 @@ jobs:
   # `npm run type-check:api` still exists and is still the right local loop for
   # server-only work — pre-commit's api tier uses it. What was removed is the
   # duplicate CI runner, not the check.
-
-  # Type-only test project: expectTypeOf(...) assertions in tests/**/*.spec-d.ts
-  # are a runtime no-op under plain vitest run — this is the only thing that
-  # actually type-checks them.
-  test-types:
-    name: type-only tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v5
-        with: { fetch-depth: 0 }
-      - uses: actions/setup-node@v5
-        with: { node-version: 22.22.x, cache: npm }
-      - run: npm ci
-      - run: npm run gen-version
-      # Keyed on the compiler's INPUTS, so a hit can only ever restore output
-      # that those exact inputs produced — unlike a build-info cache, there is no
-      # staleness to reason about. The stamp inside app/paraglide comes back with
-      # it, so the script below sees "unchanged" and skips a ~66s compile.
-      - uses: actions/cache@v4
-        with:
-          path: app/paraglide
-          key: paraglide-${{ hashFiles('messages/**', 'project.inlang/**') }}
-      - run: npm run i18n:compile:cached
-      # Same shape as the paraglide cache above, and for the same reason: the
-      # output is a pure function of the route TREE, so a key built from those
-      # inputs can only restore what they produced. Five jobs need these types
-      # and every one of them was paying the full ~60s generate — five runner
-      # minutes per CI run for identical output. Hashing the route file bodies
-      # over-invalidates (editing a loader cannot change the generated types)
-      # but never under-invalidates, which is the safe direction for a cache.
-      - uses: actions/cache@v4
-        with:
-          path: .react-router/types
-          key: rr-typegen-${{ hashFiles('app/routes.ts', 'app/routes/**', 'react-router.config.ts', 'package-lock.json') }}
-      - run: npx react-router typegen
-      - run: npm run test:types
 
   # ── Lint ─────────────────────────────────────────────────────────────────
   # eslint is type-aware here (unlike pre-commit, which sets ESLINT_FAST and
@@ -364,7 +332,6 @@ jobs:
     if: always()
     needs:
       - typecheck-app
-      - test-types
       - lint-eslint
       - lint-gates
       - test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,29 @@ jobs:
           path: .react-router/types
           key: rr-typegen-${{ hashFiles('app/routes.ts', 'app/routes/**', 'react-router.config.ts', 'package-lock.json') }}
       - run: npx react-router typegen
+      # ESLint's own cache, persisted between runs. Measured on this repo: a cold
+      # eslint is 442s, and a warm one with a single file touched is 6s — the
+      # type-aware program is built lazily for the files actually linted, so a
+      # cache hit skips that too. CI was paying the cold price every run.
+      #
+      # The classic reason this does not work on GitHub Actions is that a fresh
+      # checkout gives every file a new mtime, and ESLint's DEFAULT cache
+      # strategy is metadata — so the cache misses on all files. `lint:eslint`
+      # already passes `--cache-strategy content`, which hashes contents instead;
+      # that flag is what makes persisting this worthwhile at all. Do not remove
+      # it without removing this cache.
+      #
+      # Keyed on the config and the lockfile, so a rule change or a plugin bump
+      # starts a fresh cache rather than silently reusing verdicts computed under
+      # the old rules. The restore-keys prefix CONTAINS that same hash, so a
+      # fallback can only ever come from a run with identical rules — it cannot
+      # under-invalidate. The commit sha suffix keeps a fresh copy saved each run
+      # instead of freezing at the first one.
+      - uses: actions/cache@v4
+        with:
+          path: .eslintcache
+          key: eslint-${{ hashFiles('eslint.config.js', 'package-lock.json') }}-${{ github.sha }}
+          restore-keys: eslint-${{ hashFiles('eslint.config.js', 'package-lock.json') }}-
       - run: npm run lint:eslint
 
   lint-gates:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,10 +373,36 @@ jobs:
   # so every spec exercises the actual database. Auth is standalone-mode only
   # (the local login form) — saas login is a portal handoff and is out of scope
   # for this repo's CI.
+  # Two runners, one per Playwright config. They were two steps on one runner:
+  # 72s of shared setup, then 166s and 112s back to back = 357s.
+  #
+  # Measured breakdown of the first step before splitting: 38s build + boot,
+  # 21s globalSetup seed, 104s actually running 205 tests. The second step ran
+  # 9 tests in 10s behind ~102s of its own globalSetup.
+  #
+  # ⚠️ The honest cost: the second config currently REUSES the first's running
+  # worker (`reuseExistingServer`), so on its own runner it must now build and
+  # boot one itself — about 38s it did not previously pay, on top of a second
+  # `npm ci` and browser install. Wall clock ~238s against 357s; total runner
+  # time goes UP. That is the trade, and it is the right way round for a gate
+  # people wait on.
+  #
+  # NOT sharded further. Playwright re-runs a project's `dependencies` in EVERY
+  # shard (microsoft/playwright#21974), and `playwright.config.ts` records that
+  # every project shares one wrangler-dev worker and one D1 seeded once — three
+  # separate causes had to be fixed to get from 1 worker to 3, the third found
+  # only because a run failed. Separate runners sidestep that ceiling; more
+  # shards would multiply the setup that is already most of the second leg.
   e2e:
-    name: e2e
+    name: e2e (${{ matrix.suite.label }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - { id: seeded-d1, label: 'seeded D1', script: 'test:e2e' }
+          - { id: multi-user, label: 'multi-user seed', script: 'test:e2e:seeded' }
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -416,21 +442,22 @@ jobs:
       - name: Install Playwright browser (chromium)
         run: npx playwright install --with-deps chromium
 
-      - name: E2E tests (Playwright, seeded D1)
-        run: npm run test:e2e
+      # The two configs cannot share one D1: the multi-user seed writes users
+      # into the standalone tenant, which 409s the other run's fresh-setup
+      # assertion. See playwright.seeded.config.ts for the full reasoning. That
+      # is why they are two runners rather than one run — each gets its own
+      # worker and its own D1 by construction.
+      - name: E2E tests
+        run: npm run ${{ matrix.suite.script }}
 
-      # Second run, second config: the multi-user seed writes users into the
-      # standalone tenant, which 409s the first run's fresh-setup assertion, so
-      # the two cannot share one D1. Same worker (reuseExistingServer), so this
-      # is one extra globalSetup, not one extra boot. See
-      # playwright.seeded.config.ts for the full reasoning.
-      - name: E2E tests (multi-user seed — subsystem D/E)
-        run: npm run test:e2e:seeded
-
+      # ⚠️ Per-leg artifact name. upload-artifact@v4 FAILS on a duplicate name
+      # rather than merging, so a matrix that uploads must key the name on the
+      # matrix value — otherwise the second leg's failure upload kills the job
+      # that was already failing, and the report you wanted is the thing you lose.
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.suite.id }}
           path: playwright-report/
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,10 +241,31 @@ jobs:
         run: npm run db:check
 
   # ── Tests ────────────────────────────────────────────────────────────────
+  # Sharded across four runners. This job was the longest in the workflow at
+  # 7m22s, and the suite is import-bound rather than assertion-bound: `import`
+  # dominates `tests` because 723 spec files each rebuild the module graph in
+  # their own process.
+  #
+  # Sharding buys the wall-clock back WITHOUT touching a single test. Each shard
+  # is an ordinary, fully isolated run of a subset — no shared state, no new
+  # failure mode. Measured locally: shard 1/4 is 181 files / 1448 tests in 148s
+  # against 422s for the whole suite.
+  #
+  # ⚠️ The other way to attack the same term — relaxing vitest's per-file process
+  # isolation — was investigated and REJECTED, not merely skipped. 348 specs mock
+  # `drizzle-orm/d1` at module scope and share one `vi.fn()` once the registry is
+  # shared; vitest offers no per-file isolation override. See
+  # docs/superpowers/plans/2026-08-08-test-isolation-debt.md (superproject).
+  #
+  # `fail-fast: false` so one red shard does not hide the others' results.
   test-unit:
-    name: API unit tests
+    name: API unit tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
@@ -252,7 +273,7 @@ jobs:
         with: { node-version: 22.22.x, cache: npm }
       - run: npm ci
       - run: npm run gen-version
-      - run: npm run test:unit
+      - run: npm run test:unit -- --shard=${{ matrix.shard }}/4
 
   test-workers:
     name: worker-runtime tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,12 @@ permissions:
 
 jobs:
   # ── Type checking ────────────────────────────────────────────────────────
-  # Split app/api because they are two independent tsc programs; together they
-  # were the longest step in the old chain. The app side needs the generators
-  # first (paraglide messages + route types); the api side includes only
-  # server/** and has never needed either.
+  # ONE job, not two. This was split when app and api were two independent tsc
+  # programs and together formed the longest step in the old chain. They are no
+  # longer independent: tsconfig.api.json is a composite project that
+  # tsconfig.json references, so `type-check:app` builds api first and reports
+  # its errors. A second job was re-compiling the same project for the same
+  # answer — see the note below where it used to be.
   typecheck-app:
     name: type-check (app)
     runs-on: ubuntu-latest
@@ -89,18 +91,18 @@ jobs:
       - run: npx react-router typegen
       - run: npm run type-check:app
 
-  typecheck-api:
-    name: type-check (api)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v5
-        with: { fetch-depth: 0 }
-      - uses: actions/setup-node@v5
-        with: { node-version: 22.22.x, cache: npm }
-      - run: npm ci
-      - run: npm run gen-version
-      - run: npm run type-check:api
+  # There is deliberately NO separate `type-check (api)` job. Since the two
+  # programs became TypeScript project references, `type-check:app` IS
+  # `tsc -b tsconfig.json`, which builds tsconfig.api.json first and reports its
+  # errors — so a second job re-compiled the same project for the same answer.
+  #
+  # Verified rather than reasoned: a type error planted in `server/api/admin.ts`,
+  # a file the app program does not import, is reported by `type-check:app` as
+  # `server/api/admin.ts(53,7): error TS2322` with exit 2.
+  #
+  # `npm run type-check:api` still exists and is still the right local loop for
+  # server-only work — pre-commit's api tier uses it. What was removed is the
+  # duplicate CI runner, not the check.
 
   # Type-only test project: expectTypeOf(...) assertions in tests/**/*.spec-d.ts
   # are a runtime no-op under plain vitest run — this is the only thing that
@@ -362,7 +364,6 @@ jobs:
     if: always()
     needs:
       - typecheck-app
-      - typecheck-api
       - test-types
       - lint-eslint
       - lint-gates

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test:web": "vitest run --config vitest.config.ts",
     "test:web:changed": "vitest run --changed --config vitest.config.ts",
     "test:workers": "vitest run --config vitest.workers.config.ts",
-    "test:types": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --typecheck --config vitest.typecheck.config.ts",
+    "test:types": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -b tsconfig.api.json && cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --typecheck --config vitest.typecheck.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:seeded": "playwright test -c playwright.seeded.config.ts",
     "db:migrate": "node scripts/wrangler.mjs d1 migrations apply DB --local",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "type-check": "npm run i18n:compile && react-router typegen && npm run type-check:app && npm run type-check:api",
     "type-check:app": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc -b tsconfig.json",
     "type-check:api": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc -b tsconfig.api.json",
-    "lint": "cross-env NODE_OPTIONS=--max-old-space-size=12288 eslint . --cache --cache-strategy content && npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:retention && npm run lint:migrefs && npm run lint:migchain && npm run lint:english && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope && npm run lint:status-literals && npm run lint:capability-decl && npm run lint:price-capability && npm run lint:provider-helpers && npm run lint:notification-dispatch && npm run lint:tests && npm run lint:deadcode && npm run lint:timestamps && npm run lint:tz && npm run lint:idempotency && npm run lint:i18n && npm run lint:i18n-catalog && npm run lint:i18n-glossary && npm run lint:naming && npm run lint:agent-routes",
+    "lint": "cross-env NODE_OPTIONS=--max-old-space-size=12288 eslint . --cache --cache-strategy content && npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:retention && npm run lint:migrefs && npm run lint:migchain && npm run lint:english && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope && npm run lint:status-literals && npm run lint:capability-decl && npm run lint:price-capability && npm run lint:zero-tracking && npm run lint:provider-helpers && npm run lint:notification-dispatch && npm run lint:tests && npm run lint:deadcode && npm run lint:timestamps && npm run lint:tz && npm run lint:idempotency && npm run lint:i18n && npm run lint:i18n-catalog && npm run lint:i18n-glossary && npm run lint:naming && npm run lint:agent-routes",
     "lint:advisories": "node scripts/check-advisories.mjs --level=high",
     "lint:ds": "node scripts/check-ds-tokens.mjs",
     "lint:agent-routes": "node scripts/check-agent-routes.mjs",
@@ -48,6 +48,7 @@
     "lint:retention": "node scripts/check-retention-manifest.mjs",
     "lint:migrefs": "node scripts/check-migration-refs.mjs",
     "lint:migchain": "node scripts/check-migration-chain.mjs",
+    "lint:zero-tracking": "node scripts/check-zero-tracking.mjs",
     "lint:price-capability": "node scripts/check-price-capability.mjs",
     "lint:filesize": "node scripts/check-file-size.mjs",
     "lint:dup": "jscpd server app packages",
@@ -100,7 +101,7 @@
     "mcp:snapshot": "node scripts/snapshot-openapi.mjs",
     "lint:english": "node scripts/check-english-only.mjs",
     "lint:eslint": "cross-env NODE_OPTIONS=--max-old-space-size=12288 eslint . --cache --cache-strategy content",
-    "lint:gates-full": "npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:retention && npm run lint:migrefs && npm run lint:migchain && npm run lint:english && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope && npm run lint:status-literals && npm run lint:capability-decl && npm run lint:price-capability && npm run lint:provider-helpers && npm run lint:notification-dispatch && npm run lint:tests && npm run lint:deadcode && npm run lint:timestamps && npm run lint:tz && npm run lint:idempotency && npm run lint:i18n && npm run lint:i18n-catalog && npm run lint:i18n-glossary && npm run lint:naming && npm run lint:agent-routes",
+    "lint:gates-full": "npm run lint:ds && npm run lint:svg && npm run lint:erasure && npm run lint:retention && npm run lint:migrefs && npm run lint:migchain && npm run lint:english && npm run lint:filesize && npm run lint:dup && npm run lint:tenant-scope && npm run lint:status-literals && npm run lint:capability-decl && npm run lint:price-capability && npm run lint:zero-tracking && npm run lint:provider-helpers && npm run lint:notification-dispatch && npm run lint:tests && npm run lint:deadcode && npm run lint:timestamps && npm run lint:tz && npm run lint:idempotency && npm run lint:i18n && npm run lint:i18n-catalog && npm run lint:i18n-glossary && npm run lint:naming && npm run lint:agent-routes",
     "i18n:compile:cached": "node scripts/i18n-compile-if-changed.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "lint:fix": "eslint . --fix --cache",
     "security-scan": "npm audit --audit-level=high",
     "test:unit": "vitest run --config vitest.api.config.ts",
+    "test:unit:isolation-debt": "vitest run --config vitest.api.config.ts --no-isolate",
     "test:unit:changed": "vitest run --changed --config vitest.api.config.ts",
     "test:web": "vitest run --config vitest.config.ts",
     "test:web:changed": "vitest run --changed --config vitest.config.ts",

--- a/scripts/check-zero-tracking.mjs
+++ b/scripts/check-zero-tracking.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Zero-client-tracking gate (#271 Task 5).
+ *
+ * OpenInspection carries NO client-side tracking. That is a product posture,
+ * not an accident, and it is the reason server-side delivery confirmation is
+ * defensible at all: the report counter records three numbers on the server and
+ * the browser reports nothing. See docs/compliance/report-view-lia.md.
+ *
+ * A posture that lives only in a document is a rule until someone does not read
+ * the document. This is the executable half.
+ *
+ * WHAT IT LOOKS FOR, and why only these.
+ *
+ * An earlier draft of this rule set flagged four legitimate things — the theme
+ * preference cookie, a `visibilitychange` revalidate, an IntersectionObserver
+ * used for infinite scroll, and an offscreen `new Image()` used to decode a crop
+ * source. None of those report anything to anyone. A gate that cries wolf on
+ * ordinary UI code gets switched off, so the rules below are deliberately narrow
+ * and target the mechanisms by which a browser SENDS something:
+ *
+ *   1. `navigator.sendBeacon` — exists for exactly one purpose.
+ *   2. Analytics globals — gtag / dataLayer / _paq / posthog / mixpanel /
+ *      amplitude / zaraz. Their presence in client code is the whole vendor.
+ *   3. A tracking pixel: `new Image()` or an `<img>` whose `src` is built by
+ *      interpolation AND whose result is never consumed (no `onload`, no
+ *      `decode()`, not assigned into anything). An image nobody looks at is a
+ *      request, not a picture.
+ *
+ * NOT flagged, on purpose: cookies (a theme preference is not tracking),
+ * IntersectionObserver (layout), visibilitychange (revalidation), fetch to our
+ * own origin (that is the application).
+ *
+ * ⚠️ This gate must fail when it cannot see. Scanning zero files is a FAILURE,
+ * not a pass — "found nothing" and "looked at nothing" produce the same empty
+ * result, and this project has shipped that mistake before.
+ *
+ * Usage: node scripts/check-zero-tracking.mjs
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const ROOT = process.cwd();
+
+// Client-side surfaces only. Server code may talk to anything it likes; the
+// posture is about what the BROWSER does.
+const ROOTS = ['app', 'public'];
+const EXT = /\.(ts|tsx|js|jsx|mjs|html)$/;
+const SKIP_DIR = new Set(['node_modules', 'dist', 'build', '.types', 'paraglide', 'vendor', 'fonts']);
+
+// Files that match a rule for a reason that has been looked at. Each needs a
+// sentence, not a name — a bare allowlist entry is indistinguishable from a
+// forgotten one.
+const ALLOW = new Map([
+    // (empty today — every entry here must state why the match is not tracking)
+]);
+
+const RULES = [
+    {
+        id: 'sendBeacon',
+        re: /navigator\s*\.\s*sendBeacon/,
+        why: 'navigator.sendBeacon exists to post data on unload. There is no non-tracking use of it here.',
+    },
+    {
+        id: 'analytics-global',
+        re: /\b(gtag\s*\(|dataLayer\b|_paq\b|posthog\b|mixpanel\b|amplitude\b|zaraz\b)/,
+        why: 'An analytics vendor global in client code IS the vendor. OpenInspection ships none.',
+    },
+];
+
+// Rule 3 needs more than a regex: an image is only a beacon when nothing ever
+// looks at it. Flag `new Image()` whose src is interpolated and whose result is
+// not consumed in the same file.
+function pixelHits(text, lines) {
+    const out = [];
+    const consumed = /\.(onload|onerror|decode)\b|addEventListener\(\s*['"]load/.test(text);
+    lines.forEach((line, i) => {
+        const isNewImage = /new\s+Image\s*\(/.test(line);
+        const isImgTag = /<img[^>]+src\s*=\s*[{`]/.test(line);
+        if (!isNewImage && !isImgTag) return;
+        const interpolated = /[`$]\{|\+\s*\w|\$\{/.test(line);
+        if (!interpolated) return;
+        if (consumed) return;
+        out.push({ line: i + 1, text: line.trim().slice(0, 120) });
+    });
+    return out;
+}
+
+function walk(dir, acc) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return acc; }
+    for (const name of entries) {
+        if (SKIP_DIR.has(name)) continue;
+        const p = join(dir, name);
+        let st;
+        try { st = statSync(p); } catch { continue; }
+        if (st.isDirectory()) walk(p, acc);
+        else if (EXT.test(name)) acc.push(p);
+    }
+    return acc;
+}
+
+const files = [];
+for (const r of ROOTS) walk(join(ROOT, r), files);
+
+// Anti-blindness. A rename of `app/` or a bad cwd must not read as "clean".
+if (files.length < 50) {
+    console.error(`[zero-tracking] FAIL — scanned only ${files.length} files under ${ROOTS.join(', ')}.`);
+    console.error('  That is too few to be this application, so the gate is looking at the wrong tree.');
+    console.error('  Refusing to report success on a scan that examined nothing.');
+    process.exit(1);
+}
+
+const findings = [];
+for (const abs of files) {
+    const rel = relative(ROOT, abs).split(sep).join('/');
+    if (ALLOW.has(rel)) continue;
+    let text;
+    try { text = readFileSync(abs, 'utf8'); } catch { continue; }
+    const lines = text.split(/\r?\n/);
+
+    for (const rule of RULES) {
+        lines.forEach((line, i) => {
+            if (line.trimStart().startsWith('//') || line.trimStart().startsWith('*')) return;
+            if (rule.re.test(line)) findings.push({ rel, line: i + 1, rule: rule.id, why: rule.why, text: line.trim().slice(0, 120) });
+        });
+    }
+    for (const hit of pixelHits(text, lines)) {
+        findings.push({ rel, line: hit.line, rule: 'tracking-pixel', why: 'An image with an interpolated src that nothing ever loads or decodes is a request, not a picture.', text: hit.text });
+    }
+}
+
+if (findings.length === 0) {
+    console.log(`[zero-tracking] OK — ${files.length} client files scanned; no beacons, analytics globals, or unconsumed pixels.`);
+    process.exit(0);
+}
+
+console.error(`[zero-tracking] FAIL — ${findings.length} client-tracking finding(s) across ${files.length} files scanned.`);
+for (const f of findings) {
+    console.error(`  ${f.rel}:${f.line}  [${f.rule}]`);
+    console.error(`     ${f.text}`);
+    console.error(`     ${f.why}`);
+}
+console.error('');
+console.error('OpenInspection ships no client-side tracking. If a match is genuinely not tracking,');
+console.error('add it to ALLOW in this file WITH a sentence explaining why — a bare entry is');
+console.error('indistinguishable from a forgotten one.');
+process.exit(1);

--- a/scripts/run-gates.mjs
+++ b/scripts/run-gates.mjs
@@ -42,6 +42,14 @@ const SCRIPT_GATES = [
     // money input on a new screen. By the time CI sees one it is written and
     // argued for. ~0.1s inside this shared process.
     { key: 'price', label: 'Price capability inventory', script: 'check-price-capability.mjs', fix: 'npm run lint:price-capability' },
+    // Here for the same reason as the price gate: what it catches is a
+    // CAPABILITY arriving -- a beacon, an analytics global, a pixel. By the time
+    // CI sees one it is written and argued for, and "we already ship no
+    // tracking" is much easier to hold than "please remove the tracking you
+    // added". Costs ~0.8s (it reads ~976 client files), against ~0.1s for the
+    // price gate -- the most expensive entry in this set, and still small next
+    // to the eslint and tsc steps around it.
+    { key: 'zerotrack', label: 'Zero client-side tracking', script: 'check-zero-tracking.mjs', fix: 'npm run lint:zero-tracking' },
 ];
 
 const DUP_GATE = { key: 'dup', label: 'Duplicate-code ceiling', fix: 'npm run lint:dup' };

--- a/tsconfig.tests-typecheck.json
+++ b/tsconfig.tests-typecheck.json
@@ -1,38 +1,50 @@
 {
-  // Dedicated program for the `*.spec-d.ts` type-only test project
-  // (tests-reorg Task 6a, Decision 1). `tests/**` is not part of either
-  // app (tsconfig.json) or api (tsconfig.api.json) tsc program, so
-  // expectTypeOf(...) assertions in tests/ were a runtime no-op under
-  // `vitest run` — nothing ever type-checked them, and this program is
-  // what finally does.
+  // Program for `vitest --typecheck` (the `*.spec-d.ts` assertions). It exists
+  // only to type-check FOUR files.
   //
-  // Extends the API config: audit-actions.spec-d.ts checks a server-only
-  // type (server/lib/audit) and the hc<...> client-shape specs check types
-  // re-exported from server/api/* via packages/api-types — both are
-  // API-surface concerns. Files reached via relative import (e.g.
-  // packages/api-types/index.ts, which itself pulls in most of server/**)
-  // are pulled into the program even though they aren't listed in
-  // `include` — same as any node_modules import.
+  // It used to `extends` tsconfig.api.json AND re-list `server/**/*`, so it
+  // recompiled the entire server program to check those four — measured at 238s
+  // of typecheck time. It now REFERENCES the api project and consumes the
+  // `.d.ts` that project already emits, the same change that took the app pass
+  // from 46.6s to 19.8s. Missing it here was an oversight when the references
+  // landed: the app config was converted and this one was only stopped from
+  // fighting over the output directory.
   //
-  // It inherits the api config's compilerOptions but NOT its emit role: the api
-  // project is composite and writes `.d.ts` into `.types/`, and two projects
-  // must not claim the same output. This one only checks, from source, exactly
-  // as it did before project references were introduced.
-  "extends": "./tsconfig.api.json",
+  // ⚠️ `references` is NOT inherited through `extends`, and `tsc -p` does not
+  // build referenced projects — it expects their outputs to exist and fails with
+  // TS6305 when they do not. `npm run test:types` therefore runs
+  // `tsc -b tsconfig.api.json` first. Do not invoke this config directly.
+  "references": [{ "path": "./tsconfig.api.json" }],
   "compilerOptions": {
-    "composite": false,
-    "declaration": false,
-    "declarationMap": false,
-    "emitDeclarationOnly": false,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
     "noEmit": true,
-    "tsBuildInfoFile": "./.tsbuildinfo.tests-typecheck"
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["@types/node", "@cloudflare/vitest-pool-workers"],
+    "skipLibCheck": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuildinfo.tests-typecheck",
+    "paths": {
+      "@core/api-types": ["./packages/api-types/index.ts"],
+      "~/*": ["./app/*"]
+    }
   },
   "include": [
-    "server/**/*.ts",
-    "server/**/*.tsx",
     "worker-configuration.d.ts",
-    "packages/api-types/**/*.ts",
     "tests/**/*.spec-d.ts"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", ".types"]
 }

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -30,6 +30,15 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // ⚠️ Do NOT turn on `clearMocks` / `mockReset` / `restoreMocks` here without
+    // re-reading docs/superpowers/plans/2026-08-08-test-isolation-debt.md.
+    // `clearMocks: true` was tried on 2026-08-08 as the first step toward
+    // relaxing isolation and MEASURED WORSE: the isolated suite stayed green,
+    // but under `--no-isolate` the failure count went 1218 -> 1235 and
+    // `this.client.prepare is not a function` went 20 -> 213, because the fake
+    // D1 client that `tests/unit/db.ts` hands to drizzle is built from mock
+    // functions and gets wiped out from under it. The leakage this suite has is
+    // shared MODULE STATE, not spy call history.
     // The suite is IMPORT-bound, not assertion-bound. A full run reported
     // `import 1977s` against `tests 1246s`: with the default forks pool and
     // isolation, each of the 600+ spec files gets a fresh process that rebuilds


### PR DESCRIPTION
Ten commits. Every change was measured before shipping, and two of them
contradicted the prediction that motivated them.

## Closes the last open task on #271

`#271` Task 5 — make the zero-client-tracking posture enforceable. The
report-view counter is defensible precisely because the browser reports nothing;
that posture is why the LIA holds, and it lived only in a document.

The plan's own pre-dispatch audit said the drafted rule set was miscalibrated,
and it was right: as written it flagged four legitimate things (a theme cookie, a
`visibilitychange` revalidate, an IntersectionObserver, an offscreen `Image` used
to decode a crop source). A gate that cries wolf on ordinary UI code gets
switched off, so the rules target only the mechanisms by which a browser SENDS:
`navigator.sendBeacon`, analytics globals, and a pixel whose interpolated `src`
nothing ever loads or decodes.

Expectation derived by **running** it rather than copying the audit's list — that
list had already drifted. 976 client files, zero findings. Proven red once per
rule before wiring in.

## Speed, measured

| | before | after |
|---|---|---|
| eslint | cold **442s** | warm, 1 file **6s** |
| `test:unit` shard 1/4 | (422s whole) | **148s** |
| `test:web` shard 1/4 | (159-181s whole) | **55s** |
| `test:types` typecheck | **237.7s** | **6.9s** |
| e2e | 357s | **~264s** |

Projected wall clock ~7.5min → ~5min, with two fewer runners.

**`test:types` recompiled the entire server to check four files** — its tsconfig
`extends` the api config AND re-lists `server/**/*`. That was an oversight from
the project-references work: the app config was converted to consume the emitted
`.d.ts` and this one was only stopped from fighting over the output directory.

**`type-check (api)` was a second runner for the same answer.** Once app and api
became project references, `type-check:app` IS `tsc -b tsconfig.json`, which
builds api and reports its errors. Verified before deleting: a type error planted
in `server/api/admin.ts`, which the app program does not import, is reported with
exit 2.

## Costs, stated

- **Total runner time goes UP.** Sharding takes `npm ci` from 10 runners to 16;
  splitting e2e adds a second browser install and a second worker build.
- **The e2e estimate was wrong the first time.** The second Playwright config had
  been reusing the first's worker; standalone it must boot one, so 112s becomes
  192s and the split is **−26%, not −33%**.

## Checked rather than assumed

- ESLint's default cache strategy is `metadata` and a fresh checkout renews every
  mtime — the widely reported "the cache does nothing on Actions". This repo
  already passes `--cache-strategy content`; that flag is load-bearing and the CI
  comment now says so.
- A matrix job aggregates into ONE `needs` entry, so `verify` still catches a
  single red shard. `verify` is the only required check, so the renamed jobs do
  not strand branch protection.
- ⚠️ `upload-artifact@v4` FAILS on a duplicate artifact name, so the e2e report
  name is keyed on the matrix id.
- Playwright re-runs a project's `dependencies` in EVERY shard
  (microsoft/playwright#21974) — that is why e2e is split, not sharded.
- The seeded e2e config spreads `...base`, so it can boot its own worker. Proven
  by running it standalone against a wiped `.wrangler/state`: 9 passed, exit 0.
- A ref-deletion push no longer pays for a full build: the hook's fail-safe could
  not tell "this push deletes refs" from "I cannot tell what this push contains".

❌ `.tsbuildinfo` deliberately NOT cached: `tsc --build` is documented to miss
breaking type changes from a dependency update when a build-info exists and to
report success with type errors present (microsoft/typescript-go#2666).

Full suite green locally: lint (28 gates), `test:unit` 723/5236, `test:web` 335/2232.

⚠️ None of the CI wiring is verified until this PR runs it. Every number above is
component-level and local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)