### PR TITLE
ci: verify can be run on demand, because a force-push never reaches it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,23 @@ name: CI
 # emit phantom failures. Separate CI jobs are separate runners, so this is safe
 # here and is not a licence to background them side by side in a terminal.
 #
-# This workflow runs ONLY on pull_request, not on push-to-main. Re-running the
-# full suite on the merge commit is redundant: branch protection requires
-# "branches up to date before merging" (strict), so a PR's tested tree equals
-# the post-squash main tree. Default-branch security scanning still runs via
-# codeql.yml (push + PR + schedule); release automation runs via
-# release-please.yml (push).
+# This workflow runs on pull_request, and on demand. Re-running the full suite
+# on every merge commit is redundant: branch protection requires "branches up
+# to date before merging" (strict), so a PR's tested tree equals the resulting
+# main tree. Default-branch security scanning still runs via codeql.yml
+# (push + PR + schedule); release automation runs via release-please.yml (push).
+#
+# `workflow_dispatch` exists because that equality has one hole, and it is not
+# hypothetical: a FORCE-PUSH to main never passes through a pull request, so
+# nothing runs `verify` on what landed — and `verify` is the only required
+# status check this branch has. A history rewrite on 2026-08-23 put 27 commits
+# onto main that way. Without a manual trigger the only way to check them after
+# the fact is to open a throwaway PR, which means adding a commit to main in
+# order to test main.
 on:
   pull_request:
     branches: [master, main]
+  workflow_dispatch:
 
 # Cancel superseded runs on the same ref to save CI minutes.
 concurrency:

--- a/tests/e2e/subsystem-e-flows.spec.ts
+++ b/tests/e2e/subsystem-e-flows.spec.ts
@@ -116,8 +116,17 @@ test.describe('Subsystem E — pre-flight, list workflow, exports, metrics, repo
         await loginAsSeedUser(page, SEED_EMAILS.admin);
         await page.goto('/settings/integrations');
 
+        // "AI provider", not "Gemini AI". The multi-provider AI work renamed the
+        // card when the feature stopped being about one vendor; the message KEY
+        // is still `settings_integrations_gemini_name`, so a grep for the key
+        // finds nothing wrong and only the rendered value moved.
+        //
+        // This assertion was stale from that rename until it first ran here.
+        // These specs only run on a pull request, and the work that renamed the
+        // card reached main by a force-push — so nothing executed them in
+        // between. The gap, not the label, is the thing worth remembering.
         for (const name of ['QuickBooks Online', 'Google Calendar', 'Google Places',
-                            'Resend', 'Zapier', 'Gemini AI']) {
+                            'Resend', 'Zapier', 'AI provider']) {
             await expect(page.getByText(name, { exact: true })).toBeVisible();
         }
         // Stripe is on this page, but as its own panel — not a grid card.


### PR DESCRIPTION
`verify` is this branch's only required status check, and it only triggers on
`pull_request`. That was a deliberate design with a stated reason: branch
protection is strict, so a PR's tested tree equals the tree that lands on main,
and re-running the suite on the merge commit would test the same thing twice.

The reasoning has one hole. A force-push does not pass through a pull request,
so nothing runs `verify` on what lands. Without a manual trigger the only way
to check main after the fact is to open a throwaway PR — adding a commit to
main in order to test main.

This adds `workflow_dispatch`, and rewrites the comment to record the hole
rather than the tidy version of the argument. It also corrects "post-squash
main tree": squash merges were retired some time ago and every repository here
uses a normal merge commit.

## Why this is a PR and not a push

Pushing it directly is refused: the ruleset wants CodeQL results for the
commit, and CodeQL only runs after a push succeeds. A pull request is the way
out of that — and it is the better one, because it also runs `verify` over the
whole tree rather than just this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EjZz4TXny7rQrmoBUhWxQ
