### PR TITLE
perf: split the queue consumer out of the API graph, and measure the render's duplicate reads

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -691,7 +691,7 @@ app.notFound((c) => {
 // without this `Handler does not export a scheduled() function` fires
 // on every cron tick and the automation flush never runs.
 import { scheduled as baseScheduled } from './scheduled';
-import { handleSyncDlqBatch } from './portal/integration.module';
+import { queue as queueConsumer } from './queue';
 export default {
     fetch: app.fetch.bind(app),
     scheduled: async (event: ScheduledEvent, env: HonoConfig['Bindings'], ctx: ExecutionContext) => {
@@ -703,35 +703,11 @@ export default {
     // (`inspectorhub-cmd-saas`, portal→core commands — A-21), and the sync DLQ
     // (`inspectorhub-sync-dlq-saas`, dead core→portal envelopes → outbox
     // `failed` writeback). Never throws.
-    queue: async (batch: MessageBatch<unknown>, env: HonoConfig['Bindings'], _ctx: ExecutionContext) => {
-        if (batch.queue.includes('word-export')) {
-            const { handleWordExportBatch } = await import('./services/report-export-consumer');
-            const images = (env as unknown as { IMAGES?: import('./lib/media/strip-exif').ImagesBinding }).IMAGES;
-            await handleWordExportBatch({
-                DB: env.DB, PHOTOS: env.PHOTOS, TENANT_CACHE: env.TENANT_CACHE,
-                KEY_ENCRYPTION_SECRET: env.KEY_ENCRYPTION_SECRET, JWT_SECRET: env.JWT_SECRET,
-                ...(images ? { IMAGES: images } : {}),
-            }, batch);
-            return;
-        }
-        // The cron queue. One message = one job = one Worker invocation with its
-        // own CPU budget; that split is what keeps the scheduled path inside the
-        // Workers Free 10 ms per-invocation ceiling.
-        if (batch.queue.includes('-cron')) {
-            const { handleCronBatch } = await import('./cron/consumer');
-            await handleCronBatch(env as never, batch as never);
-            return;
-        }
-        if (batch.queue.includes('-cmd-') && !batch.queue.includes('cmd-dlq')) {
-            const { handleCmdBatch } = await import('./portal/cmd-batch');
-            // SYNC_QUEUE carries replies (A-21 batch 2); PHOTOS/EXPORTS serve
-            // offboarding (batch 3) and the DOs let purge empty them; the last
-            // argument is the secret a report amendment is signed with (cmd-batch.ts).
-            await handleCmdBatch(env.DB, env.TENANT_CACHE, batch, env.SYNC_QUEUE, { photos: env.PHOTOS, exports: env.EXPORTS_BUCKET }, { INSPECTION_DOC: env.INSPECTION_DOC, TENANT_PRESENCE: env.TENANT_PRESENCE }, env, env.KEY_ENCRYPTION_SECRET || env.JWT_SECRET);
-            return;
-        }
-        await handleSyncDlqBatch(env.DB, batch);
-    },
+    //
+    // The body moved to `./queue` so `workers/app.ts` can reach it without
+    // evaluating this module (and with it every route). This export stays so
+    // the default export keeps its full shape for any other consumer.
+    queue: queueConsumer,
 };
 export { SignCompletionWorkflow } from './workflows/sign-completion-workflow';
 

--- a/server/lib/middleware/require-capability.ts
+++ b/server/lib/middleware/require-capability.ts
@@ -9,6 +9,7 @@ import {
 } from '../auth/capabilities';
 import { isRole } from '../auth/roles';
 import { users } from '../db/schema';
+import { memoOnce } from '../request-scope';
 import type { HonoConfig } from '../../types/hono';
 
 /**
@@ -28,8 +29,21 @@ const resolveOverridesFromDb: OverrideResolver = async (c) => {
     const userId = c.get('user')?.sub;
     const sdb = c.get('sdb');
     if (!userId || !sdb) return null;
-    // getById is tenant-scoped (users has a tenantId column) and fail-closed.
-    const row = await sdb.getById(users, userId);
+    // Memoised for the REQUEST, which is what keeps "fresh" true. The doc above
+    // requires reading the column per gated request because an admin can change
+    // overrides without the user re-logging-in; a request-scoped memo re-reads
+    // on the next request, so that invariant holds unchanged.
+    //
+    // What it removes is intra-render repetition. Measured 2026-09-07 by
+    // tests/workers/render-duplicate-reads.spec.ts: this exact statement ran
+    // THREE times in one render — /api/auth/me, /inspections/:id/hub and
+    // /api/services each call capabilitiesFor(), and a render fans out to all
+    // three under one scope. Keyed by user id, so an admin editing SOMEONE
+    // ELSE's overrides shares no entry with their own.
+    const tenantId = c.get('tenantId') ?? '-';
+    const row = await memoOnce(c.env, `caps-overrides:${tenantId}:${userId}`, async () =>
+        // getById is tenant-scoped (users has a tenantId column) and fail-closed.
+        await sdb.getById(users, userId));
     // permission_overrides is drizzle { mode: 'json' } → may be an object,
     // a string, or null. coerceOverrides handles all three and whitelists
     // to the four boolean capability keys.

--- a/server/portal/integration.module.ts
+++ b/server/portal/integration.module.ts
@@ -66,38 +66,8 @@ export async function drainPortalOutbox(env: PortalDrainEnv): Promise<void> {
     await flushOutboxOnce(env.DB, env.SYNC_QUEUE, 50);
 }
 
-/**
- * DLQ writeback core. Processes one batch of dead messages from
- * `inspectorhub-sync-dlq-saas`: each message body is a SyncEnvelope that
- * exhausted the portal consumer's retries. For each, mark the originating
- * outbox row `failed` (the durable failure record surfaced by the console),
- * then ack the message. Tolerant: a malformed body is logged and acked (never
- * recycled — there is nothing to retry on a dead message). Never throws the
- * batch. Exported standalone so unit tests can drive it without a worker.
- */
-export async function handleSyncDlqBatch(
-    db: D1Database,
-    batch: MessageBatch<unknown>,
-): Promise<void> {
-    const svc = new OutboxService(db);
-    for (const msg of batch.messages) {
-        try {
-            const body = msg.body as Partial<SyncEnvelope> | undefined;
-            const id = body && typeof body.id === 'string' ? body.id : undefined;
-            if (id) {
-                await svc.markFailedFromDlq(id, 'dlq: retries exhausted');
-            } else {
-                logger.warn('[dlq] message without a parseable envelope id — acking', {
-                    messageId: msg.id,
-                });
-            }
-        } catch (err) {
-            logger.error('[dlq] writeback failed for message', { messageId: msg.id },
-                err instanceof Error ? err : undefined);
-        } finally {
-            // Always ack: a dead message has nothing left to retry. Re-driving
-            // happens via the outbox row (sync-redrive), not the DLQ.
-            msg.ack();
-        }
-    }
-}
+// The DLQ writeback core moved to `./sync-dlq`, and is re-exported here so
+// every existing import site (server/index.ts and two test files) is unchanged.
+// The move is what keeps it reachable without this module's route imports —
+// see the note in sync-dlq.ts.
+export { handleSyncDlqBatch } from './sync-dlq';

--- a/server/portal/sync-dlq.ts
+++ b/server/portal/sync-dlq.ts
@@ -1,0 +1,47 @@
+import type { SyncEnvelope } from '../lib/sync-events/envelope';
+import { OutboxService } from './outbox.service';
+import { logger } from '../lib/logger';
+
+/**
+ * DLQ writeback core. Processes one batch of dead messages from
+ * `inspectorhub-sync-dlq-saas`: each message body is a SyncEnvelope that
+ * exhausted the portal consumer's retries. For each, mark the originating
+ * outbox row `failed` (the durable failure record surfaced by the console),
+ * then ack the message. Tolerant: a malformed body is logged and acked (never
+ * recycled — there is nothing to retry on a dead message). Never throws the
+ * batch. Exported standalone so unit tests can drive it without a worker.
+ *
+ * It lives in this module rather than in `integration.module.ts` — which
+ * re-exports it, so every existing import site is unchanged — for one reason:
+ * that module statically imports `integration.routes` and
+ * `statutory-admin.routes`, so reaching this function through it pulled two
+ * route modules and their Zod schemas into the queue consumer's import graph.
+ * The consumer needs `OutboxService` and a logger. Keeping the DLQ handler in
+ * a module with no route imports is what lets `server/queue.ts` stay small.
+ */
+export async function handleSyncDlqBatch(
+    db: D1Database,
+    batch: MessageBatch<unknown>,
+): Promise<void> {
+    const svc = new OutboxService(db);
+    for (const msg of batch.messages) {
+        try {
+            const body = msg.body as Partial<SyncEnvelope> | undefined;
+            const id = body && typeof body.id === 'string' ? body.id : undefined;
+            if (id) {
+                await svc.markFailedFromDlq(id, 'dlq: retries exhausted');
+            } else {
+                logger.warn('[dlq] message without a parseable envelope id — acking', {
+                    messageId: msg.id,
+                });
+            }
+        } catch (err) {
+            logger.error('[dlq] writeback failed for message', { messageId: msg.id },
+                err instanceof Error ? err : undefined);
+        } finally {
+            // Always ack: a dead message has nothing left to retry. Re-driving
+            // happens via the outbox row (sync-redrive), not the DLQ.
+            msg.ack();
+        }
+    }
+}

--- a/server/queue.ts
+++ b/server/queue.ts
@@ -1,0 +1,60 @@
+import type { HonoConfig } from './types/hono';
+import type { ImagesBinding } from './lib/media/strip-exif';
+
+/**
+ * The queue entry point, for all four consumers this worker owns.
+ *
+ * Split out of `server/index.ts` for the same reason `scheduled.ts` was: the
+ * default export lived in the module that builds the API, so reaching a queue
+ * handler meant evaluating every route and every Zod schema first. The
+ * dispatcher itself needs none of that — it reads `batch.queue` and hands off.
+ *
+ * ⚠️ The saving here is NOT the same as the cron split's, and the cron split's
+ * own production result was NULL. Measured 2026-09-07: removing this import
+ * from the scheduled handler cut a COLD isolate from 273 ms to 59 ms locally,
+ * and changed production not at all (10.48 ms/tick before, 10.86 ms after)
+ * because production cron ticks land on isolates other traffic already warmed.
+ * A queue consumer is invoked the same way. So treat this as removing a cold-
+ * start cost that is paid rarely, not as a per-invocation win — and measure a
+ * WARM isolate before claiming otherwise.
+ *
+ * Every branch keeps its dynamic import, so a word-export batch still does not
+ * load the cmd consumer. Never throws.
+ */
+export async function queue(
+    batch: MessageBatch<unknown>,
+    env: HonoConfig['Bindings'],
+    _ctx: ExecutionContext,
+): Promise<void> {
+    if (batch.queue.includes('word-export')) {
+        const { handleWordExportBatch } = await import('./services/report-export-consumer');
+        const images = (env as unknown as { IMAGES?: ImagesBinding }).IMAGES;
+        await handleWordExportBatch({
+            DB: env.DB, PHOTOS: env.PHOTOS, TENANT_CACHE: env.TENANT_CACHE,
+            KEY_ENCRYPTION_SECRET: env.KEY_ENCRYPTION_SECRET, JWT_SECRET: env.JWT_SECRET,
+            ...(images ? { IMAGES: images } : {}),
+        }, batch);
+        return;
+    }
+    // The cron queue. One message = one job = one Worker invocation with its
+    // own CPU budget; that split is what keeps the scheduled path inside the
+    // Workers Free 10 ms per-invocation ceiling.
+    if (batch.queue.includes('-cron')) {
+        const { handleCronBatch } = await import('./cron/consumer');
+        await handleCronBatch(env as never, batch as never);
+        return;
+    }
+    if (batch.queue.includes('-cmd-') && !batch.queue.includes('cmd-dlq')) {
+        const { handleCmdBatch } = await import('./portal/cmd-batch');
+        // SYNC_QUEUE carries replies (A-21 batch 2); PHOTOS/EXPORTS serve
+        // offboarding (batch 3) and the DOs let purge empty them; the last
+        // argument is the secret a report amendment is signed with (cmd-batch.ts).
+        await handleCmdBatch(env.DB, env.TENANT_CACHE, batch, env.SYNC_QUEUE, { photos: env.PHOTOS, exports: env.EXPORTS_BUCKET }, { INSPECTION_DOC: env.INSPECTION_DOC, TENANT_PRESENCE: env.TENANT_PRESENCE }, env, env.KEY_ENCRYPTION_SECRET || env.JWT_SECRET);
+        return;
+    }
+    // Imported dynamically, and from `./portal/sync-dlq` rather than from
+    // `integration.module` — that module statically imports two route modules,
+    // which would put the whole point of this file back.
+    const { handleSyncDlqBatch } = await import('./portal/sync-dlq');
+    await handleSyncDlqBatch(env.DB, batch);
+}

--- a/tests/unit/sync/portal-isolation.spec.ts
+++ b/tests/unit/sync/portal-isolation.spec.ts
@@ -109,7 +109,7 @@ describe('SaaS-Portal isolation', () => {
     expect(stray, `raw integration.routes/outbox imports outside server/portal/: ${stray.join(', ')}`).toEqual([]);
   });
 
-  it('no concrete server/portal/ import outside the three composition points', () => {
+  it('no concrete server/portal/ import outside the composition points', () => {
     // Stricter than the route/outbox gate: catches ANY import from server/portal/*
     // (service-binding-guard, portal.provider, etc.). The three composition points
     // are the only allowed importers; everything else uses the seams/abstractions.
@@ -123,6 +123,13 @@ describe('SaaS-Portal isolation', () => {
       // rather than kept alongside.
       'server/cron/jobs/integrations.ts',
       'server/lib/middleware/di.ts',
+      // Same move as `scheduled.ts` above, in the other direction: the queue
+      // dispatcher left `server/index.ts` so the entry could reach it without
+      // evaluating every route, and the portal imports it already owned
+      // (cmd-batch, sync-dlq) travelled with it. The queue composition point
+      // moved address; it was not created here. `server/index.ts` stays on this
+      // list because it still imports portal for `registerPortalIntegration`.
+      'server/queue.ts',
     ];
     const stray = hits.filter(
       f => !f.startsWith('server/portal/') && !ALLOWED_IMPORTERS.includes(f),

--- a/tests/workers/render-duplicate-reads.spec.ts
+++ b/tests/workers/render-duplicate-reads.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * What the page render actually asks the database, twice.
+ *
+ * A render fans out into ~13 in-process API calls sharing one request scope.
+ * Statements they repeat cost D1 quota and CPU but NOT round trips — they are
+ * already inside `Promise.all` waves — so this is a spec that REPORTS, and
+ * ratchets only the number it can defend.
+ *
+ * ⚠️ Why it has to be authenticated, and why an unauthenticated probe is worse
+ * than no probe: a request without a valid token 401s in the middleware chain,
+ * before a single handler runs. A first attempt at this measured 9 statements
+ * and 0 duplicates and looked like a clean bill of health. It had measured the
+ * auth wall. `middleware-d1-floor.spec.ts` is unauthenticated ON PURPOSE for the
+ * opposite reason — a 401 pays the full middleware floor, which is all it counts.
+ */
+import { env as testEnv } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import app from '../../server/index';
+import { createRequestScope, REQUEST_SCOPE } from '../../server/lib/request-scope';
+import { buildKeyring, signJwt } from '../../server/lib/jwt-keyring';
+import { applyMigrations as replayMigrations } from './migration-replay';
+
+const migrationSql = import.meta.glob('../../migrations/*.sql', {
+    query: '?raw', import: 'default', eager: true,
+}) as Record<string, string>;
+
+/**
+ * Statements this render issues MORE THAN ONCE, counted as the excess (a
+ * statement run 3× wastes 2). Measured, not chosen: 6 before
+ * `resolveOverridesFromDb` was memoised, 3 after (41 statements, 38 distinct).
+ *
+ * Lower it in the same commit that removes one. All three that remain belong to
+ * the hub aggregate, and none is the same job:
+ *   - full `inspections` row ×2 and `inspection_people.contact_id` ⋈ ×2 — both
+ *     INSIDE /hub, so the fix is passing one result down, the way
+ *     `computePublishReadiness` now takes its caller's row.
+ *   - people ⋈ contacts ⋈ role_profiles ×2 — /hub and /people genuinely both
+ *     need it; deduping means one of them serving the other.
+ *
+ * Two things this count is NOT, both learned by getting them wrong first:
+ *   - `tenants.slug` ×2 appears WITHOUT the warm-up below and vanishes with it,
+ *     because `inspectorPaletteMiddleware` resolves it KV-first and the warm-up
+ *     populates that entry. It was never a second D1 reader. Memoising
+ *     `resolveTenantSlug` moved this number by exactly zero, which is why that
+ *     memo was reverted instead of kept on a hunch.
+ *   - It is not a CPU emergency. These cost D1 quota and CPU but ZERO round
+ *     trips — they already sit inside `Promise.all` waves — and production was
+ *     measured 2026-09-07 at one `exceededCpu` per ~2000 invocations.
+ */
+const WASTED_BASELINE = 3;
+
+const TENANT = 'dupe-tenant';
+const USER = 'dupe-user';
+const INSPECTION = 'dupe-inspection';
+
+/** Records the SQL text of every prepared statement. Proxy rather than a spread
+ *  copy: D1Database carries `prepare` on the prototype. */
+function capture(db: D1Database, onStatement: (sql: string) => void): D1Database {
+    const wrapStmt = (stmt: D1PreparedStatement): D1PreparedStatement =>
+        new Proxy(stmt, {
+            get(t, p, r) {
+                const v = Reflect.get(t, p, r);
+                if (typeof v !== 'function') return v;
+                return (...args: unknown[]) => {
+                    const out = (v as (...a: unknown[]) => unknown).apply(t, args);
+                    return out && typeof out === 'object' && 'bind' in (out as object)
+                        ? wrapStmt(out as D1PreparedStatement)
+                        : out;
+                };
+            },
+        });
+    return new Proxy(db, {
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, receiver);
+            if (prop === 'prepare' && typeof value === 'function') {
+                return (sql: string) => {
+                    onStatement(sql);
+                    return wrapStmt((value as (s: string) => D1PreparedStatement).call(target, sql));
+                };
+            }
+            if (prop === 'batch' && typeof value === 'function') {
+                return (statements: unknown[]) => {
+                    for (const _ of statements) onStatement('<batch>');
+                    return (value as (s: unknown[]) => unknown).call(target, statements);
+                };
+            }
+            return typeof value === 'function' ? (value as () => unknown).bind(target) : value;
+        },
+    }) as D1Database;
+}
+
+const normalise = (sql: string) => sql.replace(/\s+/g, ' ').replace(/\?\d*/g, '?').trim();
+
+const b = testEnv as unknown as { DB: D1Database };
+
+describe('what one render asks the database twice', () => {
+    let token: string;
+
+    beforeAll(async () => {
+        await replayMigrations(b.DB, migrationSql);
+        const keyring = await buildKeyring(testEnv as never);
+        token = await signJwt(
+            { sub: USER, 'custom:tenantId': TENANT, 'custom:userRole': 'owner', role: 'owner' },
+            keyring,
+        );
+        // Columns read off the Drizzle schema, not guessed: `tenants` has no
+        // `name` at all, and `created_at` is notNull with no default.
+        const now = Date.now();
+        await b.DB.prepare("INSERT OR IGNORE INTO tenants (id, slug, created_at) VALUES (?, ?, ?)")
+            .bind(TENANT, 'dupe-tenant', now).run();
+        await b.DB.prepare(
+            "INSERT OR IGNORE INTO users (id, tenant_id, email, password_hash, name, role, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ).bind(USER, TENANT, 'dupe@example.com', 'x', 'Dupe User', 'owner', now).run();
+        await b.DB.prepare(
+            "INSERT OR IGNORE INTO inspections (id, tenant_id, property_address, date, status, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ).bind(INSPECTION, TENANT, '1 Test St', '2026-09-07', 'scheduled', now).run();
+        // No tenant_configs row is seeded on purpose. One was added here while
+        // chasing a 500, written as `INSERT ... (id, tenant_id)` with a
+        // `.catch()` — and `tenant_configs` has no `id` column, so it threw
+        // every run and the catch swallowed it. It never inserted anything, and
+        // the endpoints answer 200 without it. `lint:seed-sql` is what caught
+        // the dead statement; the 500 was positional and the warm-up fixed it.
+    });
+
+    it('reports every statement issued more than once under one scope', async () => {
+        const seen: string[] = [];
+        const scopedEnv = {
+            ...testEnv,
+            DB: capture(b.DB, (s) => seen.push(s)),
+            [REQUEST_SCOPE]: createRequestScope(),
+        } as unknown as Record<string, unknown>;
+
+        // The endpoint set the inspector-portal loader fans out to.
+        const paths = [
+            '/api/auth/me',
+            `/api/inspections/${INSPECTION}/hub`,
+            `/api/inspections/${INSPECTION}/people`,
+            `/api/inspections/${INSPECTION}/versions`,
+            '/api/role-profiles',
+            '/api/team/members',
+            '/api/services',
+            '/api/session/context',
+        ];
+        // Warm-up, deliberately OUTSIDE the capture and outside the scope.
+        // Whichever endpoint runs first in a fresh fixture 500s — proven by
+        // moving /api/auth/me from first to last, which moved the 500 onto
+        // /hub instead. It is positional, not an endpoint defect. A 5xx stops
+        // issuing statements partway, so without this the first endpoint's
+        // reads go uncounted and every duplicate total is an undercount.
+        await Promise.resolve(app.fetch(
+            new Request('http://x/api/auth/me', { headers: { Authorization: `Bearer ${token}` } }),
+            { ...testEnv, [REQUEST_SCOPE]: createRequestScope() } as never,
+        )).catch(() => null);
+
+        // Sequential, sharing ONE scope. A render fans these out in parallel,
+        // but parallel makes statements unattributable — and the memo scope is
+        // what decides duplication, not the ordering, so the counts hold either
+        // way while this ordering also says WHICH endpoint issued what.
+        const statuses: (number | string)[] = [];
+        const bodies: string[] = [];
+        const owner = new Map<string, Set<string>>();
+        for (const p of paths) {
+            const before = seen.length;
+            const r = await Promise.resolve(app.fetch(
+                new Request(`http://x${p}`, { headers: { Authorization: `Bearer ${token}` } }),
+                scopedEnv as never,
+            )).catch(() => null);
+            statuses.push(r?.status ?? 'threw');
+            if (r && r.status >= 500) {
+                bodies.push(`${p} -> ${(await r.text()).slice(0, 300)}`);
+            }
+            for (const sql of seen.slice(before)) {
+                const k = normalise(sql);
+                if (!owner.has(k)) owner.set(k, new Set());
+                owner.get(k)!.add(p);
+            }
+        }
+        const authWalled = statuses.filter((s) => s === 401 || s === 403).length;
+
+        const counts = new Map<string, number>();
+        for (const s of seen) {
+            const k = normalise(s);
+            counts.set(k, (counts.get(k) ?? 0) + 1);
+        }
+        const dupes = [...counts.entries()].filter(([, n]) => n > 1).sort((a, x) => x[1] - a[1]);
+        const repeated = dupes.reduce((acc, [, n]) => acc + (n - 1), 0);
+
+        // The workerd pool does not forward console.log, so the report travels
+        // in the assertion message — the one channel that always surfaces.
+        const report = [
+            `statuses=${statuses.join(',')} authWalled=${authWalled}`,
+            ...bodies,
+            `total=${seen.length} distinct=${counts.size} dupeGroups=${dupes.length} wastedStatements=${repeated}`,
+            ...dupes.slice(0, 20).map(([sql, n]) => `x${n} [${[...(owner.get(sql) ?? [])].join(' + ')}] :: ${sql.slice(0, 90)}`),
+        ].join(' ||| ');
+
+        // The instrument, asserted before anything it measures.
+        expect(seen.length, 'no statements captured — the capture proxy is broken, not the code')
+            .toBeGreaterThan(0);
+        // The failure mode that made the first attempt useless: if every call is
+        // auth-walled, the handlers never ran and a low duplicate count is a lie.
+        expect(authWalled, `every call was auth-walled (statuses ${statuses.join(',')}) — this measures the middleware, not the render`)
+            .toBeLessThan(paths.length);
+
+        // A 5xx endpoint stops issuing statements partway, so it makes the
+        // duplicate count an UNDERCOUNT and the baseline below meaningless.
+        // Assert the render's endpoints actually answered.
+        const failed = statuses.filter((s) => typeof s === 'number' && s >= 500);
+        expect(failed.length, `an endpoint 5xx'd, so the counts below are an undercount. ${report}`)
+            .toBe(0);
+
+        expect(repeated, `wasted statements grew past the baseline. ${report}`)
+            .toBeLessThanOrEqual(WASTED_BASELINE);
+    });
+});

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -250,9 +250,19 @@ export default {
     const { scheduled: runScheduled } = await import("../server/scheduled");
     return runScheduled(controller, env, ctx);
   },
+  // Imported DIRECTLY, like `scheduled` above and for the same reason: the
+  // dispatcher reads `batch.queue` and hands off, so it never needed the route
+  // graph that living in server/index.ts forced it to evaluate.
+  //
+  // ⚠️ Do not repeat the cron claim here without measuring. That split cut a
+  // cold isolate 273ms -> 59ms locally and moved production NOT AT ALL, because
+  // production invocations land on already-warm isolates. This is the same
+  // shape, so the honest expectation is "cheaper cold start, unchanged warm".
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  queue: async (batch: any, env: any, ctx: any) =>
-    (await getApi()).default.queue(batch, env, ctx),
+  queue: async (batch: any, env: any, ctx: any) => {
+    const { queue: runQueue } = await import("../server/queue");
+    return runQueue(batch, env, ctx);
+  },
 };
 
 // Re-export Durable Objects + Workflow so wrangler can bind them on the single


### PR DESCRIPTION
Two changes, and the second one is mostly a measuring instrument.

## 1. The queue consumer no longer imports the API graph

The dispatcher reads `batch.queue` and hands off to one of four handlers, each
behind its own dynamic import. It needed none of the route graph — it just lived
in `server/index.ts`, where the default export lives, so reaching it evaluated
all 426 routes and every Zod schema first. It is now `server/queue.ts`, imported
directly by `workers/app.ts`.

Moving the dispatcher alone would have achieved **nothing**: it called
`handleSyncDlqBatch`, which lived in `portal/integration.module.ts` — a module
that statically imports `integration.routes` and `statutory-admin.routes`. That
dragged two route modules straight back in. The handler now lives in
`server/portal/sync-dlq.ts` (it needs `OutboxService` and a logger, nothing
else), and `integration.module` re-exports it so `server/index.ts` and both test
files that import it are untouched.

### ⚠️ This may deliver nothing in production, and that is a measured claim

The analogous cron split measured **273ms → 59ms on a cold isolate locally and
changed production by nothing**: 10.48 ms/tick before, 10.86 ms after, over ~40
minutes post-deploy. Production invocations land on isolates other traffic has
already warmed, so the import was already amortised there. A queue consumer is
invoked the same way.

The honest expectation is a cheaper cold start that is paid rarely — not a
per-invocation win. Both the new module and the entry say so in comments, so the
claim is not repeated without measuring. The test is a **warm** A/B after deploy.

## 2. One user-overrides read per request, and a gate that counts the rest

`resolveOverridesFromDb` read the acting user's full `users` row on every gated
request. A render fans out into ~13 in-process calls under one request scope, and
three of them — `/api/auth/me`, `/inspections/:id/hub`, `/api/services` — each
call `capabilitiesFor()`. The identical statement ran three times.

Memoised on the **request** scope, which is what keeps that function's own
contract true: its doc requires a fresh read per gated request because an admin
can change overrides without the user re-logging-in, and a request-scoped memo
re-reads on the next request. Keyed by user id, so an admin editing someone
else's overrides shares no entry with their own.

**Measured: 6 wasted statements → 3** (41 total, 38 distinct).

`tests/workers/render-duplicate-reads.spec.ts` fires the render's endpoint set
under one scope and ratchets the excess. Proven red at 2 before landing at 3.

### It has to be authenticated, and the first attempt proves why

An unauthenticated probe 401s in the middleware before any handler runs. The
first version reported **9 statements and 0 duplicates** and read like a clean
bill of health. It had measured the auth wall. The spec now asserts
`authWalled < paths.length` and that no endpoint 5xx'd — a 5xx stops issuing
statements partway and silently undercounts.

### Four things measurement corrected that would otherwise have shipped

- A memo on `resolveTenantSlug` moved the number by **exactly zero** — those
  `tenants.slug` reads do not go through it. Reverted rather than kept on a hunch.
- `tenants.slug` ×2 was never a duplicate: it appears only without the warm-up,
  because `inspectorPaletteMiddleware` resolves it KV-first.
- Whichever endpoint runs **first** in a fresh fixture 500s. Proven positional by
  moving `/api/auth/me` from first to last, which moved the 500 onto `/hub`. It
  was truncating the first endpoint's statements.
- `lint:seed-sql` caught a dead seed I wrote: `INSERT INTO tenant_configs (id,
  tenant_id)` — that table has no `id` column — wrapped in `.catch()`, so it threw
  every run, inserted nothing, and said nothing.

## What is deliberately left

The three remaining duplicates are all inside the `/hub` aggregate, recorded in
the spec header with what each would take. They cost D1 quota and CPU but **zero
round trips** — they already sit inside `Promise.all` waves — and production
measured **one `exceededCpu` per ~2000 invocations**. That context is in the
header so the next person can weigh the risk rather than assume urgency.

## Verified

type-check clean · eslint 0 errors · 76/76 gates · `test:unit` 1043 files / 8902
tests · `test:web` 426 / 3113 · `test:workers` 36 / 181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYKeSqU9GicoW7ZJ174gFq
