### PR TITLE
docs(shots): capture at 960, and photograph the workspace shell

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -91,7 +91,13 @@ export function Sidebar() {
             <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M16.5 10.5a6 6 0 11-12 0 6 6 0 0112 0z" /></svg>
             <span className="font-medium">{m.nav_action_search()}</span>
             <kbd className="ih-kbd ml-auto">
-              {typeof navigator !== "undefined" && navigator.platform?.startsWith("Mac") ? "⌘K" : "Ctrl /"}
+              {/* Ctrl+K, not Ctrl+/. The palette's own handler is
+                  `(metaKey || ctrlKey) && key === "k"` (CommandPalette.tsx), and
+                  `/` is taken: it opens the comment library inside the report
+                  editor (useKeyboard.ts). This label read "Ctrl /" on Windows,
+                  so the one hint the app gives about its search shortcut named
+                  a key that does something else. */}
+              {typeof navigator !== "undefined" && navigator.platform?.startsWith("Mac") ? "⌘K" : "Ctrl K"}
             </kbd>
           </button>
         </div>

--- a/playwright.docs-shots.config.ts
+++ b/playwright.docs-shots.config.ts
@@ -56,14 +56,60 @@ export default defineConfig({
             name: 'desktop',
             use: {
                 ...devices['Desktop Chrome'],
-                // Wide enough for the three-pane editor without a horizontal
-                // scrollbar, short enough that a full-page capture is readable
-                // at the width the portal renders it.
-                viewport: { width: 1440, height: 900 },
-                // Physical pixels stay 1:1 so an image is the size it says it
-                // is; a 2x capture doubles every file for no gain in a doc that
-                // is displayed at ~800px wide.
-                deviceScaleFactor: 1,
+                // 960 CSS px, and the number is derived, not chosen.
+                //
+                // WHAT WENT WRONG AT 1440. The published guide renders its
+                // prose — and therefore its images — inside a fixed column:
+                // `.ihp-prose` is `max-w-2xl` (42rem = 672px) and its images
+                // are `max-width: 100%`. A 1440px-wide capture is displayed at
+                // 672px, i.e. 0.47x, so the app's 14px UI text reached the
+                // reader at about 6.5px. Every screenshot in the manual was
+                // technically correct and practically unreadable.
+                //
+                // WHY 960 AND NOT MORE. Display scale is 672/width: 1440 gives
+                // 0.47, 1040 gives 0.65, 960 gives 0.70. True 1:1 would need a
+                // 672px viewport, which is a phone — the `mobile` project
+                // already documents that layout where a guide wants it.
+                //
+                // WHAT 960 COSTS, AND WHY IT IS NOW AFFORDABLE. Two hard edges
+                // sit just above it:
+                //   * the workspace sidebar is `hidden lg:flex`
+                //     (app/components/Sidebar.tsx) and Tailwind's `lg` is
+                //     1024px — this repo overrides no breakpoint. Below that
+                //     the shell swaps to MobileHeader + drawer.
+                //   * the report editor's shell is `min-w-[1024px]`
+                //     (app/routes/inspection-edit.tsx) — narrower than that and
+                //     the three-pane guide is photographed mid-horizontal-
+                //     scroll.
+                // Both used to force every capture wide, because the guides
+                // said "in the left-hand nav" and no page had ever shown the
+                // reader what that was. One guide now owns that explanation
+                // (`finding-your-way-around`), so the rest are free to be
+                // photographed at a width where their own content is legible.
+                //
+                // The two files that still NEED the wider shell say so
+                // themselves, with a `test.use({ viewport })` naming the reason
+                // — workspace-shell.shots.ts, which photographs the sidebar,
+                // and the editor block in staff-lifecycle.shots.ts. A project
+                // default cannot express "this guide, for this reason", and a
+                // second project would silently re-shoot every id under a
+                // different width.
+                viewport: { width: 960, height: 900 },
+                // 2x, and this is a consequence of the line above rather than
+                // an independent taste. The previous comment here argued that
+                // 1x costs nothing "in a doc that is displayed at ~800px wide",
+                // which held only while the capture was much wider than its
+                // display box. It no longer is: 1040 CSS px shown in a 672px
+                // column is 1344 DEVICE px on a 2x screen, so a 1x capture is
+                // UPSCALED 1.29x for most laptop readers and the text goes
+                // soft. At 2x the file is 2080 device px and downsamples
+                // cleanly on 1x and 2x alike.
+                //
+                // ⚠️ Full-page captures are now 2x tall in pixels as well.
+                // Chromium refuses a screenshot past ~16384px on either axis,
+                // so a page over ~8000 CSS px cannot be shot full-page at all —
+                // one more reason a long page should be captured as sections.
+                deviceScaleFactor: 2,
             },
         },
         {

--- a/tests/docs-shots/_docs-fixtures.ts
+++ b/tests/docs-shots/_docs-fixtures.ts
@@ -192,7 +192,13 @@ export async function ensureDocsInspection(page: Page, templateId: string): Prom
     if (listed.ok()) {
         const body = (await listed.json()) as { data?: Array<{ id: string; propertyAddress?: string }> };
         const found = (body.data ?? []).find((i) => i.propertyAddress === address);
-        if (found) return found.id;
+        if (found) {
+            // Also on the already-exists path: the service line is what makes
+            // the inspection billable, and a run against a database that
+            // already holds the inspection would otherwise skip it.
+            await ensureDocsInspectionIsBilled(page, found.id);
+            return found.id;
+        }
     }
     await apiPost(page, '/api/inspections', {
         propertyAddress: address,
@@ -204,7 +210,35 @@ export async function ensureDocsInspection(page: Page, templateId: string): Prom
     const body = (await after.json()) as { data?: Array<{ id: string; propertyAddress?: string }> };
     const created = (body.data ?? []).find((i) => i.propertyAddress === address);
     if (!created) throw new Error('docs fixture: inspection was created but does not list');
+    await ensureDocsInspectionIsBilled(page, created.id);
     return created.id;
+}
+
+/**
+ * Put a priced service line on the docs inspection.
+ *
+ * WITHOUT THIS THE INVOICING GUIDE CANNOT BE PHOTOGRAPHED. `POST
+ * /api/inspections` takes no service, so the inspection was worth $0.00 and its
+ * Invoice card offered "Set amount", not "Request payment" — the button the
+ * capture walk clicks. The guide's own alt text promises "the service lines
+ * carried across", which an inspection with no service can never show.
+ *
+ * Idempotent by the endpoint's own contract: adding a service the inspection
+ * already has returns the existing line unchanged, so a re-run costs one call
+ * and changes nothing.
+ */
+async function ensureDocsInspectionIsBilled(page: Page, inspectionId: string): Promise<void> {
+    const catalogue = await apiGet(page, '/api/services');
+    if (!catalogue.ok()) return;
+    const body = (await catalogue.json()) as { data?: Array<{ id: string; name: string }> };
+    const service = (body.data ?? []).find((s) => s.name === 'Full Home Inspection');
+    // Silent when the catalogue is empty rather than throwing: the caller that
+    // needs a price is the invoicing walk, and it asserts on the button it
+    // needs. A fixture that throws here would take down every guide that has
+    // nothing to do with money.
+    if (!service) return;
+    await apiPost(page, `/api/inspections/${inspectionId}/services`, { serviceId: service.id })
+        .catch(() => undefined);
 }
 
 /**

--- a/tests/docs-shots/_harness.ts
+++ b/tests/docs-shots/_harness.ts
@@ -57,6 +57,41 @@ export interface ShotOptions {
     mask?: Locator[];
     /** Capture the whole scrollable page rather than the viewport. */
     fullPage?: boolean;
+    /**
+     * Photograph ONE ELEMENT instead of the window.
+     *
+     * Playwright scrolls the element into view and captures all of it, even the
+     * part below the fold, so this is not "a viewport shot that happens to be
+     * pointed at something" — a 1200px-tall card comes back whole.
+     *
+     * Takes precedence over `fullPage`, which has no meaning once the frame is
+     * the element's own box.
+     */
+    element?: Locator;
+}
+
+/** One picture in a multi-picture capture. See `shot.sections`. */
+export interface ShotSection {
+    /**
+     * This part's OWN marker id.
+     *
+     * ⚠️ There is no such thing as "part 2 of shot X". The publisher joins
+     * `<id>.png` to `<!-- shot: <id> | … -->` by exact set equality
+     * (apps/portal/scripts/lib/docs-shots.mjs), so splitting one picture into
+     * three means the prose gains three markers and loses one. That is a change
+     * in BOTH repositories or it is a failed docs build — a capture the prose
+     * does not ask for is reported as "capture with no marker".
+     */
+    id: string;
+    /** The container to photograph. Must be a stable element, not a text node. */
+    element: Locator;
+    /** Extra regions to cover for this part only. */
+    mask?: Locator[];
+}
+
+export interface GuideShot {
+    (page: Page, id: string, options?: ShotOptions): Promise<void>;
+    sections(page: Page, sections: readonly ShotSection[]): Promise<void>;
 }
 
 /**
@@ -68,21 +103,89 @@ export interface ShotOptions {
  * The id is the join key with the prose. It must be url-safe kebab-case; the
  * validator rejects anything else rather than guessing.
  */
-export function shotsFor(guideSlug: string) {
-    return async function shot(page: Page, id: string, options: ShotOptions = {}): Promise<void> {
+export function shotsFor(guideSlug: string): GuideShot {
+    const shot = async (page: Page, id: string, options: ShotOptions = {}): Promise<void> => {
         const dir = path.join(SHOT_ROOT, guideSlug);
         mkdirSync(dir, { recursive: true });
-        await page.screenshot({
+        const common = {
             path: path.join(dir, `${id}.png`),
             mask: [...standingMasks(page), ...(options.mask ?? [])],
-            fullPage: options.fullPage ?? false,
             // Both of these are pure noise in a still image, and both differ
             // between runs: a caret blinks, and a transition caught mid-flight
             // photographs a control halfway to somewhere.
-            animations: 'disabled',
-            caret: 'hide',
-        });
+            animations: 'disabled' as const,
+            caret: 'hide' as const,
+        };
+        if (options.element) {
+            await options.element.screenshot(common);
+            return;
+        }
+        await page.screenshot({ ...common, fullPage: options.fullPage ?? false });
     };
+
+    /**
+     * Capture one long screen as SEVERAL pictures, one per container.
+     *
+     * THE PROBLEM THIS SOLVES. A settings page is often 3000+ CSS px tall. Shot
+     * full-page it becomes a strip that the guide displays 0.65x wide and
+     * scrolled past in one flick — a picture of everything, which points at
+     * nothing. Worse now than before: a narrower capture viewport reflows a long
+     * page TALLER, and at deviceScaleFactor 2 a page over ~8000 CSS px cannot be
+     * captured full-page at all (Chromium's ~16384px limit).
+     *
+     * WHY ELEMENT-SCOPED RATHER THAN SLICING BY VIEWPORT HEIGHT. A height slice
+     * is arithmetic, not meaning: it cuts wherever the number lands, so a
+     * heading arrives at the bottom of one picture and its form at the top of
+     * the next, and the cut moves every time the page's content changes length.
+     * A container is what the reader is being shown, and the pages that need
+     * splitting already have stable ones — `/settings/communication` carries
+     * `#email-delivery`, `#sms-delivery`, `#email-templates`, `#google-calendar`
+     * as scroll-spy anchors, guarded by settings-communication-nav.spec.ts. When
+     * a screen genuinely has no container to name, the honest fix is to give it
+     * one in the app, not to guess an offset here.
+     *
+     * WHAT IT COSTS. Each part is a separate marker id in the prose — see
+     * ShotSection.id. This is a two-repository change; there is no way to emit
+     * more files under one id without failing the publisher's exact-set check.
+     */
+    const sections = async (page: Page, entries: readonly ShotSection[]): Promise<void> => {
+        for (const entry of entries) {
+            // Fail here rather than photograph the wrong thing. `count()` is
+            // deliberately not consulted: a section that has silently stopped
+            // rendering must break the capture run, because the alternative is
+            // a guide that quietly loses a picture and a validator that then
+            // blames the prose.
+            await entry.element.first().scrollIntoViewIfNeeded();
+            await shot(page, entry.id, { element: entry.element.first(), mask: entry.mask });
+        }
+    };
+
+    return Object.assign(shot, { sections });
+}
+
+/**
+ * The panel a heading sits in — the frame for an element-scoped capture.
+ *
+ * A workspace screen is a column of panels, and they are NOT one component: most
+ * are `<Card>` from packages/shared-ui (`bg-ih-bg-card border border-ih-border
+ * rounded-ih-card shadow-ih-card`), while a few hand-roll the same surface —
+ * DocumentsSection is a `<section className="rounded-xl border border-ih-border
+ * bg-ih-bg-card p-5">`. The one class both spellings share is the BACKGROUND,
+ * so that is the anchor. `rounded-ih-card` would have matched two of the hub's
+ * three panels and thrown on the third.
+ *
+ * Nearest-ancestor, not first-in-document: `bg-ih-bg-card` also lands on inputs
+ * and selects, but a heading is never inside one, so the first ancestor carrying
+ * it is the panel.
+ *
+ * ⚠️ Anchoring on a utility class is a compromise, not a pattern. It beats the
+ * alternatives on offer — a text locator returns the `<h2>` itself, which
+ * photographs as one line of type — but if a panel needs framing precisely, give
+ * it a real id in the app and locate on that. This helper is for panels that
+ * have none.
+ */
+export function panelAround(heading: Locator): Locator {
+    return heading.locator('xpath=ancestor::*[contains(@class,"bg-ih-bg-card")][1]');
 }
 
 /**

--- a/tests/docs-shots/_settings-shots.ts
+++ b/tests/docs-shots/_settings-shots.ts
@@ -39,12 +39,41 @@ export function resetSettingsGuides(entries: readonly SettingsShot[]): void {
     for (const guide of new Set(entries.map((e) => e.guide))) resetGuide(guide);
 }
 
+/**
+ * ⚠️ THE LONG PAGES HERE STILL SHIP AS ONE STRIP, and cannot stop until the
+ * prose moves too.
+ *
+ * `/settings/communication` and `/settings/workspace` are several thousand CSS
+ * px tall, so one `fullPage: true` picture is displayed at ~0.65x in a 672px
+ * column and read by nobody. The mechanism to fix that exists — `shot.sections`
+ * in `_harness.ts`, element-scoped, and those two pages already carry the stable
+ * containers it needs (`#email-delivery`, `#sms-delivery`, `#email-templates`,
+ * `#google-calendar`, guarded by settings-communication-nav.spec.ts).
+ *
+ * What blocks it is the join, not the capture: the publisher matches `<id>.png`
+ * to `<!-- shot: <id> -->` by exact set equality, so turning `settings-
+ * communication` into four pictures means the guide in
+ * `apps/portal/docs/user-guide/` loses that marker and gains four. Emitting the
+ * extra PNGs first would fail the docs build with "capture with no marker",
+ * which is the check working. Convert a page here and its prose in the same
+ * change, never one without the other.
+ */
 export async function captureSettings(page: Page, entry: SettingsShot): Promise<void> {
     const shot = shotsFor(entry.guide);
     await page.goto(entry.path);
     // Assert, don't sleep: a settings page whose fetch failed still renders its
     // crumb and its heading, so waiting on "the URL changed" photographs the
     // empty state and calls it documentation.
-    await expect(page.getByText(entry.ready).first()).toBeVisible({ timeout: 20_000 });
+    //
+    // SCOPED TO `main`, and that is not tidiness. Unscoped, `/Team/i` matched
+    // the SIDEBAR's own "Team" link, which is present on every page — so the
+    // wait was satisfied by the navigation rather than by the page, and would
+    // have passed on a screen that never loaded. It only surfaced when the
+    // capture viewport came down to 960: the sidebar is `hidden lg:flex`, the
+    // first match became a display:none node, and the wait failed on a page
+    // that had in fact rendered. A readiness check answered by the chrome
+    // around the page is not a readiness check.
+    const content = page.getByRole('main');
+    await expect(content.getByText(entry.ready).first()).toBeVisible({ timeout: 20_000 });
     await shot(page, entry.id, { fullPage: true });
 }

--- a/tests/docs-shots/staff-lifecycle.shots.ts
+++ b/tests/docs-shots/staff-lifecycle.shots.ts
@@ -1,4 +1,4 @@
-import { test, shotsFor, expect } from './_harness';
+import { test, shotsFor, panelAround, expect } from './_harness';
 
 // Desktop only. The mobile project exists for the guides that document a phone
 // flow; running these there would overwrite every capture with a narrow one
@@ -54,33 +54,56 @@ test('the inspection page: overview, people, files, communication', async ({ pag
     await expect(page.getByRole('link', { name: /Open editor/i }).first()).toBeVisible();
     await HUB(page, 'hub-overview');
 
-    // The remaining three are regions of the SAME page, so each is scrolled to
-    // and photographed in the viewport rather than captured full-page — a
-    // full-page shot of a long hub shows everything and points at nothing.
-    for (const [id_, heading] of [
-        ['hub-people', /People/i],
-        ['hub-communication', /Communication/i],
-        ['hub-documents', /Documents/i],
-    ] as const) {
-        const section = page.getByText(heading).first();
-        if (!(await section.count())) continue;
-        await section.scrollIntoViewIfNeeded();
-        await HUB(page, id_);
-    }
+    // The remaining three are regions of the SAME page, and each is photographed
+    // as ITS OWN PANEL rather than as the viewport that happens to contain it.
+    //
+    // The previous version scrolled the heading into view and shot the window.
+    // That was already better than a full-page strip, but the frame was decided
+    // by scroll position: `scrollIntoViewIfNeeded` does nothing when the element
+    // is already visible, so a panel could arrive anywhere in the picture, with
+    // however many neighbours happened to be beside it — and near the foot of
+    // the page it could not be centred at all. Every id below is unchanged, so
+    // this changes the pictures and not the join with the prose.
+    //
+    // Located by ROLE, not by text: the old `getByText(/People/i)` matched any
+    // element whose text merely contained the word, which on this page includes
+    // the nav. Each panel's title is a real `<h2>` (BlockHeading), and the
+    // strings come from messages/en (`inspections_hub_block_people`,
+    // `comm_block_title`, `documents_heading`).
+    await HUB.sections(page, [
+        { id: 'hub-people', element: panelAround(page.getByRole('heading', { name: /^People$/i })) },
+        { id: 'hub-communication', element: panelAround(page.getByRole('heading', { name: /^Communication$/i })) },
+        { id: 'hub-documents', element: panelAround(page.getByRole('heading', { name: /^Documents$/i })) },
+    ]);
 });
 
-test('the editor: three panes, and an item being rated', async ({ page }) => {
-    const id = await setup(page);
-    await page.goto(`/inspections/${id}/edit`);
-    // The section list is the editor's leftmost pane and only exists once the
-    // template snapshot has loaded — "the URL changed" would photograph a shell.
-    await expect(page.getByText('Exterior').first()).toBeVisible({ timeout: 30_000 });
-    await EDITOR(page, 'editor-three-panes');
+/**
+ * Wider than the project default of 960, and the app decides that, not taste.
+ *
+ * The editor shell is `min-w-[1024px]` (app/routes/inspection-edit.tsx), so at
+ * the default width the three-pane picture is taken mid-horizontal-scroll and
+ * the guide's own subject is cut off. 1040 is that minimum plus room for
+ * Chromium's classic scrollbar.
+ *
+ * Scoped to this one test: every other picture in this file is a panel that
+ * reads better at 960.
+ */
+test.describe('the editor', () => {
+    test.use({ viewport: { width: 1040, height: 900 } });
 
-    await page.getByText('Roof covering').first().click();
-    await expect(page.getByText(/Satisfactory/i).first()).toBeVisible();
-    await page.getByText(/Satisfactory/i).first().click();
-    await EDITOR(page, 'editor-rating-an-item');
+    test('the editor: three panes, and an item being rated', async ({ page }) => {
+        const id = await setup(page);
+        await page.goto(`/inspections/${id}/edit`);
+        // The section list is the editor's leftmost pane and only exists once the
+        // template snapshot has loaded — "the URL changed" would photograph a shell.
+        await expect(page.getByText('Exterior').first()).toBeVisible({ timeout: 30_000 });
+        await EDITOR(page, 'editor-three-panes');
+
+        await page.getByText('Roof covering').first().click();
+        await expect(page.getByText(/Satisfactory/i).first()).toBeVisible();
+        await page.getByText(/Satisfactory/i).first().click();
+        await EDITOR(page, 'editor-rating-an-item');
+    });
 });
 
 test('the publish check', async ({ page }) => {
@@ -144,7 +167,12 @@ test('sending the report, and the delivery record', async ({ page }) => {
     await DELIVER(page, 'send-report');
 
     await page.keyboard.press('Escape');
-    const comms = page.getByText(/Communication/i).first();
-    await comms.scrollIntoViewIfNeeded();
-    await DELIVER(page, 'delivery-record');
+    // The delivery record lives in the Communication panel, so photograph the
+    // panel — same reasoning as the hub regions above, same unchanged id.
+    await DELIVER.sections(page, [
+        {
+            id: 'delivery-record',
+            element: panelAround(page.getByRole('heading', { name: /^Communication$/i })),
+        },
+    ]);
 });

--- a/tests/docs-shots/workspace-shell.shots.ts
+++ b/tests/docs-shots/workspace-shell.shots.ts
@@ -1,0 +1,135 @@
+import { test, shotsFor, expect } from './_harness';
+import { loginAsSeedUser } from '../e2e/helpers/seed-login';
+import { SEED_EMAILS } from '../seed-fixtures';
+
+/**
+ * Captures for the guide that introduces the workspace frame itself.
+ *
+ * NO COPY LIVES HERE — every id has its `<!-- shot: … -->` in the prose, which
+ * lives with the hosted docs.
+ *
+ * WHY THIS GUIDE EXISTS, AND WHY IT CHANGES THE OTHER FILES. Every other guide
+ * used to have to be photographed wide enough to keep the left-hand navigation
+ * in frame, because its prose said things like "in the left-hand nav" and the
+ * reader had been shown that nav nowhere else. One page now owns that
+ * explanation, so the rest are free to photograph the panel they are actually
+ * about. That is what let the capture viewport come down to a width where the
+ * app's own text is legible in a 672px column.
+ *
+ * DESKTOP ONLY, INCLUDING THE NARROW PICTURE. `shell-narrow` is taken by
+ * resizing the page rather than by running in the `mobile` project, and that is
+ * a deliberate retreat: this file was the FIRST test this suite had ever run in
+ * that project, and it failed at the login step. The shared helper clicks the
+ * submit button, the click landed before hydration, and the login form has no
+ * server action — so nothing happened at all and the page simply sat at /login
+ * while `waitForURL` timed out. That is a real gap in the mobile project, and
+ * it is not this guide's to fix.
+ *
+ * A resize gives the same answer for what this picture is of. The subject is a
+ * LAYOUT — which breakpoint the shell is on — and that is decided by width, not
+ * by touch emulation or a phone user-agent.
+ */
+const SHELL = shotsFor('finding-your-way-around');
+
+// NO per-guide reset. `_global-setup.ts` clears `.docs-shots/` once per run,
+// which is all this needs — and a `beforeEach` reset actively breaks a guide
+// with more than one picture. It did: the desktop project still ENTERS the
+// mobile-only test below before `test.skip` fires, so the reset ran again and
+// deleted the two shots the previous test had just written. The run reported
+// green with an empty directory. `_settings-shots.ts` records the same trap
+// from the other direction.
+
+/**
+ * Photographed as the ADMIN.
+ *
+ * The navigation is capability-filtered — Dispatch appears only for someone who
+ * may schedule other people — and the guide's own section on that says so. An
+ * inspector's sidebar would illustrate the exception rather than the rule, and
+ * the reader has no way to tell from a picture which one they are looking at.
+ */
+async function signIn(page: import('@playwright/test').Page): Promise<void> {
+    await loginAsSeedUser(page, SEED_EMAILS.admin);
+    await page.goto('/inspections');
+}
+
+/**
+ * Wider than the project default of 960, and this is the one guide entitled to
+ * be.
+ *
+ * The sidebar is `hidden lg:flex` and Tailwind's `lg` is 1024px, so at the
+ * default width there is no sidebar to photograph — the pictures below would
+ * show the narrow shell twice and the guide would illustrate none of what it
+ * describes. 1040 is 1024 plus room for Chromium's classic scrollbar, so the
+ * LAID-OUT width stays at or above the breakpoint on a page tall enough to
+ * scroll.
+ *
+ * Scoped to this block rather than the file: a file-level `test.use` would also
+ * override the `mobile` project's own viewport, and `shell-narrow` below is
+ * precisely a picture of the narrow shell. Every other guide stays at 960
+ * because this page exists to explain the navigation once.
+ */
+test.describe('the wide shell', () => {
+    test.use({ viewport: { width: 1040, height: 900 } });
+
+    test('expanded and collapsed', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === 'mobile', 'the sidebar does not exist below lg');
+    await signIn(page);
+
+    const sidebar = page.locator('aside.ih-sidebar');
+    await expect(sidebar).toBeVisible();
+    // The shell renders before the nav's capability filter has an answer, and a
+    // sidebar photographed in that moment is missing entries for a reason the
+    // picture cannot show. Team is the last item in the Workspace group, so its
+    // arrival means the whole group has one.
+    await expect(page.getByRole('link', { name: /^Team$/ })).toBeVisible();
+    await SHELL(page, 'shell-expanded');
+
+    // The collapse handle is `opacity-0` until the sidebar is hovered or the
+    // button is focused, which is exactly what the guide tells the reader. A
+    // click alone would work, but hovering first is what a person does and it
+    // keeps the handle visible in anything captured afterwards.
+    await sidebar.hover();
+    const collapse = page.getByRole('button', { name: /Collapse sidebar/i });
+    await collapse.click();
+
+    // The SEARCH BUTTON is the signal, not a nav label. Collapsing hides the
+    // labels but keeps `title={item.label()}` on each link
+    // (app/components/sidebar/SidebarNavItem.tsx), so the accessible name of
+    // "Inspections" is unchanged and an assertion on it passes in both states.
+    // The search button is rendered only while expanded and has no such
+    // fallback. A width or class assertion would pass mid-transition.
+    const search = page.getByRole('button', { name: /Open command palette/i });
+    await expect(search).toBeHidden();
+    await SHELL(page, 'shell-collapsed');
+
+    // Leave the workspace as it was found. The collapsed state is written to a
+    // cookie, so a capture run that ended here would hand every later guide a
+    // sidebar with no labels in it.
+    await sidebar.hover();
+    await page.getByRole('button', { name: /Expand sidebar/i }).click();
+    await expect(search).toBeVisible();
+    });
+});
+
+test('the navigation drawer on a narrow window', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === 'mobile', 'taken by resizing in the desktop project');
+    await signIn(page);
+
+    // Resize AFTER signing in, not before: the login is the step the mobile
+    // project fell over on, and it is the one part of this walk that has
+    // nothing to do with the picture.
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    // The menu button is the readiness check AND the proof of the layout: it
+    // exists only below `lg`, and it is what the picture is about. An assertion
+    // on the sidebar being hidden would also pass at the project's own 960,
+    // where the resize has not happened yet.
+    const menu = page.getByRole('button', { name: /Open menu/i });
+    await expect(menu).toBeVisible();
+    await menu.click();
+    // The drawer carries the same entries as the sidebar, filtered by the same
+    // capabilities — waiting for one of them is what proves the drawer is open
+    // AND populated, which an animation-complete wait would not.
+    await expect(page.getByRole('link', { name: /^Inspections$/ })).toBeVisible();
+    await SHELL(page, 'shell-narrow');
+});


### PR DESCRIPTION
The screenshots in the user guide were captured at 1440px and are displayed inside a 672px prose column. That is 0.47x, so the app's own 14px text reached the reader at about 6.5px — technically correct pictures that nobody could read.

## The viewport comes down to 960

Display scale is `672 / width`:

| capture width | displayed at |
|---|---|
| 1440 (before) | 0.47x |
| 1040 | 0.65x |
| **960** | **0.70x** |

True 1:1 would need a 672px viewport, which is a phone; the `mobile` project already documents that layout where a guide wants it.

**What was blocking 960, and what unblocked it.** Two hard edges sit just above it — the workspace sidebar is `hidden lg:flex` and Tailwind's `lg` is 1024px, and the report editor's shell is `min-w-[1024px]`. The sidebar mattered because guides say things like "in the left-hand nav" and no page had ever shown the reader what that was, so every capture had to keep the navigation in frame.

One guide now owns that explanation. `workspace-shell.shots.ts` photographs the shell expanded, collapsed, and as the narrow-window drawer; its prose is published from the hosted docs, like every guide's. The two places that genuinely still need the wider shell say so themselves, with a scoped `test.use({ viewport })` naming the reason.

## Four things this found

**The settings readiness check was answered by the chrome, not the page.** `getByText(/Team/i).first()` matched the sidebar's own Team link, which is present on every screen — so the wait would have been satisfied on a page that never loaded. Narrowing surfaced it: below `lg` the first match became a `display:none` node and the wait failed on a page that had in fact rendered. Now scoped to `main`.

**The docs inspection was never billable.** `POST /api/inspections` takes no service, so the fixture inspection was worth $0.00 and its Invoice card offered "Set amount" rather than the "Request payment" the capture walk clicks. The invoicing guide's own alt text promises "the service lines carried across", which an inspection with no service can never show. The fixture now attaches the catalogue service, on both the create and the already-exists path.

**A per-test `resetGuide` deletes the pictures of the test before it.** The desktop project still *enters* a mobile-only test before `test.skip` fires, so a `beforeEach` reset ran again and emptied the directory the previous test had just filled — a green run with no output. `_global-setup.ts` already clears `.docs-shots/` once per run, so there is no reset in this file at all. `_settings-shots.ts` records the same trap from the other direction.

**The sidebar's search button named the wrong key on Windows.** It read `Ctrl /`, while the command palette listens for `(metaKey || ctrlKey) && key === "k"` and `/` is taken — it opens the comment library inside the report editor. The one hint the app gives about its own search pointed at a key that does something else.

## A gap left where it is

This file was the first test this suite had ever run in the `mobile` project, and it failed at login. The shared helper clicks the submit button, the click landed before hydration, and the login form has no server action — so nothing happened at all and the page sat at `/login` until `waitForURL` timed out. `shell-narrow` is taken by resizing inside the desktop project instead, since the subject is a layout and a layout is decided by width. The mobile project's login gap is real; it is named here rather than papered over.

## Also here

`shot.sections` for element-scoped captures and `panelAround` for framing a heading's own panel, both used by the inspection-page walk so a region is photographed as its own panel rather than as whatever the viewport happened to contain when it was scrolled into view.

## Verification

Full capture run: **19 of 19 passed, 45 captures across 25 guides.** The prose/capture join reports 39 guides, 46 markers, 0 problems. The three new pictures were reviewed by eye: the expanded shell shows `Search... Ctrl K`, the collapsed strip keeps the icons while the labels, company name, notices bell and search button all go, and the narrow one shows the drawer over a dimmed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PeSSKgRBYGc7ZEAUVX1B6
