### PR TITLE
fix(deps): override qs and @humanfs/node past this week's advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,25 +1919,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmmirror.com/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmmirror.com/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmmirror.com/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -11478,9 +11492,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -263,6 +263,8 @@
     "brace-expansion": "^5.0.9",
     "ip-address": ">=10.2.2",
     "fast-uri": "^3.1.6",
+    "qs": "^6.16.0",
+    "@humanfs/node": "^0.16.8",
     "postcss": ">=8.5.18",
     "valibot": ">=1.4.2"
   },


### PR DESCRIPTION
Three advisories published 2026-09-02. None of them was introduced by recent
work here — the lockfile change that shipped with #331 touched neither package.

| package | severity | scope | range | patched |
|---|---|---|---|---|
| `qs` | medium ×2 | runtime | `>= 2.2.5 < 6.16.0` | 6.16.0 |
| `@humanfs/node` | medium | development | `< 0.16.8` | 0.16.8 |

`qs` arrives under the MCP SDK's `express`; `@humanfs/node` under `eslint`.
Both are transitive with no direct dependency to bump, so they join the
`overrides` block.

The floors are set **past** the advisory rather than merely permitting the
patched version. A floor that sits inside the vulnerable range locks a
snapshot, not an invariant: the resolver happens to pick a safe version today
and may pick a vulnerable one on the next clean resolve. This is the same
correction `fast-uri` needed in #331, where the override read `^3.1.5` while
the advisory covered `< 3.1.6`.

The lockfile was updated in place and never regenerated — on Windows a fresh
resolve drops the linux binaries and breaks CI on the ubuntu runner. Verified
by count: 329 linux entries before, 329 after.

Full local suite green (`lint`, `test:unit`, `test:web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
