### PR TITLE
Fix what the docs claim against what the code does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ The open-source inspection engine. A single Cloudflare Worker (the
 cloudflare/react-router-hono-fullstack-template shape): a Hono entry that mounts the full
 API in-process and delegates page routes to React Router v8 SSR.
 
-**Docs**: `docs/README.md` is the map — `docs/operate/` (deploy, upgrade, configure) · `docs/develop/` (architecture, testing, design system) · `docs/reference/` (API, database, roles, deployment modes) · `docs/concepts/` (how the engine works) · `docs/integrations/` (external services) · `docs/compliance/` (data handling). Docs here cover the **engine**: deploying it, operating it, changing it, integrating it. Using the product day to day is documented at <https://inspectorhub.io/docs>, which serves self-hosted and hosted deployments alike.
+**Docs**: `docs/README.md` is the map — `docs/operate/` (deploy, upgrade, JWT-keyring rotation, SMS compliance) · `docs/develop/` (architecture, testing, design system) · `docs/reference/` (API, database, roles, deployment modes) · `docs/concepts/` (how the engine works) · `docs/integrations/` (external services) · `docs/compliance/` (data handling). Docs here cover the **engine**: deploying it, operating it, changing it, integrating it. Using the product day to day is documented at <https://inspectorhub.io/docs>, which serves self-hosted and hosted deployments alike.
 
 ## Commands
 
@@ -28,7 +28,8 @@ npm run dev:tunnel   # Like `dev`, but also exposed over a Cloudflare Quick Tunn
 npm run build        # react-router build — bundles server/ (API) + app/ (RR SSR) into one worker
 npm run deploy       # standalone: build + wrangler deploy (real ids via wrangler.local.jsonc)
 npm run deploy:saas  # saas: build + wrangler deploy with wrangler.saas.jsonc
-npm run type-check   # react-router typegen, then app + api tsc passes serially (lower peak RAM)
+npm run type-check   # i18n:compile + react-router typegen, then FOUR tsc passes serially
+                     # (app, api, e2e, tests) — serial to keep peak RAM down
 npm run type-check:app   # `tsc -b tsconfig.json` — the app/worker program
 npm run type-check:api   # `tsc -b tsconfig.api.json` — the server program; fastest loop for server/ work
 
@@ -65,7 +66,7 @@ One file per deploy target; the build bakes whichever config wins (vite `configP
 |---|---|---|
 | `wrangler.jsonc` | committed (PLACEHOLDER ids) | standalone + the **Deploy to Cloudflare** one-click default — CF auto-provisions D1/KV/R2 and injects real ids (no real ids in the repo). |
 | `wrangler.local.jsonc` | gitignored | your real standalone ids (written by `scripts/setup-cloudflare.js`). |
-| `wrangler.saas.jsonc` | gitignored | SaaS-mode config (`APP_MODE=saas`, `SYNC_QUEUE` producer + sync-DLQ consumer, crons, `*-saas` resources). Multi-tenant; absent in standalone. |
+| `wrangler.saas.jsonc` | gitignored | SaaS-mode config (`APP_MODE=saas`, `*-saas` resources, the same three crons). Carries three queue producers — `SYNC_QUEUE`, `WORD_EXPORT_QUEUE`, `CRON_QUEUE` — plus the sync-DLQ and cmd consumers, `OAUTH_KV`, the shared `EXPORTS_BUCKET`, and a `RATE_LIMITER` unsafe binding. Multi-tenant; absent in standalone. |
 
 `wrangler deploy` runs against the built `build/server/wrangler.json`. `scripts/wrangler.mjs`
 applies the same config resolution to direct wrangler commands (db:migrate).
@@ -89,7 +90,7 @@ Directory = suite; a spec's location alone decides which config runs it
 | `tests/workers/` | `test:workers` (CI) | `vitest.workers.config.ts` |
 | `tests/contract/<party>/*.contract.spec.ts` | `test:contract` (CI) | `vitest.contract.config.ts` |
 | `tests/contract/<party>/*.live.spec.ts` | `test:contract:live` (pre-push when `server/services/qbo/` changed; needs a connected sandbox) | `vitest.contract.live.config.ts` |
-| `tests/e2e/` | `test:e2e` (+ integration/remote modes) | `playwright.config.ts` (local, seeds D1) / `.integration` / `.remote` |
+| `tests/e2e/` | `test:e2e` · `test:e2e:seeded` (+ integration/remote/docs-shots modes) | `playwright.config.ts` (local, seeds D1) / `.seeded` / `.integration` / `.remote`. `npm run lint:e2e-coverage` prints which config OWNS each spec — read it there. |
 | `tests/docs-shots/**/*.shots.ts` | `docs:shots` (NOT a test suite) | `playwright.docs-shots.config.ts` |
 
 Choosing a home for a new spec:
@@ -161,7 +162,7 @@ OpenInspection runs as ONE Cloudflare Worker (cloudflare/react-router-hono-fulls
 ### Standalone Engine (Single-Tenant)
 - Optimized for single-tenant deployments (Private Instances).
 - Resolves configuration via a fixed `SINGLE_TENANT_ID`.
-- Stable API surface designed to be extended by SaaS overlay branches (e.g., `saas` branch).
+- Stable API surface. The SaaS overlay is **not a branch** — it is `APP_MODE=saas` plus `server/portal/` in this same tree, read through `server/lib/deployment-profile.ts`. (This line named a `saas` branch; no such branch exists.)
 
 ### Inspection Engine
 - JSON-schema based inspection templates (`server/types/template-schema.ts`, single canonical v2 — see `server/lib/validations/template.schema.ts`).
@@ -176,10 +177,10 @@ OpenInspection runs as ONE Cloudflare Worker (cloudflare/react-router-hono-fulls
 - **Rendering**: Full SSR — RR v8 server renders on the edge, hydrates on the client.
 - **Styling**: Tailwind CSS v4 with Design System 0523 tokens (`app/styles/tailwind.css`). Tailwind is v4-only (via `@tailwindcss/vite`); no separate server-side CSS build.
 - **API calls**: `hono/client` with end-to-end type safety via `packages/api-types/`. RR v8 loader/action functions call the in-process API through the injected `API_WORKER` binding (`createApi(context)` in `app/lib/api-client.server.ts`) — no network hop.
-- **State management**: React hooks — `useInspection` (~900 LOC), `useFindings`, `useKeyboard`, `useCannedComments`, `useOfflineQueue`, `usePresence`, `useTheme`, `useUnsavedChanges`.
-- **Component library**: `packages/shared-ui/` provides 25 design-system components consumed by the frontend — Button, Pill, StatCard, Icon, Eyebrow, PageHeader, TabStrip, Input, Select, Textarea, Checkbox, Radio, RadioGroup, EmptyState, Skeleton, Card, Banner, Modal, Drawer, Popover, Pagination, FileDropzone, Table, SegmentedControl, Avatar. See `docs/develop/design-system.md`.
+- **State management**: React hooks in `app/hooks/` — `useInspection`, `useFindings`, `useKeyboard`, `useCannedComments`, `usePresence`, `useTheme`, `useUnsavedChanges`, plus the `findings/` and `inspection/` sub-hook directories. (`useOfflineQueue` was RETIRED with the rest of the bespoke offline layer in #181; do not reach for it.)
+- **Component library**: `packages/shared-ui/` — `src/index.ts` is the authoritative list (Button, IconButton, MenuItem, Pill, StatCard, Icon, Eyebrow, PageHeader, TabStrip, Input, Select, Textarea, Checkbox, Radio, RadioGroup, RadioCardGroup, EmptyState, Skeleton, Card, Banner, Modal, Drawer, Popover, Pagination, FileDropzone, Table, SegmentedControl, Avatar). Do not maintain a count here — read the file. See `docs/develop/design-system.md`.
 - **Dark mode**: `data-color-scheme` attribute on `<html>`, managed by `useTheme` hook (auto/light/dark).
-- **Offline**: Service Worker + `useOfflineQueue` hook for photo upload queue and field sync.
+- **Offline**: Service Worker for the app shell; FIELD DATA is offline-capable through the Yjs results document, which `y-indexeddb` buffers locally and merges on reconnect (`docs/concepts/collab-editing.md`). Photo and video BINARY upload writes to R2 and therefore needs a connection — offline the editor declines it rather than queueing.
 
 ## Environment Variables
 
@@ -188,14 +189,13 @@ OpenInspection runs as ONE Cloudflare Worker (cloudflare/react-router-hono-fulls
 | `JWT_CURRENT_KID` | Yes | Active JWT keypair version (e.g. `v1`). Names which `JWT_PRIVATE_KEY_V<N>`/`JWT_PUBLIC_KEY_V<N>` pair signs new tokens. |
 | `JWT_PRIVATE_KEY_V<N>` | Yes | PKCS8 PEM-encoded ES256 private key for version `vN`. At least V1 must be provisioned. |
 | `JWT_PUBLIC_KEY_V<N>` | Yes | SPKI PEM-encoded ES256 public key for version `vN`. Pairs with private key. Keep older versions in env during rotation so existing tokens stay valid. |
-| `JWT_SECRET` | Yes | KDF input for `config-crypto`, `qbo-crypto`, audit signing-key encryption, and M2M Bearer auth. **Not** used for JWT signing anymore — that moved to the ES256 keyring above. |
+| `JWT_SECRET` | Yes | KDF input, and only that: config/QBO secret crypto, audit signing-key encryption, and the several signed-URL and session HMACs (render tokens, portal sessions, video upload, unsubscribe, agent view, ICS links). **Never** used for JWT signing — that is the ES256 keyring above. It is also **not** the M2M credential: the portal→core `x-portal-m2m` HMAC key is HKDF-derived from `JWT_PRIVATE_KEY_V<N>` (`server/lib/m2m-auth.ts`), and there is no M2M Bearer token. |
 | `DB` | Yes | Cloudflare D1 Database binding |
 | `PHOTOS` | Yes | Cloudflare R2 Bucket for image storage |
 | `TENANT_CACHE`| Yes | Cloudflare KV for configuration caching |
-| `INSPECTION_DOC` | No | Durable Object binding (`class_name: InspectionDocDO`) for collaborative inspection editing (#181 — Yjs CRDT host; one DO per inspection, tenant-scoped `idFromName`). Declared in `wrangler.jsonc` (committed) and must be added to `wrangler.saas.jsonc` (gitignored) with the matching `v2` SQLite-class migration. When absent the collab routes return `501` and fail closed — editing falls back to a single-client Y.Doc with no realtime sync. See `docs/concepts/collab-editing.md`. |
-| `TURNSTILE_SECRET_KEY` | No | Server-side Turnstile verification — `POST /api/book` enforces this when set. Use test secret `1x0000000000000000000000000000000AA` for local dev. |
-| `APP_BASE_URL` | No | Public URL for OAuth and link generation |
-| `APP_BASE_URL` | No | Public origin used when building absolute links (reports, hosted `/legal/:tenant/…` Privacy & Terms). |
+| `INSPECTION_DOC` | No | Durable Object binding (`class_name: InspectionDocDO`) for collaborative inspection editing (#181 — Yjs CRDT host; one DO per inspection, tenant-scoped `idFromName`). Declared with its `v2` SQLite-class migration in `wrangler.jsonc` (committed) **and** in `wrangler.saas.jsonc` (gitignored) — both are wired; this line used to read as an outstanding task. When absent the collab routes return `501` and fail closed — editing falls back to a single-client Y.Doc with no realtime sync. See `docs/concepts/collab-editing.md`. |
+| `TURNSTILE_SECRET_KEY` | No | Server-side Turnstile verification on the two anonymous submit surfaces, `POST /api/public/book` and agent signup. Whether a challenge applies is the `botProtectionMandatory` capability, not whether this key is set: `saas` always enforces (falling back to Cloudflare's public test key), `standalone` challenges only when the key is present. Use test secret `1x0000000000000000000000000000000AA` for local dev. See `docs/integrations/turnstile.md`. |
+| `APP_BASE_URL` | No | Public origin used for OAuth redirect URIs and when building absolute links (reports, hosted `/legal/:tenant/…` Privacy & Terms). Must be the exact origin the deployment answers on — Intuit matches the QuickBooks redirect URI byte for byte. |
 | `RESEND_API_KEY`| No | Platform-default email delivery (Resend). Tenants may switch to their OWN Resend key + verified sender via Settings → Communication (per-tenant override; the email pipeline resolves own-vs-platform explicitly). |
 | `GEMINI_API_KEY`| No | The env name is legacy; it holds a workspace's own AI provider key whatever the provider is. Not the credential AI features run on by itself: `resolve-provider.ts` decides credentials, endpoint and model per call — a workspace's own stored key (Settings → Advanced → AI) always wins, and where `profile.hasManagedAi` holds, a deployment-provided key may serve workspaces granted managed access. Otherwise there is no managed path at all — the workspace's key or nothing. |
 | `AI_MODEL` | No | Model id every AI call uses, in the chosen backend's own naming. Through an AI gateway that is `{provider}/{model}`. **No default is compiled in**: when unset, AI features fail closed with a 503 rather than silently pinning whichever model was current when the code was written. Required for any AI feature to work, in every mode. A workspace may override it per company (Settings → Advanced → AI). |
@@ -212,7 +212,7 @@ OpenInspection runs as ONE Cloudflare Worker (cloudflare/react-router-hono-fulls
 | `STRIPE_SECRET_KEY` | No | Stripe Connect (each tenant's OWN account; the platform never collects payments). Resolution is tenant-DB-preferred: a tenant's stored key always beats this env, so a platform-level binding can never hijack tenant payments. |
 | `STRIPE_WEBHOOK_SECRET` | No | Stripe webhook HMAC verification |
 | `QBO_ENV` | No | Which Intuit host the QuickBooks Online integration calls: `sandbox` (`https://sandbox-quickbooks.api.intuit.com`) or `production` (`https://quickbooks.api.intuit.com`). **No default and no fallback** — when unset, every QuickBooks API call throws and `GET /api/integrations/qbo/callback` refuses to store a connection. That is deliberate: Intuit Development keys authenticate only against sandbox companies and Production keys only against real ones, so a guessed host is wrong for one of them and fails in a way that reads like a bad credential. Required (together with `QBO_CLIENT_ID` / `QBO_CLIENT_SECRET`, which may instead be set per tenant in Settings → Integrations) for any QuickBooks sync. The OAuth authorize, token, and revoke endpoints are shared by both environments and are not affected by this setting. |
-| `GOOGLE_PLACES_API_KEY` | No | Google Places API key powering address autocomplete on the dashboard new-inspection wizard and the public `/book` page (proxied via `/api/places/*` and `/public/geocode`). When unset, both endpoints return `{ data: [], reason: 'NO_API_KEY' }` and the address inputs degrade gracefully to plain text — the customer can still type a free-form address and submit. |
+| `GOOGLE_PLACES_API_KEY` | No | Google Places API key powering address autocomplete on the dashboard new-inspection wizard and the public `/book` page (proxied via `/api/places/*` and `/api/public/geocode`). When unset, both endpoints return `{ data: [], reason: 'NO_API_KEY' }` and the address inputs degrade gracefully to plain text — the customer can still type a free-form address and submit. |
 | `ESTATED_API_KEY` | No | Estated.io public-records key for the `POST /api/inspections/:id/property-facts/autofill` endpoint. Resolves year built / sqft / foundation / lot size / bedrooms / bathrooms by address. When unset, returns `{ data: null, reason: 'NO_API_KEY' }` and the Property Facts card shows a polite "auto-fill not configured" hint while still accepting manual entry. Same graceful-degrade pattern as `GOOGLE_PLACES_API_KEY`. |
 | `STREAM` | No | Cloudflare Stream binding (binding name `STREAM`). Required only when the video backend is set to Stream (self-host: Settings → Integrations → Video; SaaS: paid tier). Absent in the default R2 configuration. |
 | `STREAM_CUSTOMER_SUBDOMAIN` | No | Your Cloudflare Stream customer subdomain (e.g. `customer-abc123`, the prefix before `.cloudflarestream.com`). Required in SaaS mode for paid tenants (plan-gated; free/trial tenants use R2). In self-host mode this is stored per-tenant in `integrationConfig` via Settings → Integrations → Video, not as an env var. |
@@ -229,12 +229,12 @@ OpenInspection runs as ONE Cloudflare Worker (cloudflare/react-router-hono-fulls
 
 **Mandatory** for any code that touches authentication. Violations reintroduce critical vulnerabilities.
 
-- **ES256 keyring**: All JWT signing and verification MUST go through `server/lib/jwt-keyring.ts`. Direct `sign()` / `verify()` calls from `hono/jwt` are FORBIDDEN — the keyring pins the algorithm to ES256 (ECDSA P-256 SHA-256), stamps the `kid` header, and enforces multi-version verification. Per-request keyrings are pre-built in `diMiddleware` and exposed as `await c.var.keyringPromise`.
+- **ES256 keyring**: All JWT signing and verification MUST go through `server/lib/jwt-keyring.ts`. Direct `sign()` / `verify()` calls from `hono/jwt` are FORBIDDEN — the keyring pins the algorithm to ES256 (ECDSA P-256 SHA-256), stamps the `kid` header, and enforces multi-version verification. Per-request keyrings are pre-built in `contextBootstrap` (NOT `diMiddleware` — JWT auth needs the keyring before di runs) and exposed as `await c.var.keyringPromise`.
 - **kid required**: Every JWT MUST carry a `kid` header. `signJwt()` sets it from `JWT_CURRENT_KID`; `verifyJwt()` rejects tokens with no kid, or with a kid not in the keyring.
 - **iat claim**: `signJwt()` auto-injects `iat: Math.floor(Date.now() / 1000)` when the caller omits it. Without `iat`, KV session invalidation (`pwchanged:{userId}`) cannot work.
-- **No HS256 fallback**: There is NO legacy HS256 path. Pre-launch architectural choice — see rotation scripts and docs. The remaining `JWT_SECRET` env binding is now used only as KDF input for `config-crypto`, `qbo-crypto`, and audit signing-key encryption — never for JWT signing.
+- **No HS256 fallback**: There is NO legacy HS256 path. Pre-launch architectural choice — see rotation scripts and docs. The remaining `JWT_SECRET` env binding is KDF input only, never a JWT signing key. State it that way rather than listing its consumers: there are dozens of files reading it (secret crypto, signed-URL and session HMACs, token derivation), and every enumeration written here has gone stale.
 - **Key rotation flow**: To rotate, provision `JWT_PRIVATE_KEY_V<N+1>` + `JWT_PUBLIC_KEY_V<N+1>` first (verify-only window), then flip `JWT_CURRENT_KID` to the new version. Old tokens remain verifiable until V<N> is retired.
-- **Token NOT in response body**: Login, setup, and join endpoints MUST NOT return the JWT in the JSON response. Tokens are delivered exclusively via `Set-Cookie` (HttpOnly).
+- **Token NOT in response body — one carved-out exception.** Login, setup and join MUST NOT return the JWT to a browser; delivery is `Set-Cookie` (HttpOnly). The exception is the in-process BFF, which identifies itself with `x-token-relay: 1` and then receives `token` in the body, because Workers `fetch()` may strip `Set-Cookie` on a server-to-server hop and the BFF has to write its own session cookie. A browser never sends that header. Do not add a second exception without one here.
 - **Cookie name**: Always use `__Host-inspector_token` (enforces `Secure`, `Path=/`, no `Domain`).
 - **setCookie attributes**: Every `setCookie()` MUST include `httpOnly: true, secure: true, sameSite: 'Strict', path: '/'`.
 - **deleteCookie secure**: Every `deleteCookie()` MUST include `{ path: '/', secure: true }`. Omitting `secure` on `__Host-` cookies throws a runtime exception.
@@ -289,11 +289,11 @@ DB design policies (2026-06-04 DBA review). These apply to ALL new tables/column
 
 ## Quality gates
 
-Pre-commit and CI run the same logical checks; CI's `verify` job is the authoritative gate (wire it up as a required status check). The pre-commit hook is a fast local guard — bypass only with `--no-verify` (discouraged). Mechanism, steps, and Node version are aligned across the superproject and the portal/cms submodules.
+CI is a strict superset of pre-commit, not the same set: the hook runs the `precommit` rung of the gate registry and a tiered tsc, while CI runs every gate at both rungs plus the type-aware eslint pass, the full type-check and every suite. `verify` is the authoritative gate (wire it up as a required status check). The pre-commit hook is a fast local guard — bypass only with `--no-verify` (discouraged). Mechanism, steps, and Node version are aligned across the superproject and the portal/cms submodules.
 
 - **Hook mechanism**: `.githooks/pre-commit`, activated by the `prepare` npm script (`git config core.hooksPath .githooks`) on `npm install`/`npm ci` — native git hooks, **no husky**.
-- **Pre-commit** (`.githooks/pre-commit`): tiered type-check (scoped to staged files — skip / api-only / full) → `lint-staged` (eslint --fix) → DS-token conformance (`lint:ds`) → small-text contrast (`lint:contrast`) → migration-ref hygiene (`lint:migrefs`) → Worker bundle-size (gated to bundle-affecting changes). Docs/tests-only commits skip the heavy steps.
-- **CI** (`.github/workflows/ci.yml`, Node 22): `npm ci` → `gen-version` → `type-check` → `npm run lint` (eslint + `lint:ds` + `lint:contrast` + `lint:erasure` + `lint:migrefs`) → `db:check` (migration drift) → `test:unit` → `test:workers` → `test:web` → `build` → bundle-size gate. CodeQL runs separately (`codeql.yml`).
+- **Pre-commit** (`.githooks/pre-commit`): tiered type-check (scoped to staged files — skip / api-only / full) → `lint-staged` (eslint --fix, `ESLINT_FAST=1`) → every gate declared at the `precommit` rung in `scripts/lib/gate-registry.mjs`, run in ONE node process by `scripts/run-gates.mjs`. That is two dozen gates, not the three this line used to name; the registry is the list and must not be copied here. Commits with no staged `.ts`/`.tsx` skip the type-check entirely. The Worker bundle-size gate is NOT here — it lives in `.githooks/pre-push`.
+- **CI** (`.github/workflows/ci.yml`, Node 22): nine parallel jobs — `typecheck-app`, `lint-eslint`, `lint-gates` (+ `db:check`), `test-unit` (4 shards), `test-contract`, `test-workers`, `test-web` (4 shards), `build` (+ bundle size), and `e2e` (a 2-way matrix). `verify` does no work of its own: it is the aggregate job branch protection keys off, and it waits on all nine including `e2e`. CodeQL runs separately (`codeql.yml`). Details: `docs/develop/testing.md`.
 
 ## Comment Rules
 
@@ -302,7 +302,7 @@ Migration sequence numbers are an unstable, positional ordering token — squash
 - **No migration sequence numbers in code comments** (`migration 0045`, `0052_inspector_slug.sql`, `pre-migration 0040`, …). The only allowed reference is `0000_baseline.sql` — it never renumbers. Enforced by `npm run lint:migrefs` (`scripts/check-migration-refs.mjs`); also runs in `npm run lint` and pre-commit.
 - **State the invariant, not the history.** Put *why a column/index exists* next to its definition in `server/lib/db/schema/` (it travels with the field and survives any renumber). "the `lot_size` column on `inspections`" beats "the `lot_size` column added in migration 0045". History lives in `git blame`.
 - **For traceability, cite a stable id** — PR# / issue# (`see #144`) or a feature name — never a migration number. These never renumber and link to full context.
-- **"Must stay in sync with X" coupling → make it executable, not prose.** A comment that says "must match the inline DDL / the backfill list" is a latent bug; people forget. Prefer a shared constant both sides import, or a test that asserts the equality. Example: `tests/unit/inline-ddl-schema-sync.spec.ts` asserts the workers specs' hand-maintained `tenant_configs` DDL covers every Drizzle schema column — replacing the old "remember to sync this DDL" comment that blocked #164.
+- **"Must stay in sync with X" coupling → make it executable, not prose.** A comment that says "must match the inline DDL / the backfill list" is a latent bug; people forget. Prefer a shared constant both sides import, or a test that asserts the equality. Example: `tests/unit/platform/inline-ddl-schema-sync.spec.ts` asserts the workers specs' hand-maintained `tenant_configs` DDL covers every Drizzle schema column — replacing the old "remember to sync this DDL" comment that blocked #164.
 
 ## Cross-Portal Reuse
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ These are summarized from `CLAUDE.md` — read that file for the canonical, exha
 
 - **Language**: TypeScript with strict mode. All source code, comments, docs, commit messages, and user-facing strings in **English only**.
 - **Validation**: Every API endpoint uses Zod. Schemas live in `server/lib/validations/*.schema.ts`. No manual `if (!field)` checks.
-- **Auth**: HS256 JWT in HttpOnly cookie, PBKDF2 password hashing. Never use a fallback secret. Read `CLAUDE.md` § JWT & Auth Security Rules.
+- **Auth**: **ES256** JWT (a versioned keyring, `kid` in the header) in an HttpOnly `__Host-` cookie, PBKDF2-SHA256 password hashing. `JWT_SECRET` is KDF input only and never signs a JWT. Never use a fallback secret. Read `CLAUDE.md` § JWT & Auth Security Rules and [`docs/operate/rotate-jwt-keyring.md`](docs/operate/rotate-jwt-keyring.md).
 - **Multi-tenant**: Every D1 table includes `tenant_id`. Use `c.var.services.xxx` (DI proxy) — services auto-scope to the tenant.
 - **Logging**: Server-side code uses `import { logger } from '../lib/logger'`. Browser-side `console.*` is fine.
 - **CSS**: Tailwind v4 utilities + the Design System 0523 token layer defined in `app/styles/tailwind.css` (`bg-ih-*`, `text-ih-*`, `shadow-ih-*`). No raw palette classes (`bg-slate-200`, `shadow-lg`, ...) — enforced by `npm run lint:ds`. Full reference: [`docs/develop/design-system.md`](docs/develop/design-system.md).
@@ -76,7 +76,7 @@ OpenInspection follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.
 - Performance improvements with before/after benchmarks
 - Accessibility fixes with reproduction case
 - New seed templates (open-source license, ≥ 8 sections)
-- Translation contributions to public-facing strings (welcomed once i18n lands)
+- Translation contributions to public-facing strings — i18n has landed (paraglide, `messages/`); read [`docs/develop/conventions/i18n-glossary.md`](docs/develop/conventions/i18n-glossary.md) first, because term choices are fixed there and gated
 - Integration scaffolds (Zapier, QuickBooks, Make.com, etc.)
 
 ## What gets pushed back

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ OpenInspection is [open source home inspection software](https://inspectorhub.io
 - One deployable; React Router loaders/actions call the API directly through an in-process `API_WORKER` self-binding (no network hop, no second worker)
 
 ### Inspector workflow
-- 3-pane editor; a new workspace starts with 250+ canned comments, 80 repair items, 4 rating systems and 17 templates
+- 3-pane editor; a new workspace starts with 250+ canned comments, 80 repair items, 4 rating systems and 7 inspection templates (residential, pre-listing, new construction ×2, sewer scope, radon, mold)
 - Keyboard-driven: `1`-`5` ratings, `/` canned-comment library, `;` snippets, `?` cheatsheet, `⌘K` palette in the workspace
 - Simultaneous editing — inspection results are a Yjs CRDT in a Durable Object
-- Offline-capable PWA with photo upload queue
-- Migrate from Spectora in under 5 minutes via paste-JSON import
+- Installable PWA; field data is offline-capable (the results document buffers in IndexedDB and merges on reconnect). Photo and video *binary* upload needs a connection and says so rather than queueing
+- Migrate from Spectora through the import wizard, which shows what the conversion produced before anything is written
 
 ### Customer experience
 - Company-level public booking widget (`/book/<slug>`) with auto-assignment, optional inspector choice, and Turnstile bot protection
@@ -111,7 +111,7 @@ Deep dive: [`docs/operate/deploy.md`](docs/operate/deploy.md). Architecture over
 - **Drizzle ORM** + Cloudflare D1: SQLite at the edge
 - **Cloudflare R2 / KV**: object storage and config cache
 - **Tailwind CSS**: v4 only (via `@tailwindcss/vite`, design system tokens + utility CSS)
-- **Optional**: Gemini AI, Stripe Connect, Resend email, Google Places
+- **Optional**: any OpenAI-compatible AI endpoint, Stripe Connect, email (Resend / SendGrid / Postmark / Mailgun), SMS (Twilio / Telnyx), QuickBooks Online, Google or Apple calendar, Google Places
 
 ## Community
 

--- a/docs/concepts/inspection-workflow.md
+++ b/docs/concepts/inspection-workflow.md
@@ -59,7 +59,9 @@ POST /api/inspections/:id/upload
 Content-Type: multipart/form-data
 ```
 
-Worker stores the file in R2 under `{tenantId}/{inspectionId}/{filename}`. Files retrieved via `GET /api/inspections/files/:key` (tenant-scoped verification before proxying from R2).
+Worker stores the file in R2 under `{tenantId}/{inspectionId}/{filename}`. Photos are read back through `GET /api/inspections/:id/photo?key=<r2-key>` — role-guarded, and scoped to the caller's tenant and inspection by the key prefix. The R2 key contains `/`, which is why it travels as a query parameter rather than a path segment. The public report viewer has its own token-scoped twin in `public-report.ts`.
+
+(There is no `GET /api/inspections/files/:key`. This page named one for a long time and no such route has ever existed.)
 
 Photos can have annotations and captions (`inspection_media_pool` table).
 
@@ -84,7 +86,10 @@ Report viewer: `app/routes/public/report.tsx` (card-stack layout with section na
 | `POST /api/ai/comment-assist` | Professional rewrite of inspector's note |
 | `POST /api/ai/auto-summary` | Bullet-point summary of all defects |
 
-Both call Gemini 1.5 Flash. Temperature 0.2.
+Both go through the one OpenAI-compatible adapter, at whatever endpoint and
+model the deployment or the company configured — there is no compiled-in vendor
+or model, and with `AI_MODEL` / `AI_BASE_URL` unset both fail closed with a 503.
+See [AI](../integrations/ai.md).
 
 ## 6. Template Management
 
@@ -103,7 +108,7 @@ Bringing templates over from another product is not an endpoint on this router: 
 
 Inspectors manage weekly schedule + date overrides via `availability` / `availability_overrides` tables.
 
-Public booking: `GET /public/book/:tenant` returns the company booking page with all services and available slots; the system auto-assigns the first available qualified inspector. An optional inspector-choice dropdown is shown when the tenant enables "Allow clients to choose their inspector" (Settings → Online Booking → Booking policies). Customer submits via `POST /public/book` with Turnstile bot protection. Legacy per-inspector URLs `GET /public/book/:tenant/:slug` redirect 302 to the company page with that inspector pre-selected.
+Public booking: the page is a React Router route at `/book/:tenant`, and its data comes from `GET /api/public/book/:tenant` (all services and available slots). The system auto-assigns the first available qualified inspector. An optional inspector-choice dropdown is shown when the tenant enables "Allow clients to choose their inspector" (Settings → Online Booking → Booking policies). Customer submits via `POST /api/public/book` with Turnstile bot protection. Legacy per-inspector URLs `/book/:tenant/:slug` redirect 302 to the company page with that inspector pre-selected.
 
 ## 8. Execution Flow
 
@@ -114,13 +119,16 @@ Public booking: `GET /public/book/:tenant` returns the company booking page with
 2. Inspector opens inspection in the editor (/inspections/:id/edit)
    → template JSON parsed into interactive checklist
    → keyboard-driven: 1-5 ratings, / snippet picker, Cmd-K palette
-   → responses saved to IndexedDB immediately
+   → every edit lands in the Yjs results document, buffered in IndexedDB
 
 3. Inspector photographs defects
    → POST /api/inspections/:id/upload → R2
+   → binary upload needs a connection; offline it is declined, not queued
 
-4. Background sync pushes IndexedDB data
-   → PATCH /api/inspections/:id/results (field-level merge)
+4. The Durable Object merges and persists
+   → edits sync over the collab WebSocket; the DO is the only writer of
+     inspection_results.data, and it also stores the binary CRDT state
+   → offline edits merge on reconnect with no lost operations
 
 5. Inspector publishes report
    → report version snapshot created
@@ -139,8 +147,8 @@ Public booking: `GET /public/book/:tenant` returns the company booking page with
 | `server/api/inspections.ts` | Inspection + template CRUD |
 | `server/api/bookings.ts` | Public booking + availability |
 | `server/api/ai.ts` | AI comment assist + auto-summary |
-| `server/services/inspection.service.ts` | Core business logic (130KB) |
+| `server/services/inspection.service.ts` | Core business logic |
 | `server/lib/validations/template.schema.ts` | Template v2 schema validation |
 | `app/routes/inspection-edit.tsx` | 3-pane inspection editor (single fill surface) |
-| `app/hooks/useInspection.ts` | Inspection state management (866 LOC) |
+| `app/hooks/useInspection.ts` | Inspection state management |
 | `app/hooks/useCannedComments.ts` | Comment picker logic |

--- a/docs/concepts/kv-cache.md
+++ b/docs/concepts/kv-cache.md
@@ -22,20 +22,34 @@ TTL:   3600 seconds (1 hour)
 
 Written non-blocking via `c.executionCtx.waitUntil()`.
 
-## All KV Key Patterns (standalone)
+## The main KV key patterns (standalone)
+
+⚠️ **This table is not exhaustive and has never been gated.** It was headed "All
+KV Key Patterns" for a long time while carrying a key that does not exist
+(`google_token:…`) and a wrong shape for another, so treat it as a guide to the
+load-bearing ones and grep for the rest. New keys arrive without anything
+failing.
 
 | Key pattern | Written by | Read by | TTL |
 |---|---|---|---|
 | `global_tenant:{tenantId}` | Fixed-tenant resolver | Fixed-tenant resolver (every request) | 3600s |
 | `pwchanged:{userId}` | Password change/reset handlers | Auth middleware (JWT validation) | None |
+| `pw_reset:{token}` | Password-reset request | Password-reset redeem | 3600s, one-time |
+| `agent_view_token:{token}` | Agent report-share link mint | The shared-report reader | 30 days |
 | `qbo_oauth_state:{state}` | QBO OAuth initiation | QBO OAuth callback | 600s |
-| `google_token:{tenantId}:{userId}` | Google Calendar OAuth | Calendar API calls | 3500s |
-| `places:{hash}` | Google Places proxy | Address autocomplete | 3600s |
+| `places:auto:{sha256(query)}` · `places:detail:{placeId}` | Google Places proxy | Address autocomplete | 3600s |
 | `intsecrets:{tenantId}` | Integration-secrets middleware (on D1 read) | Every /api request (decrypted tenant secrets) | 300s — invalidated on PUT/POST /api/admin/secrets |
 | `branding:{tenantId}` | Branding middleware (on D1 read) | Page renders / email pipeline | 3600s — invalidated on branding update |
+| `cron:cursor:{job}` · `cron:lastrun:{job}` | The cron queue consumer | The next run of the same job | None — bookkeeping, see [architecture](../develop/architecture.md#background-work) |
+| `msg_notify:contact:{address}` | Transactional email dispatch | The same, as a send throttle | short-lived |
 
 > SaaS mode adds subdomain/silo routing keys (`tenant:{subdomain}`, `silo:{tenantId}`,
 > `sso:{code}`); those are not used by a standalone deploy.
+>
+> `OAUTH_KV` is a **second, separate namespace**, owned by
+> `@cloudflare/workers-oauth-provider` and holding MCP OAuth grants. Nothing in
+> this document applies to it: the library owns its key shapes and its binding
+> name cannot be changed.
 
 ## Why Not Alternatives?
 

--- a/docs/develop/architecture.md
+++ b/docs/develop/architecture.md
@@ -18,9 +18,9 @@ OpenInspection is a home inspection app deployed as a single Cloudflare Worker (
 | PDF rendering | Cloudflare Browser Run — `env.BROWSER.quickAction("pdf", { url })` (free tier, 10 min/day) |
 | E-signatures | Ed25519 per-tenant keypair + SHA-256 hash-chained audit log (ESIGN Act + UETA) |
 | Styling | Tailwind CSS v4 + Design System 0523 tokens |
-| Shared components | `packages/shared-ui/` — 12 token-based React components |
-| AI | Google Gemini API (optional) |
-| Email | Resend |
+| Shared components | `packages/shared-ui/` — token-based React components (`src/index.ts` is the list) |
+| AI | Any OpenAI-compatible endpoint (optional) — see [`../integrations/ai.md`](../integrations/ai.md) |
+| Email | Resend, SendGrid, Postmark or Mailgun (HTTP APIs only, no SMTP) |
 | Payments | Stripe Connect (optional) |
 | Auth | ES256 JWT in HttpOnly cookie + PBKDF2-SHA256 password hashing |
 
@@ -36,7 +36,7 @@ OpenInspection runs as ONE Cloudflare Worker. `workers/app.ts` is a Hono app tha
                     │  ┌──────────────────┐  ┌────────────────┐ │
                     │  │ /api/*, /status, │  │ everything else│ │
                     │  │ /sign/*, … →     │  │ → React Router │ │
-                    │  │ API app (server/)│  │ v7 SSR (app/)  │ │
+                    │  │ API app (server/)│  │ v8 SSR (app/)  │ │
                     │  │ in-process       │◄─┤ in-process     │ │
                     │  │ Hono+Drizzle+D1  │  │ API_WORKER     │ │
                     │  └──────────────────┘  └────────────────┘ │
@@ -45,10 +45,10 @@ OpenInspection runs as ONE Cloudflare Worker. `workers/app.ts` is a Hono app tha
                     └──────────────────────────────────────────┘
 ```
 
-- **`workers/app.ts`** — a Hono app is the worker entry. It routes API-owned paths (`/api/*`, `/status`, `/m2m/*`, `/photos/*`, `/.well-known/*`, `/doc`, `/sso`, `/sign/*`, `/webhooks/*`, the ICS feed) to the API app and sends everything else to the React Router v8 SSR handler. It injects an in-process `API_WORKER` self-binding so React Router loaders/actions call the API app DIRECTLY (no network hop, no second worker, no Service Binding between workers).
+- **`workers/app.ts`** — a Hono app is the worker entry. It routes API-owned paths (`/api/*`, `/status`, `/m2m/*`, `/photos/*`, `/.well-known/*`, `/doc`, `/sso`, `/sign/*`, `/webhooks/*`, `/agent/magic-login`, the ICS feed) to the API app and sends everything else to the React Router v8 SSR handler. `/mcp` and `/mcp/{slug}` are deliberately absent from that list: when MCP is enabled the OAuth provider wrapper owns that prefix and the request never reaches this router; when it is off the path falls through to the SSR 404. It injects an in-process `API_WORKER` self-binding so React Router loaders/actions call the API app DIRECTLY (no network hop, no second worker, no Service Binding between workers).
 - **`server/`** — Hono + Drizzle + D1. Handles all business logic, authentication, and data access. Exposes a typed JSON API.
 - **`app/`** — React Router v8 + React 19 + Tailwind v4. Server-side renders the React UI on the edge.
-- **Shared UI** (`packages/shared-ui/`) — Design System 0523 token-based React components (Button, Pill, Card, etc.).
+- **Shared UI** (`packages/shared-ui/`) — Design System 0523 token-based React components (Button, Pill, Card, etc.). `packages/shared-ui/src/index.ts` is the authoritative list; [`design-system.md`](design-system.md) describes each one.
 - **API Types** (`packages/api-types/`) — Re-exports the Hono app type so the web layer's `hono/client` gets full end-to-end type safety.
 
 The web layer uses a **Token Relay BFF** pattern: the React Router v8 server holds the JWT cookie and forwards it to the in-process API on every request, so the browser never sees the token directly.
@@ -87,7 +87,7 @@ apps/openinspection/
 │   │   ├── auth.ts                # /api/auth/{login,register,reset-password,...}
 │   │   ├── inspections.ts         # /api/inspections/* + share/print
 │   │   ├── ai.ts                  # /api/ai/{suggest-comment,comment/edit}
-│   │   ├── booking.ts             # /public/* (no auth) + /api/book
+│   │   ├── bookings.ts            # /api/public/* (no auth) — booking page data + submit
 │   │   └── ...
 │   ├── services/                  # Business logic, DB queries (Drizzle)
 │   ├── features/                  # Feature-scoped modules
@@ -111,8 +111,8 @@ apps/openinspection/
 │   ├── lib/                       # API client (hono/client over the in-process binding), session, helpers
 │   └── styles/tailwind.css        # Design System 0523 token layer
 ├── migrations/                    # D1 SQL migrations (drizzle-kit schema-first: one regenerated 0000_baseline.sql, forward files on top)
-├── tests/                         # API unit + integration + E2E tests
-├── tests/web/                     # Web E2E + unit tests
+├── tests/                         # unit / workers / contract / e2e — see develop/testing.md
+│                                  # (web unit specs are CO-LOCATED under app/; tests/web/ is retired)
 ├── packages/
 │   ├── shared-ui/src/             # shared React components
 │   └── api-types/                 # CoreApiType for hono/client
@@ -147,14 +147,24 @@ API request (from an RR loader/action via the in-process API_WORKER binding, or 
    ↓
 Cloudflare edge → single Worker (workers/app.ts) → Hono routes API-owned paths to the API app
    ↓
-Hono middleware stack (in order):
+Hono middleware stack, in the order `server/index.ts` registers it
+(pinned by tests/unit/platform/middleware-order.spec.ts):
    1. CSP / security headers
-   2. Branding resolver (KV → D1 fallback)
+   2. Context bootstrap
    3. Tenant router (standalone: pins the one fixed tenant)
-   4. JWT auth (skip on /api/auth, /api/public, /api/setup)
-   5. Bot protection (Turnstile + threat score)
-   6. Tier guard (subscription check, no-op in standalone)
-   7. DI proxy (lazy-instantiates services)
+   4. Branding resolver (KV → D1 fallback)
+   5. Tenant-active guard
+   6. JWT auth (skipped on the public prefixes)
+   7. Agent terms gate
+   8. Idempotency guard (mutating routes)
+   9. Integration secrets (merges the tenant's decrypted keys into a COPY of env)
+  10. DI proxy (lazy-instantiates services)
+  11. Inspector palette
+  12. Last-active touch (/api/* only)
+   ↓
+Bot protection (Turnstile) is NOT in this stack — it is applied per route, on
+the two surfaces an anonymous visitor can submit to. See
+[`../integrations/turnstile.md`](../integrations/turnstile.md).
    ↓
 Route handler reads validated input via c.req.valid('json')
    ↓
@@ -339,16 +349,21 @@ The DI proxy in `server/lib/middleware/di.ts` lazy-instantiates each service on 
 ## Frontend layer
 
 - **React Router v8 SSR**: Routes in `app/routes/` use `loader()` for data fetching and `action()` for mutations. Full server-side rendering on Cloudflare Workers.
-- **React components**: 59 components in `app/components/`, organized by domain (inspection, template, booking, etc.).
-- **Hooks**: 9 custom hooks handle complex state — `useInspection` (866 LOC), `useFindings`, `useKeyboard` (shortcuts), `useCannedComments`, `useOfflineQueue`, `usePresence` (WebSocket), `useTheme`, `useUnsavedChanges`, `useSessionContext`.
+- **React components**: `app/components/`, organized by domain (inspection, template, booking, media-studio, portal, …). Counts are not written here because they go stale between releases; `ls app/components` is the answer.
+- **Hooks**: `app/hooks/` holds the state hooks the editor is built from — `useInspection`, `useFindings`, `useKeyboard` (shortcuts), `useCannedComments`, `usePresence` (WebSocket), `useTheme`, `useUnsavedChanges`, `useSessionContext`, and the `findings/` and `inspection/` sub-hook directories.
 - **Design tokens**: Tailwind v4 with Design System 0523 tokens in `app/styles/tailwind.css`.
-- **Shared UI**: `packages/shared-ui/` provides 12 design-system components (Button, Pill, Card, etc.) consumed by the frontend.
+- **Shared UI**: `packages/shared-ui/` provides the design-system components (Button, Pill, Card, …) consumed by the frontend; its `src/index.ts` is the list.
 - **Dark mode**: `data-color-scheme` attribute on `<html>`, managed by `useTheme` hook (auto/light/dark).
 
 ### Future app path
 
-1. **PWA** (current) — installable, offline-capable via Service Worker plus the
-   `useOfflineQueue` hook, which carries the photo-upload queue and field sync.
+1. **PWA** (current) — installable, and offline-capable for field data: the
+   results document is a Yjs CRDT buffered in IndexedDB and merged on reconnect
+   (see [`../concepts/collab-editing.md`](../concepts/collab-editing.md)). The
+   `useOfflineQueue` hook this line used to name was retired with the rest of
+   the bespoke offline layer in #181. Photo and video BINARY upload still
+   requires a connection — it writes to R2 — so that half is not offline-capable
+   and the editor says so rather than queueing.
 2. **A native client** (direction, unspecified) — designed for the field rather
    than inherited from the browser: capture, local storage, sync and conflict
    resolution are the requirement, not follow-ups to a shell.
@@ -363,8 +378,10 @@ responsive web is the field surface.
 ## Storage
 
 - **D1**: structured data (tenants, users, inspections, templates, comments, agreements, audit logs, ...)
-- **R2**: blobs. Bucket bindings: `PHOTOS` (field photos, logos) and `REPORTS` (pre-rendered report + e-sign PDFs). Accessed via signed URL or a Worker pass-through endpoint.
-- **KV**: short-lived signed tokens (agent share, password reset, magic link), tenant config cache, rate-limit counters.
+- **R2**: blobs. **One bucket binding, `PHOTOS`** — field photos, logos, pre-rendered report and certificate PDFs, and e-sign evidence packs all live in it. There is no `REPORTS` bucket; this document named one for a long time and `wrangler.jsonc` has never bound it. Accessed via signed URL or a Worker pass-through endpoint. (A SaaS deployment adds one more, `EXPORTS_BUCKET`, shared with the control plane for offboarding exports.)
+- **KV**: two namespaces. `TENANT_CACHE` holds short-lived signed tokens (agent share, password reset), the tenant config and branding caches, cron cursors and rate-limit counters — see [`../concepts/kv-cache.md`](../concepts/kv-cache.md). `OAUTH_KV` is owned by `@cloudflare/workers-oauth-provider` and holds MCP OAuth grants; its binding name is fixed by that library.
+- **Queues**: `CRON_QUEUE` (one background job per invocation — see [Background work](#background-work)) and `WORD_EXPORT_QUEUE` (async `.docx` export). Both are declared in `wrangler.jsonc`, producer and consumer, because neither is a SaaS-only feature.
+- **Durable Objects**: `INSPECTION_PRESENCE` and `TENANT_PRESENCE` (live presence), `INSPECTION_DOC` (the collaborative results document), `INSPECTOR_MCP` (the remote MCP server).
 
 ## Background work
 
@@ -376,7 +393,7 @@ responsive web is the field surface.
   |---|---|
   | `*/5 * * * *` | The main tick. It **probes and enqueues only** — see below. |
   | `0 3 * * *` | Daily R2 usage measurement (`r2-usage`). |
-  | `0 4 * * *` | Daily log-table retention sweep and intake expiry reminders (`retention-logs`). |
+  | `0 4 * * *` | Daily log-table retention sweep (`retention-logs`) and the statutory-form revision watch (`statutory-revision-watch`). |
 
   Cron Triggers are limited to **5 per account** on the Free plan, which is the budget these
   three are spent from.
@@ -404,9 +421,12 @@ this paragraph:
   the same script, which prints what it checked next to what it found on every run and treats
   "checked nothing" as a failure.
 - **Probe-then-enqueue, not enqueue-always.** The other Free ceiling is Queues at 10,000
-  operations/day, shared with the Word-export queue; enqueueing thirteen jobs unconditionally
-  would spend 7,488 of them a day on jobs with nothing to do. A single-inspector deployment's
-  ticks are almost all empty, so probing first sends almost nothing.
+  operations/day, shared with the Word-export queue. The five-minute tick fires 288 times a
+  day and every message costs two operations (the send and the read), so enqueueing each
+  tick-owned job unconditionally would spend roughly `jobs × 576` of that budget a day on
+  jobs with nothing to do — 6,912 at the twelve currently on the tick, and the count grows
+  with the registry. A single-inspector deployment's ticks are almost all empty, so probing
+  first sends almost nothing.
 
 Cursors live in Workers KV (`cron:cursor:<job>`), not in a column — they are bookkeeping, every
 paged job is idempotent, and a column would mean a migration in both deployment modes.
@@ -440,4 +460,14 @@ A solo inspector doing 50 inspections/month uses approximately 1-2% of Free tier
 | D1 reads | 5M/day | — |
 | R2 storage | 10 GB | — |
 
-React Router v8 SSR adds ~1-3ms CPU per request. The combined Worker bundle stays well within limits. Browser Run (server-side PDF) is on the Free tier (10 min/day); requires `compatibility_date >= "2026-03-24"` and the `browser` binding in `wrangler.jsonc`.
+⚠️ **The "~1-3ms CPU per request" figure that used to sit here is withdrawn** —
+it was an SSR microcost quoted as if it were the whole request. Measured against
+a live deployment over seven days of real traffic (2026-09-05): **p50 8ms, p95
+49ms, p99 106ms, max 494ms**, and a statutory-form render is ~470ms in workerd
+on its own. See [Why React Router v8](#why-react-router-v8) above; that section
+is where this number is maintained, and this one repeated a stale copy of it for
+long enough to be worth naming.
+
+The combined Worker bundle stays within the size limit. Browser Run (server-side
+PDF) is on the Free tier (10 min/day); it requires `compatibility_date >=
+"2026-03-24"` and the `browser` binding in `wrangler.jsonc`.

--- a/docs/develop/conventions/i18n-glossary.md
+++ b/docs/develop/conventions/i18n-glossary.md
@@ -1,8 +1,10 @@
 # es-419 translation glossary
 
-One equivalent per term, decided once. The catalogue is 4,300 keys across 29
-module files in `messages/`; without a fixed term list the same noun acquires
-four translations across those files and the result reads as machine output.
+One equivalent per term, decided once. The catalogue is thousands of keys across
+three dozen module files in `messages/` — `npm run lint:i18n-glossary` prints
+the live key count on every run, so read it there rather than from a figure
+frozen into this sentence. Without a fixed term list the same noun acquires four
+translations across those files and the result reads as machine output.
 
 This file is **machine-read** — but only in part, and the difference matters.
 `npm run lint:i18n-glossary` (`scripts/check-i18n-glossary.mjs`) parses the

--- a/docs/develop/conventions/mcp-oauth-notes.md
+++ b/docs/develop/conventions/mcp-oauth-notes.md
@@ -24,20 +24,23 @@
 `@cloudflare/vitest-pool-workers` nesting an unrelated `zod@3.25.76` under itself.
 No `overrides` entry is needed for zod.
 
-### React 19 peer dep conflict (agents)
+### React peer dep (agents) — the original conflict is gone
 
-`agents@0.17.1` requires `react@^19.0.0` as a **peer dependency** (not listed in `peerDependenciesMeta`
-as optional). Our project is on `react@^18.3.1` and is not ready to upgrade to React 19 —
-that would be a large, unrelated breaking change.
+`agents@0.17.1` requires `react@^19.0.0` as a **peer dependency** (not listed in
+`peerDependenciesMeta` as optional).
 
-**Resolution:** Install with `--legacy-peer-deps`. The React 19 peer dep exists because
-`agents` ships frontend hooks (imported via `agents/react`) that target React 19's concurrent
-features. We only import from `agents/mcp` (the Durable Object base class) which has zero
-React runtime dependency. The peer dep requirement is a metadata-level constraint with no
-runtime impact for our server-side usage.
+⚠️ **This section recorded a conflict that no longer exists.** It was written when the
+project was on `react@^18.3.1` and said an upgrade was out of scope; the project has since
+moved to React 19 (`react@^19.2.8`), so the peer dependency is satisfied on its own terms.
 
-A project-root `.npmrc` with `legacy-peer-deps=true` is committed alongside `package.json`
-so `npm install` works for all developers and CI without passing the flag explicitly.
+The committed project-root `.npmrc` still carries `legacy-peer-deps=true`, and its comment
+still gives the React 18 reason. Nothing has been changed here on that basis — removing an
+install-wide flag is a dependency-tree decision, not a documentation one — but a reader
+should not take that comment as a current statement about React. Re-audit with
+`npm ls --depth=0` before assuming the flag is still load-bearing.
+
+We import only from `agents/mcp` (the Durable Object base class), which has no React runtime
+dependency; `agents/react` (the frontend hooks the peer dep exists for) is not imported.
 
 ---
 
@@ -151,7 +154,7 @@ Generic position: **Env, State, Props** (in that order). For a tenant-aware agen
 
 ```ts
 type MyProps = { tenantSlug: string; userId: string; scopes: string[] };
-class InspectionMcpAgent extends McpAgent<Env, never, MyProps> { ... }
+class InspectorMcp extends McpAgent<Env, never, MyProps> { ... }
 ```
 
 ### `serve()` signature
@@ -286,18 +289,22 @@ shared resource regardless of workspace, losing the per-workspace token isolatio
 
 For any MCP integration to work, the following must be present in wrangler.jsonc:
 
+What actually shipped, in the committed `wrangler.jsonc` — the binding name and class are
+**not** `McpAgent`'s defaults, and the migration tag is whichever one is next in that file's
+own chain (`v3` here, because two DO classes preceded it):
+
 ```jsonc
 {
   "durable_objects": {
     "bindings": [
-      { "name": "MCP_OBJECT", "class_name": "InspectionMcpAgent" }
+      { "name": "INSPECTOR_MCP", "class_name": "InspectorMcp" }
     ]
   },
   "kv_namespaces": [
     { "binding": "OAUTH_KV", "id": "<your-kv-id>" }
   ],
   "migrations": [
-    { "tag": "v2", "new_sqlite_classes": ["InspectionMcpAgent"] }
+    { "tag": "v3", "new_sqlite_classes": ["InspectorMcp"] }
   ]
 }
 ```
@@ -305,4 +312,5 @@ For any MCP integration to work, the following must be present in wrangler.jsonc
 The `OAUTH_KV` binding name is hardcoded in `@cloudflare/workers-oauth-provider` — it cannot be
 changed without forking the library.
 
-The `MCP_OBJECT` binding name can be changed: pass `{ binding: 'YOUR_BINDING' }` to `McpAgent.serve()`.
+`McpAgent.serve()` defaults its binding to `MCP_OBJECT`; this deployment overrides it by
+passing `{ binding: 'INSPECTOR_MCP' }`.

--- a/docs/develop/conventions/route-metadata.md
+++ b/docs/develop/conventions/route-metadata.md
@@ -7,7 +7,7 @@ malformed metadata fails the build.
 
 This document codifies the standard. For the broader integration architecture
 see [mcp-oauth-notes.md](mcp-oauth-notes.md) (server internals) and
-[connecting-claude-mcp.md](../../integrations/mcp.md) (how a user connects Claude).
+[integrations/mcp.md](../../integrations/mcp.md) (how a user connects Claude).
 
 ## Required fields
 
@@ -41,18 +41,22 @@ Uniqueness: every `operationId` is globally unique across the app.
 
 ## `tags` controlled vocabulary
 
-Primary tag (required, exactly one of):
+Primary tag (required, exactly one of). **`VALID_TAGS` in
+`server/lib/route-metadata-standards.ts` is the vocabulary** — the gate reads it
+from there, and this block is a copy that has to be updated with it:
 
 ```
-auth         inspections   bookings      templates     team
-agents       ai            invoices      services      messages
-notifications contacts     metrics       admin         sysadmin
-audit        marketplace   recommendations  agreements webhooks
-public       calendar      tags          ratings       guest
-profile      identity      automations   integrations  qbo
+auth         inspections   bookings      templates        team
+agents       ai            invoices      services         messages
+notifications contacts     metrics       admin            sysadmin
+audit        marketplace   recommendations  contractor-types credentials
+role-profiles agreements   webhooks      public           calendar
+tags         ratings       profile       identity         automations
+integrations qbo           sms           imports
 ```
 
-Optional secondary tags: `public`, `m2m`, `beta`, `webhook`.
+Optional secondary tags (`VALID_SECONDARY_TAGS`): `public`, `m2m`, `beta`,
+`webhook`.
 
 ## `x-scopes` mapping
 
@@ -63,7 +67,7 @@ Default by HTTP method:
 Override when:
 - `/api/admin/*` or `/api/sysadmin/*` → `['admin']`
 - agent-specific routes → `['agent']`
-- public routes (`/public/*`, `/api/auth/*`, M2M) → `[]` and set `tier: 'excluded'`
+- public routes (`/api/public/*`, `/api/auth/*`, `/webhooks/*`, M2M) → `[]` and set `tier: 'excluded'`
 
 ## `x-tier` exposure
 

--- a/docs/develop/design-system.md
+++ b/docs/develop/design-system.md
@@ -176,8 +176,9 @@ beyond the ad hoc pixel sizes already used throughout `app/components/`.
 
 ## 3. Component primitives
 
-`packages/shared-ui/src/` (exported from `index.ts`) — 25 components. **Check
-here before hand-rolling UI.** A new repeated pattern (a card variant used in
+`packages/shared-ui/src/` — everything exported from `index.ts`, which is the
+authoritative list; the table below describes each one. **Check there before
+hand-rolling UI.** A new repeated pattern (a card variant used in
 three places, a new pill tone) belongs in `shared-ui`, not copy-pasted across
 route files.
 
@@ -194,6 +195,7 @@ route files.
 | `Select` | Labeled single/multi select mirroring `Input`'s chrome; tokenized chevron in single-select mode | `label`, `error`, `hint`, `options` (`SelectOption[]`) or native `<option>` children, `multiple`, `bare`. Use for a fixed option list; use `Input` for free text |
 | `Checkbox` | Single checkbox with native `<label>` association; DS `accent-ih-primary` fill | `label`, `error`, `bare` (raw input only, e.g. inside `FormField`) |
 | `Radio` / `RadioGroup` | `RadioGroup` renders a `<fieldset>`/`role=radiogroup` set of options; `Radio` is the single control for custom layouts | `RadioGroup`: `name`, `value`, `onChange(value)`, `options` (`RadioOption[]`), `legend`, `error`, `hint`. Prefer `RadioGroup`; reach for bare `Radio` only for bespoke layouts |
+| `RadioCardGroup` | Card-style single select — a vertical stack of bordered cards, each a native `<label>`/`<input type=radio>`, with a title and optional description and badge. Selected card lifts to `border-ih-primary` | `name`, `value`, `onChange(value)`, `options` (`RadioCardOption[]` — `value`, `title`, `description`, `badge`, `disabled`), `legend`, `error`, `hint`. Arrow/Home/End move selection, skipping disabled options. Use when an option needs a description or a badge; use `SegmentedControl` or `RadioGroup` for short bare labels |
 | `Modal` | Centered dialog overlay (`role="dialog"` + `aria-modal`), full-screen `bg-ih-backdrop` scrim, Escape-to-close, click-outside-to-close, focus trap | `open`, `onClose`, `title`, `size`: `sm` \| `md` \| `lg` \| `xl`, `footer`. Use for confirm/decision moments and short forms (see §4) |
 | `Drawer` | Right-side slide-in panel sharing `Modal`'s dialog behavior + scrim | `open`, `onClose`, `title`, `footer`, `wide` (480px vs 360px; mobile always full-width), `initialFocusRef`. Use for "adjust while seeing the page" flows — filters, long side forms — NOT confirm moments (see §4) |
 | `Popover` | Anchored, non-blocking floating panel — no scrim, no scroll-lock, no hard focus-trap; Esc / click-outside close, focus restores to the anchor | `open`, `onClose`, `anchorRef` (trigger the panel positions against), `align`: `left` \| `right` (default `right`). Use for lightweight in-context choices (column toggles, dropdowns) where the page must stay visible (see §4) |
@@ -353,8 +355,10 @@ Save/Cancel (or Confirm/Cancel) actions in its `footer`.
 
 ## 5. Conformance tooling — `npm run lint:ds`
 
-`scripts/check-ds-tokens.mjs` scans `app/` and `packages/shared-ui/src/` for
-eight violation classes:
+`scripts/check-ds-tokens.mjs` scans `app/` and `packages/shared-ui/src/`. Nine
+violation classes live in its `RULES` array, and a tenth check — every `ih-*`
+alias resolves to a `@theme` entry — runs beside them (that is the one "How to
+add a token" step 4 describes):
 
 1. **Dead `-bg0` pseudo-token** — `ih-(ok|watch|bad|primary)-bg0` generates no
    utility and silently ships invisible elements.
@@ -375,6 +379,11 @@ eight violation classes:
 7. **`backdrop-blur`** — glass blur is not part of the DS surface language.
 8. **`bg-[rgba(...)]` scrims** — hand-rolled overlay tints. Use the single
    `bg-ih-backdrop` overlay token instead.
+9. **`text-white` on a `bg-ih-primary` fill** — it bypasses the theme flip. Dark
+   mode brightens `--ih-primary` and flips `--ih-fg-inverse` to a dark value
+   (≈5.8:1); white against the brightened primary is ≈2.9:1 and fails AA. 95
+   sites had hand-written white before this became a rule. Use
+   `text-ih-fg-inverse`.
 
 ### Escape hatches
 
@@ -384,20 +393,23 @@ eight violation classes:
 - **`print:`-variant utilities are ignored** — print output is intentionally
   fixed-color.
 - **File allowlist** — a short, justified list in `FILE_ALLOWLIST` inside the
-  script (currently: the printable agreement route, the email-template
-  preview, and the Media/Photo Studio chrome components, which are
-  intentionally fixed-dark regardless of theme). Keep this list short; prefer
-  a `ds-allow` comment for anything narrower than a whole file.
+  script. Every entry today is either the email-template preview (email bodies
+  render in external clients with no dark mode and no CSS variables) or one of
+  the Photo/Media Studio chrome components, which are intentionally fixed-dark
+  regardless of theme. Keep this list short; prefer a `ds-allow` comment for
+  anything narrower than a whole file.
 
 ### Where it runs
 
-- `npm run lint` (part of the aggregate lint script alongside `lint:svg`,
-  `lint:erasure`, `lint:migrefs`, `lint:filesize`, `lint:dup`,
-  `lint:tenant-scope`, `lint:tests`, and `lint:deadcode` — knip, which flags
-  unused exports so retired primitives don't linger in `shared-ui`).
-- Pre-commit (`.githooks/pre-commit`) — runs on every commit that touches
-  non-docs/tests files.
-- CI (`.github/workflows/ci.yml`, `verify` job) via `npm run lint`.
+- `npm run lint` — one of every gate in `scripts/lib/gate-registry.mjs`. That
+  registry is the list; among the ones worth knowing beside this gate are
+  `lint:contrast` (the arithmetic this one cannot do) and `lint:deadcode`
+  (knip, which flags unused exports so retired primitives don't linger in
+  `shared-ui`).
+- Pre-commit (`.githooks/pre-commit`) — it is at the `precommit` rung, so it
+  runs on **every** commit, docs-only ones included. Only the type-check tier is
+  skipped when nothing TypeScript is staged.
+- CI (`.github/workflows/ci.yml`, `lint-gates` job) via `npm run lint:gates-full`.
 
 ---
 

--- a/docs/develop/logo-design.md
+++ b/docs/develop/logo-design.md
@@ -29,9 +29,16 @@ This gradient is the same one used across the application for primary buttons, h
 
 ## Sizing & ViewBox
 
-- **ViewBox:** `236 227 552 420` — tight crop with 12px padding around the graphic
-- **Format:** SVG (vector, resolution-independent)
-- **Files:** `public/favicon.svg` (browser tab) and `public/logo.svg` (in-app branding)
+The two files carry **different** viewBoxes, on purpose — the favicon is squared
+so it does not letterbox in a browser tab, the wordmark-height logo is cropped
+tight:
+
+| File | Intrinsic size | ViewBox |
+|---|---|---|
+| `public/logo.svg` (in-app branding) | 46 × 35 | `236 227 552 420` — tight crop around the graphic |
+| `public/favicon.svg` (browser tab) | 32 × 32 | `230 155 564 564` — square |
+
+- **Format:** SVG (vector, resolution-independent). Both share the same three-stop gradient.
 
 ## Usage Rules
 

--- a/docs/develop/setup.md
+++ b/docs/develop/setup.md
@@ -47,9 +47,14 @@ you are done.
 | `npm run db:check` | Drift gate — schema and `migrations/` must agree |
 
 Do not hand-run what the pre-commit hook already runs. The hook does a tiered
-type-check, `lint-staged`, and the design-system, contrast, and migration-ref
-gates; docs-only commits skip the heavy steps. Run the full suite once before
-pushing, not after every edit.
+type-check, `lint-staged`, and every conformance gate declared at the
+`precommit` rung in `scripts/lib/gate-registry.mjs` — two dozen of them, run in
+one node process by `scripts/run-gates.mjs`, not the three this paragraph used
+to name. Commits with no staged `.ts`/`.tsx` skip the type-check entirely. Run
+the full suite once before pushing, not after every edit.
+
+That registry is the list; do not maintain a copy of it here. `npm run lint`
+(pre-push and CI) runs every gate, at both rungs.
 
 ## Project structure
 

--- a/docs/develop/testing.md
+++ b/docs/develop/testing.md
@@ -1,8 +1,9 @@
 # Testing — apps/openinspection
 
 The single Worker serves both the typed JSON API and the React Router v8 UI, so
-tests cover both surfaces. There are five suites, each pinned to a **location**:
-a spec's directory alone decides which config runs it. This document is the
+tests cover both surfaces. There are six suites — web unit, api/service unit,
+worker-runtime, contract, end-to-end and type-level — each pinned to a
+**location**: a spec's directory alone decides which config runs it. This document is the
 canonical reference for the three things you need to get right: **where a spec
 lives**, **how to write it**, and **how the run is initialized**.
 
@@ -34,7 +35,7 @@ Collection is enforced in **both** directions, by two gates rather than one:
 | `tests/workers/**/*.spec.ts` | worker-runtime | `test:workers` | `vitest.workers.config.ts` | real `workerd` |
 | `tests/contract/<party>/*.contract.spec.ts` | contract (offline) | `test:contract` | `vitest.contract.config.ts` | node, no network |
 | `tests/contract/<party>/*.live.spec.ts` | contract (live) | `test:contract:live` | `vitest.contract.live.config.ts` | node + the real third-party API |
-| `tests/e2e/*.spec.ts` | end-to-end | `test:e2e` | `playwright.config.ts` (seeds real D1) | built worker + browser |
+| `tests/e2e/*.spec.ts` | end-to-end | `test:e2e` · `test:e2e:seeded` | `playwright.config.ts` (seeds real D1) · `playwright.seeded.config.ts` | built worker + browser |
 | `tests/**/*.spec-d.ts` | type-level | `test:types` | `vitest.typecheck.config.ts` | tsc typecheck |
 
 ### Choosing a home for a new spec
@@ -56,6 +57,11 @@ Collection is enforced in **both** directions, by two gates rather than one:
 4. **Full-stack / browser / anything that hits a running worker** →
    `tests/e2e/`. One flat directory; `globalSetup` seeds real D1 so every E2E
    exercises the actual database.
+
+More than one Playwright config reads that directory, and a spec belongs to
+exactly one of them. `npm run lint:e2e-coverage` prints the full list on every
+run — which config collects a spec, which one OWNS it, and which npm script (if
+any) runs it — so read its output rather than a list copied into this page.
 
 ### The rules the gate enforces
 
@@ -300,16 +306,32 @@ never cleared.
 
 ### CI (`.github/workflows/ci.yml`)
 
-Two parallel jobs:
+**`verify` does no work of its own.** It is an aggregate job that waits on every
+other job, so branch protection has one stable name to require. Its `if:
+always()` plus an explicit result test is load-bearing: under the default
+`success()` behaviour a SKIPPED or cancelled dependency would let it pass.
 
-- **`verify`** — `npm ci` → `gen-version` → `type-check` → `lint` (eslint +
-  `lint:ds` + `lint:erasure` + `lint:migrefs` + `lint:tests`) → `db:check` →
-  `test:unit` → `test:workers` → `test:web` → `build` → bundle-size.
-- **`e2e`** — `npm ci` → `gen-version` → `node scripts/gen-e2e-dev-vars.mjs` →
-  `playwright install chromium` → `npm run test:e2e`. Playwright's `webServer`
-  builds + boots the worker; `globalSetup` seeds D1.
+The jobs it waits on run in parallel:
 
-CodeQL runs separately (`codeql.yml`).
+| Job | Runs |
+|---|---|
+| `typecheck-app` | `type-check:app` → `type-check:tests` → `test:types` |
+| `lint-eslint` | `lint:eslint` (the type-aware pass) |
+| `lint-gates` | `lint:gates-full` (every conformance gate) → `db:check` |
+| `test-unit` | `test:unit`, sharded 4 ways |
+| `test-contract` | `test:contract` (offline half only — the live half never runs in CI) |
+| `test-workers` | `test:workers` |
+| `test-web` | `test:web`, sharded 4 ways |
+| `build` | `build` → `check:bundle` |
+| `e2e` | a 2-way matrix: `test:e2e` (seeded D1) and `test:e2e:seeded` (multi-user seed) |
+
+`e2e` was once absent from `verify`'s `needs`, which left a red E2E run reading
+green on the job branch protection keys off — the whole suite was advisory
+without anyone deciding it should be. It costs `verify` the wait for the longest
+job, which is the price of the name meaning what it says.
+
+Every job that touches generated types runs `gen-version`, `i18n:compile:cached`
+and `react-router typegen` first. CodeQL runs separately (`codeql.yml`).
 
 ---
 
@@ -409,6 +431,7 @@ npm run test:web                       # web unit (happy-dom, hermetic)
 npm run test:unit                      # api/service unit (node + better-sqlite3)
 npm run test:workers                   # real workerd (queues, DOs)
 npm run test:e2e                       # Playwright, seeds real D1
+npm run test:e2e:seeded                # the multi-user-seed projects (playwright.seeded.config.ts)
 npm run test:types                     # type-level (*.spec-d.ts)
 npm run lint:tests                     # layout gate (projects must resolve to files)
 npm run lint:e2e-coverage              # coverage gate (files must be collected by a config)

--- a/docs/develop/verification-copy-policy.md
+++ b/docs/develop/verification-copy-policy.md
@@ -102,9 +102,12 @@ Two things about it are deliberate:
   this policy requires us to write, and both contain a banned phrase. The first
   version of the gate flagged them, which would have pressured an author to delete the
   disclaimer to get to green. A match counts only when the clause is not negated.
-- **Its self-test runs both ways.** Ten known-bad strings must be flagged and
-  seven careful ones must not. A regex that drifts in either direction turns a
-  clean scan into a false green, and the second direction is the expensive one.
+- **Its self-test runs both ways.** A set of known-bad strings must be flagged
+  and a set of carefully-worded ones must not. A regex that drifts in either
+  direction turns a clean scan into a false green, and the second direction is
+  the expensive one. The gate prints both counts and both sets' verdicts on
+  every run — read them there; the pair written into this sentence went stale
+  within two releases of being written.
 
 The banned list includes disguises that do not exist in the product yet —
 "Identity Verified", "Consent Verified", "Agreement Validated", "Legally

--- a/docs/integrations/google-places.md
+++ b/docs/integrations/google-places.md
@@ -15,8 +15,8 @@ costs nothing and limits the damage if it leaks.
 
 ## The key never reaches the browser
 
-Both surfaces call our own `/api/places/*` and `/public/geocode`, which proxy to
-Google server-side. The browser never sees the key, which is also why the
+Both surfaces call our own `/api/places/*` and `/api/public/geocode`, which
+proxy to Google server-side. The browser never sees the key, which is also why the
 restriction advice above is worth following: the key is only ever used from your
 Worker.
 

--- a/docs/integrations/stripe.md
+++ b/docs/integrations/stripe.md
@@ -30,15 +30,24 @@ booking. The amount comes from the invoice, which is authoritative over the
 denormalized `inspections.price` cache — see the money authority chain in
 `CLAUDE.md`.
 
-**Inbound:** the webhook at `POST /api/stripe/webhook`, verified against
+**Inbound:** the webhook at `POST /webhooks/stripe`, verified against
 `STRIPE_WEBHOOK_SECRET`. A successful payment marks the invoice paid, which is
 what releases the report pay-gate.
 
 Point your Stripe webhook endpoint at:
 
 ```
-https://<your-host>/api/stripe/webhook
+https://<your-host>/webhooks/stripe
 ```
+
+Inbound webhooks are mounted at the **top level**, not under `/api/`: the
+producer owns the body, the headers and the signature, and none of the `/api/*`
+middleware applies to them.
+
+A second, workspace-scoped mount exists at `/webhooks/stripe/<workspace-slug>`.
+A standalone deployment does not need it — the bare path resolves the one fixed
+workspace — but a multi-workspace deployment does, because the verifier secret
+is per workspace and has to be resolved before the signature can be checked.
 
 ## Testing it
 

--- a/docs/integrations/video.md
+++ b/docs/integrations/video.md
@@ -93,11 +93,11 @@ PDF renders (via `env.BROWSER.quickAction('pdf', ...)`) cannot embed video. `ser
 | `tests/unit/storage/r2-backend.spec.ts` | Token mint/verify (tamper + expiry), type/size validation, R2 key shape, finalize idempotency |
 | `tests/unit/media/media-video.spec.ts` | `MediaVideoService` (Stream) + `StreamVideoBackend` tenant guard and finalize |
 | `tests/unit/reports/report-video.spec.ts` | `selectReportMedia` — image / video-player / video-poster branches |
-
+| `tests/unit/media/session-context-video.spec.ts` | `sessionContext` video fields exposed to the frontend |
 | `app/components/media-studio/VideoPlayer.test.tsx` | `VideoPlayer` — Stream iframe vs native `<video>`, and the three fail-closed paths (no subdomain, missing R2 ids, still transcoding) |
 | `app/components/media-studio/VideoCapture.test.tsx` | `VideoCapture` — privacy notice present (R2) / absent (Stream), and that accepting it is what ENABLES the pick button |
 
-⚠️ These two live beside the components (`app/**/*.test.tsx`), not under
+⚠️ The last two live beside the components (`app/**/*.test.tsx`), not under
 `tests/`. This table previously named files under `tests/web/unit/` — a
 directory that does not exist — so it claimed coverage for years that was never
 written. If a row here names a file, open it before believing it.
@@ -106,7 +106,6 @@ The assertion worth knowing about in `VideoCapture.test.tsx` is not that the
 checkbox renders: it is that `pickDisabled` keeps the upload button disabled
 until the box is ticked. A checkbox that renders but gates nothing passes every
 presence test while letting an R2 upload start with no acceptance recorded.
-| `tests/unit/media/session-context-video.spec.ts` | `sessionContext` video fields exposed to the frontend |
 
 ---
 

--- a/docs/operate/deploy.md
+++ b/docs/operate/deploy.md
@@ -39,8 +39,30 @@ For the manual flow, see the **Quick start** section in the [README](../../READM
 | Images binding   | `IMAGES` (optional) | Downscales Appendix B photos before embedding them in Word (.docx) exports. |
 | Workflow         | `SIGN_COMPLETION_WORKFLOW` | Async e-sign pipeline (Spec 5H).                           |
 | Durable Objects  | `INSPECTION_PRESENCE`, `TENANT_PRESENCE` | Live presence for the editor.               |
+| Durable Object   | `INSPECTION_DOC` | The collaborative results document (Yjs CRDT). Absent → the editor's collab routes return `501` and collaborative editing does not engage. |
+| Durable Object   | `INSPECTOR_MCP`  | The remote MCP server. Only reached when `MCP_ENABLED` is set. |
+| KV namespace     | `OAUTH_KV`       | MCP OAuth grants. The binding NAME is fixed by `@cloudflare/workers-oauth-provider`. |
+| Queue            | `CRON_QUEUE`     | **Background jobs run on this queue, one job per invocation.** With it unbound the tick logs `CRON_QUEUE is not bound — no job will run` and every sweep, reminder and retention job stops. |
+| Queue            | `WORD_EXPORT_QUEUE` | Async `.docx` export. |
+| Stream binding   | `STREAM` (optional) | Cloudflare Stream video backend. Absent → video stays on R2, which is the default. |
 
-`npm run setup:cloudflare` provisions every binding listed above and writes their real IDs into a gitignored `wrangler.local.jsonc` (bootstrapped from the committed placeholder `wrangler.jsonc`).
+⚠️ **`npm run setup:cloudflare` does not provision all of them.** It creates the
+D1 database, **one** KV namespace (`TENANT_CACHE`) and the `PHOTOS` R2 bucket,
+and writes their real IDs into a gitignored `wrangler.local.jsonc` (bootstrapped
+from the committed placeholder `wrangler.jsonc`). The two queues and the second
+KV namespace are not created by it, and `wrangler.jsonc` carries a placeholder id
+for `OAUTH_KV`. Create them yourself before the first deploy:
+
+```bash
+npx wrangler queues create openinspection-cron
+npx wrangler queues create openinspection-word-export
+npx wrangler kv namespace create openinspection-oauth   # then paste the id over the
+                                                        # OAUTH_KV placeholder in
+                                                        # wrangler.local.jsonc
+```
+
+Durable Objects, the Workflow, `BROWSER`, `IMAGES` and `STREAM` are name-only
+bindings — declaring them in the config is all the provisioning they need.
 
 > **`IMAGES` is optional.** The committed `wrangler.jsonc` declares it (an
 > account-scoped, name-only binding). If your account has **Images →
@@ -74,7 +96,7 @@ npm run setup:cloudflare   # provisions D1/KV/R2 + writes real IDs to wrangler.l
 npm run deploy             # build + wrangler deploy (uses wrangler.local.jsonc)
 ```
 
-`npm run deploy` runs `react-router build` (bundling `server/` API + `app/` SSR into one worker) then `wrangler deploy` against the built `build/server/wrangler.json`, and finally `jwt:ensure` + `setup-code:ensure` (provision missing secrets). The build bakes whichever wrangler config wins (`WRANGLER_CONFIG` env > `wrangler.local.jsonc` > committed `wrangler.jsonc`). Apply remote D1 migrations with `npm run db:migrate:remote`.
+`npm run deploy` is the whole chain, in this order: `build` → `db:migrate:remote` → `db:lag` → `wrangler deploy` → `jwt:ensure` → `setup-code:ensure`. So **remote D1 migrations are applied by the deploy itself** — you do not need a separate `npm run db:migrate:remote` first, though running it on its own is a way to read the migration output before the build starts. `db:lag` sits between the migration and the deploy and aborts if the database and this checkout disagree about what has been applied. The build bakes whichever wrangler config wins (`WRANGLER_CONFIG` env > `wrangler.local.jsonc` > committed `wrangler.jsonc`).
 
 > **One-click**: the committed `wrangler.jsonc` carries placeholder IDs; the README's *Deploy to Cloudflare* button provisions resources and injects real IDs automatically — no manual `setup:cloudflare` needed for that path.
 

--- a/docs/operate/rotate-jwt-keyring.md
+++ b/docs/operate/rotate-jwt-keyring.md
@@ -46,7 +46,8 @@ npm run rotate:jwt
 npm run deploy
 
 # 3. Wait at least the maximum JWT TTL since rotation
-#    (default ~24h; check your auth.ts setExpirationTime() value)
+#    (24h — the `exp` claim in server/api/auth.ts is `now + 60 * 60 * 24`;
+#     this project mints JWTs by hand, so there is no setExpirationTime() to read)
 
 # 4. Prune the previous kid
 node scripts/rotate-jwt-keys.js --prune-old-kid=v<old>

--- a/docs/operate/upgrade.md
+++ b/docs/operate/upgrade.md
@@ -20,6 +20,8 @@ Releases are cut automatically by [release-please](https://github.com/googleapis
 
    The export is your portable copy; the bookmark is the fastest way back (`wrangler d1 time-travel restore <your-d1-database-name> --bookmark=<bookmark>`) if a hand-run statement goes wrong. Time Travel is remote-only and needs the database **name** from your wrangler config, not the `DB` binding. Keep `backup.sql` somewhere safe until you have verified the new deploy.
 
+   ⚠️ **`wrangler d1 export --remote` takes the database offline while it runs.** Every request that touches D1 fails for the duration, which on a live deployment means the app is down. Run it in a window you have chosen, not casually — and note that the Time Travel bookmark costs nothing and takes no outage, so if you only need a way back, take the bookmark and skip the export.
+
 3. **Ask your database what it has actually applied.** The upgrade steps below assume its migration ledger and this checkout agree. Confirm that before trusting them — see [Upgrading across a rebuilt baseline](#upgrading-across-a-rebuilt-baseline).
 
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,26 @@
 # API Reference
 
-All API routes are under `/api/`. Authenticated endpoints require a valid JWT either in the `Authorization: Bearer <token>` header or the `inspector_token` cookie.
+> ⚠️ **This page is a hand-written sample, not the API.** It describes a few
+> dozen endpoints; the deployment serves several hundred. The authoritative
+> surface is the **live OpenAPI document at `/doc`**, with Swagger UI at `/ui`,
+> both generated from the route definitions themselves — plus
+> `server/lib/mcp/openapi-snapshot.json`, the committed snapshot of the same
+> thing. Nothing generates or checks the page you are reading, and a 2026-09-09
+> audit found six endpoints on it that do not exist and three written under the
+> wrong prefix. **When this page and `/doc` disagree, `/doc` is right.**
+>
+> What is worth reading here is the part `/doc` does not carry: the auth model,
+> the response envelope, and the status-code vocabulary.
+
+Almost all API routes are under `/api/`. Inbound provider **webhooks** are the
+deliberate exception and mount at the top level (`/webhooks/{vendor}`), because
+the producer owns the body and the signature and none of the `/api/*` middleware
+applies to them. `/status`, `/photos/*`, `/.well-known/*`, `/sign/*`, `/sso`,
+`/m2m/*` and the ICS feed are also top-level.
+
+Authenticated endpoints require a valid JWT in the `__Host-inspector_token`
+HttpOnly cookie. The token is ES256-signed with a `kid` naming its keyring
+entry. A `Authorization: Bearer <token>` header is also accepted.
 
 Responses are JSON unless noted.
 
@@ -9,16 +29,26 @@ Responses are JSON unless noted.
 ## Public Endpoints (no auth)
 
 ### `GET /status`
-Health check.
+Health check. Its shape is load-bearing — `scripts/check-deploy-lag.mjs` reads
+`commit` and `branch` and refuses to report "no lag" for a status it cannot
+parse.
 
 **Response:**
 ```json
-{ "status": "Core Engine Online", "version": "1.0.0" }
+{
+  "status": "ok",
+  "app": "openinspection-core",
+  "version": "1.0.0",
+  "commit": "…",
+  "branch": "…",
+  "buildTime": "…",
+  "timestamp": "…"
+}
 ```
 
 ---
 
-### `GET /public/inspectors`
+### `GET /api/public/inspectors`
 List all inspectors for the current tenant (used by the booking page).
 
 **Response:**
@@ -32,7 +62,7 @@ List all inspectors for the current tenant (used by the booking page).
 
 ---
 
-### `GET /public/availability/:inspectorId?tenant=<slug>&start=YYYY-MM-DD&end=YYYY-MM-DD`
+### `GET /api/public/availability/:inspectorId?tenant=<slug>&start=YYYY-MM-DD&end=YYYY-MM-DD`
 Get an inspector's raw availability for a date range: base weekly windows, date overrides, and already-booked dates. Rate-limited per IP.
 
 **Query params:**
@@ -54,7 +84,7 @@ Get an inspector's raw availability for a date range: base weekly windows, date 
 
 ---
 
-### `POST /public/book`
+### `POST /api/public/book`
 Submit a booking request. Creates an inspection record with `status: 'draft'`.
 
 **Request body:**
@@ -135,24 +165,21 @@ template configured, responds `409` with `{ "code": "no_agreement_template" }`.
 
 ---
 
-### `POST /api/inspections/:id/checkout`
-Initiate a Stripe Checkout session to unlock the full report. Returns a redirect URL.
+### ~~`POST /api/inspections/:id/checkout`~~ — does not exist
 
-- If `STRIPE_SECRET_KEY` is configured, creates a real Stripe Checkout session.
-- If the tenant has a `stripeConnectAccountId`, the payment is routed through their Stripe Connect Express account with a 10% platform fee.
-- Falls back to a mock redirect if `STRIPE_SECRET_KEY` is absent or a placeholder.
-
-**Response:**
-```json
-{ "url": "https://checkout.stripe.com/..." }
-```
+**Removed from this page 2026-09-09: no such route has been found in the
+codebase.** The report pay-gate is driven from the public token track instead —
+`GET /api/public/checkout/:token` and
+`POST /api/public/inspections/:id/pay-intent`. See
+[`../integrations/stripe.md`](../integrations/stripe.md) for the payment flow
+and `/doc` for the current shapes.
 
 ---
 
 ## Auth Endpoints
 
 ### `POST /api/auth/login`
-Verify credentials and set the `inspector_token` httpOnly cookie.
+Verify credentials and set the `__Host-inspector_token` httpOnly cookie.
 
 **Request body:**
 ```json
@@ -161,17 +188,36 @@ Verify credentials and set the `inspector_token` httpOnly cookie.
 
 **Response:**
 ```json
-{ "success": true, "token": "eyJ...", "redirect": "/inspections" }
+{ "success": true, "data": { "redirect": "/inspections" } }
 ```
 
-Sets the `inspector_token` httpOnly cookie **and** returns the JWT in the response body so standalone clients can store it in `localStorage` for Bearer-authenticated API calls.
+The JWT is delivered **only** as the `__Host-inspector_token` HttpOnly cookie.
+It is not in the body, and browser JavaScript must never store a token —
+`CLAUDE.md` § JWT & Auth Security Rules makes both of those rules. The one
+exception is the server-side BFF: a caller sending `x-token-relay: 1` also gets
+`token` in `data`, because Workers `fetch()` may strip `Set-Cookie` on a
+server-to-server hop and the BFF has to put the token in its own session cookie.
+The browser never sends that header.
+
+**If the user has 2FA enabled, no session is granted here.** The response is
+`{ "success": true, "data": { "requires2fa": true, "challengeToken": "…" } }`
+with **no** `Set-Cookie` — challenge tokens travel JSON-only, so a stolen session
+cookie alone can never bypass the second factor. The challenge is valid for five
+minutes; post it back with the TOTP code to `POST /api/auth/login/2fa` to get a
+session.
 
 Returns `401` if credentials are invalid.
+
+### The rest of the 2FA surface
+
+`POST /api/auth/2fa/setup`, `/2fa/verify`, `/2fa/disable`,
+`/2fa/recovery-codes/regenerate`, and `POST /api/auth/login/2fa`. Shapes are in
+`/doc`; the server side lives in `server/api/auth/totp.ts`.
 
 ---
 
 ### `POST /api/auth/join`
-Accept a team invite token, create the user account, and set the `inspector_token` cookie.
+Accept a team invite token, create the user account, and set the `__Host-inspector_token` cookie.
 
 **Request body:**
 ```json
@@ -180,17 +226,18 @@ Accept a team invite token, create the user account, and set the `inspector_toke
 
 **Response:**
 ```json
-{ "success": true, "token": "eyJ...", "redirect": "/inspections" }
+{ "success": true, "data": { "redirect": "/inspections" } }
 ```
 
-Sets the `inspector_token` httpOnly cookie **and** returns the JWT in the response body. Store it in `localStorage` as `tenantToken` for subsequent authenticated API calls.
+Sets the `__Host-inspector_token` HttpOnly cookie. As with login, the JWT is not
+returned to a browser and must not be stored in `localStorage`.
 
 Returns `400` if the token is expired or already used.
 
 ---
 
 ### `POST /api/auth/change-password`
-Change the calling user's password. Requires a valid JWT or `inspector_token` cookie.
+Change the calling user's password. Requires a valid JWT or `__Host-inspector_token` cookie.
 
 **Request body:**
 ```json
@@ -297,7 +344,7 @@ Get a single inspection with its template schema.
 #### `POST /api/inspections`
 Create a new inspection.
 
-**Roles:** `owner`, `admin`, `inspector`
+**Roles:** `owner`, `manager`, `inspector`
 
 **Request body:**
 ```json
@@ -321,7 +368,7 @@ Create a new inspection.
 #### `DELETE /api/inspections/:id`
 Delete an inspection and its associated results. The inspection must belong to the caller's tenant.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -335,7 +382,7 @@ Returns `404` if the inspection is not found or belongs to a different tenant.
 #### `PATCH /api/inspections/:id`
 Update editable metadata on an inspection. Only the fields included in the request body are changed.
 
-**Roles:** `owner`, `admin`, `inspector`
+**Roles:** `owner`, `manager`, `inspector`
 
 **Allowed fields:** `propertyAddress`, `clientName`, `clientEmail`, `date`, `inspectorId`, `price`, `status`
 
@@ -378,31 +425,25 @@ Get the field data collected for an inspection.
 
 ---
 
-#### `PATCH /api/inspections/:id/results`
-Save (upsert) field data for an inspection. The field form calls this continuously as the inspector fills in the checklist.
+#### ~~`PATCH /api/inspections/:id/results`~~ — does not exist
 
-**Roles:** `owner`, `admin`, `inspector`
+**There has never been a `PATCH` on `/{id}/results`; the only method there is
+`GET`.** The bulk write path is `POST /api/inspections/:id/results/batch`, and
+in normal editing nothing calls it per keystroke either: the editor's writes go
+into a Yjs document held in a Durable Object, and the DO is the only writer of
+`inspection_results.data`. See
+[`../concepts/collab-editing.md`](../concepts/collab-editing.md).
 
-**Request body:**
-```json
-{
-  "data": {
-    "roof_1": { "status": "Defect", "notes": "Missing shingles", "photos": [] }
-  }
-}
-```
-
-**Response:**
-```json
-{ "success": true }
-```
+This phantom route has cost real time before — `develop/testing.md` records an
+E2E spec that patched it, got a silent 404 on its seed step, and stayed green
+while testing nothing.
 
 ---
 
 #### `POST /api/inspections/:id/complete`
 Mark an inspection as completed and email the report link to the client.
 
-**Roles:** `owner`, `admin`, `inspector`
+**Roles:** `owner`, `manager`, `inspector`
 
 **Response:**
 ```json
@@ -414,7 +455,7 @@ Mark an inspection as completed and email the report link to the client.
 #### `POST /api/inspections/:id/upload`
 Upload a photo to R2 storage for a specific checklist item.
 
-**Roles:** `owner`, `admin`, `inspector`
+**Roles:** `owner`, `manager`, `inspector`
 
 **Request:** `multipart/form-data`
 - `file` — image file
@@ -427,8 +468,15 @@ Upload a photo to R2 storage for a specific checklist item.
 
 ---
 
-#### `GET /api/inspections/files/:key`
-Proxy for serving a photo from R2. The key must start with the caller's `tenantId` (enforced server-side).
+#### `GET /api/inspections/:id/photo?key=<r2-key>`
+Streams a photo from R2, scoped to the caller's tenant and inspection by the key
+prefix. `?download=1` forces an attachment named after the stored original;
+`?w=<px>` serves an on-the-fly thumbnail. The key contains `/`, which is why it
+travels as a query parameter rather than a path segment.
+
+The public report viewer has its own token-scoped twin in `public-report.ts`.
+(This section used to describe `GET /api/inspections/files/:key`, a route that
+does not exist.)
 
 ---
 
@@ -449,7 +497,7 @@ List all inspection templates for the tenant.
 #### `GET /api/inspections/inspectors`
 List all users (inspectors) in the tenant.
 
-**Roles:** `owner`, `admin`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -581,7 +629,7 @@ Delete a date override by ID.
 List all inspection templates for the tenant.
 
 #### `POST /api/inspections/templates`
-Create a new template. **Roles:** `admin`, `owner`
+Create a new template. **Roles:** `owner`, `manager`
 
 **Request body:**
 ```json
@@ -589,26 +637,26 @@ Create a new template. **Roles:** `admin`, `owner`
 ```
 
 #### `PUT /api/inspections/templates/:id`
-Update a template name or schema. Bumps `version`. **Roles:** `admin`, `owner`
+Update a template name or schema. Bumps `version`. **Roles:** `owner`, `manager`
 
 #### `DELETE /api/inspections/templates/:id`
-Delete a template. Returns `409` if any inspection references it. **Roles:** `admin`, `owner`
+Delete a template. Returns `409` if any inspection references it. **Roles:** `owner`, `manager`
 
 ---
 
 ### Google Calendar
 
 #### `GET /api/calendar/connect`
-Redirect the inspector's browser to Google OAuth consent. Requires `GOOGLE_CLIENT_ID` to be configured and a valid `inspector_token` cookie. Returns `501` if not configured.
+Redirect the inspector's browser to Google OAuth consent. Requires `GOOGLE_CLIENT_ID` to be configured and a valid `__Host-inspector_token` cookie. Returns `501` if not configured.
 
 #### `GET /api/calendar/callback`
 Public OAuth redirect from Google. Exchanges the authorization code for tokens, fetches the primary calendar ID, and stores `googleRefreshToken` + `googleCalendarId` on the `users` row. Redirects to `/inspections?calendar=connected`.
 
 #### `DELETE /api/calendar/disconnect`
-Clears stored Google tokens from the `users` row. Requires `inspector_token` cookie.
+Clears stored Google tokens from the `users` row. Requires `__Host-inspector_token` cookie.
 
 #### `POST /api/calendar/sync`
-Fetches the inspector's Google Calendar events for the next 30 days and inserts `availabilityOverrides` rows for any busy blocks. Existing overrides for the same date are skipped. Requires `inspector_token` cookie.
+Fetches the inspector's Google Calendar events for the next 30 days and inserts `availabilityOverrides` rows for any busy blocks. Existing overrides for the same date are skipped. Requires `__Host-inspector_token` cookie.
 
 **Response:**
 ```json
@@ -622,7 +670,7 @@ Fetches the inspector's Google Calendar events for the next 30 days and inserts 
 #### `GET /api/admin/export`
 Export all tenant data as JSON for backup or migration.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -642,7 +690,7 @@ Export all tenant data as JSON for backup or migration.
 #### `POST /api/admin/invite`
 Create a 7-day team invite link. Sends a Resend email if `RESEND_API_KEY` is configured, otherwise logs the link to console.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Request body:** `{ "email": "new@example.com", "role": "inspector" }`
 
@@ -653,7 +701,7 @@ Create a 7-day team invite link. Sends a Resend email if `RESEND_API_KEY` is con
 #### `GET /api/admin/members`
 List workspace members and pending invites.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -672,7 +720,7 @@ List workspace members and pending invites.
 #### `GET /api/admin/agreements`
 List all agreement templates for the tenant.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -688,7 +736,7 @@ List all agreement templates for the tenant.
 #### `POST /api/admin/agreements`
 Create a new agreement template.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Request body:**
 ```json
@@ -705,7 +753,7 @@ Create a new agreement template.
 #### `PUT /api/admin/agreements/:id`
 Update an existing agreement template. Bumps the `version` field.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Request body** (all fields optional):
 ```json
@@ -724,7 +772,7 @@ Returns `404` if the agreement does not exist or does not belong to the caller's
 #### `DELETE /api/admin/agreements/:id`
 Delete an agreement template.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -745,7 +793,7 @@ Returns `404` if the agreement does not exist or does not belong to the caller's
 #### `GET /api/agent/my-reports`
 List inspections referred by the calling agent. Admins and owners can pass `?agentId=<id>` to view any agent's reports.
 
-**Roles:** `agent`, `admin`, `owner`
+**Roles:** `agent`, `owner`, `manager`
 
 **Query params (admin/owner only):** `agentId`
 
@@ -759,7 +807,7 @@ List inspections referred by the calling agent. Admins and owners can pass `?age
 #### `GET /api/agent/leaderboard`
 Referral leaderboard — inspection counts grouped by `referredByAgentId`, descending.
 
-**Roles:** `admin`, `owner`
+**Roles:** `owner`, `manager`
 
 **Response:**
 ```json
@@ -773,13 +821,25 @@ Referral leaderboard — inspection counts grouped by `referredByAgentId`, desce
 
 ---
 
-## Error Responses
+## Response envelope
 
-All endpoints return JSON errors in this format:
+Both halves come from `server/lib/response.ts` (`sendSuccess` / `sendError`) and
+are the same on every endpoint that uses them:
 
 ```json
-{ "error": "Human-readable error message" }
+{ "success": true, "data": { }, "meta": { } }
 ```
+
+```json
+{ "success": false, "error": { "message": "…", "code": "…", "details": { } } }
+```
+
+`code` is the machine-readable half and is what a client should branch on;
+`message` is for a person. `details` carries whatever the specific failure can
+say — the AI refusals, for instance, put their reason vocabulary there.
+
+(The flat `{ "error": "…" }` shape this section described until 2026-09-09 was
+never what the code sends.)
 
 Common status codes:
 - `400` — Missing or invalid request fields

--- a/docs/reference/roles.md
+++ b/docs/reference/roles.md
@@ -84,9 +84,13 @@ returning `undefined` and granting by accident.
 
 Concretely, from the two tables plus the routes: their own sign-in
 (`/agent-login`, password or magic link) and sign-up (`/agent-signup`), their
-own chrome, and four pages — `/agent-dashboard`, `/agent-inspectors`,
-`/agent-repair-items`, `/agent-settings/profile` — scoped to the inspections
-they are attached to. Referral tracking runs off that attachment.
+own chrome, and five pages under the agent layout — `/agent-dashboard`,
+`/agent-inspectors`, `/agent-repair-items`, `/agent-settings/profile` and
+`/agent-settings/legal` (their own terms-acceptance record) — scoped to the
+inspections they are attached to. Referral tracking runs off that attachment.
+Two more sit outside that layout on purpose: `/agent-accept-terms`, which the
+layout's own loader redirects a gated agent to, and `/agent-logout`, which ends
+the session on the agent sign-in page rather than the staff one.
 
 > There are more role-shaped enums in this codebase than these two (assignment
 > is `lead`/`helper`, agreement signers are `client`/`co_client`/`agent`/`other`,


### PR DESCRIPTION
A file-by-file review of all 47 docs plus `README.md`, `CONTRIBUTING.md` and `CLAUDE.md`, each read against the code rather than against itself. 28 files were accurate and are untouched. These are the 22 that were not.

Two commits: the docs tree first, then `CLAUDE.md`.

## Three that would have cost someone real time

**`docs/integrations/stripe.md` gave the wrong webhook URL.** It told operators to point Stripe at `POST /api/stripe/webhook`. Inbound webhooks moved to the top level; the route is `/webhooks/stripe`, with a workspace-scoped `/webhooks/stripe/<slug>` beside it because the verifier secret is per workspace. An operator who followed that page received no payment events at all.

**`docs/operate/deploy.md` omitted the queues.** With `CRON_QUEUE` unbound the tick logs `CRON_QUEUE is not bound — no job will run` and every sweep, reminder and retention job stops. Also missing from the required-resources table: the `INSPECTION_DOC` Durable Object (collaborative editing returns 501 without it) and `OAUTH_KV`. The page additionally claimed `npm run setup:cloudflare` provisions everything it lists — that script creates D1, **one** KV namespace and the `PHOTOS` bucket, so the two queues and the second KV namespace are on the operator. It now says so and gives the wrangler commands.

**`CONTRIBUTING.md` told contributors auth is HS256 JWT.** It is ES256 with a versioned keyring, and `CLAUDE.md` forbids an HS256 path outright.

## `docs/reference/api.md`

The most drifted file in the tree, and it now opens by saying what it is. It documents 49 endpoints against 517 in the OpenAPI snapshot, and nothing generates or checks it. This pass found:

- six endpoints that do not exist — `POST /:id/checkout`, `GET /inspections/files/:key`, and `PATCH /:id/results`, the last being the exact phantom route `docs/develop/testing.md` already records an E2E spec dying on;
- three written without their `/api` prefix;
- the wrong `/status` body, the wrong cookie name (`inspector_token` for `__Host-inspector_token`), and the wrong error envelope (`{ error: "…" }` rather than the `sendError` shape);
- an `admin` role the codebase does not have, in 18 places;
- no mention of the 2FA challenge flow at all.

All corrected, and `/doc` is named as the authority when the two disagree.

## `docs/develop/architecture.md`

Named an R2 bucket that has never been bound (`REPORTS`; everything is in `PHOTOS`, and `scripts/setup-cloudflare.js` says so in a comment). Had the middleware order wrong and listed two middlewares that are not global. Repeated at the bottom the very CPU figure the same file retracts higher up. Said React Router v7 in the diagram.

## The retired offline layer

`useOfflineQueue` was deleted with the rest of the bespoke offline layer in #181 but was still cited as the offline mechanism in the architecture doc, the README and `CLAUDE.md`. All three now draw the line the code draws: field data is offline-capable through the Yjs document buffered in IndexedDB, while photo and video *binary* upload is not, and the editor declines it rather than queueing.

## Counts

Corrected, or — where a gate already prints the live number on every run — replaced by a pointer to that output: shared-ui components (12 in one file, 25 in another, 28 actually exported), starter templates (17 vs 7), i18n keys (4,300 vs 5,264), the DS gate's rule count (8 vs 9), the verification-copy gate's self-test pair, `check-ds-tokens.mjs`'s file allowlist, the route-metadata tag vocabulary, and the CI job shape in three separate files.

## `CLAUDE.md` (second commit)

Twelve fixes, three of them on security machinery: `JWT_SECRET` was described as the M2M credential, which it is not; "Token NOT in response body" was written as an absolute rule that the login handler breaks for the in-process BFF; and per-request keyring construction had moved from `diMiddleware` to `contextBootstrap`. Full list in the commit message.

## Verification

- All 78 conformance gates pass.
- `lint:doclinks` resolves 159 relative links, none broken.
- `lint:english`, `lint:no-portal-routes`, `lint:schema-doc` and `lint:mode-disguises` are green.

## Deliberately not in this PR

Three findings are code, not documentation. `deploy.md` now names the first of them so an operator is not blocked by it:

1. `setup:cloudflare` does not provision the two queues or `OAUTH_KV`, and `wrangler.jsonc` ships a placeholder id for the latter.
2. `.githooks/pre-commit`'s own header comment still says six gates, and says CI runs them individually.
3. `.npmrc` still gives React 18 as the reason for `legacy-peer-deps` on a project that is on React 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2iPf2Epzvw9b8pNDg5eMP