### PR TITLE
fix: bound the last-active debounce map, and stop spawning the audit gate three times

### DIFF
--- a/server/lib/middleware/touch-last-active.ts
+++ b/server/lib/middleware/touch-last-active.ts
@@ -16,7 +16,42 @@ import type { MiddlewareHandler } from 'hono';
 import { logger } from '../logger';
 
 const DEBOUNCE_MS = 30_000;
+
+/**
+ * Above this many tracked users, sweep before adding another.
+ *
+ * The map is module-scoped, so it lives as long as the isolate and grew by one
+ * entry per distinct user forever — nothing ever removed anything. Small per
+ * entry, unbounded in aggregate, and worst on exactly the deployment that can
+ * least afford it: a shared saas isolate serving many workspaces.
+ *
+ * The number only has to be far above the users one isolate sees inside a
+ * 30-second window, because that is the only population whose entries still
+ * carry information.
+ */
+export const MAX_TRACKED_USERS = 10_000;
+
 const lastFlush = new Map<string, number>();
+
+/**
+ * Drop entries whose debounce has already expired, and if that is not enough,
+ * drop everything.
+ *
+ * An entry older than DEBOUNCE_MS carries NO information: the next request for
+ * that user passes the debounce whether the entry is there or not. So the sweep
+ * is free in behaviour terms. The clear() fallback is not quite free — it lets
+ * a few users flush one extra time — and that is already the trade this file
+ * accepts above, where ten isolates each writing once per 30s per user is
+ * called comfortably within quota.
+ */
+function sweep(now: number): void {
+    for (const [id, ts] of lastFlush) {
+        if (now - ts >= DEBOUNCE_MS) lastFlush.delete(id);
+    }
+    // `>=`, not `>`: this runs while about to ADD an entry, so leaving exactly
+    // MAX in place would put the map one over as soon as the caller sets.
+    if (lastFlush.size >= MAX_TRACKED_USERS) lastFlush.clear();
+}
 
 interface CtxUser { sub?: string; id?: string }
 
@@ -33,6 +68,9 @@ export const touchLastActiveMiddleware: MiddlewareHandler = async (c, next) => {
     const now = Date.now();
     const last = lastFlush.get(userId) ?? 0;
     if (now - last < DEBOUNCE_MS) return;
+    // Sweep before growing, and only when about to grow — a user already in the
+    // map is a replacement, not a new entry, so it cannot push us over.
+    if (!lastFlush.has(userId) && lastFlush.size >= MAX_TRACKED_USERS) sweep(now);
     lastFlush.set(userId, now);
 
     // Fire-and-forget — never await. waitUntil keeps the worker alive until

--- a/tests/unit/audit/registry-gate.spec.ts
+++ b/tests/unit/audit/registry-gate.spec.ts
@@ -1,19 +1,38 @@
+/**
+ * The audit-registry gate's own self-check.
+ *
+ * ⚠️ ONE spawn, shared by all three cases. Each `it` used to call `run()`
+ * itself, so this file shelled out to a repo-walking script three times for
+ * three assertions about the SAME output. Individually each spawn is ~2s
+ * against vitest's 5s default, which is fine on an idle machine and is not fine
+ * on a busy one: on 2026-09-06 all three timed out during a run that shared the
+ * machine with another suite, and the file read as a regression in the gate it
+ * was checking. Nothing about the assertions needed three runs.
+ *
+ * The explicit timeout is belt-and-braces on top: the work here is process
+ * startup plus a walk of the repo, and neither belongs to the class of thing a
+ * 5s default was chosen for.
+ */
 import { execFileSync } from 'node:child_process';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeAll } from 'vitest';
 
-const run = () => execFileSync('node', ['scripts/check-audit-registry.mjs'], { encoding: 'utf8' });
+let output = '';
+
+beforeAll(() => {
+    output = execFileSync('node', ['scripts/check-audit-registry.mjs'], { encoding: 'utf8' });
+}, 60_000);
 
 describe('audit registry gate', () => {
     it('prints both numbers, so a green run is checkable', () => {
-        expect(run()).toMatch(/\[audit-registry\] \d+ action\(s\) declared, \d+ written at \d+ call site\(s\)/);
+        expect(output).toMatch(/\[audit-registry\] \d+ action\(s\) declared, \d+ written at \d+ call site\(s\)/);
     });
 
     it('found a non-trivial number of call sites — an empty walk reports the same clean result as a correct one', () => {
-        const [, sites] = /written at (\d+) call site/.exec(run()) ?? [];
+        const [, sites] = /written at (\d+) call site/.exec(output) ?? [];
         expect(Number(sites)).toBeGreaterThan(80);
     });
 
     it('reports zero disagreements', () => {
-        expect(run()).toMatch(/0 undeclared, 0 unreconciled/);
+        expect(output).toMatch(/0 undeclared, 0 unreconciled/);
     });
 });

--- a/tests/unit/platform/touch-last-active-bound.spec.ts
+++ b/tests/unit/platform/touch-last-active-bound.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * The last-active debounce map must not grow without bound.
+ *
+ * It is module-scoped, so it lives as long as the isolate, and it used to gain
+ * one entry per distinct user and lose none — ever. Nothing in the request path
+ * removed anything. On a shared saas isolate serving many workspaces, that is a
+ * slow leak in the one place a Worker cannot afford one.
+ *
+ * Asserted through BEHAVIOUR rather than by reaching into the map: once the cap
+ * is exceeded the entries are dropped, so a user who was inside their debounce
+ * window flushes again. That is observable, and it is also the only externally
+ * visible consequence of the sweep -- the extra flush this test detects is
+ * precisely the cost the file accepts in exchange for the bound.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { touchLastActiveMiddleware, MAX_TRACKED_USERS } from '../../../server/lib/middleware/touch-last-active';
+
+/** Drives the middleware once for `userId`, returning whether it flushed. */
+async function visit(userId: string, touch: ReturnType<typeof vi.fn>) {
+    const before = touch.mock.calls.length;
+    const c = {
+        get: (k: string) => (k === 'user' ? { sub: userId } : undefined),
+        var: { services: { user: { touchLastActive: touch } } },
+        executionCtx: { waitUntil: (p: Promise<unknown>) => { void p; } },
+    };
+    await (touchLastActiveMiddleware as unknown as (ctx: unknown, n: () => Promise<void>) => Promise<void>)(c, async () => {});
+    return touch.mock.calls.length > before;
+}
+
+describe('touch-last-active debounce map', () => {
+    it('debounces a repeat visit, then drops entries once the cap is exceeded', async () => {
+        const touch = vi.fn(async () => {});
+
+        // Fill to exactly the cap. Every user is new, so every one flushes.
+        for (let i = 0; i < MAX_TRACKED_USERS; i++) await visit(`u${i}`, touch);
+        expect(touch).toHaveBeenCalledTimes(MAX_TRACKED_USERS);
+
+        // The debounce still holds: u0 came back well inside 30s.
+        expect(await visit('u0', touch), 'u0 is inside its debounce window').toBe(false);
+
+        // One more DISTINCT user tips it past the cap. Nothing has expired, so
+        // the expiry sweep frees nothing and the clear() fallback runs.
+        expect(await visit('overflow', touch), 'a new user always flushes').toBe(true);
+
+        // u0's entry went with it, so u0 flushes again despite being inside its
+        // window. Bounded, at the cost of one extra write -- the trade the file
+        // documents.
+        expect(await visit('u0', touch), 'the map was dropped, so u0 flushes again').toBe(true);
+    });
+
+    it('never flushes for an anonymous request', async () => {
+        const touch = vi.fn(async () => {});
+        const c = {
+            get: () => undefined,
+            var: { services: { user: { touchLastActive: touch } } },
+            executionCtx: { waitUntil: () => {} },
+        };
+        await (touchLastActiveMiddleware as unknown as (ctx: unknown, n: () => Promise<void>) => Promise<void>)(c, async () => {});
+        expect(touch).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Two items the request-scoped memoisation work deferred rather than solved.

## The debounce map was an unbounded module-scoped Map

`touch-last-active`'s `lastFlush` lives as long as the isolate and gained one entry per distinct user while losing none — **ever**. Nothing in the request path removed anything. Small per entry, unbounded in aggregate, and worst on the deployment that can least afford it: a shared SaaS isolate serving many workspaces.

It now sweeps before growing past a cap. An entry older than the 30s debounce carries **no information** — the next request for that user passes the debounce whether it is there or not — so expiring those is free in behaviour terms. The `clear()` fallback is not quite free: it lets a few users flush one extra time, which is already the trade this file documents when it calls ten isolates each writing once per 30s per user comfortably within quota.

Asserted through behaviour rather than by reaching into the map: past the cap, a user inside their debounce window flushes again — the only externally visible consequence of the sweep. The test reads `MAX_TRACKED_USERS` from the module rather than restating the number.

## The audit gate spawned itself three times

`registry-gate.spec.ts` shelled out to a repo-walking script three times, for three assertions about the same output. Each spawn is ~2s against vitest's 5s default: fine on an idle machine, not fine on a busy one. All three timed out during a run sharing the machine with another suite, and the file read as a regression in the gate it exists to check.

One spawn now, shared, with an explicit 60s budget — 3.6s for the file, assertions unchanged. Fixed at the cause rather than by raising the timeout.

Verified: lint 75/75, unit 8899, web 3113, workers 180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)