### PR TITLE
The catalogue kind you could not filter for, and the reference that reported it

### DIFF
--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -55,7 +55,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `tenant_id` | text | NN IX |  |  | Multi-tenant isolation, per the Schema Rules. |
 | `user_id` | text | NN UQ |  |  | The `users` row this acceptance was committed alongside. |
-| `actor_identity_ref` | text |  |  | `the` | The portal `identities.id` the acceptance was captured against, when it was captured over there. |
+| `actor_identity_ref` | text |  |  |  | The portal `identities.id` the acceptance was captured against, when it was captured over there. |
 | `doc` | text | NN UQ |  |  | Which document. Free text rather than an enum: the set of documents a deployment publishes is the deployment's business, and refusing an unknown one at the seam is the boundary's job, not the column's. |
 | `version` | text | NN UQ |  |  | `YYYY-MM-DD`, the version the person was shown. |
 | `content_hash` | text | NN |  |  | SHA-256 hex of the body shown. What was SHOWN, not where it lived. |
@@ -104,7 +104,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `inspection_id` | text | NN IX FK→`inspections.id` |  |  | Every agreement envelope is bound to an inspection (the send UI + every service path require it). |
 | `agreement_id` | text | NN FK→`agreements.id` |  |  | *App-layer reference to another row — no database foreign key.* |
 | `client_email` | text | NN |  |  | *An email address.* |
-| `client_name` | text |  |  | `pending, sent, viewed, signed, declined, expired` | *A name.* |
+| `client_name` | text |  |  |  | *A name.* |
 | `status` | text | NN | `'pending'` | `pending, sent, viewed, signed, declined, expired` | *State-machine column — see the Values column for the vocabulary.* |
 | `signed_at` | integer |  |  |  | Envelope completion time — THAT it completed and WHEN, which is the envelope's own fact. The signature is not: it belongs to the person who made it and lives on their `agreement_signers` row. |
 | `viewed_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
@@ -148,13 +148,13 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `role` | text | NN | `'client'` | `client, co_client, agent, other` | A LABEL on the signing party, not a permission: nothing branches on it. Every signer holds the same token-scoped rights. |
 | `contact_id` | text |  |  |  | → contacts.id (app-layer, optional) |
 | `token_hash` | text | UQ |  |  | SHA-256 hex; NULL on backfilled rows until first link build |
-| `token_enc` | text |  |  | `pending, sent, viewed, signed, declined, expired` | 't1:iv:cipher' sealed plaintext (config-crypto sealToken) |
+| `token_enc` | text |  |  |  | 't1:iv:cipher' sealed plaintext (config-crypto sealToken) |
 | `status` | text | NN | `'pending'` | `pending, sent, viewed, signed, declined, expired` | *State-machine column — see the Values column for the vocabulary.* |
 | `signature_base64` | text |  |  |  | The drawn signature image. Bare base64 OR a full `data:` URL — both are accepted, and agreements-render prefixes the bare form when composing the signed PDF. |
 | `signed_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
 | `viewed_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
 | `ip_address` | text |  |  |  | Captured from cf-connecting-ip (x-forwarded-for as fallback) at sign time and printed in the signed-confirmation email and the audit trail. |
-| `user_agent` | text |  |  | `remote, in_person` | The signer's User-Agent, truncated to 200 chars at the route. Evidence only: nothing branches on it, and it is anonymized with ipAddress above. |
+| `user_agent` | text |  |  |  | The signer's User-Agent, truncated to 200 chars at the route. Evidence only: nothing branches on it, and it is anonymized with ipAddress above. |
 | `channel` | text |  |  | `remote, in_person` | set at sign time |
 | `on_behalf_of` | text |  |  |  | client name an authorized agent signs for |
 | `on_behalf_disclaimer` | text |  |  |  | disclaimer text snapshot shown at sign time |
@@ -281,7 +281,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `recipient_role_key` | text |  |  |  | Spec 2 — the recipient's role-profile key (e.g. 'buyer_agent'), captured at enqueue so the flush/send path can mint a role-keyed portal token per recipient. |
 | `channel` | text | NN UQ | `'email'` | `email, sms, in_app` | Track L — the log's own delivery channel (a multi-channel rule emits one log each). B1 — `in_app` joined email/sms. **[more]** |
 | `send_at` | integer | NN IX |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
-| `delivered_at` | integer |  |  | `pending, sent, failed, skipped` | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
+| `delivered_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
 | `status` | text | NN IX | `'pending'` | `pending, sent, failed, skipped` | *State-machine column — see the Values column for the vocabulary.* |
 | `error` | text |  |  |  | *Message from the most recent failure.* |
 | `event_id` | text | UQ |  |  | *App-layer reference to another row — no database foreign key.* |
@@ -486,11 +486,11 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `tenant_id` | text | NN IX |  |  | *Tenant isolation key. Every read and write must filter on it.* |
 | `inspection_id` | text | NN IX |  |  | *The inspection (order) this belongs to. App-layer reference.* |
-| `uploaded_by_kind` | text | NN |  | `UPLOADER_KINDS` | Who put the file here — and, with `visibility`, the read gate: the client list and download drop inspector+internal rows, and a client may DELETE only rows whose `uploaded_by_ref` is their own. |
+| `uploaded_by_kind` | text | NN |  | `client, co_client, inspector` | Who put the file here — and, with `visibility`, the read gate: the client list and download drop inspector+internal rows, and a client may DELETE only rows whose `uploaded_by_ref` is their own. |
 | `uploaded_by_ref` | text | NN |  |  | client: recipient email; inspector: user id |
 | `uploaded_by_name` | text |  |  |  | *A name.* |
-| `category` | text | NN |  | `DOCUMENT_CATEGORIES` | Filing only: the uploader picks it at upload time (required query param) and the documents list groups rows by it in DOCUMENT_CATEGORIES order. |
-| `visibility` | text | NN |  | `DOCUMENT_VISIBILITIES` | Means something only on an INSPECTOR row: 'internal' hides the file from the client list and 404s its download. |
+| `category` | text | NN |  | ` prior_reports, plans_drawings, environmental, leases_financials, perm…` | Filing only: the uploader picks it at upload time (required query param) and the documents list groups rows by it in DOCUMENT_CATEGORIES order. |
+| `visibility` | text | NN |  | `client_visible, internal` | Means something only on an INSPECTOR row: 'internal' hides the file from the client list and 404s its download. |
 | `r2_key` | text | NN |  |  | *Object key in the R2 bucket.* |
 | `filename` | text | NN |  |  | ORIGINAL name (display + download) |
 | `content_type` | text | NN |  |  | The request's declared content-type, checked against the service allow-list (CAD extensions exempt) and also written onto the R2 object. |
@@ -731,7 +731,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 
 | Column | Type | Flags | Default | Values | Description |
 |---|---|---|---|---|---|
-| `id` | text | PK NN |  | `agent_terms` | *Primary key — an application-generated string id.* |
+| `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `doc` | text | NN UQ IX |  | `agent_terms` |  |
 | `version` | text | NN |  |  | `YYYY-MM-DD`, the date a reader is shown. Calendar-semantic, so TEXT. |
 | `body_snapshot` | text | NN |  |  | The body exactly as published, NOT NULL. `tenant_legal_versions.body_snapshot` is nullable because a tenant may revert to a built-in template, and "they went back to the default" is a publish worth recording. |
@@ -996,7 +996,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `inspector_id` | text | FK→`users.id` |  |  | *App-layer reference to another row — no database foreign key.* |
 | `scheduled_at` | integer | NN IX |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
 | `duration_min` | integer | NN |  |  | *An integer value.* |
-| `price_cents` | integer | NN | `0` | `...EVENT_STATUSES` | *Money, integer cents — never a float.* |
+| `price_cents` | integer | NN | `0` |  | *Money, integer cents — never a float.* |
 | `status` | text | NN | `'scheduled'` | `...EVENT_STATUSES` | *State-machine column — see the Values column for the vocabulary.* |
 | `notes` | text |  |  |  |  |
 | `completed_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
@@ -1304,7 +1304,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `address_lng` | real |  |  |  | written with address_lat; likewise no reader |
 | `address_geocoded_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
 | `template_id` | text | FK→`templates.id` |  |  | IA-1 — WHO is captured via inspection_people (client/agent rows); see schema/inspection/people.ts. |
-| `date` | text | NN IX |  | `...INSPECTION_STATUSES` | Calendar-semantic YYYY-MM-DD (inspection date, no time component) — intentionally TEXT per the Schema Rules calendar-field exception, not an epoch timestamp. |
+| `date` | text | NN IX |  |  | Calendar-semantic YYYY-MM-DD (inspection date, no time component) — intentionally TEXT per the Schema Rules calendar-field exception, not an epoch timestamp. |
 | `status` | text | NN IX | `'requested'` | `...INSPECTION_STATUSES` | *State-machine column — see the Values column for the vocabulary.* |
 | `report_status` | text | NN | `'in_progress'` | `...REPORT_STATUSES` | The report's lifecycle, tracked apart from `status` (the appointment). Every anonymous surface — public report, share link, /verify, repair builder — gates on isReportPublished() of this value, and only InspectionStatusService moves it, each transition asserting the current value first. |
 | `payment_status` | text | NN | `'unpaid'` | `unpaid,partial,paid` | Order-level payment state. Every reader tests `=== 'paid'` (publish pre-flight, the report gate, automation conditions), so 'partial' behaves exactly as 'unpaid' here — the finer states live on `invoices`. |
@@ -1323,7 +1323,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `reference_number` | text |  |  |  | The TENANT's own order number, for cross-referencing their other systems — we never generate it, parse it, or enforce uniqueness. |
 | `internal_notes` | text |  |  |  | Staff-private note. NOTHING WRITES IT: no request schema accepts it and no UI edits it. |
 | `year_built` | integer |  |  |  | *An integer value.* |
-| `sqft` | integer |  |  | `getPropertyFacts` | *An integer value.* |
+| `sqft` | integer |  |  |  | *An integer value.* |
 | `foundation_type` | text |  |  |  | Plain text rather than an enum: getPropertyFacts coerces anything outside basement/slab/crawlspace/other to 'other' on read, so an Estated autofill value can land here without the write path having to reject it. |
 | `bedrooms` | integer |  |  |  | *An integer value.* |
 | `bathrooms` | real |  |  |  | `real` because half-baths are normal (2.5). One of the six Property Facts columns patched together by updatePropertyFacts; Estated autofill fills it from `structure.baths`. |
@@ -1516,7 +1516,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 |---|---|---|---|---|---|
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `name` | text | NN |  |  |  |
-| `kind` | text | NN IX |  | `comments, templates, statutory` | Also the only browse axis that is an enum — property_type reuses the template validator's, and the two below are bounded free text. **[more]** |
+| `kind` | text | NN IX |  | `comments, templates, statutory` | See MARKETPLACE_KINDS above for what the values mean. Also the only browse axis that is an enum — property_type reuses the template validator's, and the two below are bounded free text. **[more]** |
 | `semver` | text | NN |  |  | The catalogue's current version. Never ordered or range-compared, only tested for EQUALITY against tenant_library_imports.imported_semver: unequal is what list() reports as `hasUpdate`, equal is what the update paths refuse. |
 | `schema` | text | NN |  |  | The pack ITSELF, not a description of one: a v2 template document for kind='templates' (validated at import time, never on write) or the entries parseLibraryComments explodes into N rows. |
 | `author_id` | text | NN | `'system'` |  | *App-layer reference to another row — no database foreign key.* |
@@ -1605,14 +1605,14 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 |---|---|---|---|---|---|
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `tenant_id` | text | NN IX |  |  | *Tenant isolation key. Every read and write must filter on it.* |
-| `created_by` | text | NN |  | `MIGRATION_INTENTS` | users.id of the operator who staged it. Soft reference. |
-| `intent` | text | NN |  | `MIGRATION_INTENTS` |  |
+| `created_by` | text | NN |  |  | users.id of the operator who staged it. Soft reference. |
+| `intent` | text | NN |  | ` templates.create, templates.overwrite, contacts.import, members.invit…` |  |
 | `target_id` | text |  |  |  | The row this run overwrites. Set ONLY for `templates.overwrite`, where the operator was standing on the template when they started; NULL for every other intent, because nothing else has a single named target. |
 | `vendor` | text | NN |  |  | Provenance for display ("imported from Spectora on ...") — never matched on. |
 | `adapter_name` | text | NN |  |  | *A name.* |
 | `adapter_version` | text | NN |  |  |  |
 | `manifest` | text | NN |  |  | The bundle manifest, stringified ONCE at stage time and JSON.parsed straight back — never re-serialized from a re-read row, so what a report shows is the bytes the producing run made. |
-| `conflict_policy` | text |  |  | `MIGRATION_CONFLICT_POLICIES` | NULL while staged: the policy is a decision made at apply time, and a default here would answer it for the operator. |
+| `conflict_policy` | text |  |  | `skip, overwrite, per_row` | NULL while staged: the policy is a decision made at apply time, and a default here would answer it for the operator. |
 | `status` | text | NN | `'staged'` | `...MIGRATION_BATCH_STATUSES` | *State-machine column — see the Values column for the vocabulary.* |
 | `created_at` | integer | NN IX |  |  | *Creation time, epoch milliseconds.* |
 | `applied_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
@@ -1643,12 +1643,12 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 |---|---|---|---|---|---|
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `batch_id` | text | NN IX |  |  | *App-layer reference to another row — no database foreign key.* |
-| `tenant_id` | text | NN IX |  | `MIGRATION_ENTITY_KINDS` | *Tenant isolation key. Every read and write must filter on it.* |
+| `tenant_id` | text | NN IX |  |  | *Tenant isolation key. Every read and write must filter on it.* |
 | `entity` | text | NN |  | `MIGRATION_ENTITY_KINDS` |  |
 | `position` | integer | NN |  |  | Index within the bundle's array for this entity kind — how a report names the entry. |
 | `payload` | text | NN |  |  | The bundle entry, stringified once at stage time. |
-| `conflict_with` | text |  |  | `MIGRATION_ROW_RESOLUTIONS` | id of the existing row this one collides with; NULL = no collision. |
-| `resolution` | text |  |  | `MIGRATION_ROW_RESOLUTIONS` |  |
+| `conflict_with` | text |  |  |  | id of the existing row this one collides with; NULL = no collision. |
+| `resolution` | text |  |  | `skip, overwrite` |  |
 | `status` | text | NN IX | `'pending'` | `...MIGRATION_ROW_STATUSES` | *State-machine column — see the Values column for the vocabulary.* |
 | `outcome` | text |  |  |  | Why this row ended where it did, in words rather than a code. NULL does NOT mean "never failed" — it means "not carrying a reason right now". |
 | `created_id` | text |  |  |  | id of the row this one produced in the real table — the undo reads it. |
@@ -1823,7 +1823,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `tenant_id` | text | NN UQ |  |  | *Tenant isolation key. Every read and write must filter on it.* |
 | `inspection_id` | text | NN UQ |  |  | *The inspection (order) this belongs to. App-layer reference.* |
-| `responses` | text |  |  | `sent, received, declined` | A free-form question -> answer map, NOT a fixed catalogue: whatever keys the upsert sends are rendered verbatim as the Appendix E definition list, so the question wording lives in the data. |
+| `responses` | text |  |  |  | A free-form question -> answer map, NOT a fixed catalogue: whatever keys the upsert sends are rendered verbatim as the Appendix E definition list, so the question wording lives in the data. |
 | `status` | text | NN | `'sent'` | `sent, received, declined` | *State-machine column — see the Values column for the vocabulary.* |
 | `share_token` | text | UQ |  |  | Persistent per-inspection share token for the no-login PSQ form (mirrors the inspection_access_tokens model; opaque, server-issued). |
 | `sent_at` | integer |  |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
@@ -2026,7 +2026,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `rendered_at` | integer | NN |  |  | *Timestamp, epoch milliseconds. NULL means it has not happened.* |
 | `source_version` | integer | NN |  |  | inspection.updatedAt timestamp at render time |
 | `version_number` | integer | UQ |  |  | #120 — the report_versions.version_number this PDF renders. Nullable for pre-#120 rows; new publishes always set it. |
-| `size_bytes` | integer |  |  | `queued, rendering, ready, failed` | *A size in bytes.* |
+| `size_bytes` | integer |  |  |  | *A size in bytes.* |
 | `status` | text | NN IX | `'ready'` | `queued, rendering, ready, failed` | *State-machine column — see the Values column for the vocabulary.* |
 | `error` | text |  |  |  | *Message from the most recent failure.* |
 | `content_hash` | text | IX |  |  | Content-hash cache key (SHA-256 of render inputs + RENDER_VERSION salt). Null for rows rendered before this feature; populated for all new renders. |
@@ -2157,7 +2157,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `kind` | text | NN |  | `primary, ancillary` | 'primary' is not just another ancillary: it is the one that must exist, the one the pay gate keys on, and the one a client means by "my report". |
 | `inspection_service_id` | text |  |  |  | The billing LINE this delivers (`inspection_services.id`), when there is one. Nullable and NOT a foreign key: a tenant may produce a report for something they did not bill separately. **[more]** |
 | `template_id` | text |  |  |  | Denormalised pointer to the template this report was generated from, the same treatment `inspections.template_id` keeps for the primary report. |
-| `title` | text | NN |  | `in_progress, published` |  |
+| `title` | text | NN |  |  |  |
 | `status` | text | NN | `'in_progress'` | `in_progress, published` | *State-machine column — see the Values column for the vocabulary.* |
 | `created_at` | integer | NN |  |  | *Creation time, epoch milliseconds.* |
 | `published_at` | integer |  |  |  | When THIS deliverable went out. `inspections.report_status` is the order-wide roll-up and cannot answer "when did the radon report ship", which is the question a client waiting on one of several documents is actually asking. |
@@ -2834,7 +2834,7 @@ neither is left blank. `[more]` marks a column whose source comment runs past
 | `id` | text | PK NN |  |  | *Primary key — an application-generated string id.* |
 | `slug` | text | NN UQ |  |  |  |
 | `tier` | text | NN | `'free'` | `free,pro,enterprise` | Commercial plan. Written ONLY by the portal command seam (`portal.provider` handleTenantUpdate) — core has no UI for it, so a standalone deploy stays 'free'. |
-| `stripe_connect_account_id` | text |  |  | `pending,active,suspended,trial` | *App-layer reference to another row — no database foreign key.* |
+| `stripe_connect_account_id` | text |  |  |  | *App-layer reference to another row — no database foreign key.* |
 | `status` | text | NN | `'pending'` | `pending,active,suspended,trial` | *State-machine column — see the Values column for the vocabulary.* |
 | `max_users` | integer | NN | `5` |  | *An integer value.* |
 | `deployment_mode` | text | NN | `'shared'` |  | shared, silo |

--- a/scripts/check-marketplace-kind-halves.mjs
+++ b/scripts/check-marketplace-kind-halves.mjs
@@ -189,13 +189,33 @@ for (const rel of [SCHEMA_FILE, SERVICE_FILE]) {
 const schema = stripComments(readFileSync(join(ROOT, SCHEMA_FILE), 'utf8'));
 const service = stripComments(readFileSync(join(ROOT, SERVICE_FILE), 'utf8'));
 
-const enumMatch = /kind:\s*text\(\s*'kind'\s*,\s*\{\s*enum:\s*\[([^\]]+)\]/.exec(schema);
+/**
+ * The kind list, read from `MARKETPLACE_KINDS` and no longer from the column.
+ *
+ * It used to match the enum literal inline in `text('kind', { enum: [...] })`.
+ * That literal moved out into an exported constant so the browse filter could
+ * DERIVE the list instead of retyping it — and this parser, which was reading
+ * the literal, immediately reported the schema unreadable.
+ *
+ * ⚠️ Worth stating because it is the whole argument for the exit(1) below: the
+ * gate did not go quietly green when its source moved. An "unreadable" that
+ * returned an empty list would have satisfied every per-kind assertion by
+ * having no kind to assert about, and it would have done so on the very change
+ * that added a third kind to the filter. Fail-closed earned its keep here.
+ */
+const enumMatch = /MARKETPLACE_KINDS\s*=\s*\[([^\]]+)\]/.exec(schema);
 if (enumMatch === null) {
-    console.log(`marketplace-kinds: could not read the kind enum from ${SCHEMA_FILE}. Unreadable `
+    console.log(`marketplace-kinds: could not read MARKETPLACE_KINDS from ${SCHEMA_FILE}. Unreadable `
         + 'is a failure here: it looks exactly like "every kind is covered".');
     process.exit(1);
 }
 const kinds = [...enumMatch[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+// A list that parsed to nothing is the same failure wearing a different face.
+if (kinds.length === 0) {
+    console.log(`marketplace-kinds: MARKETPLACE_KINDS parsed to ZERO kinds in ${SCHEMA_FILE}. `
+        + 'Every per-kind assertion below would pass by having nothing to check.');
+    process.exit(1);
+}
 
 const missing = [];
 const blind = [];

--- a/scripts/gen-schema-doc.mjs
+++ b/scripts/gen-schema-doc.mjs
@@ -135,6 +135,27 @@ const meta = {};
 // Counted from the schema text rather than the migrations: the storage type is
 // `integer` either way, and only the Drizzle mode says whether the integer is
 // seconds or milliseconds.
+/**
+ * The VALUES an enum column admits, even when the column names a constant.
+ *
+ * `enum: MARKETPLACE_KINDS` rendered as that name — correct about the source and
+ * useless to a reader who opened this document to learn which values are
+ * allowed. Resolves only a `const NAME = [ ... ]` in the SAME file, and the `;`
+ * bound keeps a non-array constant from walking forward and reporting some
+ * other array's values as this column's. Unresolved is returned untouched,
+ * never dropped: a name beats a blank cell.
+ */
+function resolveEnum(expr, fileText) {
+    if (!expr || expr.startsWith('[')) return expr;
+    const at = fileText.indexOf(`const ${expr} =`);
+    if (at === -1) return expr;
+    const open = fileText.indexOf('[', at);
+    const end = fileText.indexOf(';', at);
+    if (open === -1 || (end !== -1 && open > end)) return expr;
+    const close = fileText.indexOf(']', open);
+    return close === -1 ? expr : fileText.slice(open, close + 1);
+}
+
 let nTsMs = 0, nTsRaw = 0;
 for (const file of walk(join(root, 'server', 'lib', 'db', 'schema'))) {
     const raw = readFileSync(file, 'utf8');
@@ -164,7 +185,16 @@ for (const file of walk(join(root, 'server', 'lib', 'db', 'schema'))) {
             } else {
                 const c = s.match(/^(\w+):\s*(?:text|integer|real|blob)\(\s*['"]([a-z_0-9]+)['"]/);
                 if (c) {
-                    const en = (ln + ' ' + (lines[k + 1] || '')).match(/enum:\s*(\[[^\]]*\]|[\w.]+)/);
+                    // Read the NEXT line only when this one leaves the column's
+                    // own call open, which a wrapped `enum: [...]` does. Joining
+                    // unconditionally handed 16 columns the enum belonging to
+                    // the column BELOW: `client_name` documented as the
+                    // signature statuses, `price_cents` as having values at all.
+                    // A plausible-looking name hid it until names began
+                    // resolving to their values.
+                    const unclosed = (ln.match(/\(/g) || []).length - (ln.match(/\)/g) || []).length;
+                    const probe = unclosed > 0 ? `${ln} ${lines[k + 1] || ''}` : ln;
+                    const en = probe.match(/enum:\s*(\[[^\]]*\]|[\w.]+)/);
                     // A TRAILING comment documents its column just as well as a
                     // preceding one, and this file is full of them
                     // (`tokenHash: text('token_hash'), // SHA-256 hex; NULL on …`).
@@ -174,7 +204,7 @@ for (const file of walk(join(root, 'server', 'lib', 'db', 'schema'))) {
                     const tail = s.match(/,\s*\/\/\s*(.+)$/);
                     const parts = buf.slice();
                     if (tail) parts.push(tail[1].trim());
-                    entry.cols[c[2]] = { prop: c[1], raw: parts.join(' '), enum: en ? en[1] : null };
+                    entry.cols[c[2]] = { prop: c[1], raw: parts.join(' '), enum: resolveEnum(en ? en[1] : null, raw) };
                 }
                 buf = [];
             }

--- a/server/api/marketplace.ts
+++ b/server/api/marketplace.ts
@@ -1,6 +1,5 @@
-import { createRoute } from '@hono/zod-openapi';
+import { createRoute, z } from '@hono/zod-openapi';
 import { createApiRouter } from '../lib/openapi-router';
-import { z } from '@hono/zod-openapi';
 import { requireRole } from '../lib/middleware/rbac';
 import { requireCapability } from '../lib/middleware/require-capability';
 import { Errors, AppError } from '../lib/errors';
@@ -8,6 +7,7 @@ import { auditFromContext } from '../lib/audit';
 import { LibraryReplaceParamsSchema, LibraryReplaceBodySchema, LibraryReplacePreviewSchema } from '../lib/validations/library-replace.schema';
 import { ImportHistoryQuerySchema } from '../lib/validations/import-history.schema';
 import { MarketplaceBrowseQuerySchema } from '../lib/validations/marketplace-browse.schema';
+import { MARKETPLACE_KINDS } from '../lib/db/schema/marketplace';
 import {
     paginationQuerySchema,
     PaginatedMetaSchema,
@@ -100,7 +100,7 @@ const marketplaceRoutes = createApiRouter()
     summary: 'List marketplace catalogue entries (comment packs, templates)',
     middleware: [requireRole('owner', 'manager', 'inspector')] as const,
     request: {
-        query: z.object({ kind: z.enum(['comments', 'templates']).optional().describe('TODO describe kind field for the OpenInspection MCP integration') }).describe('TODO describe query field for the OpenInspection MCP integration'),
+        query: z.object({ kind: z.enum(MARKETPLACE_KINDS).optional().describe('TODO describe kind field for the OpenInspection MCP integration') }).describe('TODO describe query field for the OpenInspection MCP integration'),
     },
     responses: {
         200: { content: { 'application/json': { schema: z.object({ success: z.boolean().describe('TODO describe success field for the OpenInspection MCP integration'), data: z.array(z.any()).describe('TODO describe data field for the OpenInspection MCP integration') }).describe('TODO describe schema field for the OpenInspection MCP integration') } }, description: 'OK' },

--- a/server/lib/db/schema/index.ts
+++ b/server/lib/db/schema/index.ts
@@ -43,6 +43,7 @@ export {
     marketplaceLibraries,
     tenantLibraryImports,
     tenantMarketplaceImportHistory,
+    MARKETPLACE_KINDS,
 } from './marketplace';
 export { inspectionMessages } from './message';
 export type { MessageAttachment } from './message';

--- a/server/lib/db/schema/marketplace.ts
+++ b/server/lib/db/schema/marketplace.ts
@@ -6,6 +6,23 @@ import { sqliteTable, text, integer, index, uniqueIndex } from 'drizzle-orm/sqli
 // preserve. Dropping the child also removed the only FK pointing INTO
 // `templates`, which D1 makes a permanent migration liability.
 
+/**
+ * Every kind the catalogue can hold, and the ONE place the list is written.
+ *
+ * It is the `kind` column's enum, and every consumer derives from it rather
+ * than retyping it. That is not tidiness: the browse filter had its own
+ * hand-typed copy reading ['comments', 'templates'], which offered a kind no
+ * row has ever carried and made the five 'statutory' rows unreachable by
+ * filter -- visible only under "All", where nobody looking for them would
+ * think to look. Nothing failed, no test went red, and the service layer
+ * accepted all three the whole time.
+ *
+ * ⚠️ `lint:marketplace-kind-halves` does NOT cover this. It checks that each
+ * kind has an import path and an un-import path, which is a different
+ * question from whether a person can find the kind in the first place.
+ */
+export const MARKETPLACE_KINDS = ['comments', 'templates', 'statutory'] as const;
+
 // The single marketplace catalogue. Every importable kind lives here, keyed by
 // `kind`: a 1:1 kind ('templates' — one catalogue row becomes one local
 // `templates` row) and a 1:N kind ('comments' — one pack becomes N tagged
@@ -18,6 +35,7 @@ import { sqliteTable, text, integer, index, uniqueIndex } from 'drizzle-orm/sqli
 export const marketplaceLibraries = sqliteTable('marketplace_libraries', {
   id:            text('id').primaryKey(),
   name:          text('name').notNull(),
+  // See MARKETPLACE_KINDS above for what the values mean.
   // Also the only browse axis that is an enum — property_type reuses the
   // template validator's, and the two below are bounded free text. Backed by
   // idx(kind, featured), which serves list()'s featured-then-downloads order.
@@ -26,7 +44,7 @@ export const marketplaceLibraries = sqliteTable('marketplace_libraries', {
   // one, because its import validates with a schema that admits a statutory
   // declaration and its update retires the row it supersedes. Neither is
   // something an ordinary template import should ever do.
-  kind:          text('kind', { enum: ['comments', 'templates', 'statutory'] }).notNull(),
+  kind:          text('kind', { enum: MARKETPLACE_KINDS }).notNull(),
   // The catalogue's current version. Never ordered or range-compared, only
   // tested for EQUALITY against tenant_library_imports.imported_semver:
   // unequal is what list() reports as `hasUpdate`, equal is what the update

--- a/server/lib/mcp/openapi-snapshot.json
+++ b/server/lib/mcp/openapi-snapshot.json
@@ -11834,7 +11834,8 @@
             "type": "string",
             "enum": [
               "comments",
-              "templates"
+              "templates",
+              "statutory"
             ],
             "description": "TODO describe kind field for the OpenInspection MCP integration"
           }
@@ -11898,7 +11899,8 @@
             "type": "string",
             "enum": [
               "comments",
-              "templates"
+              "templates",
+              "statutory"
             ],
             "description": "Filter the catalogue to one kind of importable content"
           }

--- a/server/lib/validations/marketplace-browse.schema.ts
+++ b/server/lib/validations/marketplace-browse.schema.ts
@@ -1,5 +1,6 @@
 import { z } from '@hono/zod-openapi';
 import { PropertyTypeEnum } from './template.schema';
+import { MARKETPLACE_KINDS } from '../db/schema/marketplace';
 
 /**
  * Three browse axes, not one `category` (#293). They are independent: a Texas
@@ -20,7 +21,11 @@ import { PropertyTypeEnum } from './template.schema';
  */
 export const MarketplaceBrowseQuerySchema = z.object({
     search:         z.string().optional().describe('Free-text search over catalogue entry names'),
-    kind:           z.enum(['comments', 'templates']).optional().describe('Filter the catalogue to one kind of importable content'),
+    // Derived from the column's own enum, never retyped. Typed here it read
+    // ['comments', 'templates'], which offered a kind no row carries and hid
+    // every 'statutory' row from the filter -- the service accepted all three
+    // the whole time, so nothing anywhere went red.
+    kind:           z.enum(MARKETPLACE_KINDS).optional().describe('Filter the catalogue to one kind of importable content'),
     propertyType:   PropertyTypeEnum.optional().describe('Filter templates by the property type they are written for'),
     jurisdiction:   z.string().min(1).max(64).optional().describe("Filter by a jurisdiction's form standard, e.g. trec"),
     inspectionKind: z.string().min(1).max(64).optional().describe('Filter by inspection kind, e.g. new_construction'),

--- a/tests/unit/marketplace/browse-kind-coverage.spec.ts
+++ b/tests/unit/marketplace/browse-kind-coverage.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Every kind a catalogue row can carry must be one a person can filter for.
+ *
+ * The browse filter's enum was typed by hand as ['comments', 'templates'] while
+ * the column's own enum said ['comments', 'templates', 'statutory']. The two
+ * disagreed in both directions at once: it offered `templates`, which no row in
+ * the shipped catalogue carries, and refused `statutory`, which five of them do.
+ *
+ * Nothing failed. The service layer (`catalogue-browse.ts`) accepted all three
+ * the whole time, so the rows were still returned under "All" — they were
+ * simply unreachable by the control a person would use to find them. That is
+ * the shape this file exists to catch: not an error, an absence.
+ *
+ * ⚠️ `lint:marketplace-kind-halves` does not cover it, and saying so is the
+ * point. That gate asks whether each kind has an import path and an un-import
+ * path — whether the round trip works once you have found the thing. Whether
+ * you can find it is a different question, and no instrument was asking it.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { marketplaceLibraries, MARKETPLACE_KINDS } from '../../../server/lib/db/schema';
+import { MarketplaceBrowseQuerySchema } from '../../../server/lib/validations/marketplace-browse.schema';
+
+/** The kinds the DATABASE COLUMN admits — the authority, read off the table. */
+const columnKinds = (): readonly string[] => {
+    const col = getTableConfig(marketplaceLibraries).columns.find((c) => c.name === 'kind');
+    return (col as unknown as { enumValues?: readonly string[] }).enumValues ?? [];
+};
+
+describe('marketplace browse — the filter can name every kind that exists', () => {
+    it('CONTROL — the column really declares an enum, and it is not empty', () => {
+        // Without this, "the filter covers every column kind" is satisfied by a
+        // column that declares none, and this file would pass while measuring
+        // nothing at all.
+        expect(columnKinds().length).toBeGreaterThan(1);
+    });
+
+    it('the exported list IS the column enum, not a copy that agrees today', () => {
+        expect([...MARKETPLACE_KINDS].sort()).toEqual([...columnKinds()].sort());
+    });
+
+    it('accepts every kind the column admits', () => {
+        for (const kind of columnKinds()) {
+            const parsed = MarketplaceBrowseQuerySchema.safeParse({ kind });
+            expect(parsed.success, `browse refuses kind=${kind}`).toBe(true);
+        }
+    });
+
+    it('NEGATIVE CONTROL — and still refuses a kind no row can carry', () => {
+        // The assertion above is satisfiable by a filter that accepts anything.
+        expect(MarketplaceBrowseQuerySchema.safeParse({ kind: 'invoices' }).success).toBe(false);
+    });
+
+    it('omitting the filter is valid, because "All" is a real answer', () => {
+        expect(MarketplaceBrowseQuerySchema.safeParse({}).success).toBe(true);
+    });
+});


### PR DESCRIPTION
Three commits. One is a real filter bug; the other two are the reference
document that reported it and a snapshot that had to follow.

## The catalogue kind you could not filter for

The browse filter's `kind` enum was typed by hand as `['comments', 'templates']`
while the column's own enum says `['comments', 'templates', 'statutory']`. The
two disagreed in both directions at once: the filter offered `templates`, which
no row in the shipped catalogue carries, and refused `statutory`, which five of
them do.

Nothing failed. `catalogue-browse.ts` accepted all three the whole time, so the
statutory rows were still returned — under "All", where somebody looking for a
state form would not think to look. The failure was an absence, and absences
raise nothing.

`MARKETPLACE_KINDS` is now exported from the schema module, used BY the column's
own enum, and derived from by both query schemas. Divergence is no longer
something a person can do by typing.

⚠️ `lint:marketplace-kind-halves` does not cover this, and the new spec says so
where a reader will find it. That gate asks whether each kind has an import path
and an un-import path — whether the round trip works once you have found the
thing. Whether you can find it at all was a question no instrument was asking.

The spec asserts against the COLUMN rather than a list retyped in the test: a
copy would agree with the test and with nothing else. It carries a control that
the column really declares an enum — otherwise "covers every kind" is satisfied
by covering none — and a negative control that a kind no row can carry is still
refused. Verified by restoring the old hand-typed enum and watching it fail with
`browse refuses kind=statutory`.

**The gate behaved well and it is worth recording.** Moving the literal out from
under `lint:marketplace-kind-halves` broke its parser, and it did NOT go quietly
green: it reported the schema unreadable and exited 1 — *"unreadable is a failure
here: it looks exactly like every kind is covered"* — on the very change that
added a third kind. A parser returning an empty list would have satisfied every
per-kind assertion by having no kind to assert about. It reads
`MARKETPLACE_KINDS` now, and also refuses a list that parses to zero.

## 🔴 The schema reference was attributing enums to the wrong column

Fixing the above meant touching `gen-schema-doc.mjs`, which surfaced a defect
that has been there since the generator was written.

The generator reads a column's enum from `(thisLine + nextLine)`. The lookahead
exists for a wrapped `enum: [...]`, and it also handed every column the enum
belonging to the column BELOW it. **Sixteen columns that have no enum at all
were documented as having one:**

| column | documented as |
|---|---|
| `client_name` | `pending, sent, viewed, signed, declined, expired` |
| `price_cents` | as having values at all |
| `user_agent` | `remote, in_person` |
| `created_by` | `MIGRATION_INTENTS` |
| `actor_identity_ref` | `the` |
| `sqft` | `getPropertyFacts` |

It read as a plausible name for long enough that nobody looked twice —
`MIGRATION_INTENTS` sitting beside `created_by` is exactly what the eye accepts.
It became obvious only once enum names started resolving to their values, which
is why both fixes are in one commit.

The lookahead is now conditional on this line leaving the column's own call
open, which is the only case it was ever for. And an enum named by a constant
resolves to its values, because a reader opens that document to learn which
values are allowed, not to learn the name of a list.

Net: 16 rows stop claiming an enum they do not have, 7 resolve a constant to its
values.

## Also

The OpenAPI snapshot follows `statutory` into the two published query schemas.
That is a real movement in the API surface rather than noise.

## Verification

- `npm run lint` — 70 of 70 gates
- `npm run test:unit` — 8,810 passed
- `npm run test:web` — 3,001 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
