### PR TITLE
test(docs-shots): photograph the library, the marketplace and the statutory form PDFs

### DIFF
--- a/tests/docs-shots/_docs-fixtures.ts
+++ b/tests/docs-shots/_docs-fixtures.ts
@@ -269,3 +269,27 @@ export async function ensureDocsSignerLink(page: Page, inspectionId: string): Pr
     if (!url) throw new Error('docs fixture: signer link endpoint returned no url');
     return new URL(url, 'http://127.0.0.1').pathname + new URL(url, 'http://127.0.0.1').search;
 }
+
+/**
+ * The marketplace catalogue.
+ *
+ * WHY THIS IS NEEDED AT ALL. The seed builds its tenant with raw SQL, so
+ * `seedStarterContent` — the only thing that fills `marketplace_libraries` —
+ * has never run on it. The browse page therefore rendered "Marketplace is
+ * empty · 0 available", and the capture PASSED: the readiness locator matched,
+ * the file was written, and the guide about installing content would have
+ * shipped illustrated by a bare shelf. An empty result reads as green.
+ *
+ * `POST /api/admin/data/install-bundled-content` is the product's own installer
+ * (owner-only; the seed admin is the owner). It is idempotent by name and
+ * reports counts of what it ADDED, so re-running a capture cannot accumulate
+ * rows or change the picture.
+ */
+export async function ensureDocsCatalogue(page: Page): Promise<void> {
+    const res = await page.request.post('/api/admin/data/install-bundled-content', {
+        headers: await authedWriteHeaders(page),
+    });
+    if (!res.ok()) {
+        throw new Error(`docs fixture: bundled-content install -> ${res.status()} ${await res.text()}`);
+    }
+}

--- a/tests/docs-shots/settings-pages.shots.ts
+++ b/tests/docs-shots/settings-pages.shots.ts
@@ -1,5 +1,6 @@
 import { test } from './_harness';
 import { captureSettings, type SettingsShot } from './_settings-shots';
+import { ensureDocsCatalogue } from './_docs-fixtures';
 import { loginAsSeedUser } from '../e2e/helpers/seed-login';
 import { SEED_EMAILS } from '../seed-fixtures';
 
@@ -13,7 +14,11 @@ test.beforeEach(({}, testInfo) => {
 
 
 /**
- * Captures for the configuration guides, one picture each.
+ * Captures for the configuration guides, one picture each — plus the two
+ * library surfaces, which are not under `/settings` but want exactly the same
+ * walk: one admin login, go to a path, wait for that page's own content, shoot.
+ * Splitting them into a file of their own would buy a second login and nothing
+ * else.
  *
  * NO COPY LIVES HERE. Every id below has a matching `<!-- shot: <id> | … -->`
  * in the guide named beside it, and those live with the hosted docs.
@@ -44,10 +49,27 @@ const PAGES: SettingsShot[] = [
     { guide: 'security',               id: 'settings-security',   path: '/settings/security',   ready: /Change password/i },
     { guide: 'privacy-and-data',       id: 'settings-compliance', path: '/settings/compliance', ready: /Agreement retention window/i },
     { guide: 'advanced',               id: 'settings-advanced-ai', path: '/settings/advanced',  ready: /AI features/i },
+    // Owner-only, and the seed admin IS the owner. On this stack no authority
+    // PDF has been supplied, so the picture is the page as an operator first
+    // meets it: every revision this build publishes, each marked "Not stored".
+    // That is the state the guide describes, not a degraded one.
+    { guide: 'statutory-forms',        id: 'settings-statutory-forms', path: '/settings/statutory-forms', ready: /Statutory form PDFs|publishes no statutory forms/i },
+    // The two library surfaces. `ready` is a tile title rather than the page
+    // heading: the hub's shell renders before its tiles do.
+    { guide: 'content-library-and-marketplace', id: 'library-hub',        path: '/library',             ready: /Canned Comments/i },
+    // `ready` refuses a count of ZERO on purpose. The first version of this
+    // entry accepted "Marketplace is empty" as a loaded page, and shipped a
+    // picture of a bare shelf to illustrate a guide about installing things —
+    // green run, useless capture. Requiring a non-zero count makes an unseeded
+    // catalogue a FAILURE, which is what it is.
+    { guide: 'content-library-and-marketplace', id: 'marketplace-browse', path: '/library/marketplace', ready: /\b[1-9]\d* available/ },
 ];
 
 test('the configuration pages', async ({ page }) => {
     await loginAsSeedUser(page, SEED_EMAILS.admin);
+    // The catalogue has to exist before the marketplace is photographed — see
+    // ensureDocsCatalogue for what shipped the first time it did not.
+    await ensureDocsCatalogue(page);
     for (const entry of PAGES) {
         await captureSettings(page, entry);
     }


### PR DESCRIPTION
Three screens the documentation capture walk did not reach — the library hub, the marketplace, and the statutory form PDF page — plus one lesson the run taught while adding them.

## The library surfaces join the settings walk

They are not under `/settings`, but they want exactly the same steps: one admin login, go to a path, wait for that page's own content, shoot. A file of their own would have bought a second login and nothing else, so they join the settings list and the module comment now says why they are there.

`/settings/statutory-forms` is owner-only and the seed admin **is** the owner. On this stack no authority PDF has been supplied, so the picture is the page as an operator first meets it: every revision this build publishes, each marked "Not stored". That is the state the prose describes, not a degraded one.

## An empty result read as green

The marketplace capture **passed on its first run and was useless**.

The seed builds its tenant with raw SQL, so `seedStarterContent` — the only thing that fills `marketplace_libraries` — had never run against it. The page rendered

```
Marketplace is empty · 0 available
```

the readiness locator matched it, the file was written, the run went green, and a guide about installing content would have shipped illustrated by a bare shelf.

Two changes, and **neither is sufficient alone**:

- `ensureDocsCatalogue()` calls the product's own installer, `POST /api/admin/data/install-bundled-content`. Owner-only, idempotent by name, and it reports counts of what it *added* — so re-running a capture cannot accumulate rows or change the picture. Using the real endpoint rather than inserting fixtures keeps the photograph a photograph of the product.
- The readiness regex became `/\b[1-9]\d* available/`, which **refuses a count of zero**. Accepting "Marketplace is empty" as a loaded page is what let the first version through; an unseeded catalogue is now a failure, which is what it is.

The second one is the durable half. A fixture can stop working; a locator that cannot spell "loaded" as "empty" keeps the run honest when it does.

## Verification

`npm run docs:shots` — **17 passed, 0 failed, 42 captures**. The marketplace picture now shows five catalogue entries (a comment pack and the four statutory forms) with their Install buttons, and the tab strip reads All / Comments / Templates / Statutory.

Run from a dedicated worktree with `MCP_ENABLED=true` on the capture server, which the connected-apps entry has always needed.

## Note on scope

This repository holds only the capture half. The markers these ids answer to, the code that joins the two, and the gate that fails when they disagree all live with the published prose — a capture with nowhere to go is caught there, against the text, because this repository has no markers to check against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXzZHssNtU2gK4jiR4bXtZ
